### PR TITLE
feat(nes): per-NF energy metrics + feature-gated idle/sleep hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **nextgcore** (42054 symbols, 95664 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **nextgcore** (42274 symbols, 96147 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **nextgcore** (42054 symbols, 95664 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **nextgcore** (42274 symbols, 96147 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/NES.md
+++ b/docs/NES.md
@@ -1,0 +1,86 @@
+# Network Energy Saving (NES) — issue #22
+
+**Status: non-normative research prototype, off by default.** 3GPP defines
+the NF-profile `nfStatus` values used here (`REGISTERED`/`SUSPENDED`,
+TS 23.501/TS 29.510) and the energy-efficiency KPI families (TS 28.310),
+but there is **no frozen Rel-20 Stage-3 "6G NES" feature** — the sleep
+policy and the power numbers below are prototypes for research/education.
+
+## What it does
+
+With the `nes` cargo feature enabled on the reference NF (**udmd**) *and*
+an `nes.enabled: true` config block, the NF runs an idle/sleep loop built
+from three reusable pieces:
+
+- `nextgcore_sbi::nes::NesMachine` — a pure state machine:
+  `Active → (idle > threshold) → Draining → (in-flight settled) →
+  Suspended`, and `Suspended → (inbound activity) → Active`.
+  **Graceful drain:** the suspend transition never fires while requests are
+  in flight; if the drain window expires with work pending, the sleep
+  attempt aborts back to `Active` — no request is ever dropped.
+- `nextgcore_sbi::heartbeat` NES plumbing — the heartbeat worker now emits
+  the NF's *live* status (`build_status_patch`; default `REGISTERED` is
+  byte-identical to the historical patch), can be paused
+  (`set_heartbeat_paused`, for the deregister action), and
+  `patch_nf_status` issues the one-off transition PATCH.
+- `nextgcore_metrics::nes_energy` — live energy gauges + a minimal real
+  HTTP/1.1 `/metrics` listener (the legacy `MetricsServer` is a
+  non-binding stub).
+
+Sleep is reflected to the NRF by one of two config-selectable actions:
+
+| `action` | on suspend | on resume |
+|---|---|---|
+| `suspend` (default) | PATCH `nfStatus=SUSPENDED`; heartbeats continue, advertising `SUSPENDED` | PATCH `nfStatus=REGISTERED` |
+| `deregister` | pause heartbeats + `DELETE /nnrf-nfm/v1/nf-instances/{id}` | re-register under the same NF instance ID + unpause heartbeats |
+
+**nrfd change:** the NRF previously treated *any* heartbeat PATCH as a
+liveness signal and flipped a `SUSPENDED` profile back to `REGISTERED` —
+which would instantly undo a self-suspension. `handle_nf_update` now honors
+a PATCH whose body itself sets `nfStatus=SUSPENDED` (self-suspension) and
+skips the reactivation; the liveness timer still re-arms, so a
+sleeping-but-heartbeating NF is not auto-deregistered.
+
+## Config (`udm.yaml`, off by default)
+
+```yaml
+udm:
+  nes:
+    enabled: true            # default false — absent block = complete no-op
+    idle_threshold_secs: 300 # no inbound SBI activity before draining
+    drain_timeout_secs: 10   # max wait for in-flight work; expiry aborts
+    poll_interval_secs: 5
+    action: suspend          # suspend | deregister
+    metrics_port: 9090       # /metrics listener
+    # synthetic power model knobs:
+    capacity_rps: 100.0
+    idle_power_w: 5.0
+    max_power_w: 25.0
+```
+
+Build: `cargo build -p nextgcore-udmd --features nes`. With the feature
+off (the default build) behavior is byte-for-byte unchanged: no new
+metrics listener, no NRF status changes, the heartbeat JSON is identical.
+
+## Metrics (`curl http://<nf>:9090/metrics`)
+
+TS 28.310-aligned family (labels `nf_type`, `nf_id`):
+`energy_consumption_watts`, `energy_consumed_joules_total`,
+`energy_data_volume_bits_total`, `energy_efficiency_bits_per_joule`,
+`energy_sleep_ratio`, plus the new `nf_utilization_ratio` (0.0–1.0).
+
+## Synthetic power model (caveat)
+
+There are **no hardware energy counters** in this core; the numbers are a
+documented synthetic model computed each poll tick:
+
+```
+utilization = min(1.0, requests_this_tick / (capacity_rps * dt))
+power_w     = suspended ? 0.1 * idle_power_w
+                        : idle_power_w + (max_power_w - idle_power_w) * utilization
+joules     += power_w * dt
+data_bits  += requests_this_tick * 8192   # 1 request ≈ 8 kbit proxy
+sleep_ratio = time_suspended / observed_time
+```
+
+Treat every derived KPI (bits/J in particular) as illustrative only.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2686,6 +2686,7 @@ dependencies = [
  "proptest",
  "serde_yaml",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -1090,6 +1090,24 @@ pub fn compute_profile_changes(
 /// (TS 29.510 also allows 204; we return the profile for visibility).
 /// A failed RFC 6902 `test` op maps to 409 Conflict (RFC 5789 §2.2);
 /// malformed/inapplicable patches map to 400 ProblemDetails.
+/// Issue #22 NES: does this NFUpdate body explicitly set
+/// `nfStatus=SUSPENDED`? Such a PATCH is a self-suspension (energy saving)
+/// the NRF must honor rather than treat as a liveness signal that
+/// reactivates the profile. Covers both RFC 6902 arrays and merge-patch
+/// objects (the same shapes `handle_nf_update` dispatches on).
+fn patch_requests_self_suspension(patch: &serde_json::Value, is_json_patch: bool) -> bool {
+    if is_json_patch {
+        patch.as_array().is_some_and(|ops| {
+            ops.iter().any(|op| {
+                op.get("path").and_then(|p| p.as_str()) == Some("/nfStatus")
+                    && op.get("value").and_then(|v| v.as_str()) == Some("SUSPENDED")
+            })
+        })
+    } else {
+        patch.get("nfStatus").and_then(|v| v.as_str()) == Some("SUSPENDED")
+    }
+}
+
 async fn handle_nf_update(nf_instance_id: &str, request: &SbiRequest) -> SbiResponse {
     log::info!("NF Update: {nf_instance_id}");
 
@@ -1217,7 +1235,16 @@ async fn handle_nf_update(nf_instance_id: &str, request: &SbiRequest) -> SbiResp
     // A heartbeat on a SUSPENDED NF restores it to REGISTERED (TS 29.510).
     // The status transition is always a material change — notify regardless
     // of whether other fields changed (nrfd-02 reactivate path).
-    if manager.reactivate(nf_instance_id) {
+    //
+    // Issue #22 NES exception: a PATCH whose body itself sets nfStatus to
+    // SUSPENDED is an explicit self-suspension (energy saving), not a
+    // liveness signal — honor it instead of reactivating. The liveness
+    // timer was still re-armed above, so a sleeping-but-heartbeating NF is
+    // not auto-deregistered.
+    let self_suspension = patch_requests_self_suspension(&patch, is_json_patch);
+    if self_suspension {
+        log::info!("NF {nf_instance_id} self-suspended (NES); skipping heartbeat reactivation");
+    } else if manager.reactivate(nf_instance_id) {
         log::info!("NF {nf_instance_id} heartbeat received while SUSPENDED, back to REGISTERED");
         // Build the status-change ChangeItem from the reactivation.
         let reactivate_changes = vec![ChangeItem {
@@ -3336,6 +3363,38 @@ mod tests {
         );
         assert!(result.is_ok(), "dispatch must succeed: {result:?}");
         assert_eq!(result.unwrap(), 1, "exactly one notification dispatched");
+    }
+
+    /// Issue #22 NES: a PATCH that itself sets nfStatus=SUSPENDED is a
+    /// self-suspension and must NOT be treated as a reactivating heartbeat;
+    /// ordinary heartbeat/load patches still reactivate.
+    #[test]
+    fn test_nes_self_suspension_detection() {
+        use serde_json::json;
+
+        // RFC 6902 self-suspension (the NES heartbeat shape).
+        let suspend = json!([
+            {"op": "replace", "path": "/nfStatus", "value": "SUSPENDED"},
+            {"op": "add",     "path": "/load",     "value": 0}
+        ]);
+        assert!(patch_requests_self_suspension(&suspend, true));
+
+        // Ordinary heartbeat (REGISTERED) — reactivation stays allowed.
+        let heartbeat = json!([
+            {"op": "replace", "path": "/nfStatus", "value": "REGISTERED"},
+            {"op": "add",     "path": "/load",     "value": 12}
+        ]);
+        assert!(!patch_requests_self_suspension(&heartbeat, true));
+
+        // Load-only patch — not a self-suspension.
+        let load_only = json!([{"op": "replace", "path": "/load", "value": 50}]);
+        assert!(!patch_requests_self_suspension(&load_only, true));
+
+        // Merge-patch object form.
+        let merge = json!({"nfStatus": "SUSPENDED"});
+        assert!(patch_requests_self_suspension(&merge, false));
+        let merge_reg = json!({"nfStatus": "REGISTERED", "load": 3});
+        assert!(!patch_requests_self_suspension(&merge_reg, false));
     }
 
     /// Assert that the SUSPENDED→REGISTERED reactivate path produces a

--- a/src/bins/nextgcore-udmd/Cargo.toml
+++ b/src/bins/nextgcore-udmd/Cargo.toml
@@ -17,6 +17,15 @@ path = "src/main.rs"
 name = "nextgcore_udmd"
 path = "src/lib.rs"
 
+[features]
+## Issue #22: Network Energy Saving (non-normative research prototype; no
+## frozen Rel-20 Stage-3 exists). Adds an idle->drain->suspend runtime that
+## reflects sleep to the NRF (nfStatus=SUSPENDED or deregistration) and a
+## live /metrics energy endpoint fed by a SYNTHETIC power model. Off by
+## default: the default build is byte-for-byte unchanged.
+## Enable with: cargo build -p nextgcore-udmd --features nes
+nes = []
+
 [dependencies]
 nextgcore-core = { workspace = true }
 nextgcore-crypt = { workspace = true }

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -135,9 +135,28 @@ struct UpuYaml {
     ack_ind: Option<bool>,
 }
 
+/// Issue #22 NES sleep-policy block (off by default; only read under the
+/// `nes` cargo feature).
+#[derive(Debug, Default, Deserialize, Clone)]
+pub(crate) struct NesYaml {
+    pub(crate) enabled: Option<bool>,
+    pub(crate) idle_threshold_secs: Option<u64>,
+    pub(crate) drain_timeout_secs: Option<u64>,
+    pub(crate) poll_interval_secs: Option<u64>,
+    /// "suspend" (PATCH nfStatus=SUSPENDED) or "deregister".
+    pub(crate) action: Option<String>,
+    pub(crate) metrics_port: Option<u16>,
+    /// Synthetic power model knobs (documented in docs/NES.md).
+    pub(crate) capacity_rps: Option<f64>,
+    pub(crate) idle_power_w: Option<f64>,
+    pub(crate) max_power_w: Option<f64>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct UdmSection {
     sbi: Option<SbiYaml>,
+    /// Issue #22 NES sleep-policy block (only read under the `nes` feature).
+    nes: Option<NesYaml>,
     hnet: Option<Vec<HnetYaml>>,
     /// udmd-11: explicitly enable null-scheme SUCI (default: true).
     allow_null_scheme: Option<bool>,
@@ -156,6 +175,13 @@ struct UdmYaml {
 
 /// Global shutdown flag
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+/// Issue #22 NES bookkeeping (inert without the `nes` feature): inbound SBI
+/// request counter (activity detection) and in-flight tracker (the graceful
+/// drain gate).
+pub(crate) static NES_REQUESTS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+pub(crate) static NES_IN_FLIGHT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 // ---------------------------------------------------------------------------
 // OAuth2 rollout (Wave-6 H8): opt-in producer verification + outbound consumer
@@ -296,6 +322,8 @@ pub async fn run() -> Result<()> {
     log::info!("UDM state machine initialized");
 
     // Parse configuration (if file exists) and seed NRF URI
+    #[cfg(feature = "nes")]
+    let mut nes_yaml: Option<NesYaml> = None;
     if std::path::Path::new(&args.config).exists() {
         log::info!("Loading configuration from {}", args.config);
         match std::fs::read_to_string(&args.config) {
@@ -304,6 +332,10 @@ pub async fn run() -> Result<()> {
                 // Seed NRF URI into SBI context for NF registration
                 if let Ok(yaml) = serde_yaml::from_str::<UdmYaml>(&content) {
                     if let Some(udm) = yaml.udm {
+                        #[cfg(feature = "nes")]
+                        {
+                            nes_yaml = udm.nes.clone();
+                        }
                         if let Some(sbi) = udm.sbi {
                             // Override the advertised/bind SBI address with the
                             // routable address from config so the NRF NFProfile
@@ -449,6 +481,16 @@ pub async fn run() -> Result<()> {
     // Register with NRF and start heartbeat worker
     match register_with_nrf(&args.sbi_addr, args.sbi_port).await {
         Ok(nf_instance_id) if !nf_instance_id.is_empty() => {
+            // Issue #22 NES (off by default): idle->drain->suspend runtime.
+            #[cfg(feature = "nes")]
+            crate::nes_driver::spawn_if_enabled(
+                nes_yaml
+                    .as_ref()
+                    .map(crate::nes_driver::NesSettings::from_yaml),
+                nf_instance_id.clone(),
+                args.sbi_addr.clone(),
+                args.sbi_port,
+            );
             // G2-2: PATCH a real NFProfile "/load" gauge to NRF each heartbeat
             // (registered UEs vs configured capacity; TS 29.510 §5.2.2.3.2).
             nextgcore_sbi::heartbeat::spawn_heartbeat_worker_with_load(nf_instance_id, 5, || {
@@ -496,6 +538,26 @@ pub async fn run() -> Result<()> {
 
 /// SBI request handler for UDM
 pub async fn udm_sbi_request_handler(request: SbiRequest) -> SbiResponse {
+    // Issue #22 NES bookkeeping (inert without the `nes` feature): count
+    // inbound activity and track in-flight work for the graceful drain.
+    NES_REQUESTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    // RAII guard (issue #22 review fix): the decrement must run on EVERY
+    // exit path — normal completion, panic-unwind (caught by the SBI
+    // server), and future-drop on client cancellation — or the NES drain
+    // gate never reaches zero and sleep is permanently blocked.
+    struct InFlightGuard;
+    impl Drop for InFlightGuard {
+        fn drop(&mut self) {
+            NES_IN_FLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    NES_IN_FLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let _guard = InFlightGuard;
+    udm_sbi_route(request).await
+}
+
+/// Route an inbound SBI request to the UDM service handlers.
+async fn udm_sbi_route(request: SbiRequest) -> SbiResponse {
     let method = request.header.method.as_str();
     let uri = &request.header.uri;
 
@@ -1979,6 +2041,19 @@ async fn run_event_loop_async(udm_sm: &mut UdmSmContext, shutdown: Arc<AtomicBoo
 /// Returns the NF instance ID on success so the caller can start a heartbeat
 /// worker.
 async fn register_with_nrf(sbi_addr: &str, sbi_port: u16) -> Result<String, String> {
+    let nf_instance_id = uuid::Uuid::new_v4().to_string();
+    register_with_nrf_id(&nf_instance_id, sbi_addr, sbi_port).await
+}
+
+/// Register — or, for the issue #22 NES resume path, RE-register — the UDM
+/// with the NRF under a caller-supplied NF instance ID. Returns the ID
+/// actually registered, or an empty string when no NRF is configured
+/// (registration skipped, matching the historical behavior).
+pub(crate) async fn register_with_nrf_id(
+    nf_instance_id: &str,
+    sbi_addr: &str,
+    sbi_port: u16,
+) -> Result<String, String> {
     let sbi_ctx = nextgcore_sbi::context::global_context();
 
     let nrf_uri = sbi_ctx.get_nrf_uri().await;
@@ -1994,8 +2069,6 @@ async fn register_with_nrf(sbi_addr: &str, sbi_port: u16) -> Result<String, Stri
 
     let (nrf_host, nrf_port) = parse_nrf_host_port(&nrf_uri).ok_or("Invalid NRF URI")?;
     let client = sbi_ctx.get_client(&nrf_host, nrf_port).await;
-
-    let nf_instance_id = uuid::Uuid::new_v4().to_string();
 
     let nf_profile = serde_json::json!({
         "nfInstanceId": nf_instance_id,
@@ -2041,7 +2114,7 @@ async fn register_with_nrf(sbi_addr: &str, sbi_port: u16) -> Result<String, Stri
     match response.status {
         200 | 201 => {
             log::info!("UDM registered with NRF successfully (id={nf_instance_id})");
-            Ok(nf_instance_id)
+            Ok(nf_instance_id.to_string())
         }
         _ => Err(format!(
             "NRF registration returned status {}",
@@ -2051,7 +2124,7 @@ async fn register_with_nrf(sbi_addr: &str, sbi_port: u16) -> Result<String, Stri
 }
 
 /// Parse host and port from a URI string (e.g., "http://localhost:7777").
-fn parse_nrf_host_port(uri: &str) -> Option<(String, u16)> {
+pub(crate) fn parse_nrf_host_port(uri: &str) -> Option<(String, u16)> {
     let without_scheme = uri
         .strip_prefix("https://")
         .or_else(|| uri.strip_prefix("http://"))

--- a/src/bins/nextgcore-udmd/src/lib.rs
+++ b/src/bins/nextgcore-udmd/src/lib.rs
@@ -11,6 +11,8 @@
 pub mod app;
 pub mod context;
 pub mod event;
+#[cfg(feature = "nes")]
+pub mod nes_driver; // issue #22 Network Energy Saving runtime (off by default)
 pub mod nudm_handler;
 pub mod nudr_handler;
 pub mod sbi_path;

--- a/src/bins/nextgcore-udmd/src/nes_driver.rs
+++ b/src/bins/nextgcore-udmd/src/nes_driver.rs
@@ -1,0 +1,445 @@
+//! udmd Network Energy Saving runtime (issue #22, feature `nes`, off by
+//! default).
+//!
+//! Drives the reusable `nextgcore_sbi::nes::NesMachine` from a poll ticker:
+//! inbound activity comes from the process-global `app::NES_REQUESTS`
+//! counter, the graceful-drain gate from `app::NES_IN_FLIGHT`. On
+//! `Suspend`, the configured [`nextgcore_sbi::nes::NesAction`] is reflected
+//! to the NRF — PATCH `nfStatus=SUSPENDED` (heartbeats continue advertising
+//! the suspended status; nrfd honors the self-suspension) or full
+//! deregistration (heartbeats pause). On `Resume` the reverse happens.
+//!
+//! It also feeds the live `/metrics` energy endpoint
+//! (`nextgcore_metrics::nes_energy`) using a **SYNTHETIC power model** — no
+//! hardware counters exist in this research core:
+//!
+//! ```text
+//! utilization = min(1.0, requests_this_tick / (capacity_rps * dt))
+//! power_w     = suspended ? 0.1 * idle_power_w
+//!                         : idle_power_w + (max_power_w - idle_power_w) * utilization
+//! joules     += power_w * dt
+//! ```
+//!
+//! The whole NES policy is non-normative (no frozen Rel-20 Stage-3); see
+//! docs/NES.md.
+
+use nextgcore_metrics::nes_energy::{serve_metrics, EnergyGauges};
+use nextgcore_sbi::context::NfStatus;
+use nextgcore_sbi::nes::{NesAction, NesConfig, NesMachine, NesTransition};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+/// Resolved NES settings (YAML with defaults applied).
+#[derive(Debug, Clone)]
+pub struct NesSettings {
+    pub enabled: bool,
+    pub idle_threshold_secs: u64,
+    pub drain_timeout_secs: u64,
+    pub poll_interval_secs: u64,
+    pub action: NesAction,
+    pub metrics_port: u16,
+    pub capacity_rps: f64,
+    pub idle_power_w: f64,
+    pub max_power_w: f64,
+}
+
+impl Default for NesSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            idle_threshold_secs: 300,
+            drain_timeout_secs: 10,
+            poll_interval_secs: 5,
+            action: NesAction::Suspend,
+            metrics_port: 9090,
+            capacity_rps: 100.0,
+            idle_power_w: 5.0,
+            max_power_w: 25.0,
+        }
+    }
+}
+
+impl NesSettings {
+    /// Apply the YAML `nes:` block over the defaults.
+    pub(crate) fn from_yaml(yaml: &crate::app::NesYaml) -> Self {
+        let defaults = Self::default();
+        Self {
+            enabled: yaml.enabled.unwrap_or(false),
+            idle_threshold_secs: yaml
+                .idle_threshold_secs
+                .unwrap_or(defaults.idle_threshold_secs),
+            drain_timeout_secs: yaml
+                .drain_timeout_secs
+                .unwrap_or(defaults.drain_timeout_secs),
+            poll_interval_secs: yaml
+                .poll_interval_secs
+                .unwrap_or(defaults.poll_interval_secs)
+                .max(1),
+            action: yaml
+                .action
+                .as_deref()
+                .and_then(NesAction::parse)
+                .unwrap_or(defaults.action),
+            metrics_port: yaml.metrics_port.unwrap_or(defaults.metrics_port),
+            capacity_rps: yaml.capacity_rps.unwrap_or(defaults.capacity_rps).max(1.0),
+            idle_power_w: yaml.idle_power_w.unwrap_or(defaults.idle_power_w).max(0.0),
+            max_power_w: yaml.max_power_w.unwrap_or(defaults.max_power_w).max(0.0),
+        }
+    }
+}
+
+/// Externally visible NES actions, injected so unit tests use a recorder
+/// while production reflects transitions to the NRF.
+pub trait NesActions: Send + Sync {
+    fn on_suspend(&self);
+    fn on_resume(&self);
+}
+
+/// Production actions: reflect sleep state to the NRF.
+pub struct NrfNesActions {
+    pub action: NesAction,
+    pub nf_instance_id: String,
+    pub sbi_addr: String,
+    pub sbi_port: u16,
+}
+
+impl NesActions for NrfNesActions {
+    fn on_suspend(&self) {
+        let id = self.nf_instance_id.clone();
+        match self.action {
+            NesAction::Suspend => {
+                // Heartbeats keep flowing, now advertising SUSPENDED (nrfd
+                // honors the self-suspension without reactivating).
+                nextgcore_sbi::heartbeat::set_self_nf_status(NfStatus::Suspended);
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        nextgcore_sbi::heartbeat::patch_nf_status(&id, NfStatus::Suspended, 0).await
+                    {
+                        log::warn!("NES suspend PATCH failed: {e}");
+                    }
+                });
+            }
+            NesAction::Deregister => {
+                // A deleted profile must not be PATCHed: pause heartbeats.
+                nextgcore_sbi::heartbeat::set_heartbeat_paused(true);
+                tokio::spawn(async move {
+                    let ctx = nextgcore_sbi::context::global_context();
+                    let Some(nrf_uri) = ctx.get_nrf_uri().await else {
+                        return;
+                    };
+                    let Some((host, port)) = crate::app::parse_nrf_host_port(&nrf_uri) else {
+                        return;
+                    };
+                    let client = ctx.get_client(&host, port).await;
+                    let path = format!("/nnrf-nfm/v1/nf-instances/{id}");
+                    match client
+                        .send_request(nextgcore_sbi::message::SbiRequest::delete(&path))
+                        .await
+                    {
+                        Ok(resp) if resp.is_success() => {
+                            log::info!("NES: deregistered from NRF (sleep)");
+                        }
+                        Ok(resp) => log::warn!("NES deregister returned {}", resp.status),
+                        Err(e) => log::warn!("NES deregister failed: {e}"),
+                    }
+                });
+            }
+        }
+    }
+
+    fn on_resume(&self) {
+        let id = self.nf_instance_id.clone();
+        match self.action {
+            NesAction::Suspend => {
+                nextgcore_sbi::heartbeat::set_self_nf_status(NfStatus::Registered);
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        nextgcore_sbi::heartbeat::patch_nf_status(&id, NfStatus::Registered, 0)
+                            .await
+                    {
+                        log::warn!("NES resume PATCH failed: {e}");
+                    }
+                });
+            }
+            NesAction::Deregister => {
+                let sbi_addr = self.sbi_addr.clone();
+                let sbi_port = self.sbi_port;
+                tokio::spawn(async move {
+                    // Review fix (issue #22): a one-shot re-registration
+                    // could strand the NF deregistered with paused
+                    // heartbeats after a transient NRF outage. Retry with
+                    // capped exponential backoff; heartbeats resume only
+                    // once the NRF has accepted the profile again.
+                    let mut backoff = std::time::Duration::from_secs(1);
+                    for attempt in 1u32..=8 {
+                        match crate::app::register_with_nrf_id(&id, &sbi_addr, sbi_port).await {
+                            Ok(_) => {
+                                log::info!(
+                                    "NES: re-registered with NRF (resume, attempt {attempt})"
+                                );
+                                nextgcore_sbi::heartbeat::set_heartbeat_paused(false);
+                                return;
+                            }
+                            Err(e) => {
+                                log::warn!("NES re-registration attempt {attempt} failed: {e}");
+                            }
+                        }
+                        tokio::time::sleep(backoff).await;
+                        backoff = (backoff * 2).min(std::time::Duration::from_secs(60));
+                    }
+                    log::error!(
+                        "NES: giving up re-registration after 8 attempts; NF remains \
+                         deregistered with heartbeats paused (restart required)"
+                    );
+                });
+            }
+        }
+    }
+}
+
+/// One NES decision step (pure apart from the injected actions): feed
+/// activity into the machine, otherwise advance it; dispatch the external
+/// actions on Suspend/Resume. Unit-testable with a recorder.
+pub fn drive_tick(
+    machine: &mut NesMachine,
+    actions: &dyn NesActions,
+    now_ms: u64,
+    activity_delta: u64,
+    in_flight: u64,
+) -> Option<NesTransition> {
+    if activity_delta > 0 {
+        let transition = machine.on_activity(now_ms);
+        if transition == Some(NesTransition::Resume) {
+            actions.on_resume();
+        }
+        return transition;
+    }
+    let transition = machine.tick(now_ms, in_flight);
+    if transition == Some(NesTransition::Suspend) {
+        actions.on_suspend();
+    }
+    transition
+}
+
+/// Spawn the NES runtime when the config enables it (issue #22 toggle:
+/// absent block or `enabled: false` → complete no-op).
+pub fn spawn_if_enabled(
+    settings: Option<NesSettings>,
+    nf_instance_id: String,
+    sbi_addr: String,
+    sbi_port: u16,
+) {
+    let Some(settings) = settings else {
+        log::debug!("NES: no nes: config block; disabled");
+        return;
+    };
+    if !settings.enabled {
+        log::info!("NES: configured but disabled (nes.enabled=false)");
+        return;
+    }
+    log::info!(
+        "NES enabled: idle={}s drain={}s action={:?} metrics_port={} (non-normative prototype, synthetic power model)",
+        settings.idle_threshold_secs,
+        settings.drain_timeout_secs,
+        settings.action,
+        settings.metrics_port
+    );
+
+    let gauges = EnergyGauges::new("UDM", &nf_instance_id);
+    gauges.register_specs();
+
+    let actions = NrfNesActions {
+        action: settings.action,
+        nf_instance_id,
+        sbi_addr,
+        sbi_port,
+    };
+
+    tokio::spawn(run_nes_loop(settings, gauges, actions));
+}
+
+async fn run_nes_loop(settings: NesSettings, gauges: Arc<EnergyGauges>, actions: NrfNesActions) {
+    // Live /metrics endpoint (real HTTP/1.1; acceptance criterion).
+    let render_gauges = gauges.clone();
+    let metrics_addr = format!("0.0.0.0:{}", settings.metrics_port);
+    match metrics_addr.parse() {
+        Ok(addr) => {
+            if let Err(e) =
+                serve_metrics(addr, Arc::new(move || render_gauges.render_prometheus())).await
+            {
+                log::warn!("NES metrics endpoint failed to bind {metrics_addr}: {e}");
+            }
+        }
+        Err(e) => log::warn!("NES metrics address invalid ({metrics_addr}): {e}"),
+    }
+
+    let config = NesConfig {
+        idle_threshold_ms: settings.idle_threshold_secs * 1_000,
+        drain_timeout_ms: settings.drain_timeout_secs * 1_000,
+        action: settings.action,
+    };
+    let start = std::time::Instant::now();
+    let mut machine = NesMachine::new(config, 0);
+    let mut last_requests = crate::app::NES_REQUESTS.load(Ordering::Relaxed);
+    let dt_secs = settings.poll_interval_secs as f64;
+    let mut ticker = tokio::time::interval(tokio::time::Duration::from_secs(
+        settings.poll_interval_secs,
+    ));
+    ticker.tick().await; // first tick fires immediately; skip the zero-dt round
+
+    loop {
+        ticker.tick().await;
+        let now_ms = start.elapsed().as_millis() as u64;
+        let requests = crate::app::NES_REQUESTS.load(Ordering::Relaxed);
+        let delta = requests.saturating_sub(last_requests);
+        last_requests = requests;
+        let in_flight = crate::app::NES_IN_FLIGHT.load(Ordering::Relaxed);
+
+        if let Some(transition) = drive_tick(&mut machine, &actions, now_ms, delta, in_flight) {
+            log::info!(
+                "NES transition: {transition:?} (state={:?})",
+                machine.state()
+            );
+        }
+
+        // SYNTHETIC power model (documented in the module doc + docs/NES.md).
+        let utilization = (delta as f64 / (settings.capacity_rps * dt_secs)).min(1.0);
+        let suspended = machine.state() == nextgcore_sbi::nes::NesState::Suspended;
+        let power_w = if suspended {
+            0.1 * settings.idle_power_w
+        } else {
+            settings.idle_power_w + (settings.max_power_w - settings.idle_power_w) * utilization
+        };
+        gauges.set_utilization(utilization);
+        gauges.set_power_watts(power_w);
+        gauges.add_joules(power_w * dt_secs);
+        gauges.set_sleep_ratio(machine.sleep_ratio());
+        // Rough data-volume proxy: count requests as wire bits are not
+        // tracked per-NF (1 request ≈ 8 kbit, synthetic like the power).
+        gauges.add_data_bits(delta * 8_192);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct Recorder {
+        events: Mutex<Vec<&'static str>>,
+    }
+
+    impl NesActions for Recorder {
+        fn on_suspend(&self) {
+            self.events.lock().unwrap().push("suspend");
+        }
+        fn on_resume(&self) {
+            self.events.lock().unwrap().push("resume");
+        }
+    }
+
+    fn machine() -> NesMachine {
+        NesMachine::new(
+            NesConfig {
+                idle_threshold_ms: 1_000,
+                drain_timeout_ms: 500,
+                action: NesAction::Suspend,
+            },
+            0,
+        )
+    }
+
+    /// Acceptance (issue #22): idle → drain → suspend fires the suspend
+    /// action exactly once, and later activity fires resume.
+    #[test]
+    fn idle_drain_suspend_then_activity_resumes() {
+        let recorder = Recorder::default();
+        let mut m = machine();
+
+        assert_eq!(drive_tick(&mut m, &recorder, 500, 0, 0), None);
+        assert_eq!(
+            drive_tick(&mut m, &recorder, 1_000, 0, 0),
+            Some(NesTransition::BeginDrain)
+        );
+        assert_eq!(
+            drive_tick(&mut m, &recorder, 1_100, 0, 0),
+            Some(NesTransition::Suspend)
+        );
+        assert_eq!(*recorder.events.lock().unwrap(), vec!["suspend"]);
+
+        // Quiet suspended ticks: no repeat actions.
+        assert_eq!(drive_tick(&mut m, &recorder, 5_000, 0, 0), None);
+        assert_eq!(*recorder.events.lock().unwrap(), vec!["suspend"]);
+
+        // Inbound activity wakes the NF back up.
+        assert_eq!(
+            drive_tick(&mut m, &recorder, 6_000, 3, 1),
+            Some(NesTransition::Resume)
+        );
+        assert_eq!(*recorder.events.lock().unwrap(), vec!["suspend", "resume"]);
+    }
+
+    /// Acceptance (issue #22): graceful drain — in-flight work blocks the
+    /// suspend action; it fires only once the work settles.
+    #[test]
+    fn drain_gate_blocks_suspend_until_in_flight_settles() {
+        let recorder = Recorder::default();
+        let mut m = machine();
+
+        assert_eq!(
+            drive_tick(&mut m, &recorder, 1_000, 0, 2),
+            Some(NesTransition::BeginDrain)
+        );
+        assert_eq!(drive_tick(&mut m, &recorder, 1_100, 0, 2), None);
+        assert!(
+            recorder.events.lock().unwrap().is_empty(),
+            "no drop, no suspend"
+        );
+        assert_eq!(
+            drive_tick(&mut m, &recorder, 1_200, 0, 0),
+            Some(NesTransition::Suspend)
+        );
+        assert_eq!(*recorder.events.lock().unwrap(), vec!["suspend"]);
+    }
+
+    #[test]
+    fn drain_timeout_aborts_without_any_action() {
+        let recorder = Recorder::default();
+        let mut m = machine();
+        drive_tick(&mut m, &recorder, 1_000, 0, 1);
+        assert_eq!(
+            drive_tick(&mut m, &recorder, 1_500, 0, 1),
+            Some(NesTransition::AbortDrain)
+        );
+        assert!(recorder.events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn settings_defaults_and_yaml_overlay() {
+        let defaults = NesSettings::default();
+        assert!(!defaults.enabled, "NES must be off by default");
+        assert_eq!(defaults.action, NesAction::Suspend);
+
+        let yaml = crate::app::NesYaml {
+            enabled: Some(true),
+            idle_threshold_secs: Some(60),
+            drain_timeout_secs: None,
+            poll_interval_secs: Some(0), // clamped to 1
+            action: Some("deregister".to_string()),
+            metrics_port: Some(9191),
+            capacity_rps: None,
+            idle_power_w: Some(2.0),
+            max_power_w: None,
+        };
+        let settings = NesSettings::from_yaml(&yaml);
+        assert!(settings.enabled);
+        assert_eq!(settings.idle_threshold_secs, 60);
+        assert_eq!(settings.drain_timeout_secs, defaults.drain_timeout_secs);
+        assert_eq!(settings.poll_interval_secs, 1);
+        assert_eq!(settings.action, NesAction::Deregister);
+        assert_eq!(settings.metrics_port, 9191);
+        assert_eq!(settings.idle_power_w, 2.0);
+        assert_eq!(settings.max_power_w, defaults.max_power_w);
+    }
+}

--- a/src/libs/nextgcore-metrics/Cargo.toml
+++ b/src/libs/nextgcore-metrics/Cargo.toml
@@ -11,6 +11,8 @@ nextgcore-core = { workspace = true }
 prometheus.workspace = true
 log.workspace = true
 serde_yaml.workspace = true
+# NES (issue #22): minimal live /metrics HTTP listener + async tests
+tokio.workspace = true
 thiserror.workspace = true
 hex.workspace = true
 

--- a/src/libs/nextgcore-metrics/src/lib.rs
+++ b/src/libs/nextgcore-metrics/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod ai_native;
 pub mod context;
 pub mod instance;
+pub mod nes_energy;
 pub mod otel;
 pub mod server;
 pub mod spec;

--- a/src/libs/nextgcore-metrics/src/nes_energy.rs
+++ b/src/libs/nextgcore-metrics/src/nes_energy.rs
@@ -1,0 +1,361 @@
+//! Network Energy Saving (NES) live energy/utilization metrics (issue #22).
+//!
+//! Bridges the dormant [`crate::ai_native`] energy descriptors (TS 28.310
+//! KPI families) onto a LIVE Prometheus endpoint: [`EnergyGauges`] holds the
+//! per-NF values behind lock-free atomics, renders the TS 28.310 energy
+//! family plus a new `nf_utilization_ratio` gauge as Prometheus text, and
+//! [`serve_metrics`] is a minimal real HTTP/1.1 listener serving it at
+//! `/metrics` (the pre-existing [`crate::server::MetricsServer`] is a
+//! non-binding stub kept for API compatibility).
+//!
+//! The energy numbers an NF feeds in here are expected to come from a
+//! SYNTHETIC power model (no hardware counters exist in this research core);
+//! callers must document their model. The NES sleep policy itself is
+//! non-normative — no frozen Rel-20 Stage-3 exists.
+
+use crate::ai_native::{AiMetricCategory, AiMetricDef};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// NF utilization ratio (0.0-1.0), the issue-#22 companion gauge to the
+/// TS 28.310 energy family.
+pub const NF_UTILIZATION_RATIO: AiMetricDef = AiMetricDef {
+    name: "nf_utilization_ratio",
+    help: "NF utilization ratio derived from the NF-supplied load (0.0-1.0)",
+    category: AiMetricCategory::Energy,
+    labels: &["nf_type", "nf_id"],
+};
+
+/// Lock-free f64 cell (bit-cast into an `AtomicU64`).
+#[derive(Debug, Default)]
+struct AtomicF64(AtomicU64);
+
+impl AtomicF64 {
+    fn get(&self) -> f64 {
+        f64::from_bits(self.0.load(Ordering::Relaxed))
+    }
+
+    fn set(&self, value: f64) {
+        self.0.store(value.to_bits(), Ordering::Relaxed);
+    }
+
+    /// Add (single-writer model: the NES poll tick is the only writer, so a
+    /// plain read-modify-write is race-free in practice; documented).
+    fn add(&self, delta: f64) {
+        self.set(self.get() + delta);
+    }
+}
+
+/// Live per-NF energy/utilization gauges (thread-safe, shareable).
+#[derive(Debug)]
+pub struct EnergyGauges {
+    nf_type: String,
+    nf_id: String,
+    power_watts: AtomicF64,
+    total_joules: AtomicF64,
+    sleep_ratio: AtomicF64,
+    utilization: AtomicF64,
+    data_bits_total: AtomicU64,
+}
+
+impl EnergyGauges {
+    pub fn new(nf_type: impl Into<String>, nf_id: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self {
+            nf_type: nf_type.into(),
+            nf_id: nf_id.into(),
+            power_watts: AtomicF64::default(),
+            total_joules: AtomicF64::default(),
+            sleep_ratio: AtomicF64::default(),
+            utilization: AtomicF64::default(),
+            data_bits_total: AtomicU64::new(0),
+        })
+    }
+
+    pub fn set_power_watts(&self, watts: f64) {
+        self.power_watts.set(watts.max(0.0));
+    }
+
+    pub fn add_joules(&self, joules: f64) {
+        if joules > 0.0 {
+            self.total_joules.add(joules);
+        }
+    }
+
+    pub fn set_sleep_ratio(&self, ratio: f64) {
+        self.sleep_ratio.set(ratio.clamp(0.0, 1.0));
+    }
+
+    pub fn set_utilization(&self, ratio: f64) {
+        self.utilization.set(ratio.clamp(0.0, 1.0));
+    }
+
+    pub fn add_data_bits(&self, bits: u64) {
+        self.data_bits_total.fetch_add(bits, Ordering::Relaxed);
+    }
+
+    /// TS 28.310 EE_DV: bits per joule over the whole lifetime (0 until any
+    /// energy is recorded).
+    pub fn bits_per_joule(&self) -> f64 {
+        let joules = self.total_joules.get();
+        if joules > 0.0 {
+            self.data_bits_total.load(Ordering::Relaxed) as f64 / joules
+        } else {
+            0.0
+        }
+    }
+
+    /// Register the energy family with the (dormant) `MetricsContext` spec
+    /// registry so registry consumers see the definitions; the LIVE values
+    /// are rendered by [`Self::render_prometheus`].
+    pub fn register_specs(&self) {
+        use crate::ai_native::{
+            ENERGY_BITS_PER_JOULE, ENERGY_CONSUMPTION_WATTS, ENERGY_DATA_VOLUME_BITS,
+            ENERGY_SLEEP_RATIO, ENERGY_TOTAL_JOULES,
+        };
+        use crate::context::MetricsContext;
+        use crate::spec::MetricsSpec;
+
+        MetricsContext::init();
+        let Some(ctx) = MetricsContext::get() else {
+            return;
+        };
+        let Ok(mut ctx) = ctx.write() else {
+            return;
+        };
+        for def in [
+            &ENERGY_CONSUMPTION_WATTS,
+            &ENERGY_SLEEP_RATIO,
+            &ENERGY_BITS_PER_JOULE,
+            &NF_UTILIZATION_RATIO,
+        ] {
+            ctx.add_spec(MetricsSpec::gauge(def.name, def.help, 0, def.labels));
+        }
+        for def in [&ENERGY_TOTAL_JOULES, &ENERGY_DATA_VOLUME_BITS] {
+            ctx.add_spec(MetricsSpec::counter(def.name, def.help, def.labels));
+        }
+    }
+
+    /// Render the live energy family as Prometheus text-format 0.0.4.
+    pub fn render_prometheus(&self) -> String {
+        use crate::ai_native::{
+            ENERGY_BITS_PER_JOULE, ENERGY_CONSUMPTION_WATTS, ENERGY_DATA_VOLUME_BITS,
+            ENERGY_SLEEP_RATIO, ENERGY_TOTAL_JOULES,
+        };
+
+        let base = format!("nf_type=\"{}\",nf_id=\"{}\"", self.nf_type, self.nf_id);
+        let mut out = String::with_capacity(1024);
+        let mut emit = |def: &AiMetricDef, kind: &str, labels: &str, value: f64| {
+            out.push_str(&format!(
+                "# HELP {name} {help}\n# TYPE {name} {kind}\n{name}{{{labels}}} {value}\n",
+                name = def.name,
+                help = def.help,
+            ));
+        };
+
+        emit(
+            &ENERGY_CONSUMPTION_WATTS,
+            "gauge",
+            &format!("{base},component=\"process\""),
+            self.power_watts.get(),
+        );
+        emit(
+            &ENERGY_TOTAL_JOULES,
+            "counter",
+            &base,
+            self.total_joules.get(),
+        );
+        emit(
+            &ENERGY_DATA_VOLUME_BITS,
+            "counter",
+            &format!("{base},direction=\"total\""),
+            self.data_bits_total.load(Ordering::Relaxed) as f64,
+        );
+        emit(
+            &ENERGY_BITS_PER_JOULE,
+            "gauge",
+            &format!("{base},slice_sst=\"0\""),
+            self.bits_per_joule(),
+        );
+        emit(
+            &ENERGY_SLEEP_RATIO,
+            "gauge",
+            &format!("{base},cell_id=\"nf\""),
+            self.sleep_ratio.get(),
+        );
+        emit(
+            &NF_UTILIZATION_RATIO,
+            "gauge",
+            &base,
+            self.utilization.get(),
+        );
+        out
+    }
+}
+
+/// Serve `render()` at `GET /metrics` over a minimal real HTTP/1.1 listener
+/// (`GET /` and `GET /healthz` answer `ok`; anything else is 404). Returns
+/// the bound address (useful with port 0) and the accept-loop task handle.
+pub async fn serve_metrics(
+    addr: SocketAddr,
+    render: Arc<dyn Fn() -> String + Send + Sync>,
+) -> std::io::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
+    let listener = TcpListener::bind(addr).await?;
+    let bound = listener.local_addr()?;
+    log::info!("NES metrics endpoint listening on http://{bound}/metrics");
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _peer)) = listener.accept().await else {
+                break;
+            };
+            let render = render.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 4096];
+                let Ok(n) = stream.read(&mut buf).await else {
+                    return;
+                };
+                let head = String::from_utf8_lossy(&buf[..n]);
+                let target = head
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                let path = target.split('?').next().unwrap_or("/");
+                let (status, content_type, body) = match path {
+                    "/metrics" => (
+                        "200 OK",
+                        "text/plain; version=0.0.4; charset=utf-8",
+                        render(),
+                    ),
+                    "/" | "/healthz" => ("200 OK", "text/plain", "ok\n".to_string()),
+                    _ => ("404 Not Found", "text/plain", "not found\n".to_string()),
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            });
+        }
+    });
+
+    Ok((bound, handle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpStream;
+
+    #[test]
+    fn atomic_f64_roundtrip() {
+        let cell = AtomicF64::default();
+        assert_eq!(cell.get(), 0.0);
+        cell.set(12.75);
+        assert_eq!(cell.get(), 12.75);
+        cell.add(0.25);
+        assert_eq!(cell.get(), 13.0);
+    }
+
+    #[test]
+    fn gauges_render_all_energy_families_with_labels() {
+        let gauges = EnergyGauges::new("UDM", "udm-test-1");
+        gauges.set_power_watts(42.5);
+        gauges.add_joules(100.0);
+        gauges.add_data_bits(1_000_000);
+        gauges.set_sleep_ratio(0.25);
+        gauges.set_utilization(0.5);
+
+        let text = gauges.render_prometheus();
+        for family in [
+            "energy_consumption_watts",
+            "energy_consumed_joules_total",
+            "energy_data_volume_bits_total",
+            "energy_efficiency_bits_per_joule",
+            "energy_sleep_ratio",
+            "nf_utilization_ratio",
+        ] {
+            assert!(text.contains(&format!("# TYPE {family} ")), "{family} TYPE");
+            assert!(
+                text.contains(&format!("{family}{{")),
+                "{family} sample line"
+            );
+        }
+        assert!(text.contains("nf_type=\"UDM\",nf_id=\"udm-test-1\""));
+        assert!(text.contains("energy_consumption_watts{nf_type=\"UDM\",nf_id=\"udm-test-1\",component=\"process\"} 42.5"));
+        // EE_DV = 1e6 bits / 100 J = 10000 bits/J.
+        assert!(text.contains("energy_efficiency_bits_per_joule{nf_type=\"UDM\",nf_id=\"udm-test-1\",slice_sst=\"0\"} 10000"));
+        assert!(text.contains("nf_utilization_ratio{nf_type=\"UDM\",nf_id=\"udm-test-1\"} 0.5"));
+    }
+
+    #[test]
+    fn gauges_clamp_and_guard() {
+        let gauges = EnergyGauges::new("UDM", "udm-x");
+        gauges.set_sleep_ratio(7.0);
+        gauges.set_utilization(-3.0);
+        gauges.set_power_watts(-1.0);
+        assert!(gauges
+            .render_prometheus()
+            .contains("energy_sleep_ratio{nf_type=\"UDM\",nf_id=\"udm-x\",cell_id=\"nf\"} 1"));
+        assert!(gauges
+            .render_prometheus()
+            .contains("nf_utilization_ratio{nf_type=\"UDM\",nf_id=\"udm-x\"} 0"));
+        // No energy recorded → bits/J stays 0 (no div-by-zero).
+        assert_eq!(gauges.bits_per_joule(), 0.0);
+    }
+
+    #[test]
+    fn register_specs_populates_the_registry() {
+        let gauges = EnergyGauges::new("UDM", "udm-spec");
+        gauges.register_specs();
+        let ctx = crate::context::MetricsContext::get().expect("initialized");
+        let ctx = ctx.read().expect("read");
+        let names: Vec<String> = ctx.specs().iter().map(|s| s.name().to_string()).collect();
+        assert!(names.iter().any(|n| n == "energy_consumption_watts"));
+        assert!(names.iter().any(|n| n == "nf_utilization_ratio"));
+    }
+
+    async fn http_get(addr: SocketAddr, path: &str) -> String {
+        let mut stream = TcpStream::connect(addr).await.expect("connect");
+        stream
+            .write_all(format!("GET {path} HTTP/1.1\r\nHost: test\r\n\r\n").as_bytes())
+            .await
+            .expect("write");
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.expect("read");
+        String::from_utf8_lossy(&response).to_string()
+    }
+
+    /// Acceptance (issue #22): a real HTTP GET of /metrics returns the
+    /// energy family and the utilization gauge.
+    #[tokio::test]
+    async fn serve_metrics_answers_real_http() {
+        let gauges = EnergyGauges::new("UDM", "udm-http");
+        gauges.set_power_watts(5.0);
+        let render_gauges = gauges.clone();
+        let (bound, handle) = serve_metrics(
+            "127.0.0.1:0".parse().unwrap(),
+            Arc::new(move || render_gauges.render_prometheus()),
+        )
+        .await
+        .expect("bind");
+
+        let response = http_get(bound, "/metrics").await;
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+        assert!(response.contains("energy_consumption_watts"));
+        assert!(response.contains("nf_utilization_ratio"));
+
+        let health = http_get(bound, "/healthz").await;
+        assert!(health.starts_with("HTTP/1.1 200 OK"));
+
+        let missing = http_get(bound, "/nope").await;
+        assert!(missing.starts_with("HTTP/1.1 404"));
+
+        handle.abort();
+    }
+}

--- a/src/libs/nextgcore-sbi/src/heartbeat.rs
+++ b/src/libs/nextgcore-sbi/src/heartbeat.rs
@@ -425,11 +425,95 @@ fn parse_nrf_host_port(uri: &str) -> Option<(String, u16)> {
 /// nrfd auto-detects an array body as JSON Patch (`main.rs` dispatch on shape)
 /// and applies both the merge-object and json-patch load PATCH forms.
 pub fn build_load_patch(load: u8) -> serde_json::Value {
+    build_status_patch(load, self_nf_status())
+}
+
+/// Like [`build_load_patch`] but with an explicit `nfStatus` (issue #22
+/// NES: a self-suspended NF keeps heartbeating with `SUSPENDED` so the
+/// NRF's liveness timer stays armed without reactivating the profile).
+/// With the default [`self_nf_status`] of `Registered` the output is
+/// byte-identical to the historical `build_load_patch`.
+pub fn build_status_patch(load: u8, status: crate::context::NfStatus) -> serde_json::Value {
     let load = load.min(100);
     serde_json::json!([
-        {"op": "replace", "path": "/nfStatus", "value": "REGISTERED"},
+        {"op": "replace", "path": "/nfStatus", "value": nf_status_wire(status)},
         {"op": "add",     "path": "/load",     "value": load}
     ])
+}
+
+/// TS 29.510 wire string for an [`crate::context::NfStatus`].
+pub fn nf_status_wire(status: crate::context::NfStatus) -> &'static str {
+    match status {
+        crate::context::NfStatus::Registered => "REGISTERED",
+        crate::context::NfStatus::Suspended => "SUSPENDED",
+        crate::context::NfStatus::Undiscoverable => "UNDISCOVERABLE",
+    }
+}
+
+// ─── NES self-status plumbing (issue #22) ────────────────────────────────────
+// Defaults (Registered, unpaused) keep the heartbeat worker byte-for-byte on
+// its pre-NES behavior; only an NF that opts into NES ever mutates these.
+
+static SELF_NF_STATUS: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+static HEARTBEAT_PAUSED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Set the status this NF advertises in its own NRF heartbeats.
+pub fn set_self_nf_status(status: crate::context::NfStatus) {
+    let value = match status {
+        crate::context::NfStatus::Registered => 0,
+        crate::context::NfStatus::Suspended => 1,
+        crate::context::NfStatus::Undiscoverable => 2,
+    };
+    SELF_NF_STATUS.store(value, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The status this NF currently advertises in its own NRF heartbeats.
+pub fn self_nf_status() -> crate::context::NfStatus {
+    match SELF_NF_STATUS.load(std::sync::atomic::Ordering::Relaxed) {
+        1 => crate::context::NfStatus::Suspended,
+        2 => crate::context::NfStatus::Undiscoverable,
+        _ => crate::context::NfStatus::Registered,
+    }
+}
+
+/// Pause/resume the outbound heartbeat worker (issue #22 NES `deregister`
+/// action: a deregistered NF must not keep PATCHing its deleted profile).
+pub fn set_heartbeat_paused(paused: bool) {
+    HEARTBEAT_PAUSED.store(paused, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether the outbound heartbeat worker is paused.
+pub fn heartbeat_paused() -> bool {
+    HEARTBEAT_PAUSED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// One-off `nfStatus` PATCH toward the NRF (issue #22 NES transitions),
+/// using the exact wire shape of the heartbeat worker (RFC 6902 array,
+/// `application/json-patch+json`).
+pub async fn patch_nf_status(
+    nf_instance_id: &str,
+    status: crate::context::NfStatus,
+    load: u8,
+) -> Result<(), String> {
+    let ctx = crate::context::global_context();
+    let nrf_uri = ctx
+        .get_nrf_uri()
+        .await
+        .ok_or_else(|| "no NRF URI configured".to_string())?;
+    let (nrf_host, nrf_port) =
+        parse_nrf_host_port(&nrf_uri).ok_or_else(|| format!("invalid NRF URI '{nrf_uri}'"))?;
+    let client = SbiClient::with_host_port(&nrf_host, nrf_port);
+    let path = format!("/nnrf-nfm/v1/nf-instances/{nf_instance_id}");
+    let body = build_status_patch(load, status);
+    let request = SbiRequest::patch(&path)
+        .with_json_body(&body)
+        .map_err(|e| format!("failed to serialize nfStatus patch: {e}"))?
+        .with_header("Content-Type", "application/json-patch+json");
+    match client.send_request(request).await {
+        Ok(resp) if resp.status == 200 || resp.status == 204 => Ok(()),
+        Ok(resp) => Err(format!("NRF returned status {}", resp.status)),
+        Err(e) => Err(format!("nfStatus PATCH failed: {e}")),
+    }
 }
 
 /// Spawn a background tokio task that periodically sends a heartbeat
@@ -474,6 +558,13 @@ where
 
         loop {
             ticker.tick().await;
+
+            // Issue #22 NES: while paused (deregistered sleep) skip the
+            // tick entirely — a deleted NF profile must not be PATCHed.
+            if heartbeat_paused() {
+                log::debug!("Heartbeat paused for {nf_instance_id}, skipping tick");
+                continue;
+            }
 
             let ctx = crate::context::global_context();
             let nrf_uri = ctx.get_nrf_uri().await;
@@ -536,6 +627,44 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #22 NES: the default heartbeat body is byte-identical to the
+    /// historical hardcoded-REGISTERED patch, the status builder emits the
+    /// requested status, and the self-status/pause plumbing round-trips.
+    /// One test (not several): the statics are process-global, so mutation
+    /// and restoration happen under a single test to avoid races.
+    #[test]
+    fn test_nes_status_patch_plumbing() {
+        // Defaults: Registered, unpaused, historical JSON shape (load
+        // saturated at 100).
+        assert_eq!(self_nf_status(), crate::context::NfStatus::Registered);
+        assert!(!heartbeat_paused());
+        assert_eq!(
+            build_load_patch(150),
+            serde_json::json!([
+                {"op": "replace", "path": "/nfStatus", "value": "REGISTERED"},
+                {"op": "add",     "path": "/load",     "value": 100}
+            ])
+        );
+
+        // Explicit status builder.
+        let suspended = build_status_patch(7, crate::context::NfStatus::Suspended);
+        assert_eq!(suspended[0]["value"], "SUSPENDED");
+        assert_eq!(suspended[1]["value"], 7);
+        assert_eq!(
+            nf_status_wire(crate::context::NfStatus::Undiscoverable),
+            "UNDISCOVERABLE"
+        );
+
+        // NES plumbing round-trip; restore defaults for other tests.
+        set_self_nf_status(crate::context::NfStatus::Suspended);
+        assert_eq!(build_load_patch(1)[0]["value"], "SUSPENDED");
+        set_heartbeat_paused(true);
+        assert!(heartbeat_paused());
+        set_self_nf_status(crate::context::NfStatus::Registered);
+        set_heartbeat_paused(false);
+        assert_eq!(build_load_patch(0)[0]["value"], "REGISTERED");
+    }
 
     #[test]
     fn test_heartbeat_record_creation() {
@@ -646,7 +775,10 @@ mod tests {
     #[test]
     fn test_build_load_patch_shape() {
         use serde_json::json;
-        let patch = build_load_patch(42);
+        // Review fix (issue #22): use the explicit-status builder so this
+        // test cannot observe another test's mutation of the process-global
+        // SELF_NF_STATUS (test_nes_status_patch_plumbing is the sole mutator).
+        let patch = build_status_patch(42, crate::context::NfStatus::Registered);
         let items = patch.as_array().expect("json-patch array");
         assert_eq!(items.len(), 2, "nfStatus + load");
 
@@ -665,10 +797,10 @@ mod tests {
     fn test_build_load_patch_saturates_at_100() {
         use serde_json::json;
         // u8 max is 255; anything over 100 saturates to 100 (NFProfile.load 0..=100).
-        let patch = build_load_patch(200);
+        let patch = build_status_patch(200, crate::context::NfStatus::Registered);
         assert_eq!(patch.as_array().unwrap()[1]["value"], json!(100));
 
-        let patch = build_load_patch(0);
+        let patch = build_status_patch(0, crate::context::NfStatus::Registered);
         assert_eq!(patch.as_array().unwrap()[1]["value"], json!(0));
     }
 }

--- a/src/libs/nextgcore-sbi/src/lib.rs
+++ b/src/libs/nextgcore-sbi/src/lib.rs
@@ -48,6 +48,7 @@ pub mod heartbeat;
 pub mod http3; // HTTP/3 SBI transport prototype (issue #15, non-normative)
 pub mod message;
 pub mod multipart;
+pub mod nes; // NES idle/sleep state machine (issue #22, non-normative)
 pub mod oauth;
 pub mod overload;
 #[cfg(feature = "6g-extensions")]

--- a/src/libs/nextgcore-sbi/src/nes.rs
+++ b/src/libs/nextgcore-sbi/src/nes.rs
@@ -1,0 +1,281 @@
+//! Network Energy Saving idle/sleep state machine (issue #22).
+//!
+//! A small, reusable, PURE state machine an NF drives from its own poll
+//! tick: `Active → (idle > threshold) → Draining → (in-flight settled) →
+//! Suspended`, and `Suspended → (activity) → Active`. The machine only
+//! decides transitions; the NF performs the externally visible actions
+//! (PATCH `nfStatus=SUSPENDED` / NRF deregistration on suspend, the reverse
+//! on resume) — see `nextgcore_sbi::heartbeat::{patch_nf_status,
+//! set_self_nf_status, set_heartbeat_paused}`.
+//!
+//! Graceful drain: the machine never emits [`NesTransition::Suspend`] while
+//! requests are in flight; if the drain window expires with work still
+//! pending, it aborts back to `Active` (no request is ever dropped by a
+//! sleep transition). Times are plain `u64` milliseconds supplied by the
+//! caller, keeping the machine deterministic and unit-testable.
+//!
+//! Non-normative: TS 23.501/TS 29.510 define the `nfStatus` values used to
+//! reflect sleep toward the NRF, but a full "6G NES" sleep/scale policy has
+//! no frozen Rel-20 Stage-3 — this is a research prototype.
+
+/// What to do toward the NRF when entering the sleep state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NesAction {
+    /// Keep the NF profile but PATCH `nfStatus=SUSPENDED` (heartbeats
+    /// continue, advertising the suspended status).
+    #[default]
+    Suspend,
+    /// Deregister from the NRF entirely (heartbeats pause; re-registration
+    /// happens on resume).
+    Deregister,
+}
+
+impl NesAction {
+    /// Parse the config string (`suspend` | `deregister`).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "suspend" => Some(Self::Suspend),
+            "deregister" => Some(Self::Deregister),
+            _ => None,
+        }
+    }
+}
+
+/// NES sleep-policy configuration (an NF's off-by-default `nes:` block).
+#[derive(Debug, Clone, Copy)]
+pub struct NesConfig {
+    /// Idle time (no inbound activity) before draining starts.
+    pub idle_threshold_ms: u64,
+    /// Maximum time to wait for in-flight work to settle; expiry aborts the
+    /// sleep attempt back to `Active`.
+    pub drain_timeout_ms: u64,
+    /// Action toward the NRF on suspend.
+    pub action: NesAction,
+}
+
+/// NES lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NesState {
+    Active,
+    Draining,
+    Suspended,
+}
+
+/// Externally visible transition the caller must act on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NesTransition {
+    /// Idle threshold crossed: stop taking on deferrable work.
+    BeginDrain,
+    /// Drained: perform the configured [`NesAction`].
+    Suspend,
+    /// Drain window expired with work still in flight: back to `Active`
+    /// (nothing external to do; the sleep attempt is abandoned).
+    AbortDrain,
+    /// Activity while suspended: undo the [`NesAction`] (PATCH back to
+    /// `REGISTERED` / re-register).
+    Resume,
+}
+
+/// The pure NES state machine. All time is caller-supplied milliseconds.
+#[derive(Debug)]
+pub struct NesMachine {
+    config: NesConfig,
+    state: NesState,
+    last_activity_ms: u64,
+    drain_started_ms: u64,
+    last_tick_ms: u64,
+    time_awake_ms: u64,
+    time_suspended_ms: u64,
+}
+
+impl NesMachine {
+    pub fn new(config: NesConfig, now_ms: u64) -> Self {
+        Self {
+            config,
+            state: NesState::Active,
+            last_activity_ms: now_ms,
+            drain_started_ms: 0,
+            last_tick_ms: now_ms,
+            time_awake_ms: 0,
+            time_suspended_ms: 0,
+        }
+    }
+
+    pub fn state(&self) -> NesState {
+        self.state
+    }
+
+    pub fn action(&self) -> NesAction {
+        self.config.action
+    }
+
+    /// Fraction of observed time spent suspended (the `energy_sleep_ratio`
+    /// gauge source).
+    pub fn sleep_ratio(&self) -> f64 {
+        let total = self.time_awake_ms + self.time_suspended_ms;
+        if total > 0 {
+            self.time_suspended_ms as f64 / total as f64
+        } else {
+            0.0
+        }
+    }
+
+    /// Record inbound activity. From `Suspended` this is the wake-up signal
+    /// ([`NesTransition::Resume`]); from `Draining` it silently aborts the
+    /// drain (new demand cancels the sleep attempt — nothing was suspended
+    /// yet, so there is nothing external to undo).
+    pub fn on_activity(&mut self, now_ms: u64) -> Option<NesTransition> {
+        self.accumulate(now_ms);
+        self.last_activity_ms = now_ms;
+        match self.state {
+            NesState::Suspended => {
+                self.state = NesState::Active;
+                Some(NesTransition::Resume)
+            }
+            NesState::Draining => {
+                self.state = NesState::Active;
+                None
+            }
+            NesState::Active => None,
+        }
+    }
+
+    /// Advance the machine from a poll tick. `in_flight` is the number of
+    /// requests currently being served; [`NesTransition::Suspend`] is only
+    /// emitted once it reaches zero (graceful drain).
+    pub fn tick(&mut self, now_ms: u64, in_flight: u64) -> Option<NesTransition> {
+        self.accumulate(now_ms);
+        match self.state {
+            NesState::Active => {
+                if now_ms.saturating_sub(self.last_activity_ms) >= self.config.idle_threshold_ms {
+                    self.state = NesState::Draining;
+                    self.drain_started_ms = now_ms;
+                    Some(NesTransition::BeginDrain)
+                } else {
+                    None
+                }
+            }
+            NesState::Draining => {
+                if in_flight == 0 {
+                    self.state = NesState::Suspended;
+                    Some(NesTransition::Suspend)
+                } else if now_ms.saturating_sub(self.drain_started_ms)
+                    >= self.config.drain_timeout_ms
+                {
+                    // In-flight work outlived the drain window: never drop
+                    // it — abandon the sleep attempt instead.
+                    self.state = NesState::Active;
+                    self.last_activity_ms = now_ms;
+                    Some(NesTransition::AbortDrain)
+                } else {
+                    None
+                }
+            }
+            NesState::Suspended => None,
+        }
+    }
+
+    fn accumulate(&mut self, now_ms: u64) {
+        let elapsed = now_ms.saturating_sub(self.last_tick_ms);
+        match self.state {
+            NesState::Suspended => self.time_suspended_ms += elapsed,
+            _ => self.time_awake_ms += elapsed,
+        }
+        self.last_tick_ms = now_ms;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn machine() -> NesMachine {
+        NesMachine::new(
+            NesConfig {
+                idle_threshold_ms: 1_000,
+                drain_timeout_ms: 500,
+                action: NesAction::Suspend,
+            },
+            0,
+        )
+    }
+
+    #[test]
+    fn idle_drains_then_suspends_when_no_work_in_flight() {
+        let mut m = machine();
+        assert_eq!(m.tick(999, 0), None, "below idle threshold");
+        assert_eq!(m.state(), NesState::Active);
+
+        assert_eq!(m.tick(1_000, 0), Some(NesTransition::BeginDrain));
+        assert_eq!(m.state(), NesState::Draining);
+
+        assert_eq!(m.tick(1_100, 0), Some(NesTransition::Suspend));
+        assert_eq!(m.state(), NesState::Suspended);
+        // Suspended stays put with no activity.
+        assert_eq!(m.tick(10_000, 0), None);
+        assert_eq!(m.state(), NesState::Suspended);
+    }
+
+    /// Acceptance (issue #22): graceful drain — the sleep transition never
+    /// fires while requests are in flight.
+    #[test]
+    fn drain_waits_for_in_flight_and_suspends_only_when_settled() {
+        let mut m = machine();
+        assert_eq!(m.tick(1_000, 3), Some(NesTransition::BeginDrain));
+        assert_eq!(m.tick(1_100, 3), None, "in-flight work blocks suspend");
+        assert_eq!(m.tick(1_200, 1), None, "still one in flight");
+        assert_eq!(m.state(), NesState::Draining);
+        assert_eq!(m.tick(1_300, 0), Some(NesTransition::Suspend));
+        assert_eq!(m.state(), NesState::Suspended);
+    }
+
+    #[test]
+    fn drain_timeout_aborts_back_to_active_without_dropping_work() {
+        let mut m = machine();
+        assert_eq!(m.tick(1_000, 2), Some(NesTransition::BeginDrain));
+        // Drain window (500ms) expires with work still pending.
+        assert_eq!(m.tick(1_500, 2), Some(NesTransition::AbortDrain));
+        assert_eq!(m.state(), NesState::Active);
+        // The abort refreshed the idle clock: no immediate re-drain.
+        assert_eq!(m.tick(1_600, 0), None);
+        assert_eq!(m.tick(2_500, 0), Some(NesTransition::BeginDrain));
+    }
+
+    /// Acceptance (issue #22): activity restores the NF from Suspended
+    /// (the caller PATCHes back to REGISTERED / re-registers on Resume).
+    #[test]
+    fn activity_resumes_from_suspended_and_aborts_draining() {
+        let mut m = machine();
+        m.tick(1_000, 0);
+        m.tick(1_001, 0);
+        assert_eq!(m.state(), NesState::Suspended);
+        assert_eq!(m.on_activity(2_000), Some(NesTransition::Resume));
+        assert_eq!(m.state(), NesState::Active);
+
+        // Draining + activity: silent abort (nothing external happened yet).
+        m.tick(3_000, 0);
+        assert_eq!(m.state(), NesState::Draining);
+        assert_eq!(m.on_activity(3_100), None);
+        assert_eq!(m.state(), NesState::Active);
+
+        // Active + activity: no transition.
+        assert_eq!(m.on_activity(3_200), None);
+    }
+
+    #[test]
+    fn sleep_ratio_accumulates_by_state() {
+        let mut m = machine();
+        m.tick(1_000, 0); // BeginDrain at 1000 (1000ms awake)
+        m.tick(1_100, 0); // Suspend at 1100 (+100ms awake)
+        m.tick(2_200, 0); // +1100ms suspended
+        let ratio = m.sleep_ratio();
+        assert!((ratio - 0.5).abs() < 1e-9, "1100/2200 = 0.5, got {ratio}");
+    }
+
+    #[test]
+    fn action_parse() {
+        assert_eq!(NesAction::parse("suspend"), Some(NesAction::Suspend));
+        assert_eq!(NesAction::parse("DEREGISTER"), Some(NesAction::Deregister));
+        assert_eq!(NesAction::parse("off"), None);
+    }
+}


### PR DESCRIPTION
Closes #22

## Summary

Implements Network Energy Saving as a bounded, **feature-gated** (`nes` on udmd, off by default) increment: per-NF energy/utilization metrics on a **live** `/metrics` endpoint, and an idle/sleep hook (`Active → Draining → Suspended → Active`) that reflects sleep to the NRF via `nfStatus=SUSPENDED` or deregistration, with graceful drain. TS 23.501/29.510 `nfStatus` and TS 28.310 KPI families are the normative anchors; the sleep policy and power numbers are **documented non-normative research** (no frozen Rel-20 Stage-3) — see `docs/NES.md`.

## What the survey forced

- The pre-existing `MetricsServer` is a **non-binding stub** and no bin uses the `MetricsSpec` registry, so the acceptance criterion "curl `/metrics`" required a small **real** HTTP/1.1 listener: `nextgcore_metrics::nes_energy::serve_metrics` (tokio, `/metrics` + `/healthz`, tested with real socket round-trips). `EnergyGauges` bridges the dormant TS 28.310 `AiMetricDef` descriptors (plus new `nf_utilization_ratio`) onto live lock-free values, and also registers `MetricsSpec`s into the registry.
- The NRF treated **any** heartbeat PATCH as liveness and flipped a `SUSPENDED` profile back to `REGISTERED` — even a PATCH whose own body sets `SUSPENDED` (reactivation runs after the patch applies), making self-suspension impossible. `handle_nf_update` now honors an explicit self-suspension (`patch_requests_self_suspension`, unit-tested) while still re-arming the liveness timer — so a sleeping-but-heartbeating NF is neither reactivated nor auto-deregistered.
- The heartbeat worker hardcoded `nfStatus=REGISTERED`. `build_load_patch` now delegates to `build_status_patch(load, self_nf_status())` — **byte-identical by default** (pinned by test) — and the worker can be paused (`set_heartbeat_paused`) for the deregister action; `patch_nf_status` issues one-off transition PATCHes with the spec content-type.

## The sleep hook

`nextgcore_sbi::nes::NesMachine` is a pure, millisecond-driven state machine (fully unit-tested): idle threshold → `BeginDrain`; drained (`in_flight == 0`) → `Suspend`; drain-window expiry with work pending → `AbortDrain` back to Active (**no request is ever dropped**); activity while suspended → `Resume`.

udmd (reference NF, feature `nes`): inbound activity/in-flight tracked by two inert atomics in the request handler (in-flight decrement via **RAII guard** so panics/cancellations can't strand the drain gate); a poll ticker drives the machine and dispatches injected `NesActions` — production `NrfNesActions` PATCHes `SUSPENDED`/`REGISTERED` (heartbeats keep advertising the live status) or deregisters/re-registers under the **same NF instance id** (re-registration retries with capped exponential backoff before unpausing heartbeats). The same ticker feeds the gauges from the **synthetic power model** (documented in `docs/NES.md` and the module docs). Config = `udm.nes:` YAML block (`enabled` defaults false; absent block = complete no-op).

## Adversarial review (31 agents, 4 dimensions → 3-skeptic verification)

Three confirmed findings, all fixed in this PR: (1) the new heartbeat test mutated the process-global self-status while pre-existing patch-shape tests read it — those tests now use the explicit-status builder; (2) `NES_IN_FLIGHT` leaked on handler panic/cancellation, permanently blocking sleep — replaced with an RAII drop-guard; (3) a failed re-registration after deregister-sleep stranded the NF with paused heartbeats — now retried with capped backoff. Rejected findings were documented scope (metrics listener hardening, sub-tick PATCH/heartbeat race windows, predicate-level nrfd test granularity).

## Acceptance criteria → evidence

| Criterion | Evidence |
|---|---|
| Builds+tests with and without `--features nes` | verified both configs; clippy 0 both |
| Default byte-for-byte unchanged | `build_load_patch` exact-JSON pin test; statics/wrapper inert; no metrics listener, no status change without the feature |
| `/metrics` shows energy family + `nf_utilization_ratio` | `serve_metrics_answers_real_http` (real socket GET), `gauges_render_all_energy_families_with_labels` |
| idle→drain→suspend asserts the suspend action; activity restores REGISTERED | `idle_drain_suspend_then_activity_resumes` (recorder actions), `activity_resumes_from_suspended_and_aborts_draining`, nrfd self-suspension + heartbeat SUSPENDED-patch tests |
| Graceful drain (no in-flight drop) | `drain_gate_blocks_suspend_until_in_flight_settles`, `drain_waits_for_in_flight_and_suspends_only_when_settled`, `drain_timeout_aborts_back_to_active_without_dropping_work` |
| Docs | `docs/NES.md` (config block + synthetic-power caveat + nrfd note) |

Out of scope (documented): hardening of the metrics listener, NES on other NFs, real energy counters, and any scale-out policy.
