### PR TITLE
nwdafd: add feature-gated ISAC sensing data pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ cargo audit
 - [CHANGELOG.md](CHANGELOG.md) — release notes and version history
 - [docs/ci-and-release.md](docs/ci-and-release.md) — CI pipeline (GitHub Actions jobs) and the release process
 - [docs/sba-transport-evaluation.md](docs/sba-transport-evaluation.md) — HTTP/2 vs HTTP/3 SBI transport benchmark and evaluation (non-normative 6G research)
+- [docs/isac-sensing-pipeline.md](docs/isac-sensing-pipeline.md) — ISAC sensing data pipeline design note (non-normative 6G research)
 - [docker/rust/CI.md](docker/rust/CI.md) — the one-command matched-sim end-to-end suite (`e2e.sh`)
 - [docs/](docs/) — per-component gap analyses and architecture notes
 

--- a/docs/isac-sensing-pipeline.md
+++ b/docs/isac-sensing-pipeline.md
@@ -1,0 +1,56 @@
+# ISAC Sensing Data Pipeline (Design Note)
+
+> **Non-normative 6G research.** 3GPP ISAC work is study-stage only (SA1
+> TR 22.837; SA2 Rel-19 study, TR 23.700-series) — **no frozen Stage-3
+> specification or normative SBI exists** for any interface described here.
+> This is a research shape, not a conformance target. Tracking issue:
+> [#16](https://github.com/NextgCoreLab/nextgcore/issues/16).
+
+## Flow
+
+```
+producer (gNB/UE sensing engine)
+    │  POST /nnwdaf-sensingdata/v1/results   (JSON SensingResult)
+    ▼
+nwdafd collection endpoint  ──►  bounded in-memory ring buffer (100 results)
+    │                             in NwdafContext
+    ├── publishes SbiEventCategory::Isac ("SENSING_RESULT") on the NF-owned
+    │   pub-sub broker (nextgcore-sbi pubsub, 6g-extensions)
+    ├── increments the ISAC_SENSING_RESULTS counter
+    │   (AiMetricCategory::IsacSensing, nextgcore-metrics ai_native)
+    ▼
+consumer: GET /nnwdaf-analyticsinfo/v1/analytics?event-id=ISAC_SENSING
+    → 200 {"isacSensingSummary": {ingestedTotal, buffered, latest}}
+    → 204 when nothing has been ingested
+```
+
+Everything is behind the `sensing` cargo feature of `nextgcore-nwdafd`
+(off by default; it also enables `nextgcore-sbi/6g-extensions` for the
+pub-sub bus). The default build and default nwdafd behaviour are unchanged.
+
+## Design choices
+
+- **One canonical type set.** `nextgcore-proto::isac` (serde-capable) is the
+  wire type; the duplicate non-serde `SensingResult`/`SensingConfig` that
+  lived in `nextgcore-proto::types` was removed, and the isac types are
+  re-exported at the proto crate root.
+- **Reuse nwdafd, not a new NF.** NWDAF is the natural analytics sink; a
+  future NEF (no `nextgcore-nefd` exists today) would re-expose the summary
+  northbound to AFs — out of scope here.
+- **`ISAC_SENSING` is not a TS 29.520 `NwdafEvent`.** The analytics GET
+  intercepts the token before `AnalyticsId` parsing so the real TS 29.520
+  surface stays untouched.
+- **Bounded store, NF-context lock rules.** `RwLock<VecDeque>` capped at 100
+  (matching `AnalyticsEngine::MAX_SAMPLES` house style); callers take the
+  outer context read lock first, then exactly one interior lock at a time.
+- **Event bus liveness.** There was no `EventBroker` instance anywhere in the
+  tree; nwdafd now owns one, making `SbiEventCategory::Isac` the first live
+  event category. Delivery is in-process bookkeeping (matched subscribers
+  returned/counted) — no outbound notification HTTP yet.
+
+## Verification
+
+```bash
+cargo test -p nextgcore-nwdafd --features sensing sensing   # 3 tests: round-trip, event, fail-closed
+cargo build -p nextgcore-nwdafd                             # default build unchanged
+```

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2800,6 +2800,7 @@ dependencies = [
  "nextgcore-core",
  "nextgcore-metrics",
  "nextgcore-nrfd",
+ "nextgcore-proto",
  "nextgcore-sbi",
  "p256",
  "proptest",

--- a/src/bins/nextgcore-nwdafd/Cargo.toml
+++ b/src/bins/nextgcore-nwdafd/Cargo.toml
@@ -10,9 +10,17 @@ description = "NextGCore NWDAF (Network Data Analytics Function, TS 23.288)"
 name = "nextgcore-nwdafd"
 path = "src/main.rs"
 
+[features]
+## Non-normative 6G ISAC sensing pipeline (issue #16): collection endpoint,
+## bounded in-memory store, Isac pub-sub event + ingest metric. Off by default.
+## Enable with: cargo build -p nextgcore-nwdafd --features sensing
+sensing = ["dep:nextgcore-proto", "nextgcore-sbi/6g-extensions"]
+
 [dependencies]
 nextgcore-core = { workspace = true }
 nextgcore-sbi = { workspace = true }
+# sensing-feature-only: canonical ISAC types (issue #16, non-normative).
+nextgcore-proto = { workspace = true, optional = true }
 nextgcore-metrics = { workspace = true }
 nextgcore-app = { workspace = true }
 log.workspace = true

--- a/src/bins/nextgcore-nwdafd/src/context.rs
+++ b/src/bins/nextgcore-nwdafd/src/context.rs
@@ -5,6 +5,10 @@
 
 use crate::analytics::AnalyticsEngine;
 use std::collections::HashMap;
+#[cfg(feature = "sensing")]
+use std::collections::VecDeque;
+#[cfg(feature = "sensing")]
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
@@ -521,6 +525,19 @@ pub struct NwdafContext {
     max_subscriptions: usize,
     /// Context initialized flag
     initialized: AtomicBool,
+    /// Bounded ISAC sensing-result store (issue #16, non-normative 6G).
+    /// LOCK ORDER (nf-context-lock-deadlocks): outer context RwLock (read)
+    /// FIRST, then only this lock — never while holding another interior lock.
+    #[cfg(feature = "sensing")]
+    sensing_results: RwLock<VecDeque<nextgcore_proto::SensingResult>>,
+    /// NF-owned event broker for `SbiEventCategory::Isac` publications
+    /// (issue #16). Same lock-order rule as `sensing_results`.
+    #[cfg(feature = "sensing")]
+    event_broker: Mutex<nextgcore_sbi::pubsub::EventBroker>,
+    /// Running total of ingested sensing results — the value behind the
+    /// `nextgcore_metrics::ai_native::ISAC_SENSING_RESULTS` counter.
+    #[cfg(feature = "sensing")]
+    sensing_ingested_total: AtomicU64,
 }
 
 impl NwdafContext {
@@ -537,6 +554,12 @@ impl NwdafContext {
             next_id: AtomicUsize::new(1),
             max_subscriptions: 0,
             initialized: AtomicBool::new(false),
+            #[cfg(feature = "sensing")]
+            sensing_results: RwLock::new(VecDeque::new()),
+            #[cfg(feature = "sensing")]
+            event_broker: Mutex::new(nextgcore_sbi::pubsub::EventBroker::new()),
+            #[cfg(feature = "sensing")]
+            sensing_ingested_total: AtomicU64::new(0),
         }
     }
 
@@ -553,9 +576,81 @@ impl NwdafContext {
         );
     }
 
+    /// Bounded ISAC store capacity (issue #16); matches the ~100-sample house
+    /// style of `AnalyticsEngine::MAX_SAMPLES`.
+    #[cfg(feature = "sensing")]
+    const MAX_SENSING_RESULTS: usize = 100;
+
+    /// Ingest one sensing result into the bounded ring buffer and return the
+    /// running ingest total (the `ISAC_SENSING_RESULTS` metric value).
+    #[cfg(feature = "sensing")]
+    pub fn push_sensing_result(&self, result: nextgcore_proto::SensingResult) -> u64 {
+        let mut buf = self
+            .sensing_results
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while buf.len() >= Self::MAX_SENSING_RESULTS {
+            buf.pop_front();
+        }
+        buf.push_back(result);
+        // Counter bumped while the buffer lock is held so sensing_snapshot()
+        // can never observe a pushed result alongside a stale total.
+        self.sensing_ingested_total.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Snapshot of the sensing store: (total ingested, buffered count,
+    /// latest result if any).
+    #[cfg(feature = "sensing")]
+    pub fn sensing_snapshot(&self) -> (u64, usize, Option<nextgcore_proto::SensingResult>) {
+        let buf = self
+            .sensing_results
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Counter read while the buffer lock is held — pairs with the locked
+        // increment in push_sensing_result for a consistent view.
+        let total = self.sensing_ingested_total.load(Ordering::SeqCst);
+        (total, buf.len(), buf.back().cloned())
+    }
+
+    /// Publish an `SbiEventCategory::Isac` event on the NF-owned broker and
+    /// return the number of matched subscribers.
+    #[cfg(feature = "sensing")]
+    pub fn publish_isac_event(&self, event_type: &str, payload: String) -> usize {
+        let mut broker = self
+            .event_broker
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let event = nextgcore_sbi::SbiEvent::new(
+            broker.alloc_event_id(),
+            nextgcore_sbi::SbiEventCategory::Isac,
+            event_type,
+            self.nf_instance_id.clone(),
+            payload,
+        );
+        broker.publish(&event).len()
+    }
+
+    /// Access the NF-owned event broker (tests/introspection).
+    #[cfg(feature = "sensing")]
+    pub fn lock_event_broker(&self) -> MutexGuard<'_, nextgcore_sbi::pubsub::EventBroker> {
+        self.event_broker
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     pub fn fini(&mut self) {
         if !self.initialized.load(Ordering::SeqCst) {
             return;
+        }
+        #[cfg(feature = "sensing")]
+        {
+            let mut buf = self
+                .sensing_results
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            buf.clear();
+            drop(buf);
+            self.sensing_ingested_total.store(0, Ordering::SeqCst);
         }
         if let Ok(mut subs) = self.analytics_subscriptions.write() {
             subs.clear();

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -355,6 +355,14 @@ async fn nwdaf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
             _ => send_method_not_allowed(method, "notify"),
         },
 
+        // Issue #16 (non-normative 6G ISAC, no frozen Stage-3): sensing-result
+        // collection endpoint, feature-gated and off by default.
+        #[cfg(feature = "sensing")]
+        ["nnwdaf-sensingdata", "v1", "results"] => match method {
+            "POST" => handle_sensing_result_post(&request).await,
+            _ => send_method_not_allowed(method, "results"),
+        },
+
         _ => send_not_found(&format!("Resource not found: {path}"), None),
     }
 }

--- a/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
+++ b/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
@@ -201,6 +201,18 @@ pub async fn handle_analytics_info_query_with_ctx(
         }
     };
 
+    // Issue #16 (non-normative 6G ISAC): sensing-summary surface. Not a TS
+    // 29.520 NwdafEvent token, so intercept before AnalyticsId parsing.
+    #[cfg(feature = "sensing")]
+    if event_token == "ISAC_SENSING" {
+        // Fail closed on a malformed optional event-filter, matching the
+        // TS 29.520 path below (INVALID_QUERY_PARAM).
+        if let Err(detail) = parse_event_filter(params.get("event-filter")) {
+            return send_bad_request(&detail, Some("INVALID_QUERY_PARAM"));
+        }
+        return isac_sensing_summary_with_ctx(ctx);
+    }
+
     let analytics_id = match AnalyticsId::from_str(event_token) {
         Some(id) => id,
         None => {
@@ -275,6 +287,85 @@ pub async fn handle_analytics_info_query_with_ctx(
 pub async fn handle_analytics_info_query(request: &SbiRequest) -> SbiResponse {
     let ctx = nwdaf_self();
     handle_analytics_info_query_with_ctx(&ctx, request).await
+}
+
+/// Issue #16 (non-normative 6G ISAC): ingest one `SensingResult` posted to
+/// `POST /nnwdaf-sensingdata/v1/results`, against the global context.
+#[cfg(feature = "sensing")]
+pub async fn handle_sensing_result_post(request: &SbiRequest) -> SbiResponse {
+    let ctx = nwdaf_self();
+    handle_sensing_result_post_with_ctx(&ctx, request).await
+}
+
+/// Ingest one sensing result: store in the bounded ring buffer, publish an
+/// `SbiEventCategory::Isac` event, bump the `ISAC_SENSING_RESULTS` counter.
+#[cfg(feature = "sensing")]
+pub async fn handle_sensing_result_post_with_ctx(
+    ctx: &Arc<RwLock<NwdafContext>>,
+    request: &SbiRequest,
+) -> SbiResponse {
+    let body = match &request.http.content {
+        Some(content) => content,
+        None => return send_bad_request("Missing request body", Some("MISSING_BODY")),
+    };
+    let result: nextgcore_proto::SensingResult = match serde_json::from_str(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return send_bad_request(
+                &format!("Invalid SensingResult JSON: {e}"),
+                Some("INVALID_JSON"),
+            )
+        }
+    };
+
+    // Lock order (nf-context-lock-deadlocks): context read → one interior
+    // lock at a time (ring buffer inside push, then broker inside publish).
+    let (total, subscribers) = match ctx.read() {
+        Ok(guard) => {
+            let total = guard.push_sensing_result(result);
+            let subscribers = guard.publish_isac_event("SENSING_RESULT", body.clone());
+            (total, subscribers)
+        }
+        Err(e) => {
+            log::error!("handle_sensing_result_post: failed to read context: {e}");
+            return nextgcore_sbi::server::send_internal_error("context unavailable");
+        }
+    };
+    log::info!(
+        "ISAC sensing result ingested: {}={total}, subscribers_notified={subscribers}",
+        nextgcore_metrics::ai_native::ISAC_SENSING_RESULTS.name
+    );
+
+    SbiResponse::with_status(201)
+        .with_json_body(&serde_json::json!({ "ingestedTotal": total }))
+        .unwrap_or_else(|_| SbiResponse::with_status(201))
+}
+
+/// Issue #16: sensing summary for `GET ...analytics?event-id=ISAC_SENSING` —
+/// count + latest result; 204 when nothing has been ingested (house style for
+/// "requested analytics data does not exist").
+#[cfg(feature = "sensing")]
+fn isac_sensing_summary_with_ctx(ctx: &Arc<RwLock<NwdafContext>>) -> SbiResponse {
+    let (total, buffered, latest) = match ctx.read() {
+        Ok(guard) => guard.sensing_snapshot(),
+        Err(e) => {
+            log::error!("isac_sensing_summary: failed to read context: {e}");
+            return nextgcore_sbi::server::send_internal_error("context unavailable");
+        }
+    };
+    if total == 0 {
+        return SbiResponse::with_status(204);
+    }
+    let summary = serde_json::json!({
+        "isacSensingSummary": {
+            "ingestedTotal": total,
+            "buffered": buffered,
+            "latest": latest,
+        }
+    });
+    SbiResponse::with_status(200)
+        .with_json_body(&summary)
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
 }
 
 /// Shared parser for the `NnwdafEventsSubscription` request body used by both
@@ -1478,5 +1569,107 @@ mod tests {
             Some(55),
             "NF_LOAD threshold must be read from nfLoadLvlThds[].nfLoadLevel, not the absent `loadLevel` field"
         );
+    }
+}
+
+#[cfg(all(test, feature = "sensing"))]
+mod sensing_tests {
+    use super::*;
+    use nextgcore_proto::{SensingMode, SensingResult, SensingType};
+    use nextgcore_sbi::pubsub::{EventFilter, Subscription};
+    use nextgcore_sbi::SbiEventCategory;
+
+    fn fresh_ctx() -> Arc<RwLock<NwdafContext>> {
+        Arc::new(RwLock::new(NwdafContext::new("nwdaf-test".to_string())))
+    }
+
+    fn sensing_result_json() -> String {
+        serde_json::to_string(&SensingResult {
+            sensing_type: SensingType::TargetDetection,
+            mode: SensingMode::GnbMonostatic,
+            timestamp_us: 1_000_000,
+            targets: vec![],
+            snr_db: 12.5,
+        })
+        .expect("serialize SensingResult")
+    }
+
+    fn summary_request() -> SbiRequest {
+        let mut request = SbiRequest::get("/nnwdaf-analyticsinfo/v1/analytics");
+        request
+            .http
+            .params
+            .insert("event-id".to_string(), "ISAC_SENSING".to_string());
+        request
+    }
+
+    /// Acceptance (issue #16): POST a SensingResult -> 2xx, then the analytics
+    /// GET returns the summary with count >= 1.
+    #[tokio::test]
+    async fn sensing_ingest_then_query_roundtrip() {
+        let ctx = fresh_ctx();
+
+        // Nothing ingested yet -> 204 (requested data does not exist).
+        let empty = handle_analytics_info_query_with_ctx(&ctx, &summary_request()).await;
+        assert_eq!(empty.status, 204);
+
+        let post = SbiRequest::post("/nnwdaf-sensingdata/v1/results")
+            .with_body(sensing_result_json(), "application/json");
+        let response = handle_sensing_result_post_with_ctx(&ctx, &post).await;
+        assert_eq!(response.status, 201);
+
+        let summary = handle_analytics_info_query_with_ctx(&ctx, &summary_request()).await;
+        assert_eq!(summary.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(summary.http.content.as_deref().expect("summary body"))
+                .expect("summary JSON");
+        assert_eq!(body["isacSensingSummary"]["ingestedTotal"], 1);
+        assert_eq!(body["isacSensingSummary"]["buffered"], 1);
+        assert_eq!(
+            body["isacSensingSummary"]["latest"]["snr_db"],
+            serde_json::json!(12.5)
+        );
+    }
+
+    /// Acceptance (issue #16): ingest publishes an SbiEventCategory::Isac
+    /// event on the pub-sub bus (subscriber matched, publish counter bumped).
+    #[tokio::test]
+    async fn sensing_ingest_publishes_isac_event() {
+        let ctx = fresh_ctx();
+
+        // Subscribe to Isac events before ingesting.
+        {
+            let guard = ctx.read().expect("ctx read");
+            let mut broker = guard.lock_event_broker();
+            let sub_id = broker.alloc_subscription_id();
+            broker.subscribe(Subscription::new(
+                sub_id,
+                "consumer-1",
+                "http://consumer:8080/callback",
+                EventFilter::category(SbiEventCategory::Isac),
+            ));
+        }
+
+        let post = SbiRequest::post("/nnwdaf-sensingdata/v1/results")
+            .with_body(sensing_result_json(), "application/json");
+        let response = handle_sensing_result_post_with_ctx(&ctx, &post).await;
+        assert_eq!(response.status, 201);
+
+        let guard = ctx.read().expect("ctx read");
+        let broker = guard.lock_event_broker();
+        assert_eq!(broker.total_published(), 1);
+        assert_eq!(broker.total_delivered(), 1);
+    }
+
+    /// Malformed body fails closed with 400, ingesting nothing.
+    #[tokio::test]
+    async fn sensing_ingest_rejects_bad_json() {
+        let ctx = fresh_ctx();
+        let post = SbiRequest::post("/nnwdaf-sensingdata/v1/results")
+            .with_body("{not json", "application/json");
+        let response = handle_sensing_result_post_with_ctx(&ctx, &post).await;
+        assert_eq!(response.status, 400);
+        let (total, buffered, _) = ctx.read().expect("ctx read").sensing_snapshot();
+        assert_eq!((total, buffered), (0, 0));
     }
 }

--- a/src/libs/nextgcore-metrics/src/ai_native.rs
+++ b/src/libs/nextgcore-metrics/src/ai_native.rs
@@ -109,6 +109,14 @@ pub const NWDAF_FEEDBACK_RECEIVED: AiMetricDef = AiMetricDef {
     labels: &["consumer_nf", "analytics_id"],
 };
 
+/// ISAC sensing results ingested (counter) - non-normative 6G research
+pub const ISAC_SENSING_RESULTS: AiMetricDef = AiMetricDef {
+    name: "nwdaf_isac_sensing_results_total",
+    help: "Total ISAC sensing results ingested by NWDAF",
+    category: AiMetricCategory::IsacSensing,
+    labels: &[],
+};
+
 // ============================================================================
 // Predefined Energy Efficiency Metrics (Rel-18, TS 28.310)
 // ============================================================================

--- a/src/libs/nextgcore-metrics/src/lib.rs
+++ b/src/libs/nextgcore-metrics/src/lib.rs
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn test_spec_creation() {
-        let ctx = MetricsContext::new();
+        let _ctx = MetricsContext::new();
 
         let spec = MetricsSpec::new(
             MetricType::Counter,

--- a/src/libs/nextgcore-proto/src/lib.rs
+++ b/src/libs/nextgcore-proto/src/lib.rs
@@ -14,6 +14,11 @@ mod types; // #217: Sub-THz spectrum types (6G)
 
 pub use conv::*;
 pub use event::*;
+// Canonical ISAC sensing types at the crate root (issue #16: the duplicate
+// non-serde set that lived in `types` was removed in favour of these).
+pub use isac::{
+    DetectedTarget, IsacResourceConfig, SensingMode, SensingQos, SensingResult, SensingType,
+};
 pub use timer::*;
 pub use types::*;
 

--- a/src/libs/nextgcore-proto/src/types.rs
+++ b/src/libs/nextgcore-proto/src/types.rs
@@ -522,82 +522,8 @@ pub struct Session {
     pub smf_ip: IpAddr,
 }
 
-// ============================================================================
-// 6G ISAC (Integrated Sensing and Communication) Types
-// ============================================================================
-
-/// ISAC sensing configuration for 6G networks.
-///
-/// Defines operational parameters for integrated sensing and communication
-/// at the network level.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SensingConfig {
-    /// Whether ISAC sensing is enabled
-    pub enabled: bool,
-    /// Sensing mode (0=passive, 1=active radar, 2=hybrid)
-    pub mode: u8,
-    /// Sensing bandwidth in MHz
-    pub bandwidth_mhz: u32,
-    /// Maximum sensing range in meters
-    pub max_range_meters: f64,
-    /// Minimum detection threshold in dBm
-    pub detection_threshold_dbm: f32,
-}
-
-impl SensingConfig {
-    /// Creates a new sensing configuration.
-    pub fn new(mode: u8, bandwidth_mhz: u32, max_range_meters: f64) -> Self {
-        Self {
-            enabled: true,
-            mode,
-            bandwidth_mhz,
-            max_range_meters,
-            detection_threshold_dbm: -100.0,
-        }
-    }
-}
-
-impl Default for SensingConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            mode: 0,
-            bandwidth_mhz: 100,
-            max_range_meters: 1000.0,
-            detection_threshold_dbm: -100.0,
-        }
-    }
-}
-
-/// ISAC sensing result containing detection information.
-///
-/// Aggregated result from ISAC operations at the network layer.
-#[derive(Debug, Clone, Default)]
-pub struct SensingResult {
-    /// Timestamp of result (milliseconds since epoch)
-    pub timestamp_ms: u64,
-    /// Number of detections
-    pub detection_count: u32,
-    /// Average signal strength (dBm)
-    pub avg_signal_strength_dbm: f32,
-    /// Average range (meters)
-    pub avg_range_meters: f64,
-    /// Confidence level (0.0-1.0)
-    pub confidence: f32,
-}
-
-impl SensingResult {
-    /// Creates a new sensing result.
-    pub fn new(timestamp_ms: u64, detection_count: u32) -> Self {
-        Self {
-            timestamp_ms,
-            detection_count,
-            avg_signal_strength_dbm: 0.0,
-            avg_range_meters: 0.0,
-            confidence: 0.0,
-        }
-    }
-}
+// NOTE: the 6G ISAC types (SensingResult etc.) live in `crate::isac` — the
+// canonical, serde-capable set (issue #16 removed a duplicate set here).
 
 // ============================================================================
 // 6G Semantic Communication Types
