### PR TITLE
feat: add Kubernetes deployment manifests for Kind cluster

### DIFF
--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextg-system
+  labels:
+    app.kubernetes.io/part-of: nextg
+    app.kubernetes.io/managed-by: kubectl

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# NextG 5G/6G Kubernetes Deployment Script
+# Deploys nextgcore (5G Core) and nextgsim (UE/gNB) on a Kind cluster
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER_NAME="nextg"
+NAMESPACE="nextg-system"
+NEXTGSIM_K8S="${SCRIPT_DIR}/../../nextgsim/k8s"
+
+echo "============================================"
+echo "  NextG 5G/6G Kubernetes Deployment"
+echo "============================================"
+
+# --- Prerequisites check ---
+for cmd in kind kubectl docker; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: $cmd is required but not installed."
+    exit 1
+  fi
+done
+
+# --- Step 1: Create Kind cluster ---
+echo ""
+echo "[1/9] Creating Kind cluster: ${CLUSTER_NAME}"
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo "  Cluster '${CLUSTER_NAME}' already exists, skipping creation."
+else
+  kind create cluster --config "${SCRIPT_DIR}/kind-config.yaml" --name "${CLUSTER_NAME}"
+  echo "  Cluster created."
+fi
+kubectl cluster-info --context "kind-${CLUSTER_NAME}"
+
+# --- Step 2: Load Docker images into Kind ---
+echo ""
+echo "[2/9] Loading Docker images into Kind cluster"
+
+# Infrastructure images
+INFRA_IMAGES=("mongo:6.0" "busybox:1.36" "prom/prometheus:v2.51.0" "grafana/grafana:10.4.0" "jaegertracing/all-in-one:1.55")
+for img in "${INFRA_IMAGES[@]}"; do
+  if ! docker image inspect "$img" &>/dev/null; then
+    echo "  Pulling $img..."
+    docker pull "$img"
+  fi
+  echo "  Loading $img..."
+  kind load docker-image "$img" --name "${CLUSTER_NAME}" 2>/dev/null || true
+done
+
+# Core NF images
+CORE_IMAGES=(nrf ausf udm udr pcf nssf bsf amf smf upf)
+for nf in "${CORE_IMAGES[@]}"; do
+  img="nextgcore-rust/${nf}:latest"
+  if docker image inspect "$img" &>/dev/null; then
+    echo "  Loading $img..."
+    kind load docker-image "$img" --name "${CLUSTER_NAME}" 2>/dev/null || true
+  else
+    echo "  WARNING: Image $img not found locally. Build it first."
+  fi
+done
+
+# Simulator images
+SIM_IMAGES=("nextgsim-gnb:latest" "nextgsim-ue:latest")
+for img in "${SIM_IMAGES[@]}"; do
+  if docker image inspect "$img" &>/dev/null; then
+    echo "  Loading $img..."
+    kind load docker-image "$img" --name "${CLUSTER_NAME}" 2>/dev/null || true
+  else
+    echo "  WARNING: Image $img not found locally. Build it first."
+  fi
+done
+
+# --- Step 3: Create namespace ---
+echo ""
+echo "[3/9] Creating namespace: ${NAMESPACE}"
+kubectl apply -f "${SCRIPT_DIR}/base/namespace.yaml"
+
+# --- Step 4: Deploy nextgcore ConfigMap ---
+echo ""
+echo "[4/9] Deploying nextgcore configuration"
+kubectl apply -f "${SCRIPT_DIR}/manifests/configmap.yaml"
+
+# --- Step 5: Deploy nextgcore NFs in dependency order ---
+echo ""
+echo "[5/9] Deploying nextgcore 5G Core Network Functions"
+
+echo "  Deploying MongoDB..."
+kubectl apply -f "${SCRIPT_DIR}/manifests/mongodb.yaml"
+kubectl rollout status statefulset/mongodb -n "${NAMESPACE}" --timeout=120s
+
+# --- Step 6: Initialize MongoDB ---
+echo ""
+echo "[6/9] Initializing MongoDB (subscribers + indexes)"
+kubectl apply -f "${SCRIPT_DIR}/manifests/mongodb-init.yaml"
+echo "  Waiting for MongoDB init job to complete..."
+kubectl wait --for=condition=complete job/mongodb-init -n "${NAMESPACE}" --timeout=120s
+echo "  MongoDB initialized."
+
+# --- Step 7: Deploy Core NFs ---
+echo ""
+echo "[7/9] Deploying Core Network Functions"
+
+echo "  Deploying NRF..."
+kubectl apply -f "${SCRIPT_DIR}/manifests/nrf.yaml"
+kubectl rollout status deployment/nrf -n "${NAMESPACE}" --timeout=120s
+
+echo "  Deploying AUSF, UDM, UDR, PCF, NSSF, BSF..."
+kubectl apply -f "${SCRIPT_DIR}/manifests/ausf.yaml"
+kubectl apply -f "${SCRIPT_DIR}/manifests/udm.yaml"
+kubectl apply -f "${SCRIPT_DIR}/manifests/udr.yaml"
+kubectl apply -f "${SCRIPT_DIR}/manifests/pcf.yaml"
+kubectl apply -f "${SCRIPT_DIR}/manifests/nssf.yaml"
+kubectl apply -f "${SCRIPT_DIR}/manifests/bsf.yaml"
+
+echo "  Waiting for control plane NFs..."
+for nf in ausf udm udr pcf nssf bsf; do
+  kubectl rollout status deployment/${nf} -n "${NAMESPACE}" --timeout=120s
+done
+
+echo "  Deploying AMF..."
+kubectl apply -f "${SCRIPT_DIR}/manifests/amf.yaml"
+kubectl rollout status deployment/amf -n "${NAMESPACE}" --timeout=120s
+
+echo "  Deploying SMF..."
+kubectl apply -f "${SCRIPT_DIR}/manifests/smf.yaml"
+kubectl rollout status deployment/smf -n "${NAMESPACE}" --timeout=120s
+
+echo "  Deploying UPF..."
+kubectl apply -f "${SCRIPT_DIR}/manifests/upf.yaml"
+kubectl rollout status deployment/upf -n "${NAMESPACE}" --timeout=120s
+
+# --- Step 8: Deploy monitoring stack ---
+echo ""
+echo "[8/9] Deploying Monitoring Stack (Prometheus, Grafana, Jaeger)"
+kubectl apply -f "${SCRIPT_DIR}/monitoring/prometheus.yaml"
+kubectl apply -f "${SCRIPT_DIR}/monitoring/grafana.yaml"
+kubectl apply -f "${SCRIPT_DIR}/monitoring/jaeger.yaml"
+
+echo "  Waiting for monitoring pods..."
+for dep in prometheus grafana jaeger; do
+  kubectl rollout status deployment/${dep} -n "${NAMESPACE}" --timeout=120s
+done
+
+# --- Step 9: Deploy nextgsim ---
+echo ""
+echo "[9/9] Deploying nextgsim Simulator (gNB + UE)"
+kubectl apply -f "${NEXTGSIM_K8S}/configmap.yaml"
+
+echo "  Deploying gNB..."
+kubectl apply -f "${NEXTGSIM_K8S}/gnb.yaml"
+kubectl rollout status deployment/gnb -n "${NAMESPACE}" --timeout=120s
+
+echo "  Deploying UE..."
+kubectl apply -f "${NEXTGSIM_K8S}/ue.yaml"
+kubectl rollout status deployment/ue -n "${NAMESPACE}" --timeout=120s
+
+# --- Final Status ---
+echo ""
+echo "============================================"
+echo "  Deployment Status"
+echo "============================================"
+kubectl get pods -n "${NAMESPACE}" -o wide
+echo ""
+kubectl get services -n "${NAMESPACE}"
+echo ""
+echo "============================================"
+echo "  Deployment Complete!"
+echo "============================================"
+echo ""
+echo "Useful commands:"
+echo "  kubectl get pods -n ${NAMESPACE}                    # List all pods"
+echo "  kubectl logs -f deployment/amf -n ${NAMESPACE}      # AMF logs"
+echo "  kubectl logs -f deployment/gnb -n ${NAMESPACE}      # gNB logs"
+echo "  kubectl logs -f deployment/ue -n ${NAMESPACE}       # UE logs"
+echo "  kubectl exec deployment/ue -n ${NAMESPACE} -- ping -c 3 10.45.0.1  # Test data plane"
+echo ""
+echo "Monitoring:"
+echo "  Grafana:    http://localhost:3000   (admin/nextgcore)"
+echo "  Prometheus: http://localhost:9090"
+echo "  Jaeger:     http://localhost:16686"
+echo ""

