### PR TITLE
amfd: NTN timing-advance compensation for GMM retx timers (ntn feature)

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2323,6 +2323,7 @@ dependencies = [
  "nextgcore-metrics",
  "nextgcore-nas",
  "nextgcore-ngap",
+ "nextgcore-proto",
  "nextgcore-sbi",
  "nextgcore-sctp",
  "once_cell",

--- a/src/bins/nextgcore-amfd/Cargo.toml
+++ b/src/bins/nextgcore-amfd/Cargo.toml
@@ -23,12 +23,20 @@ path = "src/lib.rs"
 # standard SCTP. Requires Linux + libsctp at link/run time; off by default so
 # the host build keeps using the pure-Rust sctp-proto backend.
 kernel-sctp = ["nextgcore-sctp/kernel"]
+## Non-normative NTN research (issue #18, no frozen 6G Stage-3): extend the
+## GMM retransmission timers armed via the NAS retx path (T3550/T3560/T3570,
+## plus T3522 which shares that machinery) by the satellite round-trip delay
+## from a per-UE TimingAdvance, falling back to a per-AMF default set via the
+## AMF_NTN_TIMING_ADVANCE_US env var. Off by default: --features ntn
+ntn = ["dep:nextgcore-proto"]
 
 [dependencies]
 nextgcore-asn1c = { workspace = true }
 nextgcore-core = { workspace = true }
 nextgcore-crypt = { workspace = true }
 nextgcore-nas = { workspace = true }
+# ntn-feature-only: bespoke NTN research types (issue #18).
+nextgcore-proto = { workspace = true, optional = true }
 nextgcore-ngap = { workspace = true }
 nextgcore-sbi = { workspace = true }
 nextgcore-sctp = { workspace = true }

--- a/src/bins/nextgcore-amfd/src/context.rs
+++ b/src/bins/nextgcore-amfd/src/context.rs
@@ -2244,6 +2244,11 @@ pub struct AmfUe {
     /// when the UE registers as an aerial UE (UAV indication IE); drives the
     /// geofence on UAV tracking reports.
     pub uav_auth: Option<UavAuthorizationContext>,
+    /// NTN timing advance for this UE (issue #18, non-normative research).
+    /// When valid, GMM retransmission timers are extended by the satellite
+    /// round-trip delay it encodes.
+    #[cfg(feature = "ntn")]
+    pub ntn_timing_advance: Option<nextgcore_proto::TimingAdvance>,
 }
 
 /// URSP policy rule for UE policy delivery (TS 24.526)
@@ -2661,6 +2666,8 @@ impl AmfUe {
             prose_capable: false,
             pin_role: None,
             uav_auth: None,
+            #[cfg(feature = "ntn")]
+            ntn_timing_advance: None,
         }
     }
 

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -261,17 +261,54 @@ enum NasProcTimer {
 }
 
 impl NasProcTimer {
-    fn config(self, configs: &AmfTimerConfigs) -> (u32, Duration) {
-        let id = match self {
+    fn timer_id(self) -> AmfTimerId {
+        match self {
             Self::T3550 => AmfTimerId::T3550,
             Self::T3560 => AmfTimerId::T3560,
             Self::T3570 => AmfTimerId::T3570,
             Self::T3522 => AmfTimerId::T3522,
-        };
+        }
+    }
+
+    fn config(self, configs: &AmfTimerConfigs) -> (u32, Duration) {
         configs
-            .get(id)
+            .get(self.timer_id())
             .map(|c| (c.max_count, c.duration))
             .unwrap_or((4, Duration::from_secs(6)))
+    }
+
+    /// Issue #18 (non-normative NTN research): extend `base` by the UE's
+    /// satellite round-trip delay when a valid TimingAdvance is present.
+    #[cfg(feature = "ntn")]
+    fn ntn_compensated(
+        self,
+        configs: &AmfTimerConfigs,
+        base: Duration,
+        ta: Option<nextgcore_proto::TimingAdvance>,
+    ) -> Duration {
+        // Per-UE advance wins; otherwise fall back to the per-AMF default.
+        let Some(ta) = ta.or(configs.ntn_default_timing_advance) else {
+            return base;
+        };
+        // Prefer the TimerConfig method; if a future timer has no config
+        // entry (config() substitutes a fallback duration for that case),
+        // compensate the passed-in base directly instead of silently
+        // skipping the extension.
+        let compensated = match configs.get(self.timer_id()) {
+            Some(config) => config.with_ntn_compensation(&ta),
+            None if ta.valid => base + Duration::from_micros(u64::from(ta.value_us) * 2),
+            None => base,
+        };
+        if compensated != base {
+            log::debug!(
+                "NTN: {} duration {:?} -> {:?} (timing advance {}us)",
+                self.timer_id().name(),
+                base,
+                compensated,
+                ta.value_us
+            );
+        }
+        compensated
     }
 }
 
@@ -430,7 +467,26 @@ impl NgapServer {
             event_tx,
             server_event_rx,
             ue_auth_state: HashMap::new(),
-            timer_configs: AmfTimerConfigs::default(),
+            timer_configs: {
+                let configs = AmfTimerConfigs::default();
+                #[cfg(feature = "ntn")]
+                let configs = {
+                    let mut configs = configs;
+                    configs.ntn_default_timing_advance = std::env::var("AMF_NTN_TIMING_ADVANCE_US")
+                        .ok()
+                        .and_then(|v| v.parse::<u32>().ok())
+                        .map(nextgcore_proto::TimingAdvance::new);
+                    if let Some(ta) = configs.ntn_default_timing_advance {
+                        log::info!(
+                            "NTN: per-AMF default timing advance {}us (GMM retransmission timers extended by {}us round trip)",
+                            ta.value_us,
+                            u64::from(ta.value_us) * 2
+                        );
+                    }
+                    configs
+                };
+                configs
+            },
         })
     }
 
