### PR TITLE
feat(smf/upf/pfcp): load/compute-aware UPF selection, feature-gated off

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **nextgcore** (41884 symbols, 95192 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **nextgcore** (42054 symbols, 95664 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **nextgcore** (41884 symbols, 95192 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **nextgcore** (42054 symbols, 95664 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/bins/nextgcore-smfd/Cargo.toml
+++ b/src/bins/nextgcore-smfd/Cargo.toml
@@ -10,6 +10,17 @@ description = "NextGCore SMF (Session Management Function)"
 name = "nextgcore-smfd"
 path = "src/main.rs"
 
+[features]
+## Issue #20: load/compute-aware UPF selection. With the feature enabled and
+## several UPFs configured (comma-separated UPF_PFCP_ADDR), a NEW session is
+## placed on the least-loaded *associated* peer, using the load metric each
+## UPF reports via Load Control Information on its PFCP heartbeat
+## (TS 23.501 6.3.3 selection input). Off by default: session establishment
+## uses the single default client exactly as before. Rel-19 "Compute-Aware
+## Networking" has no frozen Stage-3 (non-normative research knob).
+## Enable with: cargo build -p nextgcore-smfd --features compute-aware-upf
+compute-aware-upf = []
+
 [dependencies]
 nextgcore-core = { workspace = true }
 nextgcore-nas = { workspace = true }

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -422,15 +422,31 @@ async fn main() -> Result<()> {
             .parse()
             .context("Invalid SMF PFCP listen address")?
     };
-    let upf_pfcp_addr: SocketAddr = {
-        let addr = std::env::var("UPF_PFCP_ADDR").unwrap_or_else(|_| "127.0.0.1".to_string());
-        let port: u16 = std::env::var("UPF_PFCP_PORT")
+    // Issue #20: UPF_PFCP_ADDR accepts a comma-separated peer list
+    // ("10.0.0.5,10.0.0.6:8806"); an entry without a port uses
+    // UPF_PFCP_PORT. A single entry — the default — behaves exactly as the
+    // pre-pool single-UPF configuration.
+    let upf_pfcp_addrs: Vec<SocketAddr> = {
+        let addrs = std::env::var("UPF_PFCP_ADDR").unwrap_or_else(|_| "127.0.0.1".to_string());
+        let default_port: u16 = std::env::var("UPF_PFCP_PORT")
             .ok()
             .and_then(|p| p.parse().ok())
             .unwrap_or(8805);
-        format!("{addr}:{port}")
-            .parse()
-            .context("Invalid UPF PFCP address")?
+        let mut peers = Vec::new();
+        for entry in addrs.split(',').map(str::trim).filter(|e| !e.is_empty()) {
+            let candidate = if entry.contains(':') {
+                entry.to_string()
+            } else {
+                format!("{entry}:{default_port}")
+            };
+            peers.push(
+                candidate
+                    .parse()
+                    .with_context(|| format!("Invalid UPF PFCP address '{entry}'"))?,
+            );
+        }
+        anyhow::ensure!(!peers.is_empty(), "UPF_PFCP_ADDR contains no usable peer");
+        peers
     };
     let smf_node_ip: [u8; 4] = {
         let s = std::env::var("SMF_PFCP_ADDR").unwrap_or_else(|_| "127.0.0.1".to_string());
@@ -447,20 +463,28 @@ async fn main() -> Result<()> {
             .await
             .with_context(|| format!("Failed to bind SMF PFCP socket on {pfcp_bind_addr}"))?,
     );
-    log::info!("SMF N4 PFCP socket bound on {pfcp_bind_addr} (UPF peer: {upf_pfcp_addr})");
+    log::info!("SMF N4 PFCP socket bound on {pfcp_bind_addr} (UPF peers: {upf_pfcp_addrs:?})");
 
-    let pfcp_client = Arc::new(pfcp_path::PfcpClient::new(
-        pfcp_socket.clone(),
-        upf_pfcp_addr,
-        smf_node_ip,
-    ));
-    pfcp_path::set_global_client(pfcp_client.clone());
+    let pfcp_clients: Vec<Arc<pfcp_path::PfcpClient>> = upf_pfcp_addrs
+        .iter()
+        .map(|&peer| {
+            Arc::new(pfcp_path::PfcpClient::new(
+                pfcp_socket.clone(),
+                peer,
+                smf_node_ip,
+            ))
+        })
+        .collect();
+    // Installs the whole pool and pool slot 0 as the process-wide default
+    // client (the legacy single-client paths keep working unchanged).
+    pfcp_path::set_global_pool(pfcp_clients.clone());
+    let pfcp_client = pfcp_clients[0].clone();
 
     // PFCP receive/dispatch loop: responses complete pending transactions;
     // node-level requests (heartbeat, association release) are answered by
     // the engine; Session Report Requests are handled here.
     let shutdown_pfcp = shutdown.clone();
-    let client_rx = pfcp_client.clone();
+    let clients_rx = pfcp_clients.clone();
     let sock_rx = pfcp_socket.clone();
     let pfcp_listener_handle = tokio::spawn(async move {
         let mut buf = vec![0u8; 8192];
@@ -476,7 +500,15 @@ async fn main() -> Result<()> {
             {
                 Ok(Ok((len, peer))) => {
                     let pkt = buf[..len].to_vec();
-                    if !client_rx.on_datagram(&pkt, peer).await {
+                    // Route the datagram to the client owning this peer so
+                    // transaction matching and association state stay
+                    // per-UPF. Unknown sources fall back to pool slot 0,
+                    // preserving the single-UPF behavior.
+                    let client = clients_rx
+                        .iter()
+                        .find(|c| c.peer() == peer)
+                        .unwrap_or(&clients_rx[0]);
+                    if !client.on_datagram(&pkt, peer).await {
                         handle_pfcp_incoming(&sock_rx, &pkt, peer).await;
                     }
                 }
@@ -493,7 +525,7 @@ async fn main() -> Result<()> {
     // Stamp tears the association down (stale sessions flushed) and
     // triggers re-association.
     let shutdown_assoc = shutdown.clone();
-    let client_assoc = pfcp_client.clone();
+    let clients_assoc = pfcp_clients.clone();
     let pfcp_assoc_handle = tokio::spawn(async move {
         let heartbeat_period = std::time::Duration::from_secs(10);
         let reassociate_holdoff = std::time::Duration::from_secs(10);
@@ -501,19 +533,18 @@ async fn main() -> Result<()> {
             if shutdown_assoc.load(Ordering::SeqCst) || SHUTDOWN.load(Ordering::SeqCst) {
                 break;
             }
-            if !client_assoc.is_associated().await {
-                match client_assoc.associate().await {
-                    Ok(()) => {}
-                    Err(e) => {
+            for client_assoc in &clients_assoc {
+                if !client_assoc.is_associated().await {
+                    if let Err(e) = client_assoc.associate().await {
                         // Abnormal action on association failure: declare the
-                        // UPF unreachable and hold off before a new cycle.
+                        // UPF unreachable and retry next cycle. Handled
+                        // per-peer (issue #20 review): one unreachable UPF
+                        // must not starve heartbeats to healthy pool members.
                         log::error!(
                             "PFCP Association Setup with {} failed: {e}; retrying in {}s",
                             client_assoc.peer(),
                             reassociate_holdoff.as_secs()
                         );
-                        tokio::time::sleep(reassociate_holdoff).await;
-                        continue;
                     }
                 }
             }
@@ -521,11 +552,13 @@ async fn main() -> Result<()> {
             if shutdown_assoc.load(Ordering::SeqCst) || SHUTDOWN.load(Ordering::SeqCst) {
                 break;
             }
-            if client_assoc.is_associated().await {
-                if let Err(e) = client_assoc.heartbeat_once().await {
-                    // Exhaustion already marked the association down inside
-                    // the engine; the next loop turn re-associates.
-                    log::error!("PFCP heartbeat to {} failed: {e}", client_assoc.peer());
+            for client_assoc in &clients_assoc {
+                if client_assoc.is_associated().await {
+                    if let Err(e) = client_assoc.heartbeat_once().await {
+                        // Exhaustion already marked the association down inside
+                        // the engine; the next loop turn re-associates.
+                        log::error!("PFCP heartbeat to {} failed: {e}", client_assoc.peer());
+                    }
                 }
             }
         }
@@ -1109,8 +1142,12 @@ async fn pfcp_session_establish(
 ) -> Result<PfcpSessionResult> {
     use n4_build::{pfcp_ie, FarParams, PdrParams, PfcpMessageBuilder, QerParams};
 
-    let client =
-        pfcp_path::global_client().ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
+    // Issue #20: pick the UPF for this NEW session — the least-loaded
+    // associated pool peer when the compute-aware-upf feature is enabled,
+    // the sole/default client otherwise (identical to the legacy path).
+    let client = pfcp_path::select_upf()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
 
     // TS 29.244 6.2.6.2: no session signalling without an association
     if !client.is_associated().await {
@@ -1363,6 +1400,11 @@ async fn pfcp_session_establish(
 
     log::info!("PFCP Session Established: UPF SEID=0x{upf_seid:016x}, UPF TEID=0x{upf_teid:08x}");
 
+    // Issue #20: remember which UPF this session was established on so
+    // modification/deletion keep signalling the same peer. Keyed by the
+    // SMF-side SEID: UPF-chosen SEIDs collide across a multi-UPF pool.
+    pfcp_path::record_session_peer(smf_n4_seid, client.peer());
+
     Ok(PfcpSessionResult {
         upf_seid,
         upf_teid,
@@ -1371,11 +1413,16 @@ async fn pfcp_session_establish(
 }
 
 /// Send PFCP Session Modification Request to UPF to activate DL FAR with gNB TEID
-async fn pfcp_session_modify(upf_seid: u64, gnb_teid: u32, gnb_addr: [u8; 4]) -> Result<()> {
+async fn pfcp_session_modify(
+    smf_n4_seid: u64,
+    upf_seid: u64,
+    gnb_teid: u32,
+    gnb_addr: [u8; 4],
+) -> Result<()> {
     use n4_build::{build_session_modification_request, SessionModificationParams};
 
-    let client =
-        pfcp_path::global_client().ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
+    let client = pfcp_path::client_for_session(smf_n4_seid)
+        .ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
     if !client.is_associated().await {
         anyhow::bail!("no established PFCP association with {}", client.peer());
     }
@@ -1431,9 +1478,9 @@ async fn pfcp_session_modify(upf_seid: u64, gnb_teid: u32, gnb_addr: [u8; 4]) ->
 }
 
 /// Send PFCP Session Deletion Request to UPF
-async fn pfcp_session_delete(upf_seid: u64) -> Result<()> {
-    let client =
-        pfcp_path::global_client().ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
+async fn pfcp_session_delete(smf_n4_seid: u64, upf_seid: u64) -> Result<()> {
+    let client = pfcp_path::client_for_session(smf_n4_seid)
+        .ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
     if !client.is_associated().await {
         anyhow::bail!("no established PFCP association with {}", client.peer());
     }
@@ -1457,6 +1504,8 @@ async fn pfcp_session_delete(upf_seid: u64) -> Result<()> {
     }
     match pfcp_path::parse_cause(&resp_body) {
         Some(pfcp_path::pfcp_cause::REQUEST_ACCEPTED) => {
+            // Issue #20: the session is gone — drop its UPF binding.
+            pfcp_path::forget_session_peer(smf_n4_seid);
             log::info!("PFCP Session Deletion successful");
             Ok(())
         }
@@ -2188,7 +2237,7 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
     // ---- N4: PFCP Session Establishment with policy-derived QoS ----
     // A failed N4 establishment is a hard failure for the PDU session — no
     // fabricated TEID fallback (the data path would be a black hole).
-    let smf_n4_seid = (sm_context_ref.parse::<u64>().unwrap_or(1)) | 0x1000;
+    let smf_n4_seid = smf_n4_seid_for(&sm_context_ref);
 
     let (upf_teid, upf_addr) =
         match pfcp_session_establish(smf_n4_seid, ue_ip_octets, &dnn, sst, &session_qos).await {
@@ -2363,6 +2412,13 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
 
 /// Look up the stored UPF SEID for an SM context (copy-then-drop the guards
 /// per the lock-order rule).
+/// The SMF-side N4 SEID for an SM context reference. Must match the
+/// derivation used at session establishment (it is the SEID the UPF
+/// addresses us by, and — issue #20 — the session→UPF binding key).
+fn smf_n4_seid_for(sm_context_ref: &str) -> u64 {
+    (sm_context_ref.parse::<u64>().unwrap_or(1)) | 0x1000
+}
+
 fn lookup_upf_seid(sm_context_ref: &str) -> Option<u64> {
     smf_self().read().ok().and_then(|ctx| {
         ctx.pfcp_sessions
@@ -2383,9 +2439,15 @@ fn lookup_policy_binding(sm_context_ref: &str) -> Option<context::PolicyBinding>
 }
 
 /// Send a PFCP QER modification carrying an authorized Session-AMBR.
-async fn pfcp_update_session_qer(upf_seid: u64, qfi: u8, ambr_ul: u64, ambr_dl: u64) -> Result<()> {
-    let client =
-        pfcp_path::global_client().ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
+async fn pfcp_update_session_qer(
+    smf_n4_seid: u64,
+    upf_seid: u64,
+    qfi: u8,
+    ambr_ul: u64,
+    ambr_dl: u64,
+) -> Result<()> {
+    let client = pfcp_path::client_for_session(smf_n4_seid)
+        .ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
     let params = n4_build::SessionModificationParams {
         update_qers: vec![n4_build::QerParams {
             qer_id: 1,
@@ -2413,9 +2475,9 @@ async fn pfcp_update_session_qer(upf_seid: u64, qfi: u8, ambr_ul: u64, ambr_dl: 
 
 /// Deactivate the downlink FAR (back to BUFF) — used when the AN-side
 /// resources failed or the UP connection is deactivated.
-async fn pfcp_deactivate_dl_far(upf_seid: u64) -> Result<()> {
-    let client =
-        pfcp_path::global_client().ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
+async fn pfcp_deactivate_dl_far(smf_n4_seid: u64, upf_seid: u64) -> Result<()> {
+    let client = pfcp_path::client_for_session(smf_n4_seid)
+        .ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
     let params = n4_build::SessionModificationParams {
         update_fars_deactivate: vec![2],
         ..Default::default()
@@ -2497,7 +2559,14 @@ async fn handle_sm_context_update(sm_context_ref: &str, request: &SbiRequest) ->
                 log::error!("No stored UPF SEID for ref={sm_context_ref}");
                 return SbiResponse::with_status(404);
             };
-            match pfcp_session_modify(upf_seid, gnb_teid, gnb_addr).await {
+            match pfcp_session_modify(
+                smf_n4_seid_for(sm_context_ref),
+                upf_seid,
+                gnb_teid,
+                gnb_addr,
+            )
+            .await
+            {
                 Ok(()) => {
                     log::info!(
                         "PFCP Session Modified: DL FAR activated with gNB TEID=0x{gnb_teid:08x}"
@@ -2522,7 +2591,9 @@ async fn handle_sm_context_update(sm_context_ref: &str, request: &SbiRequest) ->
         "PDU_RES_SETUP_FAIL" | "PATH_SWITCH_SETUP_FAIL" | "HANDOVER_RES_ALLOC_FAIL" => {
             log::warn!("SM Context Update ({n2_sm_info_type}): AN resource failure for ref={sm_context_ref}");
             if let Some(upf_seid) = lookup_upf_seid(sm_context_ref) {
-                if let Err(e) = pfcp_deactivate_dl_far(upf_seid).await {
+                if let Err(e) =
+                    pfcp_deactivate_dl_far(smf_n4_seid_for(sm_context_ref), upf_seid).await
+                {
                     log::warn!("DL FAR deactivation after AN failure failed: {e}");
                 }
             }
@@ -2604,7 +2675,15 @@ async fn handle_sm_context_update(sm_context_ref: &str, request: &SbiRequest) ->
 
             // Apply the authorized QoS to the N4 session QER
             if let Some(seid) = lookup_upf_seid(sm_context_ref) {
-                if let Err(e) = pfcp_update_session_qer(seid, qfi, ambr_ul, ambr_dl).await {
+                if let Err(e) = pfcp_update_session_qer(
+                    smf_n4_seid_for(sm_context_ref),
+                    seid,
+                    qfi,
+                    ambr_ul,
+                    ambr_dl,
+                )
+                .await
+                {
                     log::error!("{e}");
                     return SbiResponse::with_status(504);
                 }
@@ -2660,7 +2739,9 @@ async fn handle_sm_context_update(sm_context_ref: &str, request: &SbiRequest) ->
             if up_cnx_state == "DEACTIVATED" {
                 // UE went idle: buffer downlink traffic at the UPF
                 if let Some(upf_seid) = lookup_upf_seid(sm_context_ref) {
-                    if let Err(e) = pfcp_deactivate_dl_far(upf_seid).await {
+                    if let Err(e) =
+                        pfcp_deactivate_dl_far(smf_n4_seid_for(sm_context_ref), upf_seid).await
+                    {
                         log::warn!("DL FAR deactivation failed: {e}");
                         return SbiResponse::with_status(504);
                     }
@@ -2801,7 +2882,7 @@ async fn handle_sm_context_release(sm_context_ref: &str) -> SbiResponse {
 
     if let Some(seid) = upf_seid {
         // Send PFCP Session Deletion Request to UPF (with retransmission)
-        match pfcp_session_delete(seid).await {
+        match pfcp_session_delete(smf_n4_seid_for(sm_context_ref), seid).await {
             Ok(()) => {
                 log::info!("PFCP Session Deleted: UPF SEID=0x{seid:016x} for ref={sm_context_ref}");
                 if let Some(ref mut f) = fsm {
@@ -3006,6 +3087,7 @@ async fn handle_sm_policy_notify(sm_context_ref: &str, request: &SbiRequest) -> 
     // Apply to the N4 session QER (copy SEID out, no guards across await)
     if let Some(seid) = lookup_upf_seid(sm_context_ref) {
         if let Err(e) = pfcp_update_session_qer(
+            smf_n4_seid_for(sm_context_ref),
             seid,
             binding.qfi,
             dec.sess_ambr_ul_bps,

--- a/src/bins/nextgcore-smfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-smfd/src/pfcp_path.rs
@@ -249,6 +249,14 @@ pub struct AssociationState {
     pub peer_recovery_time_stamp: Option<u32>,
     /// UP Function Features advertised by the UPF
     pub up_function_features: Option<UpFunctionFeatures>,
+    /// Latest load metric (0..=100) the peer reported via a Load Control
+    /// Information IE on its heartbeat (issue #20, TS 29.244 §8.2.53).
+    /// None until the peer reports one — standard peers never do.
+    pub peer_load: Option<u8>,
+    /// Load Control Sequence Number of the stored `peer_load`; a stale
+    /// (lower) sequence number must not overwrite a newer metric
+    /// (TS 29.244 §8.2.52).
+    pub peer_load_seq: Option<u32>,
 }
 
 // ============================================================================
@@ -278,6 +286,134 @@ pub fn set_global_client(client: Arc<PfcpClient>) {
 /// The process-wide PFCP client, if initialised.
 pub fn global_client() -> Option<Arc<PfcpClient>> {
     PFCP_CLIENT.get().cloned()
+}
+
+// ============================================================================
+// UPF pool + load-aware selection (issue #20)
+// ============================================================================
+
+static PFCP_POOL: OnceLock<Vec<Arc<PfcpClient>>> = OnceLock::new();
+
+/// Install the process-wide UPF pool (once, at startup). The first entry is
+/// also installed as the process-wide default client, so every legacy
+/// single-client path keeps its pre-pool behavior.
+pub fn set_global_pool(clients: Vec<Arc<PfcpClient>>) {
+    if let Some(first) = clients.first() {
+        set_global_client(first.clone());
+    }
+    let _ = PFCP_POOL.set(clients);
+}
+
+/// The process-wide UPF pool (all configured peers), if initialised.
+pub fn global_pool() -> Option<&'static [Arc<PfcpClient>]> {
+    PFCP_POOL.get().map(|v| v.as_slice())
+}
+
+/// Session → UPF binding: the SMF's own N4 SEID → PFCP peer address,
+/// recorded at session establishment. Modification/deletion of an existing
+/// session must keep signalling the UPF the session was established on,
+/// which stops being implicit once more than one UPF is configured.
+///
+/// Keyed by the SMF-side SEID (unique per SM context within this SMF), NOT
+/// the UPF-chosen SEID: every UPF allocates its SEIDs independently from 1,
+/// so UPF SEIDs collide across a multi-UPF pool.
+static SESSION_PEERS: OnceLock<std::sync::RwLock<HashMap<u64, SocketAddr>>> = OnceLock::new();
+
+fn session_peers() -> &'static std::sync::RwLock<HashMap<u64, SocketAddr>> {
+    SESSION_PEERS.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+/// Record which UPF a newly established session lives on (keyed by the
+/// SMF-side N4 SEID).
+pub fn record_session_peer(smf_n4_seid: u64, peer: SocketAddr) {
+    if let Ok(mut map) = session_peers().write() {
+        map.insert(smf_n4_seid, peer);
+    }
+}
+
+/// Drop the session → UPF binding once the session is deleted.
+pub fn forget_session_peer(smf_n4_seid: u64) {
+    if let Ok(mut map) = session_peers().write() {
+        map.remove(&smf_n4_seid);
+    }
+}
+
+/// Resolve the PFCP client serving an EXISTING session by the SMF-side N4
+/// SEID. Falls back to the process-wide default client when no binding is
+/// recorded; with a single configured UPF that is always the same client,
+/// so the legacy behavior is unchanged.
+pub fn client_for_session(smf_n4_seid: u64) -> Option<Arc<PfcpClient>> {
+    let peer = session_peers()
+        .read()
+        .ok()
+        .and_then(|map| map.get(&smf_n4_seid).copied());
+    if let (Some(peer), Some(pool)) = (peer, global_pool()) {
+        if let Some(client) = pool.iter().find(|c| c.peer() == peer) {
+            return Some(client.clone());
+        }
+    }
+    global_client()
+}
+
+/// Pick the UPF for a NEW session (issue #20; UPF load is a TS 23.501
+/// §6.3.3 selection input).
+///
+/// Off by default: without the `compute-aware-upf` cargo feature — or with a
+/// pool of at most one UPF — this returns the process-wide default client,
+/// i.e. exactly the pre-pool single-client path. With the feature enabled
+/// and several UPFs configured it returns the least-loaded *associated*
+/// peer, using the metric each UPF reports via Load Control Information on
+/// its heartbeat.
+///
+/// Rel-19 "Compute-Aware Networking" has no frozen Stage-3, so treating the
+/// metric as a compute signal (rather than plain session-occupancy load) is
+/// a non-normative research prototype.
+pub async fn select_upf() -> Option<Arc<PfcpClient>> {
+    if !cfg!(feature = "compute-aware-upf") {
+        return global_client();
+    }
+    let pool = match global_pool() {
+        Some(pool) if pool.len() > 1 => pool,
+        _ => return global_client(),
+    };
+    match select_upf_from(pool).await {
+        Some(client) => Some(client),
+        None => {
+            log::warn!(
+                "select_upf: no associated UPF in the pool; falling back to the default peer"
+            );
+            global_client()
+        }
+    }
+}
+
+/// Least-loaded-associated selection over an explicit candidate slice.
+/// Deliberately NOT feature-gated so the default CI build compiles and
+/// tests the full selection path; [`select_upf`] gates whether session
+/// establishment actually uses it.
+pub async fn select_upf_from(pool: &[Arc<PfcpClient>]) -> Option<Arc<PfcpClient>> {
+    let mut candidates = Vec::with_capacity(pool.len());
+    for client in pool {
+        let assoc = client.association().await;
+        candidates.push((assoc.associated, assoc.peer_load));
+    }
+    select_least_loaded(&candidates).map(|idx| pool[idx].clone())
+}
+
+/// Pure selection core: index of the least-loaded associated candidate.
+///
+/// Each slot is `(associated, reported load)`. Un-associated peers are never
+/// selected (TS 29.244 §6.2.6.2: no session signalling without an
+/// association). An associated peer that has not reported a metric is
+/// eligible but ranked worst (unknown load); ties resolve to the lowest
+/// index, so the choice is deterministic.
+pub fn select_least_loaded(candidates: &[(bool, Option<u8>)]) -> Option<usize> {
+    candidates
+        .iter()
+        .enumerate()
+        .filter(|(_, (associated, _))| *associated)
+        .min_by_key(|(_, (_, load))| load.map(u16::from).unwrap_or(u16::MAX))
+        .map(|(idx, _)| idx)
 }
 
 impl PfcpClient {
@@ -316,6 +452,21 @@ impl PfcpClient {
     /// Snapshot of the association state.
     pub async fn association(&self) -> AssociationState {
         self.assoc.read().await.clone()
+    }
+
+    /// Test-only: force association/load state. Unit tests cannot run the
+    /// full Association Setup handshake for every selection scenario.
+    #[cfg(test)]
+    pub(crate) async fn set_assoc_state_for_test(
+        &self,
+        associated: bool,
+        peer_load: Option<u8>,
+        peer_load_seq: Option<u32>,
+    ) {
+        let mut assoc = self.assoc.write().await;
+        assoc.associated = associated;
+        assoc.peer_load = peer_load;
+        assoc.peer_load_seq = peer_load_seq;
     }
 
     /// T1/N1 parameters for a given request type.
@@ -449,6 +600,25 @@ impl PfcpClient {
                 {
                     self.check_peer_restart(rts).await;
                 }
+                // Issue #20: the UPF may piggy-back its load metric (Load
+                // Control Information) on the heartbeat. Store it for
+                // load-aware selection, discarding stale sequence numbers.
+                {
+                    let mut body_bytes = Bytes::copy_from_slice(body);
+                    if let Ok(hb) = HeartbeatRequest::decode(&mut body_bytes) {
+                        if let Some(lci) = hb.load_control_information {
+                            let mut assoc = self.assoc.write().await;
+                            let newer = match assoc.peer_load_seq {
+                                Some(seq) => lci.sequence_number >= seq,
+                                None => true,
+                            };
+                            if newer {
+                                assoc.peer_load = Some(lci.metric.min(100));
+                                assoc.peer_load_seq = Some(lci.sequence_number);
+                            }
+                        }
+                    }
+                }
                 let msg = PfcpMessage::HeartbeatResponse(HeartbeatResponse::new(
                     self.recovery_time_stamp,
                 ));
@@ -502,6 +672,12 @@ impl PfcpClient {
         {
             let mut assoc = self.assoc.write().await;
             assoc.associated = false;
+            // Issue #20: a restarted UPF restarts its LCI sequence counter
+            // from 1, so the stored high-watermark would reject every fresh
+            // (low-seq) load report. Clear the load state so the first
+            // post-restart report (peer_load_seq == None) is accepted.
+            assoc.peer_load = None;
+            assoc.peer_load_seq = None;
         }
         let cleared = clear_pfcp_sessions();
         log::warn!("PFCP association torn down ({reason}); {cleared} stale sessions flushed");
@@ -958,6 +1134,159 @@ mod tests {
         assert_eq!(
             h.msg_type,
             pfcp_message_type::VERSION_NOT_SUPPORTED_RESPONSE
+        );
+    }
+
+    // ── Issue #20: load/compute-aware UPF selection ─────────────────────────
+
+    #[test]
+    fn test_select_least_loaded_prefers_associated_minimum() {
+        // Least-loaded associated peer wins; the unassociated peer with the
+        // lowest metric is never eligible.
+        let candidates = [
+            (true, Some(80)),
+            (false, Some(1)),
+            (true, Some(20)),
+            (true, None),
+        ];
+        assert_eq!(select_least_loaded(&candidates), Some(2));
+
+        // Unknown load ranks worst among associated peers.
+        assert_eq!(
+            select_least_loaded(&[(true, None), (true, Some(100))]),
+            Some(1)
+        );
+
+        // Ties resolve to the lowest index (deterministic).
+        assert_eq!(
+            select_least_loaded(&[(true, Some(10)), (true, Some(10))]),
+            Some(0)
+        );
+
+        // No associated peer -> no selection.
+        assert_eq!(
+            select_least_loaded(&[(false, Some(3)), (false, None)]),
+            None
+        );
+        assert_eq!(select_least_loaded(&[]), None);
+    }
+
+    /// Acceptance (issue #20): with the feature off — or a pool of one —
+    /// session establishment selects the sole/global client, i.e. the
+    /// pre-pool single-client path. This is the ONLY test that installs the
+    /// process-global pool (OnceLock allows a single set per test process).
+    #[tokio::test]
+    async fn test_select_upf_defaults_to_global_client_and_bindings_resolve() {
+        let (client, _upf) = make_client_with_peer().await;
+        set_global_pool(vec![client.clone()]);
+
+        let selected = select_upf().await.expect("pool installed");
+        assert_eq!(
+            selected.peer(),
+            client.peer(),
+            "sole/default client must be selected"
+        );
+
+        // client_for_session: unknown SEID falls back to the default client.
+        let resolved = client_for_session(0xDEAD).expect("default client");
+        assert_eq!(resolved.peer(), client.peer());
+
+        // A recorded binding resolves to the bound peer and survives until
+        // the session is forgotten.
+        record_session_peer(0x77, client.peer());
+        assert_eq!(client_for_session(0x77).unwrap().peer(), client.peer());
+        forget_session_peer(0x77);
+        assert_eq!(client_for_session(0x77).unwrap().peer(), client.peer());
+    }
+
+    /// Acceptance (issue #20): a PFCP Heartbeat Request carrying Load
+    /// Control Information is parsed and updates the originating peer's
+    /// stored metric on `AssociationState`; stale sequence numbers are
+    /// discarded.
+    #[tokio::test]
+    async fn test_heartbeat_lci_updates_association_state() {
+        let (client, upf) = make_client_with_peer().await;
+        let local_addr = client.socket.local_addr().unwrap();
+
+        let hb = |seq: u32, lci_seq: u32, metric: u8| {
+            let mut req = HeartbeatRequest::new(1111);
+            req.load_control_information = Some(
+                nextgcore_pfcp::types::LoadControlInformation::new(lci_seq, metric),
+            );
+            build_message(&PfcpMessage::HeartbeatRequest(req), seq, None)
+        };
+        // Each send is followed by the engine's Heartbeat Response; waiting
+        // for it guarantees the request (and its LCI) was processed.
+        async fn exchange(upf: &UdpSocket, to: SocketAddr, pkt: &[u8]) {
+            upf.send_to(pkt, to).await.unwrap();
+            let mut buf = vec![0u8; 1024];
+            tokio::time::timeout(Duration::from_secs(2), upf.recv_from(&mut buf))
+                .await
+                .expect("heartbeat response expected")
+                .unwrap();
+        }
+
+        // First report: stored.
+        exchange(&upf, local_addr, &hb(1, 10, 30)).await;
+        let assoc = client.association().await;
+        assert_eq!(assoc.peer_load, Some(30));
+        assert_eq!(assoc.peer_load_seq, Some(10));
+
+        // Stale sequence number: ignored.
+        exchange(&upf, local_addr, &hb(2, 5, 90)).await;
+        assert_eq!(client.association().await.peer_load, Some(30));
+
+        // Newer sequence number: applied.
+        exchange(&upf, local_addr, &hb(3, 11, 55)).await;
+        let assoc = client.association().await;
+        assert_eq!(assoc.peer_load, Some(55));
+        assert_eq!(assoc.peer_load_seq, Some(11));
+    }
+
+    /// Acceptance (issue #20): the full selection path over real clients —
+    /// the least-loaded ASSOCIATED peer wins and an un-associated peer is
+    /// never selected. Runs in the default build (select_upf_from is not
+    /// feature-gated); the feature only gates whether establishment calls it.
+    #[tokio::test]
+    async fn test_select_upf_from_picks_least_loaded_associated() {
+        let (a, _peer_a) = make_client_with_peer().await;
+        let (b, _peer_b) = make_client_with_peer().await;
+        let (c, _peer_c) = make_client_with_peer().await;
+        a.set_assoc_state_for_test(true, Some(70), Some(1)).await;
+        // Least-loaded overall, but un-associated: never eligible.
+        b.set_assoc_state_for_test(false, Some(5), Some(1)).await;
+        c.set_assoc_state_for_test(true, Some(20), Some(1)).await;
+
+        let pool = vec![a.clone(), b, c.clone()];
+        let picked = select_upf_from(&pool)
+            .await
+            .expect("associated peers exist");
+        assert_eq!(picked.peer(), c.peer());
+
+        // All un-associated -> no selection.
+        a.set_assoc_state_for_test(false, Some(70), Some(1)).await;
+        c.set_assoc_state_for_test(false, Some(20), Some(1)).await;
+        assert!(select_upf_from(&pool).await.is_none());
+    }
+
+    /// Issue #20 review regression: association teardown clears the stored
+    /// load state, so a restarted UPF (whose LCI sequence counter restarts
+    /// from 1) is not stuck behind the old high-watermark.
+    #[tokio::test]
+    async fn test_teardown_clears_load_state() {
+        let (client, _upf) = make_client_with_peer().await;
+        client
+            .set_assoc_state_for_test(true, Some(40), Some(5000))
+            .await;
+
+        client.teardown_association("test: peer restarted").await;
+
+        let assoc = client.association().await;
+        assert!(!assoc.associated);
+        assert_eq!(assoc.peer_load, None);
+        assert_eq!(
+            assoc.peer_load_seq, None,
+            "a fresh low-seq post-restart report must be acceptable again"
         );
     }
 }

--- a/src/bins/nextgcore-upfd/Cargo.toml
+++ b/src/bins/nextgcore-upfd/Cargo.toml
@@ -10,6 +10,15 @@ description = "NextGCore UPF (User Plane Function)"
 name = "nextgcore-upfd"
 path = "src/main.rs"
 
+[features]
+## Issue #20: attach a Load Control Information IE (TS 29.244 7.4.3.2:
+## Sequence Number + Metric = session-occupancy percentage from get_load())
+## to UPF-initiated PFCP Heartbeat Requests so the SMF can do load/compute-
+## aware UPF selection. Off by default: heartbeat wire bytes are unchanged.
+## Rel-19 "Compute-Aware Networking" has no frozen Stage-3 (research knob).
+## Enable with: cargo build -p nextgcore-upfd --features compute-aware-upf
+compute-aware-upf = []
+
 [dependencies]
 nextgcore-core = { workspace = true }
 nextgcore-pfcp = { workspace = true }

--- a/src/bins/nextgcore-upfd/src/n4_build.rs
+++ b/src/bins/nextgcore-upfd/src/n4_build.rs
@@ -117,6 +117,9 @@ pub mod pfcp_ie {
     pub const DESTINATION_INTERFACE: u16 = 42;
     pub const UP_FUNCTION_FEATURES: u16 = 43;
     pub const APPLY_ACTION: u16 = 44;
+    pub const LOAD_CONTROL_INFORMATION: u16 = 51;
+    pub const SEQUENCE_NUMBER: u16 = 52;
+    pub const METRIC: u16 = 53;
     pub const PDR_ID: u16 = 56;
     pub const F_SEID: u16 = 57;
     pub const NODE_ID: u16 = 60;
@@ -1697,6 +1700,34 @@ pub fn build_heartbeat_request(recovery_time_stamp: u32) -> Vec<u8> {
     builder.build()
 }
 
+/// Build a Heartbeat Request carrying a Load Control Information grouped IE
+/// (issue #20: load/compute-aware UPF selection).
+///
+/// Children per TS 29.244 §7.4.3.2: Load Control Sequence Number (IE 52,
+/// u32) + Load Metric (IE 53, one octet, 0..=100 percentage per §8.2.53).
+/// Carrying the IE on the heartbeat is a nextgcore extension (TS 29.244
+/// defines it for session-level messages); the Rel-19 "Compute-Aware
+/// Networking" study has no frozen Stage-3, so the compute reading of the
+/// metric is a non-normative research prototype.
+pub fn build_heartbeat_request_with_load(
+    recovery_time_stamp: u32,
+    load_seq: u32,
+    load_metric: u8,
+) -> Vec<u8> {
+    let mut builder = PfcpMessageBuilder::new();
+    builder.add_u32(pfcp_ie::RECOVERY_TIME_STAMP, recovery_time_stamp);
+    // Grouped LCI: encode the two child TLVs into a scratch buffer first.
+    let mut lci = Vec::with_capacity(13);
+    lci.extend_from_slice(&pfcp_ie::SEQUENCE_NUMBER.to_be_bytes());
+    lci.extend_from_slice(&4u16.to_be_bytes());
+    lci.extend_from_slice(&load_seq.to_be_bytes());
+    lci.extend_from_slice(&pfcp_ie::METRIC.to_be_bytes());
+    lci.extend_from_slice(&1u16.to_be_bytes());
+    lci.push(load_metric.min(100));
+    builder.add_tlv(pfcp_ie::LOAD_CONTROL_INFORMATION, &lci);
+    builder.build()
+}
+
 /// UP Function Features actually implemented by this UPF.
 ///
 /// Only features with working code paths are advertised (TS 29.244 8.2.25):
@@ -1817,6 +1848,46 @@ pub fn parse_pfcpsmreq_flags(payload: &[u8]) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #20 cross-codec check: the raw-TLV heartbeat-with-load builder
+    /// must produce bytes the workspace nextgcore-pfcp codec (used by the
+    /// SMF receive side) parses back into the same Load Control Information.
+    #[test]
+    fn test_heartbeat_request_with_load_parses_via_lib_codec() {
+        let payload = build_heartbeat_request_with_load(0xDEAD_BEEF, 41, 87);
+        let mut bytes = bytes::Bytes::from(payload);
+        let decoded = nextgcore_pfcp::message::HeartbeatRequest::decode(&mut bytes)
+            .expect("lib codec must parse the UPF-built heartbeat");
+        assert_eq!(decoded.recovery_time_stamp, 0xDEAD_BEEF);
+        let lci = decoded
+            .load_control_information
+            .expect("LCI must survive the cross-codec round trip");
+        assert_eq!(lci.sequence_number, 41);
+        assert_eq!(lci.metric, 87);
+    }
+
+    /// The metric is a TS 29.244 §8.2.53 percentage: values above 100 are
+    /// clamped at build time.
+    #[test]
+    fn test_heartbeat_request_with_load_clamps_metric() {
+        let payload = build_heartbeat_request_with_load(1, 1, 250);
+        let mut bytes = bytes::Bytes::from(payload);
+        let decoded = nextgcore_pfcp::message::HeartbeatRequest::decode(&mut bytes).unwrap();
+        assert_eq!(decoded.load_control_information.unwrap().metric, 100);
+    }
+
+    /// Regression: the default heartbeat builder stays byte-for-byte free of
+    /// the Load Control Information IE (feature-off wire compatibility).
+    #[test]
+    fn test_plain_heartbeat_request_has_no_lci() {
+        let payload = build_heartbeat_request(7);
+        // One RecoveryTimeStamp TLV only: 4-byte IE header + 4-byte value.
+        assert_eq!(payload.len(), 8);
+        let mut bytes = bytes::Bytes::from(payload);
+        let decoded = nextgcore_pfcp::message::HeartbeatRequest::decode(&mut bytes).unwrap();
+        assert_eq!(decoded.recovery_time_stamp, 7);
+        assert!(decoded.load_control_information.is_none());
+    }
 
     #[test]
     fn test_pfcp_cause_from_u8() {

--- a/src/bins/nextgcore-upfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-upfd/src/pfcp_path.rs
@@ -863,8 +863,21 @@ impl PfcpServer {
     /// direction, TS 29.244 7.4.2). Returns the peer address if one was sent.
     pub async fn send_heartbeat_request(&self) -> Option<SocketAddr> {
         let peer = self.association.read().await.as_ref()?.peer_addr;
-        let payload = crate::n4_build::build_heartbeat_request(self.recovery_time_stamp);
         let seq = self.alloc_seq();
+        // Issue #20 (compute-aware-upf): piggy-back the session-occupancy
+        // load metric on the periodic heartbeat as a Load Control
+        // Information IE. The LCI sequence number reuses this request's
+        // monotonic PFCP sequence number so the SMF can discard stale
+        // updates. Off by default: the wire bytes are unchanged unless the
+        // feature is enabled.
+        #[cfg(feature = "compute-aware-upf")]
+        let payload = crate::n4_build::build_heartbeat_request_with_load(
+            self.recovery_time_stamp,
+            seq,
+            crate::context::upf_self().get_load(),
+        );
+        #[cfg(not(feature = "compute-aware-upf"))]
+        let payload = crate::n4_build::build_heartbeat_request(self.recovery_time_stamp);
         let message = self.build_response(pfcp_type::HEARTBEAT_REQUEST, 0, seq, &payload, false);
         match self.socket.send_to(&message, peer).await {
             Ok(_) => {

--- a/src/libs/nextgcore-pfcp/src/message.rs
+++ b/src/libs/nextgcore-pfcp/src/message.rs
@@ -7,10 +7,10 @@ use crate::header::{PfcpHeader, PfcpMessageType};
 use crate::ie::{encode_u16_ie, encode_u32_ie, encode_u8_ie, IeHeader, IeType, RawIe};
 use crate::types::{
     ApplicationIdsPfds, CpFunctionFeatures, CreateBar, CreateFar, CreatePdr, CreateQer, CreateUrr,
-    DownlinkDataReport, FSeid, FqCsid, GracefulReleasePeriod, NodeId, NodeReportType,
-    PfcpAssociationReleaseRequest, PfcpCause, PfcpSessionChangeInfo, PfdPartialFailureInformation,
-    RemoveFar, RemovePdr, ReportType, UpFunctionFeatures, UpdateFar, UpdatePdr, UsageReportSrr,
-    UserPlanePathFailureReport,
+    DownlinkDataReport, FSeid, FqCsid, GracefulReleasePeriod, LoadControlInformation, NodeId,
+    NodeReportType, PfcpAssociationReleaseRequest, PfcpCause, PfcpSessionChangeInfo,
+    PfdPartialFailureInformation, RemoveFar, RemovePdr, ReportType, UpFunctionFeatures, UpdateFar,
+    UpdatePdr, UsageReportSrr, UserPlanePathFailureReport,
 };
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
@@ -18,32 +18,58 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeartbeatRequest {
     pub recovery_time_stamp: u32,
+    /// Optional Load Control Information (issue #20): a UP function may
+    /// piggy-back its load metric on the periodic heartbeat so the CP
+    /// function can do load-aware UPF selection (TS 23.501 Section 6.3.3
+    /// input; heartbeat carriage itself is a nextgcore extension, see
+    /// [`LoadControlInformation`]). Absent on standard peers.
+    pub load_control_information: Option<LoadControlInformation>,
 }
 
 impl HeartbeatRequest {
     pub fn new(recovery_time_stamp: u32) -> Self {
         Self {
             recovery_time_stamp,
+            load_control_information: None,
         }
     }
 
     pub fn encode(&self, buf: &mut BytesMut) {
         encode_u32_ie(buf, IeType::RecoveryTimeStamp, self.recovery_time_stamp);
+
+        if let Some(lci) = &self.load_control_information {
+            let mut lci_buf = BytesMut::new();
+            lci.encode(&mut lci_buf);
+            let header = IeHeader::new(IeType::LoadControlInformation as u16, lci_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&lci_buf);
+        }
     }
 
     pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
         let mut recovery_time_stamp = 0u32;
+        let mut load_control_information = None;
 
         while buf.remaining() >= IeHeader::LEN {
             let ie = RawIe::decode(buf)?;
-            if ie.ie_type == IeType::RecoveryTimeStamp as u16 && ie.data.len() >= 4 {
-                let mut data = ie.data;
-                recovery_time_stamp = data.get_u32();
+            match ie.ie_type {
+                t if t == IeType::RecoveryTimeStamp as u16 => {
+                    if ie.data.len() >= 4 {
+                        let mut data = ie.data;
+                        recovery_time_stamp = data.get_u32();
+                    }
+                }
+                t if t == IeType::LoadControlInformation as u16 => {
+                    let mut data = ie.data;
+                    load_control_information = Some(LoadControlInformation::decode(&mut data)?);
+                }
+                _ => {}
             }
         }
 
         Ok(Self {
             recovery_time_stamp,
+            load_control_information,
         })
     }
 }
@@ -2122,9 +2148,71 @@ mod tests {
 
         if let PfcpMessage::HeartbeatRequest(req) = decoded {
             assert_eq!(req.recovery_time_stamp, 1234567890);
+            // A plain heartbeat carries no Load Control Information.
+            assert!(req.load_control_information.is_none());
         } else {
             panic!("Wrong message type");
         }
+    }
+
+    // Issue #20: Load Control Information piggy-backed on the heartbeat.
+    #[test]
+    fn test_build_parse_heartbeat_with_load_control() {
+        let mut hb = HeartbeatRequest::new(1234567890);
+        hb.load_control_information = Some(LoadControlInformation::new(7, 42));
+        let msg = PfcpMessage::HeartbeatRequest(hb);
+        let buf = build_message(&msg, 2, None);
+
+        let mut bytes = buf.freeze();
+        let (header, decoded) = parse_message(&mut bytes).unwrap();
+
+        assert_eq!(header.message_type, PfcpMessageType::HeartbeatRequest);
+        if let PfcpMessage::HeartbeatRequest(req) = decoded {
+            assert_eq!(req.recovery_time_stamp, 1234567890);
+            let lci = req.load_control_information.expect("LCI must round-trip");
+            assert_eq!(lci.sequence_number, 7);
+            assert_eq!(lci.metric, 42);
+        } else {
+            panic!("Wrong message type");
+        }
+    }
+
+    #[test]
+    fn test_heartbeat_load_control_exact_bytes() {
+        // RTS IE (96, len 4) + LCI grouped IE (51, len 13) containing
+        // Sequence Number (52, len 4) + Metric (53, len 1).
+        let mut hb = HeartbeatRequest::new(0x0102_0304);
+        hb.load_control_information = Some(LoadControlInformation::new(1, 100));
+        let mut buf = BytesMut::new();
+        hb.encode(&mut buf);
+        assert_eq!(
+            buf.as_ref(),
+            &[
+                0x00, 0x60, 0x00, 0x04, 0x01, 0x02, 0x03, 0x04, // RecoveryTimeStamp
+                0x00, 0x33, 0x00, 0x0D, // LoadControlInformation header
+                0x00, 0x34, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01, // SequenceNumber
+                0x00, 0x35, 0x00, 0x01, 0x64, // Metric = 100
+            ]
+        );
+
+        let mut bytes = buf.freeze();
+        let decoded = HeartbeatRequest::decode(&mut bytes).unwrap();
+        assert_eq!(
+            decoded.load_control_information,
+            Some(LoadControlInformation::new(1, 100))
+        );
+    }
+
+    #[test]
+    fn test_load_control_information_missing_children_rejected() {
+        // A Metric-less LCI (only a Sequence Number child) must be rejected.
+        let mut inner = BytesMut::new();
+        encode_u32_ie(&mut inner, IeType::SequenceNumber, 9);
+        let mut bytes = inner.freeze();
+        assert!(matches!(
+            LoadControlInformation::decode(&mut bytes),
+            Err(PfcpError::MissingMandatoryIe(_))
+        ));
     }
 
     #[test]

--- a/src/libs/nextgcore-pfcp/src/types.rs
+++ b/src/libs/nextgcore-pfcp/src/types.rs
@@ -1787,6 +1787,80 @@ impl MeasurementMethod {
     }
 }
 
+/// Load Control Information - grouped IE (TS 29.244 Section 7.4.3.2)
+///
+/// Carried by a UP function to convey its load toward the CP function.
+/// Children: Load Control Sequence Number (IE 52, u32, mandatory) and Load
+/// Metric (IE 53, one octet 0..=100 percentage per Section 8.2.53,
+/// mandatory). The sequence number lets the receiver order metric updates;
+/// a stale (lower) sequence number must not overwrite a newer metric.
+///
+/// Issue #20 note: TS 29.244 defines this IE for session-level responses and
+/// Session Report Requests; nextgcore additionally carries it on the PFCP
+/// Heartbeat Request (a self-contained UPF->SMF periodic channel) for
+/// load/compute-aware UPF selection. The Rel-19 "Compute-Aware Networking"
+/// study has no frozen Stage-3, so treating the metric as a compute signal
+/// is a non-normative research prototype; the load-aware use itself is a
+/// TS 23.501 Section 6.3.3 UPF-selection input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoadControlInformation {
+    /// Load Control Sequence Number (TS 29.244 Section 8.2.52).
+    pub sequence_number: u32,
+    /// Load Metric: percentage 0..=100 of the UP function's nominal capacity
+    /// in use (TS 29.244 Section 8.2.53).
+    pub metric: u8,
+}
+
+impl LoadControlInformation {
+    pub fn new(sequence_number: u32, metric: u8) -> Self {
+        Self {
+            sequence_number,
+            metric,
+        }
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        use crate::ie::{encode_u32_ie, encode_u8_ie, IeType};
+
+        encode_u32_ie(buf, IeType::SequenceNumber, self.sequence_number);
+        encode_u8_ie(buf, IeType::Metric, self.metric);
+    }
+
+    pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
+        use crate::ie::{IeHeader, IeType, RawIe};
+
+        let mut sequence_number = None;
+        let mut metric = None;
+
+        while buf.remaining() >= IeHeader::LEN {
+            let ie = RawIe::decode(buf)?;
+            match ie.ie_type {
+                t if t == IeType::SequenceNumber as u16 => {
+                    if ie.data.len() >= 4 {
+                        let mut data = ie.data;
+                        sequence_number = Some(data.get_u32());
+                    }
+                }
+                t if t == IeType::Metric as u16 => {
+                    if !ie.data.is_empty() {
+                        metric = Some(ie.data[0]);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let sequence_number = sequence_number
+            .ok_or_else(|| PfcpError::MissingMandatoryIe("Sequence Number".to_string()))?;
+        let metric = metric.ok_or_else(|| PfcpError::MissingMandatoryIe("Metric".to_string()))?;
+
+        Ok(Self {
+            sequence_number,
+            metric,
+        })
+    }
+}
+
 /// PDI (Packet Detection Information) - grouped IE within PDR
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Pdi {


### PR DESCRIPTION
Closes #20

## Summary

Implements load/compute-aware UPF selection in the SMF as a **feature-gated, off-by-default** increment (cargo feature `compute-aware-upf` on smfd and upfd). With the feature enabled and several UPFs configured, a **new** PDU session is placed on the **least-loaded associated** UPF, using a load metric each UPF reports in-band over PFCP. With the feature off (default) or a single UPF configured, session establishment uses the same single-client path as before.

The load-aware core follows TS 23.501 §6.3.3 (UPF load information as an SMF selection input). Rel-19 "Compute-Aware Networking" has no frozen Stage-3, so carrying the metric on the PFCP heartbeat and any compute reading of it are documented **non-normative research** — noted in the codec docs, feature comments, and `select_upf` docs per the issue's acceptance criteria.

## How the metric flows

```
UPF (get_load(): PFCP-session occupancy 0..=100)
  └─ [feature on] Heartbeat Request + Load Control Information (IE 51:
     Sequence Number IE 52 + Metric IE 53, TS 29.244 §7.4.3.2/§8.2.52-53)
        └─ SMF pfcp_path on_datagram: parse (always) → AssociationState
           { peer_load, peer_load_seq }  (stale seq discarded; cleared on
           association teardown so a restarted UPF's fresh low-seq
           reports are accepted)
              └─ [feature on] select_upf(): least-loaded ASSOCIATED pool
                 peer for NEW sessions; never an un-associated peer
```

## Changes by crate

**nextgcore-pfcp** (unconditional, additive): new `LoadControlInformation` grouped-IE codec; `HeartbeatRequest` gains `load_control_information: Option<…>` (`new()` unchanged; wire bytes identical when absent, so standard peers are unaffected).

**nextgcore-upfd**: `build_heartbeat_request_with_load()` raw-TLV builder (+ IE consts 51/52/53), metric clamped to ≤100, cross-codec-tested against the lib parser. Only the heartbeat call site is feature-gated; LCI seq reuses the request's monotonic PFCP sequence so the SMF can order updates.

**nextgcore-smfd**:
- `UPF_PFCP_ADDR` accepts a comma-separated peer list (`10.0.0.5,10.0.0.6:8806`; portless entries use `UPF_PFCP_PORT`). One `PfcpClient` per peer on the shared N4 socket; RX datagrams routed to the owning client by source address; association + heartbeat maintenance runs **per peer** so one unreachable UPF cannot starve heartbeats to healthy pool members.
- Session→UPF binding keyed by the **SMF-side N4 SEID** (UPF-chosen SEIDs collide across a pool — every UPF allocates from 1): modification, deletion, QER update, and DL-FAR deactivation always signal the UPF the session was established on; the binding is dropped on delete.
- `select_upf()` (feature-gated behavior) delegates to `select_upf_from()` (unconditional, so default CI compiles and tests the full selection path).

## Adversarial review (multi-agent, 4 dimensions → 13 findings → 3-skeptic verification)

Four findings survived and are fixed in this PR: (1) association teardown now clears `peer_load`/`peer_load_seq` — a restarted UPF restarts its LCI counter from 1 and would otherwise be stuck behind the old high-watermark; (2) the binding map was re-keyed from UPF SEID to SMF N4 SEID to eliminate cross-UPF SEID collisions (misrouted modify/delete); (3) the association loop was made per-peer (no shared failure flag that skipped the pool-wide heartbeat pass); (4) the selection path got an end-to-end test (`select_upf_from` over real clients) that runs in the default build.

## Default-path guarantees

- Feature off + single `UPF_PFCP_ADDR` (the default): pool of one, `select_upf()` returns the process-wide client, heartbeat bytes unchanged, association cadence unchanged. Multi-entry `UPF_PFCP_ADDR` previously failed to parse at startup, so no existing deployment is affected by the new syntax.
- CI (`--workspace`, no `--features`) covers everything except the two feature-gated call sites; both feature configs were additionally verified locally: build, clippy, and all tests green (`nextgcore-pfcp` 109, `nextgcore-upfd` 278, `nextgcore-smfd` 377 in each config).

## Acceptance criteria → evidence

| Criterion | Evidence |
|---|---|
| Builds + clippy with and without the feature | verified both configs, both bins |
| Feature off / single UPF → legacy single-client path | `test_select_upf_defaults_to_global_client_and_bindings_resolve`, `select_least_loaded` pure tests |
| Least-loaded **associated** peer, never un-associated | `test_select_upf_from_picks_least_loaded_associated`, `test_select_least_loaded_prefers_associated_minimum` |
| LCI round-trip updates `AssociationState` | `test_heartbeat_lci_updates_association_state` (end-to-end over a real socket, incl. staleness discard), lib exact-bytes + mandatory-child-rejection tests, upfd cross-codec test |
| CAN non-normative doc note | `LoadControlInformation` docs, both `[features]` comments, `select_upf` docs |

Out of scope (per issue): NRF-based UPF discovery in the SMF, the optional operator-supplied compute weight (the metric source stays `get_load()` session occupancy), and the dead `no_pfcp_rr_select` config flag (untouched).