--- a/k8s/e2e-test.sh
+++ b/k8s/e2e-test.sh
@@ -1,0 +1,470 @@
+#!/bin/bash
+# NextGCore Kubernetes E2E Test Script
+#
+# Verifies the full 5G stack deployed on Kind cluster:
+# NF startup, UE registration, PDU session, data plane ping.
+#
+# Usage:
+#   ./e2e-test.sh           # Run full E2E test
+#   ./e2e-test.sh --deploy  # Deploy first, then test
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - Test failure
+#   2 - Infrastructure failure (pods not ready, timeout)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NAMESPACE="nextg-system"
+TIMEOUT_PODS=180      # seconds to wait for all pods ready
+TIMEOUT_REGISTER=90   # seconds to wait for UE registration
+TIMEOUT_PING=30       # seconds to wait for ping success
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+RUN_DEPLOY=false
+PASSED=0
+FAILED=0
+SKIPPED=0
+TOTAL=0
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --deploy) RUN_DEPLOY=true; shift ;;
+        *)        echo "Unknown option: $1"; exit 2 ;;
+    esac
+done
+
+# ============================================================================
+# Helpers
+# ============================================================================
+log_info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[FAIL]${NC}  $*"; }
+
+assert_pass() {
+    TOTAL=$((TOTAL + 1))
+    if eval "$1" >/dev/null 2>&1; then
+        PASSED=$((PASSED + 1))
+        log_info "PASS: $2"
+    else
+        FAILED=$((FAILED + 1))
+        log_error "FAIL: $2"
+    fi
+}
+
+assert_log_contains() {
+    local deployment="$1"
+    local pattern="$2"
+    local desc="$3"
+    TOTAL=$((TOTAL + 1))
+    local tmplog
+    tmplog=$(mktemp)
+    kubectl logs "deployment/${deployment}" -n "${NAMESPACE}" --all-containers >"$tmplog" 2>&1 || true
+    if grep -q "$pattern" "$tmplog"; then
+        PASSED=$((PASSED + 1))
+        log_info "PASS: $desc"
+    else
+        FAILED=$((FAILED + 1))
+        log_error "FAIL: $desc (pattern '$pattern' not found in $deployment logs)"
+    fi
+    rm -f "$tmplog"
+}
+
+# ============================================================================
+# Step 0: Deploy (optional)
+# ============================================================================
+if [ "$RUN_DEPLOY" = true ]; then
+    log_info "Running deployment first..."
+    bash "${SCRIPT_DIR}/deploy.sh"
+fi
+
+# ============================================================================
+# Step 1: Wait for all pods to be ready
+# ============================================================================
+log_info "Waiting for all pods to be Ready (timeout: ${TIMEOUT_PODS}s)..."
+
+DEPLOYMENTS="nrf ausf udm udr pcf nssf bsf amf smf upf gnb ue"
+all_ready=true
+for dep in $DEPLOYMENTS; do
+    if ! kubectl wait --for=condition=Available "deployment/${dep}" -n "${NAMESPACE}" --timeout="${TIMEOUT_PODS}s" 2>/dev/null; then
+        log_error "Deployment ${dep} not ready"
+        all_ready=false
+    fi
+done
+
+if [ "$all_ready" = false ]; then
+    log_error "Not all deployments are ready"
+    kubectl get pods -n "${NAMESPACE}"
+    exit 2
+fi
+log_info "All 12 deployments ready"
+
+# ============================================================================
+# Step 2: Wait for UE registration + PDU session
+# ============================================================================
+log_info "Waiting for UE registration (timeout: ${TIMEOUT_REGISTER}s)..."
+
+deadline=$((SECONDS + TIMEOUT_REGISTER))
+registered=false
+while [ $SECONDS -lt $deadline ]; do
+    if kubectl logs deployment/ue -n "${NAMESPACE}" 2>&1 | grep -q "Registration Accept"; then
+        registered=true
+        break
+    fi
+    sleep 2
+done
+
+if [ "$registered" = false ]; then
+    log_warn "UE registration not detected in logs (may still work)"
+else
+    log_info "UE registration detected"
+fi
+
+# Wait for PDU session establishment
+log_info "Waiting for PDU session establishment..."
+deadline=$((SECONDS + 30))
+pdu_done=false
+while [ $SECONDS -lt $deadline ]; do
+    if kubectl logs deployment/ue -n "${NAMESPACE}" 2>&1 | grep -q "PDU Session.*ACTIVE"; then
+        pdu_done=true
+        break
+    fi
+    sleep 2
+done
+
+if [ "$pdu_done" = false ]; then
+    log_warn "PDU session not detected in UE logs (may still work)"
+else
+    log_info "PDU session established"
+fi
+
+# Give extra time for logs to flush
+sleep 5
+
+# ============================================================================
+# Step 3: Test assertions
+# ============================================================================
+echo ""
+log_info "=== E2E Test Results ==="
+echo ""
+
+# --- NF startup assertions ---
+assert_log_contains "nrf" "NextGCore NRF ready" \
+    "NRF started successfully"
+
+assert_log_contains "ausf" "NextGCore AUSF ready" \
+    "AUSF started successfully"
+
+assert_log_contains "udm" "NextGCore UDM ready" \
+    "UDM started successfully"
+
+assert_log_contains "udr" "NextGCore UDR ready" \
+    "UDR started successfully"
+
+assert_log_contains "pcf" "NextGCore PCF ready" \
+    "PCF started successfully"
+
+assert_log_contains "nssf" "NextGCore NSSF ready" \
+    "NSSF started successfully"
+
+assert_log_contains "bsf" "NextGCore BSF ready" \
+    "BSF started successfully"
+
+assert_log_contains "upf" "NextGCore UPF ready" \
+    "UPF started successfully"
+
+assert_log_contains "udr" "MongoDB connected" \
+    "UDR connected to MongoDB"
+
+# --- AMF NGAP setup ---
+assert_log_contains "amf" "Configured GUAMI" \
+    "AMF GUAMI configured"
+
+assert_log_contains "amf" "Configured TAI" \
+    "AMF TAI configured"
+
+assert_log_contains "amf" "NGAP server listening" \
+    "AMF NGAP server listening"
+
+assert_log_contains "amf" "NG Setup Request" \
+    "AMF received NG Setup Request from gNB"
+
+assert_log_contains "amf" "NG Setup successful" \
+    "AMF NG Setup successful"
+
+# --- AMF Registration flow ---
+assert_log_contains "amf" "Initial UE Message" \
+    "AMF received Initial UE Message"
+
+assert_log_contains "amf" "Sending Identity Request" \
+    "AMF sent Identity Request"
+
+assert_log_contains "amf" "Received Identity Response" \
+    "AMF received Identity Response"
+
+assert_log_contains "amf" "SUCI:" \
+    "AMF extracted SUCI from Identity Response"
+
+assert_log_contains "amf" "Calling AUSF authenticate" \
+    "AMF called AUSF SBI for authentication"
+
+assert_log_contains "amf" "AUSF auth.*success" \
+    "AMF got AUSF auth success"
+
+assert_log_contains "amf" "Authentication Request sent" \
+    "AMF sent Authentication Request to UE"
+
+assert_log_contains "amf" "Received Authentication Response" \
+    "AMF received Authentication Response from UE"
+
+assert_log_contains "amf" "HXRES.*verification passed" \
+    "AMF HXRES* verification passed"
+
+assert_log_contains "amf" "AUTHENTICATION_SUCCESS" \
+    "AUSF 5G-AKA authentication succeeded"
+
+assert_log_contains "amf" "NAS security context established" \
+    "AMF NAS security context established"
+
+assert_log_contains "amf" "Security Mode Command sent" \
+    "AMF sent Security Mode Command"
+
+assert_log_contains "amf" "Security Mode Complete" \
+    "AMF received Security Mode Complete"
+
+assert_log_contains "amf" "Registration Accept" \
+    "AMF sent Registration Accept"
+
+# --- AMF PDU Session flow ---
+assert_log_contains "amf" "PDU Session Establishment Request" \
+    "AMF received PDU Session Establishment Request"
+
+assert_log_contains "amf" "Calling SMF SM Context Create" \
+    "AMF called SMF SM Context Create (N11 SBI)"
+
+assert_log_contains "amf" "SMF SM Context Created" \
+    "AMF received SMF SM Context response"
+
+assert_log_contains "amf" "PDU Session Establishment Accept sent" \
+    "AMF sent PDU Session Accept to UE"
+
+assert_log_contains "amf" "PDU Session Resource Setup Request sent" \
+    "AMF sent NGAP PDU Session Resource Setup to gNB"
+
+assert_log_contains "amf" "PDU Session Resource Setup Response" \
+    "AMF received PDU Session Resource Setup Response"
+
+assert_log_contains "amf" "Extracted gNB TEID" \
+    "AMF extracted gNB TEID from Setup Response"
+
+assert_log_contains "amf" "Calling SMF SM Context Update" \
+    "AMF called SMF Update with gNB TEID (N11 SBI)"
+
+assert_log_contains "amf" "SMF SM Context Updated" \
+    "AMF SMF Update completed"
+
+# --- AUSF authentication ---
+assert_log_contains "ausf" "UE Authentication Request" \
+    "AUSF received UE Authentication Request"
+
+assert_log_contains "ausf" "5G-AKA Confirmation" \
+    "AUSF received 5G-AKA Confirmation"
+
+assert_log_contains "ausf" "authentication succeeded" \
+    "AUSF authentication succeeded"
+
+# --- UDM auth data generation ---
+assert_log_contains "udm" "Generate Auth Data" \
+    "UDM generated authentication data"
+
+# --- UDR subscription data ---
+assert_log_contains "udr" "Converted SUCI.*SUPI" \
+    "UDR converted SUCI to SUPI"
+
+assert_log_contains "udr" "GET authentication-subscription" \
+    "UDR retrieved auth subscription"
+
+assert_log_contains "udr" "Returning auth subscription data" \
+    "UDR returned auth subscription data"
+
+assert_log_contains "udr" "PATCH authentication-subscription" \
+    "UDR patched auth subscription (SQN update)"
+
+# --- SMF session management ---
+assert_log_contains "smf" "PFCP Session Establishment" \
+    "SMF sent PFCP Session Establishment to UPF"
+
+# --- Detect UPF data plane mode ---
+UPF_NO_DATAPLANE=false
+if kubectl logs deployment/upf -n "${NAMESPACE}" --all-containers 2>&1 | grep -q "no-dataplane\|control-plane-only\|TUN creation failed"; then
+    UPF_NO_DATAPLANE=true
+    log_warn "UPF running in no-dataplane mode (Kind/macOS nested containers)"
+fi
+
+if [ "$UPF_NO_DATAPLANE" = true ]; then
+    # Skip data plane tests in no-dataplane mode
+    for skip_desc in \
+        "SMF sent PFCP Session Modification (DL FAR with gNB TEID)" \
+        "UPF created TUN device" \
+        "UPF configured TUN IP 10.45.0.1/16" \
+        "UPF NAT configured for UE subnet" \
+        "UPF PFCP session established" \
+        "UPF added data plane session" \
+        "UPF PFCP session modified with gNB TEID" \
+        "UPF updated DL TEID to gNB"; do
+        SKIPPED=$((SKIPPED + 1))
+        log_warn "SKIP: $skip_desc (no-dataplane mode)"
+    done
+else
+    assert_log_contains "smf" "PFCP Session Modification successful" \
+        "SMF sent PFCP Session Modification (DL FAR with gNB TEID)"
+
+    assert_log_contains "upf" "Created TUN device" \
+        "UPF created TUN device"
+
+    assert_log_contains "upf" "Configured TUN device.*10.45.0.1" \
+        "UPF configured TUN IP 10.45.0.1/16"
+
+    assert_log_contains "upf" "NAT configured" \
+        "UPF NAT configured for UE subnet"
+
+    assert_log_contains "upf" "Session established.*UPF_SEID" \
+        "UPF PFCP session established"
+
+    assert_log_contains "upf" "Added data plane session" \
+        "UPF added data plane session"
+
+    assert_log_contains "upf" "Session.*modified" \
+        "UPF PFCP session modified with gNB TEID"
+
+    assert_log_contains "upf" "Updated data plane session.*DL_TEID" \
+        "UPF updated DL TEID to gNB"
+fi
+
+# --- UPF control plane (always runs) ---
+assert_log_contains "upf" "PFCP path opened" \
+    "UPF PFCP path opened"
+
+assert_log_contains "upf" "GTP-U path opened" \
+    "UPF GTP-U path opened"
+
+# --- gNB NGAP + GTP ---
+assert_log_contains "gnb" "Sent NG Setup Request" \
+    "gNB sent NG Setup Request"
+
+assert_log_contains "gnb" "NG Setup Response" \
+    "gNB received NG Setup Response"
+
+assert_log_contains "gnb" "Sending Initial UE Message" \
+    "gNB sent Initial UE Message to AMF"
+
+assert_log_contains "gnb" "GTP-U socket bound" \
+    "gNB GTP-U socket bound"
+
+assert_log_contains "gnb" "PDU Session Resource Setup Request" \
+    "gNB received PDU Session Resource Setup Request"
+
+assert_log_contains "gnb" "GTP session created" \
+    "gNB created GTP-U session"
+
+assert_log_contains "gnb" "PDU Session Resource Setup Response sent" \
+    "gNB sent PDU Session Resource Setup Response"
+
+# --- UE NAS + session ---
+assert_log_contains "ue" "Cell discovered" \
+    "UE discovered cell"
+
+assert_log_contains "ue" "Sending Registration Request" \
+    "UE sent Registration Request"
+
+assert_log_contains "ue" "Identity Request" \
+    "UE received Identity Request"
+
+assert_log_contains "ue" "Sending Identity Response" \
+    "UE sent Identity Response"
+
+assert_log_contains "ue" "Authentication Request received" \
+    "UE received Authentication Request"
+
+assert_log_contains "ue" "AUTN MAC verified" \
+    "UE verified AUTN MAC"
+
+assert_log_contains "ue" "Sending Authentication Response" \
+    "UE sent Authentication Response"
+
+assert_log_contains "ue" "Security Mode Command" \
+    "UE received Security Mode Command"
+
+assert_log_contains "ue" "Sending Security Mode Complete" \
+    "UE sent Security Mode Complete"
+
+assert_log_contains "ue" "Received Registration Accept" \
+    "UE received Registration Accept"
+
+assert_log_contains "ue" "Sending PDU Session Establishment Request" \
+    "UE sent PDU Session Establishment Request"
+
+assert_log_contains "ue" "PDU Session Establishment Accept" \
+    "UE received PDU Session Establishment Accept"
+
+assert_log_contains "ue" "PDU Session 1 established with IP" \
+    "UE PDU Session 1 got IP address"
+
+assert_log_contains "ue" "PDU Session.*ACTIVE" \
+    "UE PDU session is ACTIVE"
+
+assert_log_contains "ue" "Creating TUN interface" \
+    "UE creating TUN interface"
+
+# --- Data plane ping tests ---
+if [ "$UPF_NO_DATAPLANE" = true ]; then
+    SKIPPED=$((SKIPPED + 1))
+    log_warn "SKIP: Ping 10.45.0.1 via UE tunnel (no-dataplane mode)"
+else
+    log_info "Testing data plane (ping through GTP-U tunnel)..."
+    TOTAL=$((TOTAL + 1))
+    UE_POD=$(kubectl get pod -n "${NAMESPACE}" -l app.kubernetes.io/name=ue -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    if [ -z "$UE_POD" ]; then
+        FAILED=$((FAILED + 1))
+        log_error "FAIL: UE pod not found"
+    else
+        if kubectl exec "$UE_POD" -n "${NAMESPACE}" -- ping -c 3 -W 5 10.45.0.1 >/dev/null 2>&1; then
+            PASSED=$((PASSED + 1))
+            log_info "PASS: Ping 10.45.0.1 via UE tunnel (UPF gateway)"
+        else
+            FAILED=$((FAILED + 1))
+            log_error "FAIL: Ping 10.45.0.1 via UE tunnel"
+        fi
+    fi
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "========================================"
+echo "  Total:   $TOTAL"
+echo "  Passed:  $PASSED"
+echo "  Failed:  $FAILED"
+echo "  Skipped: $SKIPPED"
+echo "========================================"
+echo ""
+
+if [ $FAILED -gt 0 ]; then
+    log_error "$FAILED test(s) failed"
+    exit 1
+else
+    if [ $SKIPPED -gt 0 ]; then
+        log_info "All $PASSED tests passed ($SKIPPED skipped - UPF no-dataplane mode)"
+    else
+        log_info "All $PASSED tests passed"
+    fi
+    exit 0
+fi

--- a/k8s/kind-config.yaml
+++ b/k8s/kind-config.yaml
@@ -1,0 +1,29 @@
+# Kind cluster configuration for NextG 5G/6G deployment
+# Usage: kind create cluster --config kind-config.yaml --name nextg
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      # NRF SBI (debug access)
+      - containerPort: 30777
+        hostPort: 7777
+        protocol: TCP
+      # Grafana dashboard
+      - containerPort: 30300
+        hostPort: 3000
+        protocol: TCP
+      # Prometheus
+      - containerPort: 30909
+        hostPort: 9090
+        protocol: TCP
+      # Jaeger UI
+      - containerPort: 31686
+        hostPort: 16686
+        protocol: TCP

--- a/k8s/manifests/amf.yaml
+++ b/k8s/manifests/amf.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: amf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: amf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: amf
+  ports:
+    - name: ngap
+      port: 38412
+      targetPort: 38412
+      protocol: UDP
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: amf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: amf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: amf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: amf
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-nrf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
+        - name: wait-ausf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z ausf.nextg-system.svc.cluster.local 7777; do echo waiting for ausf; sleep 2; done']
+        - name: wait-udm
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z udm.nextg-system.svc.cluster.local 7777; do echo waiting for udm; sleep 2; done']
+      containers:
+        - name: amf
+          image: nextgcore-rust/amf:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/amf.yaml"]
+          ports:
+            - containerPort: 38412
+              name: ngap
+              protocol: UDP
+            - containerPort: 7777
+              name: sbi
+            - containerPort: 9090
+              name: metrics
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+            - name: AMF_SBI_ADDR
+              value: "0.0.0.0"
+            - name: SMF_SBI_ADDR
+              value: "smf.nextg-system.svc.cluster.local"
+            - name: SMF_SBI_PORT
+              value: "7777"
+            - name: AUSF_SBI_ADDR
+              value: "ausf.nextg-system.svc.cluster.local"
+            - name: AUSF_SBI_PORT
+              value: "7777"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/amf.yaml
+              subPath: amf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/ausf.yaml
+++ b/k8s/manifests/ausf.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ausf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: ausf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: ausf
+  ports:
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ausf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: ausf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ausf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ausf
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-nrf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
+      containers:
+        - name: ausf
+          image: nextgcore-rust/ausf:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/ausf.yaml"]
+          ports:
+            - containerPort: 7777
+              name: sbi
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+            - name: UDM_SBI_ADDR
+              value: "udm.nextg-system.svc.cluster.local"
+            - name: UDM_SBI_PORT
+              value: "7777"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/ausf.yaml
+              subPath: ausf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/bsf.yaml
+++ b/k8s/manifests/bsf.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bsf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: bsf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: bsf
+  ports:
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bsf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: bsf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bsf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bsf
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-nrf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
+        - name: wait-mongodb
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z mongodb.nextg-system.svc.cluster.local 27017; do echo waiting for mongodb; sleep 2; done']
+      containers:
+        - name: bsf
+          image: nextgcore-rust/bsf:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/bsf.yaml"]
+          ports:
+            - containerPort: 7777
+              name: sbi
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/bsf.yaml
+              subPath: bsf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/configmap.yaml
+++ b/k8s/manifests/configmap.yaml
@@ -1,0 +1,282 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nextgcore-configs
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/part-of: nextgcore
+data:
+  nrf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/nrf.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    nrf:
+      serving:
+        - plmn_id:
+            mcc: 999
+            mnc: 70
+      sbi:
+        server:
+          - address: 0.0.0.0
+            advertise: nrf.nextg-system.svc.cluster.local
+            port: 7777
+
+  ausf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/ausf.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    ausf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: 7777
+        client:
+          nrf:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+
+  udm.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/udm.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    udm:
+      hnet:
+        - id: 1
+          scheme: 1
+          key: /etc/nextgcore/hnet/curve25519-1.key
+        - id: 2
+          scheme: 2
+          key: /etc/nextgcore/hnet/secp256r1-2.key
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: 7777
+        client:
+          nrf:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+
+  udr.yaml: |
+    db_uri: mongodb://mongodb.nextg-system.svc.cluster.local:27017/nextgcore
+    logger:
+      file:
+        path: /var/log/nextgcore/udr.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    udr:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: 7777
+        client:
+          nrf:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+
+  pcf.yaml: |
+    db_uri: mongodb://mongodb.nextg-system.svc.cluster.local:27017/nextgcore
+    logger:
+      file:
+        path: /var/log/nextgcore/pcf.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    pcf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: 7777
+        client:
+          nrf:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+      metrics:
+        server:
+          - address: 0.0.0.0
+            port: 9090
+
+  nssf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/nssf.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    nssf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: 7777
+        client:
+          nrf:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+          nsi:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+              s_nssai:
+                sst: 1
+
+  bsf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/bsf.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    bsf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: 7777
+        client:
+          nrf:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+
+  amf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/amf.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    amf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: 7777
+        client:
+          nrf:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+      ngap:
+        server:
+          - address: 0.0.0.0
+            port: 38412
+      metrics:
+        server:
+          - address: 0.0.0.0
+            port: 9090
+      guami:
+        - plmn_id:
+            mcc: 999
+            mnc: 70
+          amf_id:
+            region: 2
+            set: 1
+      tai:
+        - plmn_id:
+            mcc: 999
+            mnc: 70
+          tac: 1
+      plmn_support:
+        - plmn_id:
+            mcc: 999
+            mnc: 70
+          s_nssai:
+            - sst: 1
+      security:
+        integrity_order: [NIA2, NIA1, NIA0]
+        ciphering_order: [NEA0, NEA1, NEA2]
+      network_name:
+        full: NextGCore
+        short: Next
+      amf_name: nextgcore-amf0
+      time:
+        t3512:
+          value: 540
+
+  smf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/smf.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    smf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: 7777
+        client:
+          nrf:
+            - uri: http://nrf.nextg-system.svc.cluster.local:7777
+      pfcp:
+        server:
+          - address: 0.0.0.0
+            port: 8805
+        client:
+          upf:
+            - address: upf.nextg-system.svc.cluster.local
+      gtpc:
+        server:
+          - address: 0.0.0.0
+      gtpu:
+        server:
+          - address: 0.0.0.0
+      metrics:
+        server:
+          - address: 0.0.0.0
+            port: 9090
+      session:
+        - subnet: 10.45.0.0/16
+          gateway: 10.45.0.1
+        - subnet: 2001:db8:cafe::/48
+          gateway: 2001:db8:cafe::1
+      dns:
+        - 8.8.8.8
+        - 8.8.4.4
+        - 2001:4860:4860::8888
+        - 2001:4860:4860::8844
+      mtu: 1400
+
+  upf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/upf.log
+      level: info
+    global:
+      max:
+        ue: 1024
+        peer: 64
+    upf:
+      pfcp:
+        server:
+          - address: 0.0.0.0
+            port: 8805
+      gtpu:
+        server:
+          - address: 0.0.0.0
+            port: 2152
+      session:
+        - subnet: 10.45.0.0/16
+          gateway: 10.45.0.1
+          dev: ogstun
+        - subnet: 2001:db8:cafe::/48
+          gateway: 2001:db8:cafe::1
+          dev: ogstun
+      metrics:
+        server:
+          - address: 0.0.0.0
+            port: 9090

--- a/k8s/manifests/mongodb-init.yaml
+++ b/k8s/manifests/mongodb-init.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-init-scripts
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/part-of: nextgcore
+data:
+  mongo-init.js: |
+    db = db.getSiblingDB('nextgcore');
+    db.subscribers.createIndex({ "imsi": 1 }, { unique: true });
+    db.subscribers.createIndex({ "msisdn": 1 });
+    db.nfInstances.createIndex({ "nfInstanceId": 1 }, { unique: true });
+    db.nfInstances.createIndex({ "nfType": 1 });
+    db.nfInstances.createIndex({ "nfStatus": 1 });
+    db.sessions.createIndex({ "supi": 1 });
+    db.sessions.createIndex({ "pduSessionId": 1 });
+    db.sessions.createIndex({ "dnn": 1 });
+    db.policyData.createIndex({ "supi": 1 });
+    db.accounts.createIndex({ "username": 1 }, { unique: true });
+    db.accounts.insertOne({
+        username: "admin",
+        password: "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy",
+        roles: ["admin"],
+        created: new Date()
+    });
+    db.subscribers.insertOne({
+        imsi: "999700000000001",
+        msisdn: ["821000000001"],
+        security: {
+            k: "465B5CE8B199B49FAA5F0A2EE238A6BC",
+            opc: "E8ED289DEBA952E4283B54E88E6D834D",
+            amf: "8000"
+        },
+        ambr: {
+            uplink: { value: 1, unit: 3 },
+            downlink: { value: 1, unit: 3 }
+        },
+        slice: [{
+            sst: 1,
+            default_indicator: true,
+            session: [{
+                name: "internet",
+                type: 3,
+                qos: { index: 9, arp: { priority_level: 8, pre_emption_capability: 1, pre_emption_vulnerability: 1 } },
+                ambr: { uplink: { value: 1, unit: 3 }, downlink: { value: 1, unit: 3 } }
+            }]
+        }],
+        access_restriction_data: 32,
+        subscriber_status: 0,
+        network_access_mode: 0,
+        subscribed_rau_tau_timer: 12,
+        created: new Date()
+    });
+    db.subscribers.insertOne({
+        imsi: "001010123456789",
+        msisdn: ["821012345678"],
+        security: {
+            k: "465B5CE8B199B49FAA5F0A2EE238A6BC",
+            opc: "E8ED289DEBA952E4283B54E88E6183CA",
+            amf: "8000"
+        },
+        ambr: {
+            uplink: { value: 1, unit: 3 },
+            downlink: { value: 1, unit: 3 }
+        },
+        slice: [{
+            sst: 1,
+            default_indicator: true,
+            session: [{
+                name: "internet",
+                type: 3,
+                qos: { index: 9, arp: { priority_level: 8, pre_emption_capability: 1, pre_emption_vulnerability: 1 } },
+                ambr: { uplink: { value: 1, unit: 3 }, downlink: { value: 1, unit: 3 } }
+            }]
+        }],
+        access_restriction_data: 32,
+        subscriber_status: 0,
+        network_access_mode: 0,
+        subscribed_rau_tau_timer: 12,
+        created: new Date()
+    });
+    print("NextGCore MongoDB initialization completed.");
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongodb-init
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-mongodb
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z mongodb.nextg-system.svc.cluster.local 27017; do echo waiting for mongodb; sleep 2; done']
+      containers:
+        - name: init
+          image: mongo:6.0
+          command: ["mongosh", "mongodb://mongodb.nextg-system.svc.cluster.local:27017/nextgcore", "/scripts/mongo-init.js"]
+          volumeMounts:
+            - name: init-scripts
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: mongodb-init-scripts

--- a/k8s/manifests/mongodb.yaml
+++ b/k8s/manifests/mongodb.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: mongodb
+  ports:
+    - port: 27017
+      targetPort: 27017
+      protocol: TCP
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  serviceName: mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mongodb
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mongodb
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:6.0
+          ports:
+            - containerPort: 27017
+          env:
+            - name: MONGO_INITDB_DATABASE
+              value: nextgcore
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: mongodb-data
+              mountPath: /data/db
+          readinessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: mongodb-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/k8s/manifests/nrf.yaml
+++ b/k8s/manifests/nrf.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nrf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: nrf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: nrf
+  ports:
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+      nodePort: 30777
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nrf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: nrf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nrf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nrf
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-mongodb
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z mongodb.nextg-system.svc.cluster.local 27017; do echo waiting for mongodb; sleep 2; done']
+      containers:
+        - name: nrf
+          image: nextgcore-rust/nrf:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/nrf.yaml"]
+          ports:
+            - containerPort: 7777
+              name: sbi
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/nrf.yaml
+              subPath: nrf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/nssf.yaml
+++ b/k8s/manifests/nssf.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nssf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: nssf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: nssf
+  ports:
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nssf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: nssf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nssf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nssf
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-nrf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
+      containers:
+        - name: nssf
+          image: nextgcore-rust/nssf:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/nssf.yaml"]
+          ports:
+            - containerPort: 7777
+              name: sbi
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/nssf.yaml
+              subPath: nssf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/pcf.yaml
+++ b/k8s/manifests/pcf.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pcf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: pcf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: pcf
+  ports:
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pcf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: pcf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pcf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pcf
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-nrf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
+        - name: wait-mongodb
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z mongodb.nextg-system.svc.cluster.local 27017; do echo waiting for mongodb; sleep 2; done']
+      containers:
+        - name: pcf
+          image: nextgcore-rust/pcf:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/pcf.yaml"]
+          ports:
+            - containerPort: 7777
+              name: sbi
+            - containerPort: 9090
+              name: metrics
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/pcf.yaml
+              subPath: pcf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/smf.yaml
+++ b/k8s/manifests/smf.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: smf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: smf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: smf
+  ports:
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+    - name: pfcp
+      port: 8805
+      targetPort: 8805
+      protocol: UDP
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: smf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: smf
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-nrf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
+      containers:
+        - name: smf
+          image: nextgcore-rust/smf:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/smf.yaml"]
+          ports:
+            - containerPort: 7777
+              name: sbi
+            - containerPort: 8805
+              name: pfcp
+              protocol: UDP
+            - containerPort: 9090
+              name: metrics
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+            - name: SMF_PFCP_ADDR
+              value: "0.0.0.0"
+            - name: UPF_PFCP_ADDR
+              value: "upf.nextg-system.svc.cluster.local"
+            - name: UPF_PFCP_PORT
+              value: "8805"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/smf.yaml
+              subPath: smf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/udm.yaml
+++ b/k8s/manifests/udm.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: udm
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: udm
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: udm
+  ports:
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udm
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: udm
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: udm
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: udm
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-nrf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
+      containers:
+        - name: udm
+          image: nextgcore-rust/udm:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/udm.yaml"]
+          ports:
+            - containerPort: 7777
+              name: sbi
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+            - name: UDR_SBI_ADDR
+              value: "udr.nextg-system.svc.cluster.local"
+            - name: UDR_SBI_PORT
+              value: "7777"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/udm.yaml
+              subPath: udm.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/udr.yaml
+++ b/k8s/manifests/udr.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: udr
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: udr
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: udr
+  ports:
+    - name: sbi
+      port: 7777
+      targetPort: 7777
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udr
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: udr
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: udr
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: udr
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-nrf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
+        - name: wait-mongodb
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z mongodb.nextg-system.svc.cluster.local 27017; do echo waiting for mongodb; sleep 2; done']
+      containers:
+        - name: udr
+          image: nextgcore-rust/udr:latest
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "/etc/nextgcore/udr.yaml"]
+          ports:
+            - containerPort: 7777
+              name: sbi
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/udr.yaml
+              subPath: udr.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+          readinessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7777
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}

