### PR TITLE
sbi: add SBA transport benchmark and feature-gated HTTP/3 prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ cargo audit
 
 - [CHANGELOG.md](CHANGELOG.md) — release notes and version history
 - [docs/ci-and-release.md](docs/ci-and-release.md) — CI pipeline (GitHub Actions jobs) and the release process
+- [docs/sba-transport-evaluation.md](docs/sba-transport-evaluation.md) — HTTP/2 vs HTTP/3 SBI transport benchmark and evaluation (non-normative 6G research)
 - [docker/rust/CI.md](docker/rust/CI.md) — the one-command matched-sim end-to-end suite (`e2e.sh`)
 - [docs/](docs/) — per-component gap analyses and architecture notes
 

--- a/docs/sba-transport-evaluation.md
+++ b/docs/sba-transport-evaluation.md
@@ -1,0 +1,92 @@
+# SBA Transport Evaluation: HTTP/2 vs HTTP/3 (QUIC)
+
+> **Non-normative 6G research.** 3GPP TS 29.500 mandates HTTP/2 + JSON as the
+> SBI transport; there is **no frozen Rel-20/6G Stage-3 specification** for any
+> alternate transport. Nothing here is a conformance target, and no NF binary
+> uses the HTTP/3 prototype. Tracking issue:
+> [#15](https://github.com/NextgCoreLab/nextgcore/issues/15).
+
+## What was built
+
+- A criterion benchmark harness, `libs/nextgcore-sbi/benches/transport.rs`,
+  measuring a warm GET round-trip (one reused connection, new stream per
+  request) through the real `SbiClient` → `SbiServer` stack on loopback.
+- A feature-gated HTTP/3-over-QUIC prototype, `libs/nextgcore-sbi/src/http3.rs`
+  (`--features http3`, off by default), built on `h3` + `quinn`. It drives the
+  same `SbiRequestHandler` the HTTP/2 server drives and returns the same
+  `SbiResponse` shape the HTTP/2 client returns; a feature-gated test proves
+  the response body is byte-identical across both transports for the same
+  request against the same handler.
+
+Run it:
+
+```bash
+cargo bench -p nextgcore-sbi                    # HTTP/2 baselines
+cargo bench -p nextgcore-sbi --features http3   # + HTTP/3 rows
+cargo test  -p nextgcore-sbi --features http3   # byte-parity test
+```
+
+## Results
+
+Warm round-trip latency (criterion median, loopback, Apple Silicon macOS,
+default `bench` profile). Fixed ASCII JSON body served by the identical
+handler; the measured path includes the real per-request client costs
+(traceparent stamping, timeout wrappers, header/body conversion).
+
+| Transport | 256 B body | 16 KiB body |
+|-----------|-----------:|------------:|
+| HTTP/2 h2c (production path) | 38.7 µs | 49.7 µs |
+| HTTP/2 over TLS 1.2/1.3      | 37.9 µs | 54.7 µs |
+| HTTP/3 over QUIC (prototype) | 44.1 µs | 93.7 µs |
+
+Observations:
+
+- **TLS is free per-request on HTTP/2** — h2c and h2-tls are within noise at
+  256 B; the handshake cost is per-connection and NFs hold connections open.
+- **HTTP/3 pays a per-request and per-byte penalty on loopback**: ~16% slower
+  than h2-tls for small bodies (~14% vs h2c), ~71% for 16 KiB. This is expected: quinn runs
+  QUIC (packetization, encryption per packet, ACK bookkeeping) in userspace
+  over UDP sockets, while the HTTP/2 path rides the kernel TCP stack.
+- **Loopback is the most hostile venue for QUIC**: zero loss and zero RTT hide
+  exactly the properties HTTP/3 exists for (no TCP head-of-line blocking under
+  loss, connection migration, 1-RTT/0-RTT setup). A meaningful evaluation
+  needs an emulated lossy/high-RTT link and concurrent multiplexed streams —
+  explicitly out of scope for this bounded spike.
+
+## Dependency and build footprint
+
+- Default build is untouched: `cargo tree -p nextgcore-sbi -e normal` shows
+  **zero** new dependencies; the `http3` deps are `optional = true` and
+  crate-local (workspace root unchanged).
+- `--features http3` adds 16 crates to the build (`h3`, `h3-quinn`, `quinn`,
+  `quinn-proto`, `quinn-udp`, `lru-slab`, `chacha20`, the `futures` family
+  and other small transitive crates). `criterion` and its ~25-crate tree are dev-dependencies, compiled
+  only for `cargo bench`/`cargo test` of this crate.
+- CI runs default features only, so neither the prototype nor its deps are
+  compiled in the fast gate; `--features http3` builds/tests must be run
+  manually.
+
+## TLS / certificate story
+
+- QUIC has **no plaintext mode** (RFC 9001 mandates TLS 1.3, ALPN `h3`), so
+  the h2c deployment style used inside trusted zones today has no HTTP/3
+  equivalent — adopting HTTP/3 SBI means PKI everywhere.
+- The prototype takes DER cert/key directly (tests generate them with
+  `rcgen`); the HTTP/2 `SbiServer` takes PEM file paths. Unifying this needs
+  an in-memory TLS-material API on `SbiServerConfig` first.
+- The N32/SEPP RFC 5705 exporter-key extraction wired into the HTTP/2 TLS
+  path (`tls::export_n32_master_key`) is **not** wired for QUIC; rustls
+  exposes an exporter on QUIC connections, but SEPP-over-HTTP/3 would need
+  its own plumbing and a spec basis that does not exist yet.
+
+## Recommendation
+
+Keep HTTP/2 as the only SBI transport. The prototype stays feature-gated and
+off by default; the new dependencies are not worth carrying in default builds
+for a transport with no 3GPP basis and no loopback win. Revisit only if (a)
+3GPP SBA evolution work produces a concrete HTTP/3/QUIC direction, and (b) a
+follow-up benchmark under emulated WAN impairments (loss, RTT, many concurrent
+streams) shows a material advantage for NF-to-NF traffic patterns. gRPC was
+deliberately not prototyped — it has only inert type stubs in-tree
+(`nextgcore-sbi/src/grpc.rs`) and a different message model; that comparison
+would be a separate spike.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -60,6 +60,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +76,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -595,6 +610,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +640,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +661,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -766,6 +825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,10 +849,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -845,7 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version 0.4.1",
@@ -1032,6 +1160,12 @@ dependencies = [
  "signature 2.2.0",
  "spki 0.7.3",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1354,8 +1488,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasm-bindgen",
 ]
 
@@ -1409,6 +1557,45 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "h3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
+dependencies = [
+ "bytes",
+ "fastrand 2.3.0",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3",
+ "quinn",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1797,6 +1984,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,7 +2048,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1861,7 +2057,7 @@ version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a412fe37705d515cba9dbf1448291a717e187e2351df908cfc0137cbec3d480"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1951,6 +2147,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matches"
@@ -2712,8 +2914,12 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "criterion",
  "h2",
+ "h3",
+ "h3-quinn",
  "hex",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2721,6 +2927,7 @@ dependencies = [
  "nextgcore-core",
  "p256",
  "proptest",
+ "quinn",
  "rand 0.9.2",
  "rcgen",
  "rustls 0.23.36",
@@ -3033,6 +3240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3261,16 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3157,6 +3380,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,7 +3445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3303,6 +3554,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "futures-io",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,6 +3624,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -3342,6 +3656,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3389,12 +3714,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3604,6 +3958,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3652,6 +4007,15 @@ name = "ryu"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -3838,7 +4202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -3849,7 +4213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -3860,7 +4224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4207,6 +4571,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4564,6 +4938,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4656,6 +5040,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,6 +5094,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/src/libs/nextgcore-sbi/Cargo.toml
+++ b/src/libs/nextgcore-sbi/Cargo.toml
@@ -10,6 +10,10 @@ description = "NextGCore SBI (Service Based Interface) Library"
 ## Gate 6G research modules (gRPC/SBI-2.0, event pub-sub).
 ## Enable with: cargo build -p nextgcore-sbi --features 6g-extensions
 6g-extensions = []
+## Gate the non-normative HTTP/3-over-QUIC SBI transport prototype (issue #15).
+## Loopback research spike only — no NF uses it; TS 29.500 mandates HTTP/2.
+## Enable with: cargo build -p nextgcore-sbi --features http3
+http3 = ["dep:h3", "dep:h3-quinn", "dep:quinn", "dep:http"]
 
 [dependencies]
 nextgcore-core = { workspace = true }
@@ -33,11 +37,23 @@ hex.workspace = true
 # probabilistic reaction (sbi-08). Workspace-pinned; no root Cargo.toml change.
 rand.workspace = true
 p256 = { workspace = true, features = ["ecdsa"] }
+# http3-feature-only: HTTP/3 transport prototype (issue #15). Crate-local, not
+# workspace-pinned — no other crate may depend on these (non-normative research).
+h3 = { version = "0.0.8", optional = true }
+h3-quinn = { version = "0.0.10", optional = true }
+quinn = { version = "0.11.11", default-features = false, features = ["runtime-tokio", "rustls-ring"], optional = true }
+http = { version = "1.4", optional = true }
 
 [dev-dependencies]
+# Bench-only: SBA transport benchmark harness (issue #15).
+criterion = "0.8.2"
 proptest.workspace = true
 # Test-only: generate a self-signed cert for the in-memory TLS exporter test.
 rcgen = "0.13"
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "transport"
+harness = false

--- a/src/libs/nextgcore-sbi/benches/transport.rs
+++ b/src/libs/nextgcore-sbi/benches/transport.rs
@@ -1,0 +1,210 @@
+//! SBA transport benchmark harness (issue #15, non-normative 6G research).
+//!
+//! Measures a warm GET round-trip (one reused connection, new stream per
+//! request) over the SBI loopback for each transport:
+//!
+//! - `h2c`    — the production path: prior-knowledge HTTP/2 over plaintext
+//!   TCP, `SbiClient` → `SbiServer` (TS 29.500 baseline).
+//! - `h2-tls` — the same path over TLS 1.2/1.3 (rustls, self-signed cert).
+//! - `h3`     — the feature-gated HTTP/3-over-QUIC prototype
+//!   (`--features http3`); QUIC has no plaintext mode, so compare it against
+//!   `h2-tls`, not `h2c`.
+//!
+//! Every transport serves the identical JSON body from the identical
+//! `SbiRequestHandler` closure. The measured client path includes the real
+//! `SbiClient` per-request costs (traceparent stamping, timeout wrappers,
+//! body/header conversion) — this benchmarks the SBI stack as NFs use it,
+//! not the bare wire.
+//!
+//! Run: `cargo bench -p nextgcore-sbi` (baseline) or
+//! `cargo bench -p nextgcore-sbi --features http3` (adds the h3 rows).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, Throughput};
+use nextgcore_sbi::{
+    SbiClient, SbiClientConfig, SbiRequest, SbiResponse, SbiServer, SbiServerConfig,
+};
+
+const PATH: &str = "/nbench/v1/fixed";
+const BODY_SIZES: [usize; 2] = [256, 16 * 1024];
+
+/// ASCII JSON body of exactly `len` bytes (ASCII survives the client's
+/// lossy UTF-8 conversion byte-for-byte).
+fn json_body(len: usize) -> String {
+    let prefix = r#"{"data":""#;
+    let suffix = r#""}"#;
+    let fill = len
+        .checked_sub(prefix.len() + suffix.len())
+        .expect("body length too small");
+    format!("{prefix}{}{suffix}", "x".repeat(fill))
+}
+
+/// Fixed-body handler shared by every transport under test.
+fn fixed_body_handler(
+    body: Arc<String>,
+) -> impl Fn(SbiRequest) -> std::pin::Pin<Box<dyn std::future::Future<Output = SbiResponse> + Send>>
+       + Clone {
+    move |_request: SbiRequest| {
+        let body = Arc::clone(&body);
+        Box::pin(async move { SbiResponse::ok().with_body(body.as_str(), "application/json") })
+    }
+}
+
+/// Pick a free loopback port (probe-bind-drop; single-process bench, and
+/// server starts retry to absorb the small TOCTOU window).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("probe bind")
+        .local_addr()
+        .expect("probe addr")
+        .port()
+}
+
+/// Start an `SbiServer` on a free port, retrying if the probed port was
+/// stolen between probe and bind.
+async fn start_h2_server<H>(
+    make_config: impl Fn(SocketAddr) -> SbiServerConfig,
+    handler: H,
+) -> (SbiServer, u16)
+where
+    H: Fn(SbiRequest) -> std::pin::Pin<Box<dyn std::future::Future<Output = SbiResponse> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    for _ in 0..5 {
+        let port = free_port();
+        let server = SbiServer::new(make_config(SocketAddr::from(([127, 0, 0, 1], port))));
+        if server.start(handler.clone()).await.is_ok() {
+            return (server, port);
+        }
+    }
+    panic!("could not bind an SbiServer after 5 attempts");
+}
+
+/// One warm GET against an `SbiClient`, asserting success and full body.
+async fn h2_get(client: &SbiClient, expected_len: usize) {
+    let response = client.get(PATH).await.expect("GET round-trip");
+    assert_eq!(response.status, 200);
+    assert_eq!(
+        response.http.content.as_deref().map(str::len),
+        Some(expected_len)
+    );
+}
+
+/// One warm GET against an `Http3Client`, asserting success and full body.
+#[cfg(feature = "http3")]
+async fn h3_get(client: &nextgcore_sbi::Http3Client, expected_len: usize) {
+    let response = client.get(PATH).await.expect("h3 GET round-trip");
+    assert_eq!(response.status, 200);
+    assert_eq!(
+        response.http.content.as_deref().map(str::len),
+        Some(expected_len)
+    );
+}
+
+fn bench_transports(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("sbi_get_roundtrip");
+
+    for len in BODY_SIZES {
+        let body = Arc::new(json_body(len));
+        let handler = fixed_body_handler(Arc::clone(&body));
+        group.throughput(Throughput::Bytes(len as u64));
+
+        // --- h2c: prior-knowledge HTTP/2 over plaintext TCP (production path).
+        {
+            let (server, port) =
+                rt.block_on(start_h2_server(SbiServerConfig::new, handler.clone()));
+            let client = SbiClient::new(SbiClientConfig::new("127.0.0.1", port).with_pool_size(1));
+            rt.block_on(h2_get(&client, len)); // warm the pooled connection
+            group.bench_function(BenchmarkId::new("h2c", len), |b| {
+                b.iter(|| rt.block_on(h2_get(&client, len)));
+            });
+            rt.block_on(async {
+                client.close().await;
+                server.stop().await.expect("h2c server stop");
+            });
+        }
+
+        // --- h2-tls: the same HTTP/2 path over TLS (self-signed, rustls).
+        {
+            let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+                .expect("self-signed cert");
+            let dir =
+                std::env::temp_dir().join(format!("nextgcore-sbi-bench-{}", std::process::id()));
+            std::fs::create_dir_all(&dir).expect("bench temp dir");
+            let cert_path = dir.join("cert.pem");
+            let key_path = dir.join("key.pem");
+            std::fs::write(&cert_path, cert.cert.pem()).expect("write cert");
+            std::fs::write(&key_path, cert.key_pair.serialize_pem()).expect("write key");
+
+            let make_config = |addr: SocketAddr| {
+                SbiServerConfig::new(addr).with_tls(
+                    key_path.to_str().expect("key path"),
+                    cert_path.to_str().expect("cert path"),
+                )
+            };
+            let (server, port) = rt.block_on(start_h2_server(make_config, handler.clone()));
+            let mut config = SbiClientConfig::new("127.0.0.1", port)
+                .with_https()
+                .with_pool_size(1);
+            config.insecure_skip_verify = true; // self-signed loopback cert
+            let client = SbiClient::new(config);
+            rt.block_on(h2_get(&client, len));
+            group.bench_function(BenchmarkId::new("h2-tls", len), |b| {
+                b.iter(|| rt.block_on(h2_get(&client, len)));
+            });
+            rt.block_on(async {
+                client.close().await;
+                server.stop().await.expect("h2-tls server stop");
+            });
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+
+        // --- h3: HTTP/3-over-QUIC prototype (feature-gated).
+        #[cfg(feature = "http3")]
+        {
+            use nextgcore_sbi::{Http3Client, Http3LoopbackServer, Http3ServerConfig};
+
+            let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+                .expect("self-signed cert");
+            let cert_der = cert.cert.der().to_vec();
+            let (server, client) = rt.block_on(async {
+                let server = Http3LoopbackServer::start(
+                    Http3ServerConfig {
+                        addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+                        cert_der: cert_der.clone(),
+                        key_der: cert.key_pair.serialize_der(),
+                    },
+                    handler.clone(),
+                )
+                .await
+                .expect("http3 server");
+                let client = Http3Client::connect(server.local_addr(), &cert_der)
+                    .await
+                    .expect("http3 client");
+                (server, client)
+            });
+            rt.block_on(h3_get(&client, len)); // warm the QUIC connection
+            group.bench_function(BenchmarkId::new("h3", len), |b| {
+                b.iter(|| rt.block_on(h3_get(&client, len)));
+            });
+            rt.block_on(async {
+                client.close().await;
+                server.stop().await;
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn main() {
+    let mut criterion = Criterion::default().configure_from_args();
+    bench_transports(&mut criterion);
+    criterion.final_summary();
+}

--- a/src/libs/nextgcore-sbi/src/http3.rs
+++ b/src/libs/nextgcore-sbi/src/http3.rs
@@ -1,0 +1,522 @@
+//! HTTP/3 (QUIC) SBI Transport Prototype (issue #15)
+//!
+//! 3GPP TS 29.500 mandates HTTP/2 as the SBI transport; 6G "SBA 2.0"
+//! discussions raise HTTP/3/QUIC as a candidate successor. **There is no
+//! frozen 3GPP Rel-20/6G Stage-3 specification for any alternate SBI
+//! transport**, so this module is explicitly non-normative research, out of
+//! scope for the TS 29.500 conformance work — like [`crate::grpc`], but
+//! unlike that type-only stub this module performs real wire I/O
+//! (RFC 9114 HTTP/3 over RFC 9000 QUIC via `h3` + `quinn`).
+//!
+//! # Status
+//!
+//! **Loopback research prototype.** No NF binary uses this transport; it is
+//! feature-gated (`http3`), off by default, and served only by
+//! [`Http3LoopbackServer`] for benchmarks and tests. The transport seam is
+//! the existing message layer: the server drives the same
+//! [`SbiRequestHandler`] the HTTP/2 [`crate::server::SbiServer`] drives, and
+//! [`Http3Client`] returns the same [`SbiResponse`] shape the HTTP/2
+//! [`crate::client::SbiClient`] returns, so a handler's response body is
+//! byte-identical across both transports (see the round-trip parity test).
+//!
+//! Unlike TCP/TLS, QUIC has no plaintext mode — every connection runs
+//! TLS 1.3 with ALPN `h3`. Callers supply a DER certificate/key pair
+//! (tests and benches generate one with `rcgen`); compare against the
+//! HTTP/2-over-TLS path, not h2c, for a like-for-like benchmark.
+//!
+//! # Known parity limitations (deliberate spike scope)
+//!
+//! Relative to the HTTP/2 server's message conversion, this prototype does
+//! not encode/decode `multipart/related` N1/N2 binary containers
+//! (`http.parts` is ignored in both directions) and does not stamp
+//! `application/problem+json` on untyped 4xx/5xx bodies. Handlers using
+//! plain JSON bodies — the benchmarked and parity-tested surface — behave
+//! identically across transports.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bytes::{Buf, Bytes, BytesMut};
+
+use crate::error::{SbiError, SbiResult};
+use crate::message::{SbiRequest, SbiResponse};
+use crate::server::SbiRequestHandler;
+
+/// ALPN protocol identifier for HTTP/3 (RFC 9114 §3.1).
+const ALPN_H3: &[u8] = b"h3";
+
+/// TLS material and bind address for the loopback HTTP/3 server.
+///
+/// Certificates are DER blobs rather than file paths (the HTTP/2
+/// `SbiServerConfig` takes paths) so tests and benches can feed `rcgen`
+/// output directly without touching the filesystem.
+pub struct Http3ServerConfig {
+    /// Bind address; use port 0 and read back [`Http3LoopbackServer::local_addr`].
+    pub addr: SocketAddr,
+    /// DER-encoded server certificate.
+    pub cert_der: Vec<u8>,
+    /// DER-encoded private key (PKCS#8 or SEC1).
+    pub key_der: Vec<u8>,
+}
+
+/// Loopback HTTP/3 server driving an [`SbiRequestHandler`].
+///
+/// Accepts QUIC connections, resolves HTTP/3 request streams, converts each
+/// request into an [`SbiRequest`] (lowercased headers, buffered UTF-8 body —
+/// mirroring the HTTP/2 server's message conversion), and writes the
+/// handler's [`SbiResponse`] back on the stream.
+pub struct Http3LoopbackServer {
+    endpoint: quinn::Endpoint,
+    local_addr: SocketAddr,
+}
+
+impl Http3LoopbackServer {
+    /// Bind a QUIC endpoint and start serving `handler`.
+    ///
+    /// Returns once the endpoint is bound; connections are accepted on a
+    /// spawned task until [`stop`](Self::stop) closes the endpoint.
+    pub async fn start<H: SbiRequestHandler>(
+        config: Http3ServerConfig,
+        handler: H,
+    ) -> SbiResult<Self> {
+        let cert = rustls::pki_types::CertificateDer::from(config.cert_der);
+        let key = rustls::pki_types::PrivateKeyDer::try_from(config.key_der)
+            .map_err(|e| SbiError::TlsError(format!("invalid private key DER: {e}")))?;
+
+        // QUIC negotiates TLS 1.3 only (RFC 9001), so build a TLS 1.3-only
+        // config rather than reusing tls::build_server_config (TLS 1.2+1.3).
+        let mut tls = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .map_err(|e| SbiError::TlsError(format!("TLS 1.3 config: {e}")))?
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], key)
+        .map_err(|e| SbiError::TlsError(format!("server cert: {e}")))?;
+        tls.alpn_protocols = vec![ALPN_H3.to_vec()];
+
+        let quic_tls = quinn::crypto::rustls::QuicServerConfig::try_from(tls)
+            .map_err(|e| SbiError::TlsError(format!("QUIC TLS config: {e}")))?;
+        let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_tls));
+        let endpoint = quinn::Endpoint::server(server_config, config.addr)?;
+        let local_addr = endpoint.local_addr()?;
+
+        let handler = Arc::new(handler);
+        let accept_endpoint = endpoint.clone();
+        tokio::spawn(async move {
+            while let Some(incoming) = accept_endpoint.accept().await {
+                let handler = Arc::clone(&handler);
+                tokio::spawn(async move {
+                    if let Ok(connection) = incoming.await {
+                        serve_connection(connection, handler).await;
+                    }
+                });
+            }
+        });
+
+        Ok(Self {
+            endpoint,
+            local_addr,
+        })
+    }
+
+    /// The bound address (real port when started on port 0).
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Close the endpoint and stop accepting connections.
+    pub async fn stop(&self) {
+        self.endpoint.close(0u32.into(), b"shutdown");
+        self.endpoint.wait_idle().await;
+    }
+}
+
+/// Serve one QUIC connection: resolve HTTP/3 request streams and dispatch
+/// each to the handler on its own task (streams multiplex like HTTP/2).
+async fn serve_connection<H: SbiRequestHandler>(connection: quinn::Connection, handler: Arc<H>) {
+    let mut h3_conn = match h3::server::Connection::new(h3_quinn::Connection::new(connection)).await
+    {
+        Ok(conn) => conn,
+        Err(_) => return,
+    };
+    loop {
+        match h3_conn.accept().await {
+            Ok(Some(resolver)) => {
+                let handler = Arc::clone(&handler);
+                tokio::spawn(async move {
+                    if let Ok((request, stream)) = resolver.resolve_request().await {
+                        let _ = serve_request(request, stream, handler).await;
+                    }
+                });
+            }
+            // Peer closed the connection or a connection-level error occurred.
+            Ok(None) | Err(_) => return,
+        }
+    }
+}
+
+/// Convert one HTTP/3 request to an [`SbiRequest`], run the handler, and
+/// write the [`SbiResponse`] back — mirroring the HTTP/2 server's
+/// buffered-body, lowercased-header message conversion.
+async fn serve_request<H, S>(
+    request: http::Request<()>,
+    mut stream: h3::server::RequestStream<S, Bytes>,
+    handler: Arc<H>,
+) -> SbiResult<()>
+where
+    H: SbiRequestHandler,
+    S: h3::quic::BidiStream<Bytes>,
+{
+    let (parts, ()) = request.into_parts();
+
+    // Mirror the HTTP/2 server's convert_request: headers into the message
+    // map, correlation-ID extraction, query string split into params (and
+    // stripped from the URI), then TS 29.501 URI decomposition.
+    let mut http = crate::message::SbiHttpMessage::new();
+    for (name, value) in &parts.headers {
+        if let Ok(value) = value.to_str() {
+            http.set_header(name.as_str().to_string(), value.to_string());
+        }
+    }
+    let correlation_id = crate::server::extract_or_generate_correlation_id(&http);
+    if let Some(query) = parts.uri.query() {
+        for pair in query.split('&') {
+            if let Some((key, value)) = pair.split_once('=') {
+                http.set_param(key.to_string(), value.to_string());
+            }
+        }
+    }
+
+    let mut body = BytesMut::new();
+    while let Some(mut chunk) = stream
+        .recv_data()
+        .await
+        .map_err(|e| SbiError::ConnectionError(format!("h3 recv_data: {e}")))?
+    {
+        let bytes = chunk.copy_to_bytes(chunk.remaining());
+        body.extend_from_slice(&bytes);
+        if body.len() > crate::server::DEFAULT_MAX_REQUEST_BODY_SIZE {
+            // Same cap the HTTP/2 server enforces via Limited.
+            let response = http::Response::builder()
+                .status(http::StatusCode::PAYLOAD_TOO_LARGE)
+                .body(())
+                .map_err(|e| SbiError::ServerError(format!("h3 413 build: {e}")))?;
+            stream
+                .send_response(response)
+                .await
+                .map_err(|e| SbiError::ConnectionError(format!("h3 send_response: {e}")))?;
+            stream
+                .finish()
+                .await
+                .map_err(|e| SbiError::ConnectionError(format!("h3 finish: {e}")))?;
+            return Ok(());
+        }
+    }
+    if !body.is_empty() {
+        // Same lossy UTF-8 conversion as the HTTP/2 server/client message
+        // layer; SBI payloads are JSON, so this is byte-faithful in practice.
+        http.content = Some(String::from_utf8_lossy(&body).to_string());
+    }
+
+    let mut header = crate::message::SbiHeader::with_method_uri(
+        parts.method.as_str().to_string(),
+        parts.uri.path().to_string(),
+    );
+    header.decompose_uri();
+    let sbi_request = SbiRequest {
+        header,
+        http,
+        correlation_id,
+        // The N32 RFC 5705 exporter is not wired for QUIC-TLS (see the
+        // evaluation doc); rustls exposes one, but SEPP-over-HTTP/3 has no
+        // spec basis yet.
+        tls_exporter_secret: None,
+    };
+
+    let sbi_response = handler.handle(sbi_request).await;
+
+    let mut response = http::Response::builder().status(
+        http::StatusCode::from_u16(sbi_response.status)
+            .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
+    );
+    for (key, value) in &sbi_response.http.headers {
+        response = response.header(key.as_str(), value.as_str());
+    }
+    let response = response
+        .body(())
+        .map_err(|e| SbiError::ServerError(format!("h3 response build: {e}")))?;
+
+    stream
+        .send_response(response)
+        .await
+        .map_err(|e| SbiError::ConnectionError(format!("h3 send_response: {e}")))?;
+    if let Some(content) = sbi_response.http.content {
+        stream
+            .send_data(Bytes::from(content))
+            .await
+            .map_err(|e| SbiError::ConnectionError(format!("h3 send_data: {e}")))?;
+    }
+    stream
+        .finish()
+        .await
+        .map_err(|e| SbiError::ConnectionError(format!("h3 finish: {e}")))?;
+    Ok(())
+}
+
+/// Minimal HTTP/3 client for the loopback prototype.
+///
+/// Holds one QUIC connection and multiplexes each request onto its own
+/// HTTP/3 stream — the semantic equivalent of the HTTP/2 client reusing one
+/// pooled connection.
+pub struct Http3Client {
+    endpoint: quinn::Endpoint,
+    send_request: h3::client::SendRequest<h3_quinn::OpenStreams, Bytes>,
+    authority: String,
+}
+
+impl Http3Client {
+    /// Connect to `server_addr`, trusting exactly the given DER certificate
+    /// (the self-signed-leaf-as-root pattern the TLS tests use). The server
+    /// certificate must cover the name `localhost`.
+    pub async fn connect(server_addr: SocketAddr, server_cert_der: &[u8]) -> SbiResult<Self> {
+        let mut roots = rustls::RootCertStore::empty();
+        roots
+            .add(rustls::pki_types::CertificateDer::from(
+                server_cert_der.to_vec(),
+            ))
+            .map_err(|e| SbiError::TlsError(format!("trust anchor: {e}")))?;
+
+        let mut tls = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .map_err(|e| SbiError::TlsError(format!("TLS 1.3 config: {e}")))?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+        tls.alpn_protocols = vec![ALPN_H3.to_vec()];
+
+        let quic_tls = quinn::crypto::rustls::QuicClientConfig::try_from(tls)
+            .map_err(|e| SbiError::TlsError(format!("QUIC TLS config: {e}")))?;
+        let mut endpoint = quinn::Endpoint::client(SocketAddr::from(([127, 0, 0, 1], 0)))?;
+        endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(quic_tls)));
+
+        let connection = endpoint
+            .connect(server_addr, "localhost")
+            .map_err(|e| SbiError::ConnectionError(format!("QUIC connect: {e}")))?
+            .await
+            .map_err(|e| SbiError::ConnectionError(format!("QUIC handshake: {e}")))?;
+
+        let (mut driver, send_request) = h3::client::new(h3_quinn::Connection::new(connection))
+            .await
+            .map_err(|e| SbiError::ConnectionError(format!("h3 handshake: {e}")))?;
+        // The driver owns connection-level I/O; park it until shutdown.
+        tokio::spawn(async move {
+            let _ = driver.wait_idle().await;
+        });
+
+        Ok(Self {
+            endpoint,
+            send_request,
+            authority: format!("localhost:{}", server_addr.port()),
+        })
+    }
+
+    /// Issue a GET and return the raw response: status, lowercased headers,
+    /// and the exact body bytes (the byte-parity surface for tests).
+    ///
+    /// Takes `&self` like the HTTP/2 client: each call clones the h3
+    /// `SendRequest` handle and opens its own request stream on the shared
+    /// QUIC connection.
+    pub async fn get_raw(&self, path: &str) -> SbiResult<(u16, HashMap<String, String>, Bytes)> {
+        let uri = format!("https://{}{}", self.authority, path);
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(&uri)
+            .body(())
+            .map_err(|e| SbiError::InvalidUri(format!("{uri}: {e}")))?;
+
+        let mut stream = self
+            .send_request
+            .clone()
+            .send_request(request)
+            .await
+            .map_err(|e| SbiError::ConnectionError(format!("h3 send_request: {e}")))?;
+        stream
+            .finish()
+            .await
+            .map_err(|e| SbiError::ConnectionError(format!("h3 finish: {e}")))?;
+
+        let response = stream
+            .recv_response()
+            .await
+            .map_err(|e| SbiError::ConnectionError(format!("h3 recv_response: {e}")))?;
+        let status = response.status().as_u16();
+        let mut headers = HashMap::new();
+        for (name, value) in response.headers() {
+            if let Ok(value) = value.to_str() {
+                headers.insert(name.as_str().to_lowercase(), value.to_string());
+            }
+        }
+
+        let mut body = BytesMut::new();
+        while let Some(mut chunk) = stream
+            .recv_data()
+            .await
+            .map_err(|e| SbiError::ConnectionError(format!("h3 recv_data: {e}")))?
+        {
+            let bytes = chunk.copy_to_bytes(chunk.remaining());
+            body.extend_from_slice(&bytes);
+        }
+        Ok((status, headers, body.freeze()))
+    }
+
+    /// Issue a GET and return an [`SbiResponse`] with the same conversion
+    /// semantics as the HTTP/2 [`crate::client::SbiClient`] (headers into a
+    /// lowercased map, body via lossy UTF-8 into `http.content`).
+    pub async fn get(&self, path: &str) -> SbiResult<SbiResponse> {
+        let (status, headers, body) = self.get_raw(path).await?;
+        let mut response = SbiResponse::with_status(status);
+        response.http.headers = headers;
+        if !body.is_empty() {
+            response.http.content = Some(String::from_utf8_lossy(&body).to_string());
+        }
+        Ok(response)
+    }
+
+    /// Close the QUIC endpoint.
+    pub async fn close(self) {
+        self.endpoint.close(0u32.into(), b"done");
+        self.endpoint.wait_idle().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::SbiResponse;
+    use crate::server::{SbiServer, SbiServerConfig};
+    use crate::SbiClient;
+
+    const BODY: &str = r#"{"transport":"parity","payload":"0123456789abcdef"}"#;
+
+    fn fixed_json_handler(
+        request: SbiRequest,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = SbiResponse> + Send>> {
+        Box::pin(async move {
+            assert_eq!(request.header.method, "GET");
+            // Conversion parity with the HTTP/2 server: query split into
+            // params (and stripped from the URI), correlation-ID populated.
+            assert_eq!(
+                request.http.get_param("target-nf-type").map(String::as_str),
+                Some("AMF")
+            );
+            assert!(!request.header.uri.contains('?'));
+            assert!(!request.correlation_id.is_empty());
+            SbiResponse::ok()
+                .with_body(BODY, "application/json")
+                .with_header("x-transport-parity", "1")
+        })
+    }
+
+    const REQ_PATH: &str = "/nbench/v1/fixed?target-nf-type=AMF";
+
+    fn self_signed() -> (Vec<u8>, Vec<u8>) {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("self-signed cert");
+        (cert.cert.der().to_vec(), cert.key_pair.serialize_der())
+    }
+
+    async fn start_http3(
+        handler: fn(
+            SbiRequest,
+        )
+            -> std::pin::Pin<Box<dyn std::future::Future<Output = SbiResponse> + Send>>,
+    ) -> (Http3LoopbackServer, Vec<u8>) {
+        let (cert_der, key_der) = self_signed();
+        let server = Http3LoopbackServer::start(
+            Http3ServerConfig {
+                addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+                cert_der: cert_der.clone(),
+                key_der,
+            },
+            handler,
+        )
+        .await
+        .expect("http3 server");
+        (server, cert_der)
+    }
+
+    #[tokio::test]
+    async fn http3_get_roundtrip() {
+        let (server, cert_der) = start_http3(fixed_json_handler).await;
+
+        let client = Http3Client::connect(server.local_addr(), &cert_der)
+            .await
+            .expect("http3 client");
+        let response = client.get(REQ_PATH).await.expect("h3 GET");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            response.http.get_header("content-type").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(response.http.content.as_deref(), Some(BODY));
+
+        client.close().await;
+        server.stop().await;
+    }
+
+    /// Acceptance criterion for issue #15: the same request against the same
+    /// handler returns a body byte-identical to the HTTP/2 path.
+    #[tokio::test]
+    async fn http3_body_is_byte_identical_to_http2() {
+        // HTTP/2 (h2c) side — probe-bind-drop to pick a free port (the
+        // server binds only its configured address), retrying if a parallel
+        // test steals the port in the probe→bind window.
+        let (h2_server, port) = {
+            let mut started = None;
+            for _ in 0..5 {
+                let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+                let port = probe.local_addr().expect("probe addr").port();
+                drop(probe);
+                let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+                    [127, 0, 0, 1],
+                    port,
+                ))));
+                if server.start(fixed_json_handler).await.is_ok() {
+                    started = Some((server, port));
+                    break;
+                }
+            }
+            started.expect("h2 server after 5 attempts")
+        };
+        let h2_client = SbiClient::with_host_port("127.0.0.1", port);
+        let h2_response = h2_client.get(REQ_PATH).await.expect("h2 GET");
+        assert_eq!(h2_response.status, 200);
+        let h2_body = h2_response.http.content.expect("h2 body");
+
+        // HTTP/3 side — same handler, same path.
+        let (h3_server, cert_der) = start_http3(fixed_json_handler).await;
+        let h3_client = Http3Client::connect(h3_server.local_addr(), &cert_der)
+            .await
+            .expect("http3 client");
+        let (h3_status, h3_headers, h3_body) = h3_client.get_raw(REQ_PATH).await.expect("h3 GET");
+
+        assert_eq!(h3_status, h2_response.status);
+        assert_eq!(h3_body.as_ref(), h2_body.as_bytes(), "body bytes differ");
+        assert_eq!(
+            h3_headers.get("content-type").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(
+            h3_headers.get("x-transport-parity").map(String::as_str),
+            Some("1")
+        );
+
+        h3_client.close().await;
+        h3_server.stop().await;
+        h2_server.stop().await.expect("h2 stop");
+    }
+}