@@ -3885,6 +3941,14 @@ impl NgapServer {
     /// Arm a GMM procedure retransmission timer for a UE
     fn arm_retx(&mut self, amf_ue_ngap_id: u64, timer: NasProcTimer, ngap_pdu: Vec<u8>) {
         let (_max, duration) = timer.config(&self.timer_configs);
+        #[cfg(feature = "ntn")]
+        let duration = timer.ntn_compensated(
+            &self.timer_configs,
+            duration,
+            self.ue_auth_state
+                .get(&amf_ue_ngap_id)
+                .and_then(|s| s.amf_ue.ntn_timing_advance),
+        );
         if let Some(state) = self.ue_auth_state.get_mut(&amf_ue_ngap_id) {
             state.retx = Some(NasRetx {
                 timer,
@@ -3916,6 +3980,12 @@ impl NgapServer {
                 continue;
             };
             let (max_count, duration) = retx.timer.config(&self.timer_configs);
+            #[cfg(feature = "ntn")]
+            let duration = retx.timer.ntn_compensated(
+                &self.timer_configs,
+                duration,
+                state.amf_ue.ntn_timing_advance,
+            );
 
             if retx.retries < max_count {
                 retx.retries += 1;
@@ -7300,5 +7370,40 @@ mod tests {
         let ctx = crate::context::amf_self();
         let guard = ctx.read().expect("ctx lock");
         guard.n1n2_subscription_remove(supi, sub_id);
+    }
+}
+
+#[cfg(all(test, feature = "ntn"))]
+mod ntn_retx_tests {
+    use super::*;
+    use nextgcore_proto::TimingAdvance;
+
+    /// Issue #18: a per-AMF default advance extends every GMM retransmission
+    /// timer resolved through the live retx path (T3550/T3560/T3570, and
+    /// T3522 which shares the same arming machinery) even when the UE has no
+    /// per-UE advance; with no advance at all the base duration is unchanged.
+    #[test]
+    fn per_amf_default_extends_retx_durations() {
+        let mut configs = AmfTimerConfigs::default();
+        configs.ntn_default_timing_advance = Some(TimingAdvance::new(270_000));
+        for timer in [
+            NasProcTimer::T3550,
+            NasProcTimer::T3560,
+            NasProcTimer::T3570,
+            NasProcTimer::T3522,
+        ] {
+            let (_, base) = timer.config(&configs);
+            assert_eq!(
+                timer.ntn_compensated(&configs, base, None),
+                base + Duration::from_micros(540_000)
+            );
+        }
+
+        let no_ta = AmfTimerConfigs::default();
+        let (_, base) = NasProcTimer::T3550.config(&no_ta);
+        assert_eq!(
+            NasProcTimer::T3550.ntn_compensated(&no_ta, base, None),
+            base
+        );
     }
 }

--- a/src/bins/nextgcore-amfd/src/timer.rs
+++ b/src/bins/nextgcore-amfd/src/timer.rs
@@ -105,6 +105,19 @@ impl TimerConfig {
             duration: Duration::from_secs(duration_secs),
         }
     }
+
+    /// Issue #18 (non-normative NTN research; no frozen 6G Stage-3): return
+    /// this timer's duration extended by the satellite round-trip
+    /// propagation delay derived from a `TimingAdvance` — twice the one-way
+    /// advance in microseconds — when the advance is valid. An invalid
+    /// advance yields exactly the base duration.
+    #[cfg(feature = "ntn")]
+    pub fn with_ntn_compensation(&self, ta: &nextgcore_proto::TimingAdvance) -> Duration {
+        if !ta.valid {
+            return self.duration;
+        }
+        self.duration + Duration::from_micros(u64::from(ta.value_us) * 2)
+    }
 }
 
 /// AMF timer configurations
@@ -124,6 +137,11 @@ pub struct AmfTimerConfigs {
     pub t3570: TimerConfig,
     /// NG holding configuration
     pub ng_holding: TimerConfig,
+    /// Per-AMF default NTN timing advance (issue #18, non-normative
+    /// research). Applied to any UE without a per-UE advance; populated at
+    /// NGAP-server startup from the `AMF_NTN_TIMING_ADVANCE_US` env var.
+    #[cfg(feature = "ntn")]
+    pub ntn_default_timing_advance: Option<nextgcore_proto::TimingAdvance>,
 }
 
 impl Default for AmfTimerConfigs {
@@ -147,6 +165,8 @@ impl Default for AmfTimerConfigs {
                 max_count: 0,
                 duration: Duration::from_secs(30),
             },
+            #[cfg(feature = "ntn")]
+            ntn_default_timing_advance: None,
         }
     }
 }
@@ -433,5 +453,32 @@ mod tests {
 
         manager.stop_all_ue_timers(100);
         assert_eq!(manager.active_timer_count(), 1);
+    }
+}
+
+#[cfg(all(test, feature = "ntn"))]
+mod ntn_tests {
+    use super::*;
+    use nextgcore_proto::TimingAdvance;
+
+    /// Issue #18 acceptance: a valid TimingAdvance strictly extends the base
+    /// duration by the round-trip delay; an invalid one changes nothing.
+    #[test]
+    fn ntn_compensation_extends_valid_and_ignores_invalid() {
+        let config = TimerConfig::new(4, 6);
+
+        // GEO-ish one-way advance of 270ms -> +540ms round trip.
+        let ta = TimingAdvance::new(270_000);
+        let compensated = config.with_ntn_compensation(&ta);
+        assert!(compensated > config.duration);
+        assert_eq!(
+            compensated,
+            config.duration + Duration::from_micros(540_000)
+        );
+
+        assert_eq!(
+            config.with_ntn_compensation(&TimingAdvance::invalid()),
+            config.duration
+        );
     }
 }