--- a/k8s/manifests/upf.yaml
+++ b/k8s/manifests/upf.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upf-wrapper
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: upf
+    app.kubernetes.io/part-of: nextgcore
+data:
+  wrapper.sh: |
+    #!/bin/sh
+    set -e
+    # Try to create TUN device (Open5GS/UERANSIM pattern)
+    # Works on production K8s with privileged: true
+    # Fails on Kind/Docker Desktop macOS (nested containers)
+    if ip tuntap add name ogstun mode tun 2>/dev/null; then
+      echo "[wrapper] TUN device created successfully"
+      ip addr add 10.45.0.1/16 dev ogstun
+      sysctl -w net.ipv6.conf.all.disable_ipv6=1 >/dev/null 2>&1 || true
+      ip link set ogstun up
+      sysctl -w net.ipv4.ip_forward=1 >/dev/null 2>&1 || true
+      iptables -t nat -A POSTROUTING -s 10.45.0.0/16 ! -o ogstun -j MASQUERADE 2>/dev/null || true
+      echo "[wrapper] TUN configured: ogstun 10.45.0.1/16, NAT enabled"
+      exec /usr/local/bin/nf-binary -c /etc/nextgcore/upf.yaml --pfcp-addr 0.0.0.0 --gtpu-addr 0.0.0.0
+    else
+      echo "[wrapper] TUN creation failed (nested containers / Kind on macOS)"
+      echo "[wrapper] Starting UPF in control-plane-only mode (--no-dataplane)"
+      exec /usr/local/bin/nf-binary -c /etc/nextgcore/upf.yaml --pfcp-addr 0.0.0.0 --gtpu-addr 0.0.0.0 --no-dataplane
+    fi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: upf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: upf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  selector:
+    app.kubernetes.io/name: upf
+  ports:
+    - name: gtpu
+      port: 2152
+      targetPort: 2152
+      protocol: UDP
+    - name: pfcp
+      port: 8805
+      targetPort: 8805
+      protocol: UDP
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: upf
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: upf
+    app.kubernetes.io/part-of: nextgcore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: upf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: upf
+        app.kubernetes.io/part-of: nextgcore
+    spec:
+      initContainers:
+        - name: wait-smf
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z smf.nextg-system.svc.cluster.local 7777; do echo waiting for smf; sleep 2; done']
+      containers:
+        - name: upf
+          image: nextgcore-rust/upf:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/scripts/wrapper.sh"]
+          ports:
+            - containerPort: 2152
+              name: gtpu
+              protocol: UDP
+            - containerPort: 8805
+              name: pfcp
+              protocol: UDP
+            - containerPort: 9090
+              name: metrics
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_ADMIN
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/upf.yaml
+              subPath: upf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+            - name: dev-tun
+              mountPath: /dev/net/tun
+            - name: wrapper
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: nextgcore-configs
+        - name: logs
+          emptyDir: {}
+        - name: dev-tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        - name: wrapper
+          configMap:
+            name: upf-wrapper
+            defaultMode: 0755