--- a/src/libs/nextgcore-sbi/src/lib.rs
+++ b/src/libs/nextgcore-sbi/src/lib.rs
@@ -44,6 +44,8 @@ pub mod error;
 #[cfg(feature = "6g-extensions")]
 pub mod grpc; // SBI 2.0 gRPC support (B6.1)
 pub mod heartbeat;
+#[cfg(feature = "http3")]
+pub mod http3; // HTTP/3 SBI transport prototype (issue #15, non-normative)
 pub mod message;
 pub mod multipart;
 pub mod oauth;
@@ -72,6 +74,8 @@ pub use heartbeat::{
     global_heartbeat_manager, init_heartbeat_manager, spawn_heartbeat_worker, HeartbeatConfig,
     HeartbeatManager, HeartbeatRecord, HeartbeatStats, HeartbeatStatus,
 };
+#[cfg(feature = "http3")]
+pub use http3::{Http3Client, Http3LoopbackServer, Http3ServerConfig};
 pub use message::{
     Guami, InvalidParam, PlmnId, ProblemDetails, SNssai, SbiDiscoveryOption, SbiHeader,
     SbiHttpMessage, SbiMessageParams, SbiPart, SbiRequest, SbiResponse, Tai, UriComponents,


### PR DESCRIPTION
## Summary

Bounded, non-normative research spike per #15: a criterion benchmark of the existing HTTP/2 SBI loopback path plus a feature-gated, off-by-default HTTP/3-over-QUIC prototype. TS 29.500 mandates HTTP/2; there is no frozen Rel-20/6G Stage-3 spec for any alternate transport — nothing here is a conformance target and no NF binary uses the prototype.

- **`benches/transport.rs`** (criterion): warm GET round-trip through the real `SbiClient`→`SbiServer` stack — plaintext h2c, HTTP/2-over-TLS, and (with `--features http3`) HTTP/3 — at 256 B and 16 KiB.
- **`src/http3.rs`** behind a new `http3` feature: `h3`+`quinn` loopback server driving the existing `SbiRequestHandler`; request conversion mirrors the HTTP/2 server (query→params, TS 29.501 URI decomposition, correlation-ID, body cap → 413). Multipart parts and problem+json stamping are documented as deliberate spike scope.
- **Byte-parity test**: the same request (incl. query string) against the same handler returns a body byte-identical to the HTTP/2 path.
- **`docs/sba-transport-evaluation.md`**: loopback numbers, dependency/TLS trade-offs, recommendation.

## Results (loopback, warm connection)

| Transport | 256 B | 16 KiB |
|-----------|------:|-------:|
| HTTP/2 h2c | 38.7 µs | 49.7 µs |
| HTTP/2 TLS | 37.9 µs | 54.7 µs |
| HTTP/3 QUIC | 44.1 µs | 93.7 µs |

Recommendation: keep HTTP/2 as the only SBI transport; the prototype stays gated for future WAN-impairment evaluation.

## Acceptance criteria (from #15)

- [x] Default `cargo build -p nextgcore-sbi` unchanged — `cargo tree -e normal` gains zero crates (all new deps optional + crate-local; criterion dev-only)
- [x] `cargo bench -p nextgcore-sbi` runs the HTTP/2 baseline and reports numbers
- [x] Prototype builds only under `--features http3`
- [x] Feature-gated test proves byte-identical body vs HTTP/2
- [x] `cargo test -p nextgcore-sbi` passes (175/175 with the feature); clippy clean on both configs; full workspace gate (fmt/clippy/test) green
- [x] Evaluation committed alongside the code, marked non-normative

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