### PR DESCRIPTION
## Summary

Non-normative NTN research per #18: `nextgcore_proto::TimingAdvance` gets its first live consumer — AMF GMM retransmission timers extended by satellite round-trip propagation delay, behind an off-by-default `ntn` feature.

- **`ntn` feature** on amfd (`= ["dep:nextgcore-proto"]`, following the `kernel-sctp` precedent). Default build byte-identical; default dep tree gains nothing.
- **`TimerConfig::with_ntn_compensation(&TimingAdvance) -> Duration`**: base + 2× the one-way advance (µs) when `valid`; exactly base otherwise.
- **Wired at the real chokepoint**: research showed `timer.rs`'s `TimerManager` is dead in production (only its own tests call it) — the live path is `NasProcTimer`/`arm_retx`/`process_nas_timers` in `ngap_path.rs`. Compensation applies at both duration-consuming sites there. This covers **T3550/T3560/T3570 and also T3522**, which shares the same arming machinery (deliberate; documented in the feature doc).
- **Actually reachable at runtime** (pre-commit review caught the initial version being a silent no-op): per-UE `AmfUe.ntn_timing_advance` plus a per-AMF default populated from the `AMF_NTN_TIMING_ADVANCE_US` env var at NGAP-server startup, per the issue's "or a per-AMF NTN default" option. NAS `NtnTimingAdvance` IE decode remains the tracked follow-up.

## Acceptance criteria (from #18)

- [x] Default `cargo build -p nextgcore-amfd` unchanged; `--features ntn` builds
- [x] `TimingAdvance` referenced from live non-test amfd code (`timer.rs`, `ngap_path.rs`, `context.rs`)
- [x] Unit test: valid advance ⇒ strictly greater duration; invalid ⇒ exactly base — plus a live-path test proving the per-AMF default extends all four retx timers (+540 ms for a GEO-ish 270 ms advance)
- [x] `cargo test -p nextgcore-amfd` passes with (398) and without (397) the feature
- [x] Default clippy clean (0 warnings both configs)

Adversarially reviewed pre-commit (1 major: the never-populated field, fixed via the env-driven per-AMF default; 2 minors: T3522 scope documented, missing-config fallback made symmetric); full workspace gate green.

Closes #18