--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: nextg-system
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.nextg-system.svc.cluster.local:9090
+        isDefault: true
+        editable: false
+      - name: Jaeger
+        type: jaeger
+        access: proxy
+        url: http://jaeger.nextg-system.svc.cluster.local:16686
+        editable: false
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+  namespace: nextg-system
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: 'default'
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: false
+        updateIntervalSeconds: 10
+        allowUiUpdates: true
+        options:
+          path: /var/lib/grafana/dashboards
+          foldersFromFilesStructure: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.4.0
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: admin
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: nextgcore
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
+              subPath: datasources.yaml
+              readOnly: true
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards/dashboards.yaml
+              subPath: dashboards.yaml
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      nodePort: 30300

--- a/k8s/monitoring/jaeger.yaml
+++ b/k8s/monitoring/jaeger.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jaeger
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jaeger
+    spec:
+      containers:
+        - name: jaeger
+          image: jaegertracing/all-in-one:1.55
+          env:
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
+          ports:
+            - containerPort: 16686
+              name: ui
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 14268
+              name: collector
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 14269
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: jaeger
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: jaeger
+  ports:
+    - name: ui
+      port: 16686
+      targetPort: 16686
+      nodePort: 31686
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+    - name: collector
+      port: 14268
+      targetPort: 14268

