### PR TITLE
sbi: negotiate hybrid X25519MLKEM768 in TLS under new pqc-tls feature

### DIFF
--- a/src/libs/nextgcore-sbi/Cargo.toml
+++ b/src/libs/nextgcore-sbi/Cargo.toml
@@ -14,6 +14,10 @@ description = "NextGCore SBI (Service Based Interface) Library"
 ## Loopback research spike only — no NF uses it; TS 29.500 mandates HTTP/2.
 ## Enable with: cargo build -p nextgcore-sbi --features http3
 http3 = ["dep:h3", "dep:h3-quinn", "dep:quinn", "dep:http"]
+## Gate the non-normative hybrid PQC TLS key exchange (issue #17): rustls
+## aws-lc-rs provider offering X25519MLKEM768 when PqcTlsConfig.enabled.
+## The default provider stays ring. Enable with: --features pqc-tls
+pqc-tls = ["rustls/aws-lc-rs"]
 
 [dependencies]
 nextgcore-core = { workspace = true }

--- a/src/libs/nextgcore-sbi/src/security.rs
+++ b/src/libs/nextgcore-sbi/src/security.rs
@@ -286,17 +286,15 @@ impl PqcTlsConfig {
 
     /// Get the cipher suite identifiers for TLS configuration
     pub fn cipher_suite_names(&self) -> Vec<&'static str> {
-        let mut suites = vec![
+        let suites = vec![
             "TLS_AES_256_GCM_SHA384",
             "TLS_AES_128_GCM_SHA256",
             "TLS_CHACHA20_POLY1305_SHA256",
         ];
 
-        if self.enabled {
-            // PQC hybrid cipher suites (IANA assignments pending, using draft IDs)
-            suites.insert(0, "TLS_AES_256_GCM_SHA384_MLKEM768");
-        }
-
+        // The hybrid ML-KEM exchange lives in the key-exchange groups (see
+        // kex_group_names), not in the cipher-suite list: TLS 1.3 keeps the
+        // standard suites. No fabricated "…_MLKEM768" suite is advertised.
         suites
     }
 
@@ -305,7 +303,11 @@ impl PqcTlsConfig {
         let mut groups = vec!["x25519", "secp256r1", "secp384r1"];
 
         if self.enabled {
-            groups.insert(0, "x25519_mlkem768");
+            // IETF/rustls group name for the default hybrid suite that
+            // tls.rs::select_provider offers first under the `pqc-tls`
+            // feature (issue #17). Pure-ML-KEM mode negotiates "MLKEM768"
+            // instead; this advisory list covers the hybrid default.
+            groups.insert(0, "X25519MLKEM768");
         }
 
         groups
@@ -313,17 +315,16 @@ impl PqcTlsConfig {
 
     /// Get the signature algorithm names
     pub fn sig_alg_names(&self) -> Vec<&'static str> {
-        let mut algs = vec![
+        let algs = vec![
             "ecdsa_secp256r1_sha256",
             "ecdsa_secp384r1_sha384",
             "rsa_pss_rsae_sha256",
             "ed25519",
         ];
 
-        if self.enabled {
-            algs.insert(0, "mldsa65");
-        }
-
+        // Signature algorithms stay classical even with PQC enabled: rustls
+        // 0.23 ships no ML-DSA certificate support (see tls.rs). "mldsa65"
+        // is deliberately NOT advertised until it can actually be negotiated.
         algs
     }
 }
@@ -525,19 +526,21 @@ mod tests {
         let suites = pqc.cipher_suite_names();
         assert!(!suites.iter().any(|s| s.contains("MLKEM")));
         let groups = pqc.kex_group_names();
-        assert!(!groups.iter().any(|s| s.contains("mlkem")));
+        assert!(!groups.iter().any(|s| s.contains("MLKEM")));
     }
 
     #[test]
     fn test_pqc_tls_config_enabled() {
         let pqc = PqcTlsConfig::enabled();
         assert!(pqc.enabled);
+        // TLS 1.3 keeps standard suites: the hybrid lives in the kx groups.
         let suites = pqc.cipher_suite_names();
-        assert!(suites[0].contains("MLKEM"));
+        assert!(!suites.iter().any(|s| s.contains("MLKEM")));
         let groups = pqc.kex_group_names();
-        assert!(groups[0].contains("mlkem"));
+        assert_eq!(groups[0], "X25519MLKEM768");
+        // Signatures stay classical until rustls ships ML-DSA support.
         let algs = pqc.sig_alg_names();
-        assert!(algs[0].contains("mldsa"));
+        assert!(!algs.iter().any(|s| s.contains("mldsa")));
     }
 
     #[test]

--- a/src/libs/nextgcore-sbi/src/tls.rs
+++ b/src/libs/nextgcore-sbi/src/tls.rs
@@ -95,13 +95,13 @@ fn get_pqc_signature_schemes(config: &PqcTlsConfig) -> Vec<SignatureScheme> {
     let mut schemes = Vec::new();
 
     if config.enabled {
-        // Note: These are placeholder values as rustls doesn't natively support PQC yet.
-        // In a real implementation, this would require a custom CryptoProvider with
-        // PQC algorithm support (e.g., via liboqs or AWS libcrypto).
+        // Key exchange is the real PQC surface (see `select_provider`, which
+        // negotiates X25519MLKEM768 under the `pqc-tls` feature). Signature
+        // schemes remain classical: rustls 0.23 ships no ML-DSA certificate
+        // support, so the hybrid choice maps to ECDSA P-256 for now.
         match config.signature_scheme {
             PqcSignatureScheme::MlDsa65 => {
-                // Future: Add ML-DSA-65 signature scheme
-                log::debug!("PQC: ML-DSA-65 signature requested (not yet in rustls)");
+                log::debug!("PQC: ML-DSA-65 signature requested (unsupported: rustls 0.23 ships no ML-DSA certificates; staying classical)");
             }
             PqcSignatureScheme::HybridEcdsaP256MlDsa65 => {
                 // Use ECDSA P-256 for now, with planned ML-DSA-65 hybrid
@@ -127,6 +127,47 @@ fn get_pqc_signature_schemes(config: &PqcTlsConfig) -> Vec<SignatureScheme> {
 /// Get the ring crypto provider.
 fn provider() -> Arc<rustls::crypto::CryptoProvider> {
     Arc::new(rustls::crypto::ring::default_provider())
+}
+
+/// Select the crypto provider for a PQC-aware builder (issue #17,
+/// non-normative — no frozen 3GPP Stage-3 covers PQC TLS).
+///
+/// With the `pqc-tls` feature compiled in and `pqc_config.enabled`, returns
+/// the rustls aws-lc-rs provider with the requested ML-KEM key-exchange group
+/// first (`X25519MLKEM768` for the hybrid suite, pure `MLKEM768` otherwise);
+/// `allow_fallback` keeps the classical groups after it. In every other case
+/// this is exactly the default ring provider, byte-for-byte the pre-existing
+/// behaviour.
+#[cfg(feature = "pqc-tls")]
+fn select_provider(pqc_config: &PqcTlsConfig) -> Arc<rustls::crypto::CryptoProvider> {
+    use rustls::crypto::aws_lc_rs::kx_group;
+
+    if !pqc_config.enabled {
+        return provider();
+    }
+    let preferred: &'static dyn rustls::crypto::SupportedKxGroup = match pqc_config.cipher_suite {
+        PqcCipherSuite::HybridX25519MlKem768 => kx_group::X25519MLKEM768,
+        PqcCipherSuite::MlKem768 => kx_group::MLKEM768,
+    };
+    let mut pqc_provider = rustls::crypto::aws_lc_rs::default_provider();
+    pqc_provider.kx_groups = if pqc_config.allow_fallback {
+        vec![
+            preferred,
+            kx_group::X25519,
+            kx_group::SECP256R1,
+            kx_group::SECP384R1,
+        ]
+    } else {
+        vec![preferred]
+    };
+    Arc::new(pqc_provider)
+}
+
+/// Without the `pqc-tls` feature the PQC-aware builders compile to exactly
+/// the classical ring path.
+#[cfg(not(feature = "pqc-tls"))]
+fn select_provider(_pqc_config: &PqcTlsConfig) -> Arc<rustls::crypto::CryptoProvider> {
+    provider()
 }
 
 /// Load PEM-encoded certificates from a file path.
@@ -187,7 +228,7 @@ pub fn build_server_config_with_pqc(
     key: PrivateKeyDer<'static>,
     pqc_config: &PqcTlsConfig,
 ) -> SbiResult<ServerConfig> {
-    let config = ServerConfig::builder_with_provider(provider())
+    let config = ServerConfig::builder_with_provider(select_provider(pqc_config))
         .with_safe_default_protocol_versions()
         .map_err(|e| SbiError::TlsError(format!("Failed to set protocol versions: {e}")))?
         .with_no_client_auth()
@@ -201,8 +242,8 @@ pub fn build_server_config_with_pqc(
             pqc_config.signature_scheme,
             pqc_config.allow_fallback
         );
-        // Note: Actual PQC cipher suite configuration would require custom CryptoProvider
-        // This is a framework for future PQC integration
+        // Key-exchange group selection happened in `select_provider` above;
+        // under `--features pqc-tls` this handshake offers X25519MLKEM768.
     }
 
     Ok(config)
@@ -226,11 +267,18 @@ pub fn build_server_config_mtls_with_pqc(
 ) -> SbiResult<ServerConfig> {
     let root_store = load_root_store(client_ca_path)?;
 
-    let client_verifier = WebPkiClientVerifier::builder(Arc::new(root_store))
-        .build()
-        .map_err(|e| SbiError::TlsError(format!("Failed to build client verifier: {e}")))?;
+    // builder() would resolve the ambient process-default CryptoProvider,
+    // which is ambiguous in this workspace (tokio-rustls enables aws-lc-rs
+    // beside our ring pin) and panics at runtime — pass the provider
+    // explicitly, same as every config builder in this module.
+    let client_verifier = WebPkiClientVerifier::builder_with_provider(
+        Arc::new(root_store),
+        select_provider(pqc_config),
+    )
+    .build()
+    .map_err(|e| SbiError::TlsError(format!("Failed to build client verifier: {e}")))?;
 
-    let config = ServerConfig::builder_with_provider(provider())
+    let config = ServerConfig::builder_with_provider(select_provider(pqc_config))
         .with_safe_default_protocol_versions()
         .map_err(|e| SbiError::TlsError(format!("Failed to set protocol versions: {e}")))?
         .with_client_cert_verifier(client_verifier)
@@ -243,8 +291,8 @@ pub fn build_server_config_mtls_with_pqc(
             pqc_config.cipher_suite,
             pqc_config.signature_scheme
         );
-        // PQC certificate chain validation would be implemented here
-        // with custom verifier supporting ML-DSA signatures
+        // Certificate chains remain classical (no ML-DSA certificate
+        // support in rustls 0.23); only the key exchange is hybrid.
     }
 
     Ok(config)
@@ -277,7 +325,7 @@ pub fn build_client_config_with_pqc(
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     }
 
-    let mut config = ClientConfig::builder_with_provider(provider())
+    let mut config = ClientConfig::builder_with_provider(select_provider(pqc_config))
         .with_safe_default_protocol_versions()
         .map_err(|e| SbiError::TlsError(format!("Failed to set protocol versions: {e}")))?
         .with_root_certificates(root_store)
@@ -291,7 +339,7 @@ pub fn build_client_config_with_pqc(
             pqc_config.cipher_suite,
             pqc_config.signature_scheme
         );
-        // PQC cipher suite negotiation would be configured here
+        // Key-exchange group selection happened in `select_provider` above.
     }
 
     if insecure_skip_verify {
@@ -340,7 +388,7 @@ pub fn build_client_config_mtls_with_pqc(
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     }
 
-    let mut config = ClientConfig::builder_with_provider(provider())
+    let mut config = ClientConfig::builder_with_provider(select_provider(pqc_config))
         .with_safe_default_protocol_versions()
         .map_err(|e| SbiError::TlsError(format!("Failed to set protocol versions: {e}")))?
         .with_root_certificates(root_store)
@@ -355,7 +403,8 @@ pub fn build_client_config_mtls_with_pqc(
             pqc_config.cipher_suite,
             pqc_config.signature_scheme
         );
-        // PQC client certificate and key exchange would be configured here
+        // Key-exchange selection happened in `select_provider`; the client
+        // certificate remains classical (no ML-DSA in rustls 0.23).
     }
 
     if insecure_skip_verify {
@@ -691,5 +740,167 @@ mod tests {
         assert!(!server.is_handshaking(), "server handshake incomplete");
 
         HandshakeOutput { client, server }
+    }
+}
+
+#[cfg(all(test, feature = "pqc-tls"))]
+mod pqc_tls_tests {
+    use super::*;
+
+    /// In-memory handshake through the real PQC-aware builders; returns the
+    /// negotiated key-exchange group plus both peers' N32 exporter keys.
+    fn pqc_handshake(pqc: &PqcTlsConfig) -> (rustls::NamedGroup, Vec<u8>, Vec<u8>) {
+        use rustls::pki_types::ServerName;
+
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert_der = CertificateDer::from(cert.cert.der().to_vec());
+        let key_der = PrivateKeyDer::try_from(cert.key_pair.serialize_der()).expect("private key");
+
+        let server_config =
+            build_server_config_with_pqc(vec![cert_der], key_der, pqc).expect("server config");
+
+        // Feed the self-signed cert through the real CA-path loading. The
+        // dir must be unique per call: tests run in parallel in one process,
+        // and a shared path races create/write against remove_dir_all.
+        static DIR_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let seq = DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let dir =
+            std::env::temp_dir().join(format!("nextgcore-sbi-pqc-{}-{seq}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let ca_path = dir.join("ca.pem");
+        std::fs::write(&ca_path, cert.cert.pem()).expect("write ca");
+        let client_config =
+            build_client_config_with_pqc(Some(ca_path.to_str().expect("ca path")), false, pqc)
+                .expect("client config");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let server_name = ServerName::try_from("localhost").unwrap();
+        let mut client =
+            rustls::ClientConnection::new(Arc::new(client_config), server_name).unwrap();
+        let mut server = rustls::ServerConnection::new(Arc::new(server_config)).unwrap();
+
+        for _ in 0..16 {
+            let mut buf = Vec::new();
+            client.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                server.read_tls(&mut buf.as_slice()).unwrap();
+                server.process_new_packets().unwrap();
+            }
+            let mut buf2 = Vec::new();
+            server.write_tls(&mut buf2).unwrap();
+            if !buf2.is_empty() {
+                client.read_tls(&mut buf2.as_slice()).unwrap();
+                client.process_new_packets().unwrap();
+            }
+            if !client.is_handshaking() && !server.is_handshaking() {
+                break;
+            }
+        }
+        assert!(!client.is_handshaking(), "client handshake incomplete");
+        assert!(!server.is_handshaking(), "server handshake incomplete");
+
+        let group = client
+            .negotiated_key_exchange_group()
+            .expect("negotiated kx group")
+            .name();
+        let client_key = export_n32_master_key(&client, None).expect("client exporter");
+        let server_key = export_n32_master_key(&server, None).expect("server exporter");
+        (group, client_key, server_key)
+    }
+
+    /// Issue #17 acceptance: PQC enabled on both ends negotiates the hybrid
+    /// X25519MLKEM768 group, and the N32-f exporter still agrees.
+    #[test]
+    fn pqc_enabled_negotiates_x25519mlkem768() {
+        let (group, client_key, server_key) = pqc_handshake(&PqcTlsConfig::hybrid());
+        assert_eq!(group, rustls::NamedGroup::X25519MLKEM768);
+        assert_eq!(client_key, server_key, "N32 exporter keys must agree");
+        assert_eq!(client_key.len(), N32_MASTER_KEY_LEN);
+    }
+
+    /// Issue #17 acceptance: with PQC disabled the same builders negotiate a
+    /// classical group (ring provider, X25519 first).
+    #[test]
+    fn pqc_disabled_negotiates_classical_group() {
+        let (group, client_key, server_key) = pqc_handshake(&PqcTlsConfig::default());
+        assert_eq!(group, rustls::NamedGroup::X25519);
+        assert_eq!(client_key, server_key);
+    }
+
+    /// Pure ML-KEM mode (no hybrid, no fallback) negotiates MLKEM768.
+    #[test]
+    fn pqc_pure_mode_negotiates_mlkem768() {
+        let (group, client_key, server_key) = pqc_handshake(&PqcTlsConfig::pure_pqc());
+        assert_eq!(group, rustls::crypto::aws_lc_rs::kx_group::MLKEM768.name());
+        assert_eq!(client_key, server_key);
+    }
+
+    /// mTLS builders complete a hybrid handshake end-to-end — in particular
+    /// the client-cert verifier must not resolve the ambient (ambiguous)
+    /// process-default provider.
+    #[test]
+    fn pqc_mtls_handshake_negotiates_hybrid() {
+        use rustls::pki_types::ServerName;
+
+        let pqc = PqcTlsConfig::hybrid();
+        let server_cert =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let client_cert = rcgen::generate_simple_self_signed(vec!["client".to_string()]).unwrap();
+
+        static DIR_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let seq = DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!(
+            "nextgcore-sbi-pqc-mtls-{}-{seq}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let server_ca = dir.join("server-ca.pem");
+        let client_ca = dir.join("client-ca.pem");
+        std::fs::write(&server_ca, server_cert.cert.pem()).expect("write server ca");
+        std::fs::write(&client_ca, client_cert.cert.pem()).expect("write client ca");
+
+        let server_config = build_server_config_mtls_with_pqc(
+            vec![CertificateDer::from(server_cert.cert.der().to_vec())],
+            PrivateKeyDer::try_from(server_cert.key_pair.serialize_der()).unwrap(),
+            client_ca.to_str().expect("client ca path"),
+            &pqc,
+        )
+        .expect("mtls server config");
+        let client_config = build_client_config_mtls_with_pqc(
+            vec![CertificateDer::from(client_cert.cert.der().to_vec())],
+            PrivateKeyDer::try_from(client_cert.key_pair.serialize_der()).unwrap(),
+            Some(server_ca.to_str().expect("server ca path")),
+            false,
+            &pqc,
+        )
+        .expect("mtls client config");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let server_name = ServerName::try_from("localhost").unwrap();
+        let mut client =
+            rustls::ClientConnection::new(Arc::new(client_config), server_name).unwrap();
+        let mut server = rustls::ServerConnection::new(Arc::new(server_config)).unwrap();
+        for _ in 0..16 {
+            let mut buf = Vec::new();
+            client.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                server.read_tls(&mut buf.as_slice()).unwrap();
+                server.process_new_packets().unwrap();
+            }
+            let mut buf2 = Vec::new();
+            server.write_tls(&mut buf2).unwrap();
+            if !buf2.is_empty() {
+                client.read_tls(&mut buf2.as_slice()).unwrap();
+                client.process_new_packets().unwrap();
+            }
+            if !client.is_handshaking() && !server.is_handshaking() {
+                break;
+            }
+        }
+        assert!(!client.is_handshaking() && !server.is_handshaking());
+        assert_eq!(
+            client.negotiated_key_exchange_group().expect("kx").name(),
+            rustls::NamedGroup::X25519MLKEM768
+        );
     }
 }


### PR DESCRIPTION
## Summary

Non-normative PQC research per #17 (no frozen 3GPP Stage-3 covers PQC TLS): the SBI TLS 1.3 handshake now **actually negotiates the hybrid `X25519MLKEM768` group** under a new off-by-default `pqc-tls` feature, replacing the log-only placeholder path.

- **`pqc-tls` feature** on `nextgcore-sbi` (`= ["rustls/aws-lc-rs"]`): the default provider stays ring; no new locked dependencies (aws-lc-rs was already resolved transitively). 3-file diff, no `Cargo.lock` change.
- **`select_provider()`**: with the feature on and `PqcTlsConfig.enabled`, the four `*_with_pqc` builders use the aws-lc-rs provider with `X25519MLKEM768` first (pure `MLKEM768` for the non-hybrid suite); `allow_fallback` keeps classical groups after it. Feature off / PQC disabled = the exact pre-existing ring path.
- **Critical pre-existing fix** (found by pre-commit adversarial review, empirically reproduced): the mTLS client-cert verifier used `WebPkiClientVerifier::builder()`, which resolves the ambient process-default `CryptoProvider` — ambiguous in this workspace (ring pinned + aws-lc-rs via tokio-rustls defaults) and **panicking at startup for any NF with `verify_client` configured**. Now `builder_with_provider()`.
- **Advisory surface reconciled**: `security.rs` now advertises `X25519MLKEM768` (the IETF/rustls name), no fabricated `…_MLKEM768` cipher suite, no `mldsa65` signature claim (rustls 0.23 ships no ML-DSA certificates); stale "not yet in rustls" comments corrected.

## Acceptance criteria (from #17)

- [x] Default `cargo build -p nextgcore-sbi` unchanged, still ring
- [x] `--features pqc-tls` builds; full test suite passes (177/177; default 173/173; `http3,pqc-tls` combo builds)
- [x] Hybrid handshake negotiates `X25519MLKEM768` (asserted via `negotiated_key_exchange_group()`); disabled negotiates classical `X25519`; plus pure-`MLKEM768` and end-to-end mTLS hybrid tests
- [x] RFC 5705 exporter tests pass in both configs; the hybrid test additionally asserts N32 exporter-key agreement
- [x] Stale placeholder comments corrected; the two `PqcTlsConfig` surfaces no longer disagree about the hybrid group name

Adversarially reviewed pre-commit (6 findings: 1 critical = the mTLS panic, 5 minor — all fixed); full workspace gate (fmt/clippy/test) green.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