@@ -930,23 +856,6 @@ mod hex {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ISAC tests
-    #[test]
-    fn test_sensing_config_new() {
-        let config = SensingConfig::new(1, 200, 500.0);
-        assert!(config.enabled);
-        assert_eq!(config.mode, 1);
-        assert_eq!(config.bandwidth_mhz, 200);
-        assert_eq!(config.max_range_meters, 500.0);
-    }
-
-    #[test]
-    fn test_sensing_result_new() {
-        let result = SensingResult::new(1000, 5);
-        assert_eq!(result.timestamp_ms, 1000);
-        assert_eq!(result.detection_count, 5);
-    }
 
     // Semantic communication tests
     #[test]


### PR DESCRIPTION
## Summary

Non-normative 6G research spike per #16 (SA1 TR 22.837 / SA2 Rel-19 study — no frozen Stage-3 ISAC spec exists): a minimal, feature-gated core-side sensing data pipeline that turns the previously orphaned ISAC types into a working collect→store→expose path.

- **Type dedup**: the non-serde `SensingResult`/`SensingConfig` duplicates in `nextgcore-proto::types` are removed; the canonical serde-capable `isac::*` set is re-exported at the crate root. Exactly one `SensingResult` remains.
- **`sensing` feature** on `nextgcore-nwdafd` (off by default; also enables `nextgcore-sbi/6g-extensions` for the pub-sub bus).
- **Collection**: `POST /nnwdaf-sensingdata/v1/results` deserializes a `SensingResult` into a bounded 100-entry ring buffer in `NwdafContext` (house lock-order rules respected).
- **Events + metric**: ingest publishes `SbiEventCategory::Isac` on an NF-owned `EventBroker` — the first live use of the pub-sub bus anywhere in the tree — and bumps the new `ISAC_SENSING_RESULTS` counter (`AiMetricCategory::IsacSensing` stops being dead).
- **Exposure**: `GET /nnwdaf-analyticsinfo/v1/analytics?event-id=ISAC_SENSING` returns `{"isacSensingSummary": {ingestedTotal, buffered, latest}}` (204 when empty), intercepted before TS 29.520 `AnalyticsId` parsing so the real spec surface is untouched; malformed `event-filter` still fails closed with 400.
- **Design note**: `docs/isac-sensing-pipeline.md` (+ README link) with the non-normative caveat.

## Acceptance criteria (from #16)

- [x] `cargo build` and `cargo build -p nextgcore-nwdafd --features sensing` both green
- [x] Exactly one `SensingResult` in `nextgcore-proto`; `cargo build -p nextgcore-proto` green (63 tests pass)
- [x] POST → 201, retrievable via analytics GET; round-trip test asserts count ≥ 1
- [x] Ingest publishes an `SbiEventCategory::Isac` event (test asserts bus delivery) and increments the `IsacSensing` metric counter
- [x] Default build unchanged: no new routes/deps (`cargo tree -e normal` gains nothing); nwdafd default tests pass (103/103)
- [x] Design doc under `docs/` with the no-frozen-spec caveat

Adversarially reviewed pre-commit (6 minor findings — filter validation, counter reset on `fini()`, lock-poison recovery, snapshot ordering — all fixed); full workspace gate (fmt/clippy/test) green.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