--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: nextg-system
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+      scrape_timeout: 10s
+    scrape_configs:
+      - job_name: "nextgcore-nrf"
+        static_configs:
+          - targets: ["nrf.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "NRF" }
+      - job_name: "nextgcore-amf"
+        static_configs:
+          - targets: ["amf.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "AMF" }
+      - job_name: "nextgcore-smf"
+        static_configs:
+          - targets: ["smf.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "SMF" }
+      - job_name: "nextgcore-upf"
+        static_configs:
+          - targets: ["upf.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "UPF" }
+      - job_name: "nextgcore-ausf"
+        static_configs:
+          - targets: ["ausf.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "AUSF" }
+      - job_name: "nextgcore-udm"
+        static_configs:
+          - targets: ["udm.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "UDM" }
+      - job_name: "nextgcore-udr"
+        static_configs:
+          - targets: ["udr.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "UDR" }
+      - job_name: "nextgcore-pcf"
+        static_configs:
+          - targets: ["pcf.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "PCF" }
+      - job_name: "nextgcore-nssf"
+        static_configs:
+          - targets: ["nssf.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "NSSF" }
+      - job_name: "nextgcore-bsf"
+        static_configs:
+          - targets: ["bsf.nextg-system.svc.cluster.local:9090"]
+            labels: { nf_type: "BSF" }
+      - job_name: "prometheus"
+        static_configs:
+          - targets: ["localhost:9090"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.51.0
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+            - "--storage.tsdb.retention.time=7d"
+            - "--web.enable-lifecycle"
+          ports:
+            - containerPort: 9090
+              name: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: nextg-system
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      nodePort: 30909

--- a/k8s/teardown.sh
+++ b/k8s/teardown.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# NextG Kubernetes Teardown Script
+# Deletes the Kind cluster and all resources
+set -euo pipefail
+
+CLUSTER_NAME="nextg"
+
+echo "============================================"
+echo "  NextG Kubernetes Teardown"
+echo "============================================"
+
+if ! command -v kind &>/dev/null; then
+  echo "ERROR: kind is required but not installed."
+  exit 1
+fi
+
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo "Deleting Kind cluster: ${CLUSTER_NAME}"
+  kind delete cluster --name "${CLUSTER_NAME}"
+  echo "Cluster deleted."
+else
+  echo "Cluster '${CLUSTER_NAME}' does not exist."
+fi
+
+echo "Teardown complete."


### PR DESCRIPTION
- Kind cluster config, deploy.sh (9-step orchestrated deployment), e2e-test.sh (70 assertions)
- Core NF manifests: MongoDB, NRF, AUSF, UDM, UDR, PCF, NSSF, BSF, AMF, SMF, UPF
- AMF: exec-based probes, env vars for SBI routing (SMF, AUSF addresses)
- AUSF: UDM_SBI_ADDR env var for K8s DNS routing
- UDM: UDR_SBI_ADDR env var for K8s DNS routing
- SMF: PFCP env vars for UPF communication
- UPF: wrapper script with TUN fallback to --no-dataplane for Kind/macOS
- Monitoring stack: Prometheus, Grafana, Jaeger
- MongoDB init job for subscriber provisioning
- E2E test with UPF no-dataplane mode detection (skips data plane tests on Kind/macOS)
- teardown.sh for cluster cleanup