### PR TITLE
feat(pcfd): intent-driven closed-loop policy spike, feature-gated off (issue #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ cargo audit
 - [docs/ci-and-release.md](docs/ci-and-release.md) — CI pipeline (GitHub Actions jobs) and the release process
 - [docs/sba-transport-evaluation.md](docs/sba-transport-evaluation.md) — HTTP/2 vs HTTP/3 SBI transport benchmark and evaluation (non-normative 6G research)
 - [docs/isac-sensing-pipeline.md](docs/isac-sensing-pipeline.md) — ISAC sensing data pipeline design note (non-normative 6G research)
+- [docs/intent-driven-policy-loop.md](docs/intent-driven-policy-loop.md) — intent-driven closed-loop policy design note (non-normative 6G research)
 - [docker/rust/CI.md](docker/rust/CI.md) — the one-command matched-sim end-to-end suite (`e2e.sh`)
 - [docs/](docs/) — per-component gap analyses and architecture notes
 

--- a/docker/rust/configs/5gc/pcf.yaml
+++ b/docker/rust/configs/5gc/pcf.yaml
@@ -33,3 +33,19 @@ pcf:
     key: /etc/nextgcore/certs/pcf.key
     ca: /etc/nextgcore/certs/ca.crt
     min_version: "1.2"
+  # Issue #24: intent-driven closed-loop policy spike (non-normative 6G
+  # research). Declares ONE outcome — keep slice (sst/sd) latency below
+  # max_latency_ms — for the PCF→NWDAF monitor→decide→act controller.
+  # Requires a pcfd built with `--features intent-loop`; with the block
+  # absent or enabled: false the controller never starts, and without the
+  # feature the block is ignored. See docs/intent-driven-policy-loop.md.
+  intent:
+    enabled: false
+    sst: 1
+    sd: "000001"
+    max_latency_ms: 20.0
+    poll_interval_secs: 30
+    aggressiveness: 0.5
+    # Synthetic NF_LOAD -> latency proxy slope (ms per load percent):
+    # today's nwdafd serves real data only for NF_LOAD.
+    nf_load_latency_ms_per_pct: 0.5

--- a/docs/intent-driven-policy-loop.md
+++ b/docs/intent-driven-policy-loop.md
@@ -1,0 +1,125 @@
+# Intent-Driven Closed-Loop Policy (Design Note)
+
+> **Non-normative 6G research.** Intent-driven, closed-loop network
+> management ("declare an outcome, let the core measure and self-adjust")
+> is a 6G / autonomous-networks research theme. **No frozen Rel-20 Stage-3
+> specification exists for it**; the closest normative anchor is the
+> Rel-17/18 intent-management work (TS 28.312), with TS 23.288 §6.9 /
+> TS 29.520 (NWDAF analytics) and TS 23.503 / TS 29.512 (PCF policy) as the
+> surrounding machinery. This is a research shape for education, not a
+> conformance target.
+> Tracking issue: [#24](https://github.com/NextgCoreLab/nextgcore/issues/24).
+
+## Intent schema
+
+One declarative intent, one outcome: *keep slice X latency below N ms*.
+Declared as a `pcf.intent` YAML block (see `docker/rust/configs/5gc/pcf.yaml`):
+
+```yaml
+pcf:
+  intent:
+    enabled: true            # default false; controller never starts when false
+    sst: 1                   # target slice S-NSSAI SST
+    sd: "000001"             # target slice S-NSSAI SD (informational in the spike)
+    max_latency_ms: 20.0     # THE declared outcome
+    poll_interval_secs: 30
+    aggressiveness: 0.5      # SlaPolicyAdapter tuning knob, clamped to 0..=1
+    nf_load_latency_ms_per_pct: 0.5   # synthetic latency proxy slope (see below)
+```
+
+At startup the block is deserialized into the **existing**
+`PolicyIntent { intent_type: MinLatency, constraints: [MaxLatencyMs(N)] }`
+(`intent_policy.rs` — previously `#[allow(dead_code)]` scaffolding, now
+consumed by the loop) and translated once by `IntentPolicyTranslator` into
+the baseline `GeneratedPolicy` (5QI 1, ARP 2, 10 ms DRX for `MinLatency`).
+
+## The monitor → decide → act loop
+
+```
+        pcf.intent YAML ──► PolicyIntent ──► IntentPolicyTranslator ──► baseline GeneratedPolicy
+                                                                              │
+  ┌─────────────────────── controller task (tokio, every poll_interval_secs) ─┴──────────┐
+  │                                                                                      │
+  │ MONITOR  GET /nnwdaf-analyticsinfo/v1/analytics?event-id=QOS_SUSTAINABILITY (204 today)
+  │          GET /nnwdaf-analyticsinfo/v1/analytics?event-id=NF_LOAD  ──► Observation     │
+  │          (NWDAF found via NRF discovery: nnrf-disc, target-nf-type=NWDAF)            │
+  │ DECIDE   Observation ──► AnalyticsState (populated) ──► AnalyticsPolicyEngine (log)  │
+  │          Observation ──► SlaFeedback ──► SlaPolicyAdapter::adapt (DRX tightened)     │
+  │ ACT      adapted GeneratedPolicy ──► SessionData ──► build_sm_policy_decision        │
+  │          + structured log: "monitor → observed=… target=… action=…"                  │
+  └──────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+The decide row reuses code that was previously dead or test-only
+(`intent_policy.rs`, `AnalyticsState` / `AnalyticsPolicyEngine` in
+`context.rs`); the act row reuses the production `sm_policy_build.rs`
+decision builder. The loop (`intent_loop.rs`) only connects them.
+
+## The latency observation is a synthetic proxy (caveat)
+
+The intent semantically wants the QoS-sustainability analytic, and the loop
+does ask for it first — but today's `nwdafd` **serves real data only for
+`NF_LOAD`** (`SUPPORTED_EVENTS = [NF_LOAD]`; `QOS_SUSTAINABILITY` is a
+recognised token that always answers 204 no-data, and neither this build's
+dead `QosSustainabilityPrediction` struct nor TS 29.520's
+`QosSustainabilityInfo` carries a direct latency member). So the loop falls
+back to the one live analytic and models observed latency as:
+
+```
+observed_ms = worst nfLoadLevelAverage (percent) × nf_load_latency_ms_per_pct
+```
+
+This is **illustrative only** — the same honesty rule as the NES synthetic
+power model (`docs/NES.md`). When `nwdafd` grows a real QoS-sustainability
+computation, `observe_nwdaf` is the single place to swap the source.
+
+## Scope limits
+
+- **One intent, one outcome.** No general intent engine, no multi-intent
+  conflict resolution (out of scope per the issue).
+- **Polling GET**, not `Nnwdaf_EventsSubscription` subscribe/notify.
+- **Tighten-only.** A violated target shrinks DRX via `SlaPolicyAdapter`
+  (aggressiveness-weighted, 5 ms floor); a reading back within target does
+  not relax the policy (no hysteresis in the spike).
+- **The re-issued decision is produced and logged, not delivered.** The
+  adjusted `SmPolicyDecision` is built through the production
+  `build_sm_policy_decision`; pushing it to an SMF over
+  `Npcf_SMPolicyControl` UpdateNotify needs a per-session sweep plus a
+  parts-taking notify variant (today's `…update_notify` re-derives from
+  UDR) — a follow-up, not the spike.
+- **`AnalyticsPolicyEngine` is observability-only** in the loop: its
+  congestion reaction (throttle) can oppose a min-latency intent, so its
+  verdict is logged (`engine=…`) but not applied.
+- DRX and energy mode have no TS 29.512 `SmPolicyDecision` representation;
+  they stay loop-internal.
+
+## Observability
+
+One structured log line per iteration (the acceptance signal):
+
+```
+intent-loop: monitor → observed=40.0ms(nf-load-proxy) target=20.0ms action=adapt(drx 10ms→5ms; rebuilt SmPolicyDecision intent-1) (slice sst=1 engine=CongestionAvoidance/Throttle)
+```
+
+(That example is self-consistent: 80% NF load × 0.5 ms/% slope = 40 ms
+observed; latency ratio 2.0 × aggressiveness 0.5 halves the 10 ms DRX to its
+5 ms floor; load ≥ 75% also trips the analytics engine's congestion verdict.)
+
+`action` is one of `none(no-analytics)`, `none(within-target)`,
+`none(no-headroom; …)` (still violated but DRX already at the adapter's 5 ms
+floor — no false "adapt" claim, no identical decision rebuild), or
+`adapt(…)`.
+
+## Verification
+
+```sh
+# default build/behavior unchanged (feature off, block ignored)
+cargo build -p nextgcore-pcfd
+# feature build + the closed-loop unit tests (incl. the end-to-end iteration)
+cargo test -p nextgcore-pcfd --features intent-loop intent_loop
+```
+
+Live demo: build pcfd with `--features intent-loop`, set
+`pcf.intent.enabled: true`, and run it against a stack with NRF + NWDAF up
+(NWDAF needs NRF NFStatusNotify traffic to have NF_LOAD samples); the PCF
+then logs the `monitor → observed=… target=… action=…` line each poll.

--- a/src/bins/nextgcore-pcfd/Cargo.toml
+++ b/src/bins/nextgcore-pcfd/Cargo.toml
@@ -17,6 +17,17 @@ path = "src/main.rs"
 name = "nextgcore_pcfd"
 path = "src/lib.rs"
 
+[features]
+## Issue #24: intent-driven closed-loop policy spike (non-normative 6G /
+## autonomous-networks research; no frozen Rel-20 Stage-3 exists — nearest
+## anchor TS 28.312). Wires the pre-existing intent_policy scaffolding to a
+## live NWDAF Nnwdaf_AnalyticsInfo poll for ONE outcome: keep slice X latency
+## below N ms (pcf.intent YAML block). Off by default: the controller is
+## fully compiled out of the default build and the pcf.intent block is
+## ignored (only an inert raw-YAML field capture is unconditional).
+## Enable with: cargo build -p nextgcore-pcfd --features intent-loop
+intent-loop = []
+
 [dependencies]
 nextgcore-core = { workspace = true }
 nextgcore-sbi = { workspace = true }

--- a/src/bins/nextgcore-pcfd/src/app.rs
+++ b/src/bins/nextgcore-pcfd/src/app.rs
@@ -123,9 +123,35 @@ struct SbiYaml {
     client: Option<SbiClientYaml>,
 }
 
+/// Declarative intent block (issue #24, feature `intent-loop`): ONE slice
+/// latency outcome for the closed-loop controller. Converted leniently from
+/// the raw `PcfSection::intent` value under the feature; without the feature
+/// the block is ignored.
+#[derive(Debug, Default, Deserialize, Clone)]
+pub(crate) struct IntentYaml {
+    pub(crate) enabled: Option<bool>,
+    /// Target slice S-NSSAI SST.
+    pub(crate) sst: Option<u8>,
+    /// Target slice S-NSSAI SD (hex string; informational in the spike).
+    pub(crate) sd: Option<String>,
+    /// The declared outcome: keep slice latency below this many ms.
+    pub(crate) max_latency_ms: Option<f64>,
+    pub(crate) poll_interval_secs: Option<u64>,
+    /// SlaPolicyAdapter aggressiveness (0.0..=1.0).
+    pub(crate) aggressiveness: Option<f64>,
+    /// Synthetic NF_LOAD→latency proxy slope (ms per load percent); see
+    /// docs/intent-driven-policy-loop.md.
+    pub(crate) nf_load_latency_ms_per_pct: Option<f64>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct PcfSection {
     sbi: Option<SbiYaml>,
+    /// Raw YAML value, NOT the typed [`IntentYaml`]: a malformed intent
+    /// block must never fail the whole `PcfYaml` parse (which would silently
+    /// skip SBI-address/NRF-URI seeding, in the default build too). The
+    /// typed conversion happens leniently under the `intent-loop` feature.
+    intent: Option<serde_yaml::Value>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -264,6 +290,8 @@ pub async fn run() -> Result<()> {
 
     // Parse configuration (if file exists) and seed NRF URI
     let mut sbi_fqdn: Option<String> = None;
+    #[cfg(feature = "intent-loop")]
+    let mut intent_yaml: Option<IntentYaml> = None;
     if std::path::Path::new(&args.config).exists() {
         log::info!("Loading configuration from {}", args.config);
         match std::fs::read_to_string(&args.config) {
@@ -272,6 +300,20 @@ pub async fn run() -> Result<()> {
                 // Seed NRF URI into SBI context for NF registration
                 if let Ok(yaml) = serde_yaml::from_str::<PcfYaml>(&content) {
                     if let Some(pcf) = yaml.pcf {
+                        #[cfg(feature = "intent-loop")]
+                        {
+                            intent_yaml = pcf.intent.clone().and_then(|v| {
+                                match serde_yaml::from_value::<IntentYaml>(v) {
+                                    Ok(y) => Some(y),
+                                    Err(e) => {
+                                        log::warn!(
+                                            "intent-loop: invalid pcf.intent block ignored: {e}"
+                                        );
+                                        None
+                                    }
+                                }
+                            });
+                        }
                         if let Some(sbi) = pcf.sbi {
                             // Override the advertised/bind SBI address with the
                             // routable address from config so the NRF NFProfile
@@ -370,6 +412,17 @@ pub async fn run() -> Result<()> {
     }
 
     log::info!("NextGCore PCF ready");
+
+    // Issue #24: intent-driven closed-loop policy controller (feature
+    // `intent-loop`, off by default). Spawned regardless of NRF-registration
+    // outcome: without an NRF, NWDAF discovery degrades to
+    // `observed=unavailable` rather than blocking startup.
+    #[cfg(feature = "intent-loop")]
+    crate::intent_loop::spawn_if_enabled(
+        intent_yaml
+            .as_ref()
+            .map(crate::intent_loop::IntentSettings::from_yaml),
+    );
 
     // Main event loop (async)
     run_event_loop_async(&mut pcf_sm, shutdown).await?;

--- a/src/bins/nextgcore-pcfd/src/intent_loop.rs
+++ b/src/bins/nextgcore-pcfd/src/intent_loop.rs
@@ -1,0 +1,626 @@
+//! Intent-driven closed-loop policy controller (issue #24, feature `intent-loop`).
+//!
+//! Non-normative 6G / autonomous-networks research prototype: no frozen
+//! Rel-20 Stage-3 exists for intent-driven management; the closest normative
+//! anchor is the Rel-17/18 intent work (TS 28.312). This module connects the
+//! pre-existing scaffolding into ONE running loop for ONE declared outcome —
+//! "keep slice X latency below N ms":
+//!
+//! - intent → policy: [`crate::intent_policy::IntentPolicyTranslator`]
+//! - monitor: live `Nnwdaf_AnalyticsInfo` GET (TS 29.520) via NRF discovery
+//! - decide: [`crate::intent_policy::SlaPolicyAdapter`], plus
+//!   [`crate::context::AnalyticsPolicyEngine`] for observability
+//! - act: re-issue an updated SM policy decision through
+//!   [`crate::sm_policy_build::build_sm_policy_decision`]
+//!
+//! Latency-observation caveat: today's nwdafd serves real data only for
+//! `NF_LOAD` (`QOS_SUSTAINABILITY` is a recognised token but always answers
+//! 204 no-data), so the loop derives its observed latency from NF load
+//! through a documented synthetic proxy (`nf_load_latency_ms_per_pct`).
+//! See `docs/intent-driven-policy-loop.md`.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::app::IntentYaml;
+use crate::context::{AnalyticsPolicyEngine, AnalyticsState, PolicyAdjustment};
+use crate::intent_policy::{
+    GeneratedPolicy, IntentPolicyTranslator, PolicyConstraint, PolicyIntent, PolicyIntentType,
+    SlaFeedback, SlaPolicyAdapter,
+};
+use crate::nudr_handler::SessionData;
+use crate::sm_policy_build::{build_sm_policy_decision, SmPolicyDecisionParts};
+
+/// Resolved intent-loop configuration (YAML overlaid onto defaults).
+#[derive(Debug, Clone)]
+pub struct IntentSettings {
+    pub enabled: bool,
+    /// Target slice S-NSSAI SST.
+    pub sst: u8,
+    /// Target slice S-NSSAI SD (hex string; informational in the spike).
+    pub sd: Option<String>,
+    /// The declared outcome: keep slice latency below this many milliseconds.
+    pub max_latency_ms: f64,
+    pub poll_interval_secs: u64,
+    /// [`SlaPolicyAdapter`] aggressiveness (clamped to 0.0..=1.0).
+    pub aggressiveness: f64,
+    /// Synthetic NF_LOAD→latency proxy slope: observed latency is modelled
+    /// as `load_pct * nf_load_latency_ms_per_pct` ms (see the design doc).
+    pub nf_load_latency_ms_per_pct: f64,
+}
+
+impl Default for IntentSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            sst: 1,
+            sd: None,
+            max_latency_ms: 20.0,
+            poll_interval_secs: 30,
+            aggressiveness: 0.5,
+            nf_load_latency_ms_per_pct: 0.5,
+        }
+    }
+}
+
+impl IntentSettings {
+    /// Overlay a parsed `pcf.intent` YAML block onto the defaults, clamping
+    /// nonsensical values instead of failing startup.
+    pub(crate) fn from_yaml(yaml: &IntentYaml) -> Self {
+        let d = Self::default();
+        Self {
+            enabled: yaml.enabled.unwrap_or(d.enabled),
+            sst: yaml.sst.unwrap_or(d.sst),
+            sd: yaml.sd.clone(),
+            max_latency_ms: yaml
+                .max_latency_ms
+                .filter(|v| *v > 0.0)
+                .unwrap_or(d.max_latency_ms),
+            poll_interval_secs: yaml
+                .poll_interval_secs
+                .unwrap_or(d.poll_interval_secs)
+                .max(1),
+            aggressiveness: yaml
+                .aggressiveness
+                .filter(|v| v.is_finite())
+                .unwrap_or(d.aggressiveness)
+                .clamp(0.0, 1.0),
+            nf_load_latency_ms_per_pct: yaml
+                .nf_load_latency_ms_per_pct
+                .filter(|v| *v > 0.0)
+                .unwrap_or(d.nf_load_latency_ms_per_pct),
+        }
+    }
+
+    /// Express the declared outcome as the existing [`PolicyIntent`] shape
+    /// (issue #24: reuse `PolicyIntentType::MinLatency` +
+    /// `PolicyConstraint::MaxLatencyMs`; no new intent type).
+    pub fn to_policy_intent(&self) -> PolicyIntent {
+        PolicyIntent {
+            id: 1,
+            intent_type: PolicyIntentType::MinLatency,
+            target_sst: Some(self.sst),
+            priority: 1,
+            constraints: vec![PolicyConstraint::MaxLatencyMs(self.max_latency_ms)],
+        }
+    }
+}
+
+/// One monitor reading, derived from live NWDAF analytics.
+#[derive(Debug, Clone)]
+pub struct Observation {
+    /// Observed (proxy) latency for the slice, in milliseconds.
+    pub latency_ms: f64,
+    /// NF load percent (0-100) the proxy latency was derived from.
+    pub load_pct: f64,
+}
+
+/// Derive an [`Observation`] from an `NF_LOAD` `AnalyticsData` body
+/// (TS 29.520 `nfLoadLevelInfos`). Uses the worst (max) per-instance
+/// `nfLoadLevelAverage`, then applies the synthetic latency proxy slope.
+pub fn observation_from_nf_load(body: &serde_json::Value, ms_per_pct: f64) -> Option<Observation> {
+    let infos = body.get("nfLoadLevelInfos")?.as_array()?;
+    let worst = infos
+        .iter()
+        .filter_map(|i| i.get("nfLoadLevelAverage").and_then(|v| v.as_f64()))
+        .fold(f64::NAN, f64::max);
+    if !worst.is_finite() {
+        return None;
+    }
+    Some(Observation {
+        latency_ms: worst * ms_per_pct,
+        load_pct: worst,
+    })
+}
+
+/// What one loop iteration decided.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IterationAction {
+    /// No analytics available this round (no NRF/NWDAF, or no data yet).
+    NoData,
+    /// Observed latency within target; policy untouched, nothing re-issued.
+    WithinTarget,
+    /// Latency violated: [`SlaPolicyAdapter`] tightened the policy and an
+    /// updated SM policy decision was rebuilt (produced + logged; delivery
+    /// to an SMF is out of the spike's scope).
+    Adapted {
+        drx_before_ms: u32,
+        drx_after_ms: u32,
+    },
+    /// Latency still violated but the adapter has no headroom left (DRX at
+    /// its 5 ms floor, or aggressiveness 0): policy unchanged, nothing
+    /// rebuilt.
+    NoHeadroom { drx_ms: u32 },
+}
+
+/// Outcome of one monitor→decide→act iteration. (No `Debug` derive:
+/// `SmPolicyDecisionParts` deliberately doesn't implement it.)
+pub struct IterationOutcome {
+    pub observed_ms: Option<f64>,
+    pub target_ms: f64,
+    pub action: IterationAction,
+    /// The rebuilt decision (only on [`IterationAction::Adapted`]).
+    pub decision: Option<SmPolicyDecisionParts>,
+    /// What the broader analytics engine would do with this reading
+    /// (observability only in the spike; not applied to the decision).
+    pub analytics_adjustment: Option<PolicyAdjustment>,
+}
+
+/// The closed-loop controller state: declared intent, translated baseline
+/// policy, the currently active (possibly adapted) policy, and the two
+/// pre-existing decision engines.
+pub struct IntentController {
+    settings: IntentSettings,
+    intent: PolicyIntent,
+    baseline: GeneratedPolicy,
+    current: GeneratedPolicy,
+    adapter: SlaPolicyAdapter,
+    engine: AnalyticsPolicyEngine,
+    analytics: AnalyticsState,
+    iterations: u64,
+}
+
+impl IntentController {
+    pub fn new(settings: IntentSettings) -> Self {
+        let intent = settings.to_policy_intent();
+        let mut translator = IntentPolicyTranslator::new();
+        let baseline = translator.translate(&intent);
+        let current = baseline.clone();
+        let adapter = SlaPolicyAdapter::new(settings.aggressiveness);
+        Self {
+            settings,
+            intent,
+            baseline,
+            current,
+            adapter,
+            engine: AnalyticsPolicyEngine::new(),
+            analytics: AnalyticsState::default(),
+            iterations: 0,
+        }
+    }
+
+    /// The intent-derived baseline policy (before any SLA adaptation).
+    pub fn baseline(&self) -> &GeneratedPolicy {
+        &self.baseline
+    }
+
+    /// The currently active policy (baseline, possibly tightened by `adapt`).
+    pub fn current(&self) -> &GeneratedPolicy {
+        &self.current
+    }
+
+    /// The [`AnalyticsState`] populated from the most recent NWDAF reading.
+    pub fn analytics(&self) -> &AnalyticsState {
+        &self.analytics
+    }
+
+    pub fn iterations(&self) -> u64 {
+        self.iterations
+    }
+
+    /// One monitor→decide→act iteration, pure given the observation so tests
+    /// can inject readings (the async NWDAF poll lives in [`observe_nwdaf`]).
+    pub fn drive_iteration(&mut self, observation: Option<Observation>) -> IterationOutcome {
+        self.iterations += 1;
+        let target_ms = self.settings.max_latency_ms;
+        let Some(obs) = observation else {
+            return IterationOutcome {
+                observed_ms: None,
+                target_ms,
+                action: IterationAction::NoData,
+                decision: None,
+                analytics_adjustment: None,
+            };
+        };
+
+        // Populate the (previously never-populated) AnalyticsState from the
+        // live reading: congestion = load fraction, sustainability = its
+        // complement — proxy semantics documented in the design note.
+        let load_fraction = (obs.load_pct / 100.0).clamp(0.0, 1.0) as f32;
+        self.analytics.predicted_congestion = load_fraction;
+        self.analytics.qos_sustainability = 1.0 - load_fraction;
+        self.analytics.last_query_epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        // Observability: what the broader analytics engine would do. Its
+        // congestion reaction (throttle) can oppose a min-latency intent, so
+        // the spike logs it without applying it.
+        let current_5qi = u8::try_from(self.current.five_qi).unwrap_or(9);
+        let analytics_adjustment =
+            self.engine
+                .evaluate(&self.analytics, current_5qi, self.current.arp_priority);
+
+        // Feed ONLY the declared outcome (latency) into the SLA adapter; the
+        // throughput/loss targets are set trivially-satisfied.
+        let feedback = SlaFeedback {
+            latency_ms: obs.latency_ms,
+            target_latency_ms: target_ms,
+            throughput_mbps: 0.0,
+            target_throughput_mbps: 0.0,
+            packet_loss_pct: 0.0,
+            target_packet_loss_pct: 100.0,
+        };
+        if !feedback.latency_violated() {
+            return IterationOutcome {
+                observed_ms: Some(obs.latency_ms),
+                target_ms,
+                action: IterationAction::WithinTarget,
+                decision: None,
+                analytics_adjustment,
+            };
+        }
+
+        let drx_before_ms = self.current.drx_cycle_ms;
+        self.current = self.adapter.adapt(&self.current, &feedback);
+        // No-op detection: with only the latency target able to fire, DRX is
+        // the sole field `adapt` can change; when it didn't move (5 ms floor,
+        // or aggressiveness 0) don't claim an adaptation or rebuild an
+        // identical decision.
+        if self.current.drx_cycle_ms == drx_before_ms {
+            return IterationOutcome {
+                observed_ms: Some(obs.latency_ms),
+                target_ms,
+                action: IterationAction::NoHeadroom {
+                    drx_ms: drx_before_ms,
+                },
+                decision: None,
+                analytics_adjustment,
+            };
+        }
+        let decision = decision_from_policy(&self.current, &format!("intent-{}", self.intent.id));
+        IterationOutcome {
+            observed_ms: Some(obs.latency_ms),
+            target_ms,
+            action: IterationAction::Adapted {
+                drx_before_ms,
+                drx_after_ms: self.current.drx_cycle_ms,
+            },
+            decision: Some(decision),
+            analytics_adjustment,
+        }
+    }
+}
+
+/// Map a [`GeneratedPolicy`] onto the existing SM policy decision builder
+/// (5QI/ARP direct, MBR kbps → session AMBR bps; DRX and energy mode have no
+/// TS 29.512 SmPolicyDecision representation and stay loop-internal).
+pub fn decision_from_policy(policy: &GeneratedPolicy, sm_policy_id: &str) -> SmPolicyDecisionParts {
+    let session_data = SessionData {
+        qos_index: u8::try_from(policy.five_qi).unwrap_or(9),
+        arp_priority_level: policy.arp_priority,
+        arp_preempt_cap: false,
+        arp_preempt_vuln: true,
+        ambr_uplink: policy.mbr_ul_kbps.saturating_mul(1000),
+        ambr_downlink: policy.mbr_dl_kbps.saturating_mul(1000),
+        pcc_rules: vec![],
+    };
+    build_sm_policy_decision(sm_policy_id, &session_data)
+}
+
+/// Spawn the controller task when a `pcf.intent` block is present and
+/// enabled; logged no-op otherwise (default build/behavior unchanged).
+pub(crate) fn spawn_if_enabled(settings: Option<IntentSettings>) {
+    let Some(settings) = settings else {
+        log::debug!("intent-loop: no pcf.intent block configured; controller not started");
+        return;
+    };
+    if !settings.enabled {
+        log::debug!("intent-loop: pcf.intent.enabled=false; controller not started");
+        return;
+    }
+    log::info!(
+        "intent-loop: starting (slice sst={} sd={} outcome: latency<{:.1}ms poll={}s aggressiveness={:.2})",
+        settings.sst,
+        settings.sd.as_deref().unwrap_or("-"),
+        settings.max_latency_ms,
+        settings.poll_interval_secs,
+        settings.aggressiveness
+    );
+    tokio::spawn(run_intent_loop(settings));
+}
+
+async fn run_intent_loop(settings: IntentSettings) {
+    let mut controller = IntentController::new(settings.clone());
+    log::info!(
+        "intent-loop: intent translated → baseline policy 5qi={} arp={} drx={}ms",
+        controller.current().five_qi,
+        controller.current().arp_priority,
+        controller.current().drx_cycle_ms
+    );
+    let mut ticker =
+        tokio::time::interval(std::time::Duration::from_secs(settings.poll_interval_secs));
+    // The first tick fires immediately (tokio interval default) — deliberate,
+    // so the loop emits its first monitor line at startup.
+    loop {
+        ticker.tick().await;
+        let observation = observe_nwdaf(&settings).await;
+        let outcome = controller.drive_iteration(observation);
+        log_outcome(&settings, &outcome);
+    }
+}
+
+/// Poll live NWDAF analytics: discover an NWDAF via the NRF, ask for the
+/// slice's QoS-sustainability analytic first (the analytic the intent
+/// semantically wants, TS 23.288 §6.9), then fall back to the one analytic
+/// today's nwdafd actually serves (`NF_LOAD`) and derive the latency proxy.
+async fn observe_nwdaf(settings: &IntentSettings) -> Option<Observation> {
+    let ep = match crate::sbi_path::pcf_discover_endpoint("NWDAF", "nnwdaf-analyticsinfo").await {
+        Ok(Some(ep)) => ep,
+        Ok(None) => {
+            log::debug!("intent-loop: no NWDAF discovered (no NRF configured or no instance)");
+            return None;
+        }
+        Err(e) => {
+            log::debug!("intent-loop: NWDAF discovery failed: {e}");
+            return None;
+        }
+    };
+    let client = crate::sbi_path::client_for(&ep, nextgcore_sbi::types::NfType::Nwdaf);
+
+    match query_analytics(&client, "QOS_SUSTAINABILITY").await {
+        Some((200, Some(body))) => {
+            // Neither this build nor TS 29.520 QosSustainabilityInfo carries a
+            // direct latency member; log and fall through to the NF_LOAD proxy.
+            log::debug!("intent-loop: QOS_SUSTAINABILITY returned data: {body}");
+        }
+        Some((status, _)) => {
+            log::debug!("intent-loop: QOS_SUSTAINABILITY status={status} (no data)");
+        }
+        None => return None, // transport error; NF_LOAD would fail identically
+    }
+
+    match query_analytics(&client, "NF_LOAD").await {
+        Some((200, Some(body))) => {
+            observation_from_nf_load(&body, settings.nf_load_latency_ms_per_pct)
+        }
+        Some((status, _)) => {
+            log::debug!("intent-loop: NF_LOAD status={status} (no data)");
+            None
+        }
+        None => None,
+    }
+}
+
+/// GET `/nnwdaf-analyticsinfo/v1/analytics?event-id=…`; returns the HTTP
+/// status and parsed JSON body (204 no-data arrives as `(204, None)`).
+async fn query_analytics(
+    client: &nextgcore_sbi::client::SbiClient,
+    event_id: &str,
+) -> Option<(u16, Option<serde_json::Value>)> {
+    let request = nextgcore_sbi::message::SbiRequest::get("/nnwdaf-analyticsinfo/v1/analytics")
+        .with_param("event-id", event_id);
+    match client.send_request(request).await {
+        Ok(resp) => {
+            let body = resp
+                .http
+                .content
+                .as_deref()
+                .and_then(|c| serde_json::from_str(c).ok());
+            Some((resp.status, body))
+        }
+        Err(e) => {
+            log::debug!("intent-loop: analytics GET event-id={event_id} failed: {e}");
+            None
+        }
+    }
+}
+
+fn log_outcome(settings: &IntentSettings, outcome: &IterationOutcome) {
+    let observed = match outcome.observed_ms {
+        Some(ms) => format!("{ms:.1}ms(nf-load-proxy)"),
+        None => "unavailable".to_string(),
+    };
+    let action = match &outcome.action {
+        IterationAction::NoData => "none(no-analytics)".to_string(),
+        IterationAction::WithinTarget => "none(within-target)".to_string(),
+        IterationAction::Adapted {
+            drx_before_ms,
+            drx_after_ms,
+        } => format!(
+            "adapt(drx {drx_before_ms}ms→{drx_after_ms}ms; rebuilt SmPolicyDecision intent-1)"
+        ),
+        IterationAction::NoHeadroom { drx_ms } => {
+            format!("none(no-headroom; drx at {drx_ms}ms floor, latency still violated)")
+        }
+    };
+    let engine = match &outcome.analytics_adjustment {
+        Some(adj) => format!(" engine={:?}/{:?}", adj.reason, adj.action),
+        None => String::new(),
+    };
+    log::info!(
+        "intent-loop: monitor → observed={observed} target={:.1}ms action={action} (slice sst={}{engine})",
+        outcome.target_ms,
+        settings.sst
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::AdjustmentReason;
+
+    fn enabled_settings(max_latency_ms: f64) -> IntentSettings {
+        IntentSettings {
+            enabled: true,
+            max_latency_ms,
+            ..IntentSettings::default()
+        }
+    }
+
+    #[test]
+    fn settings_defaults_and_yaml_overlay() {
+        let empty = IntentYaml::default();
+        let s = IntentSettings::from_yaml(&empty);
+        assert!(!s.enabled, "intent loop must default to disabled");
+        assert_eq!(s.sst, 1);
+        assert!((s.max_latency_ms - 20.0).abs() < f64::EPSILON);
+
+        let yaml = IntentYaml {
+            enabled: Some(true),
+            sst: Some(2),
+            sd: Some("000001".to_string()),
+            max_latency_ms: Some(10.0),
+            poll_interval_secs: Some(0),            // clamped up to 1
+            aggressiveness: Some(7.0),              // clamped to 1.0
+            nf_load_latency_ms_per_pct: Some(-3.0), // invalid → default
+        };
+        let s = IntentSettings::from_yaml(&yaml);
+        assert!(s.enabled);
+        assert_eq!(s.sst, 2);
+        assert_eq!(s.sd.as_deref(), Some("000001"));
+        assert!((s.max_latency_ms - 10.0).abs() < f64::EPSILON);
+        assert_eq!(s.poll_interval_secs, 1);
+        assert!((s.aggressiveness - 1.0).abs() < f64::EPSILON);
+        assert!((s.nf_load_latency_ms_per_pct - 0.5).abs() < f64::EPSILON);
+
+        // NaN must not escape the clamp (it would propagate through
+        // SlaPolicyAdapter and behave as maximum aggressiveness).
+        let yaml = IntentYaml {
+            aggressiveness: Some(f64::NAN),
+            ..IntentYaml::default()
+        };
+        let s = IntentSettings::from_yaml(&yaml);
+        assert!((s.aggressiveness - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn to_policy_intent_maps_min_latency() {
+        let s = enabled_settings(12.5);
+        let intent = s.to_policy_intent();
+        assert_eq!(intent.intent_type, PolicyIntentType::MinLatency);
+        assert_eq!(intent.target_sst, Some(1));
+        assert!(matches!(
+            intent.constraints.as_slice(),
+            [PolicyConstraint::MaxLatencyMs(ms)] if (*ms - 12.5).abs() < f64::EPSILON
+        ));
+    }
+
+    #[test]
+    fn observation_from_nf_load_uses_worst_instance_and_slope() {
+        let body = serde_json::json!({
+            "nfLoadLevelInfos": [
+                { "nfType": "AMF", "nfInstanceId": "amf-01", "nfLoadLevelAverage": 35, "confidence": 90 },
+                { "nfType": "SMF", "nfInstanceId": "smf-01", "nfLoadLevelAverage": 60, "confidence": 80 }
+            ],
+            "timeStampGen": "2026-07-17T00:00:00Z"
+        });
+        let obs = observation_from_nf_load(&body, 0.5).expect("observation");
+        assert!((obs.load_pct - 60.0).abs() < f64::EPSILON);
+        assert!((obs.latency_ms - 30.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn observation_from_nf_load_empty_or_missing_is_none() {
+        assert!(
+            observation_from_nf_load(&serde_json::json!({ "nfLoadLevelInfos": [] }), 0.5).is_none()
+        );
+        assert!(observation_from_nf_load(&serde_json::json!({}), 0.5).is_none());
+    }
+
+    /// Issue #24 acceptance test: one loop iteration end-to-end. A declarative
+    /// intent (`max_latency_ms = 10`) plus an injected analytics reading above
+    /// target produces an adjusted SmPolicyDecision (reduced DRX, intent 5QI/
+    /// ARP in the re-issued decision); a reading within target produces no
+    /// adjustment and no re-issue.
+    #[test]
+    fn closed_loop_iteration_end_to_end() {
+        let mut controller = IntentController::new(enabled_settings(10.0));
+        // MinLatency translate: 5QI=1, ARP=2, DRX=10ms baseline.
+        assert_eq!(controller.baseline().five_qi, 1);
+        assert_eq!(controller.baseline().arp_priority, 2);
+        let baseline_drx = controller.baseline().drx_cycle_ms;
+
+        // Reading above target (25ms > 10ms) → adapted + re-issued decision.
+        let outcome = controller.drive_iteration(Some(Observation {
+            latency_ms: 25.0,
+            load_pct: 50.0,
+        }));
+        let IterationAction::Adapted {
+            drx_before_ms,
+            drx_after_ms,
+        } = outcome.action
+        else {
+            panic!("expected Adapted, got {:?}", outcome.action);
+        };
+        assert_eq!(drx_before_ms, baseline_drx);
+        assert!(
+            drx_after_ms < baseline_drx,
+            "latency violation must reduce DRX ({drx_after_ms} !< {baseline_drx})"
+        );
+        assert_eq!(controller.current().drx_cycle_ms, drx_after_ms);
+        let decision = outcome.decision.expect("adjusted decision re-issued");
+        let auth_def_qos = &decision.sess_rules["SessRule-intent-1"]["authDefQos"];
+        assert_eq!(auth_def_qos["5qi"], 1, "decision carries the intent 5QI");
+        assert_eq!(auth_def_qos["arp"]["priorityLevel"], 2);
+
+        // Second consecutive violation: DRX already at the adapter's 5ms
+        // floor → steady-state no-headroom, no false "Adapted", no identical
+        // decision rebuild.
+        let outcome = controller.drive_iteration(Some(Observation {
+            latency_ms: 25.0,
+            load_pct: 50.0,
+        }));
+        assert_eq!(outcome.action, IterationAction::NoHeadroom { drx_ms: 5 });
+        assert!(outcome.decision.is_none());
+
+        // Reading within target (5ms < 10ms) → no adjustment, no re-issue.
+        let tightened_drx = controller.current().drx_cycle_ms;
+        let outcome = controller.drive_iteration(Some(Observation {
+            latency_ms: 5.0,
+            load_pct: 10.0,
+        }));
+        assert_eq!(outcome.action, IterationAction::WithinTarget);
+        assert!(outcome.decision.is_none());
+        assert_eq!(controller.current().drx_cycle_ms, tightened_drx);
+
+        // No analytics at all → explicit no-data action, no re-issue.
+        let outcome = controller.drive_iteration(None);
+        assert_eq!(outcome.action, IterationAction::NoData);
+        assert!(outcome.decision.is_none());
+        assert_eq!(controller.iterations(), 4);
+    }
+
+    #[test]
+    fn analytics_state_populated_and_engine_observability() {
+        let mut controller = IntentController::new(enabled_settings(10.0));
+        // 80% load → congestion 0.8 (≥ engine threshold 0.75) → the analytics
+        // engine reports a CongestionAvoidance adjustment (observability only).
+        let outcome = controller.drive_iteration(Some(Observation {
+            latency_ms: 40.0,
+            load_pct: 80.0,
+        }));
+        assert!((controller.analytics().predicted_congestion - 0.8).abs() < 1e-6);
+        assert!((controller.analytics().qos_sustainability - 0.2).abs() < 1e-6);
+        assert!(controller.analytics().last_query_epoch > 0);
+        let adj = outcome.analytics_adjustment.expect("engine adjustment");
+        assert_eq!(adj.reason, AdjustmentReason::CongestionAvoidance);
+        // The engine's throttle reaction is NOT applied to the decision: the
+        // re-issued decision still carries the intent policy 5QI/ARP.
+        let decision = outcome.decision.expect("latency violation re-issues");
+        assert_eq!(
+            decision.sess_rules["SessRule-intent-1"]["authDefQos"]["5qi"],
+            1
+        );
+    }
+}

--- a/src/bins/nextgcore-pcfd/src/lib.rs
+++ b/src/bins/nextgcore-pcfd/src/lib.rs
@@ -15,10 +15,19 @@ pub mod am_sm;
 pub mod app;
 pub mod context;
 pub mod event;
-/// Future-use intent-policy translation (Rel-20 research scaffolding): not
-/// wired to any live handler, kept crate-internal (mirrors udrd's non-public
-/// `nudr_handler` precedent) and NOT part of the public crate API.
-#[allow(dead_code)]
+/// Issue #24: intent-driven closed-loop policy controller (non-normative 6G
+/// research spike, off by default). Crate-internal like `intent_policy`; the
+/// `pcf.intent` YAML block + `--features intent-loop` activate it.
+#[cfg(feature = "intent-loop")]
+pub(crate) mod intent_loop;
+/// Intent-policy translation (TS 28.312-inspired research scaffolding),
+/// consumed by the feature-gated `intent_loop` controller (issue #24). Kept
+/// crate-internal (mirrors udrd's non-public `nudr_handler` precedent) and
+/// NOT part of the public crate API. Without the `intent-loop` feature
+/// nothing references it; the conditional allowance documents that intent —
+/// the workspace-wide `dead_code = "allow"` (src/Cargo.toml) already
+/// suppresses the lint in both configurations.
+#[cfg_attr(not(feature = "intent-loop"), allow(dead_code))]
 mod intent_policy;
 pub mod npcf_handler;
 pub mod nudr_handler;

--- a/src/bins/nextgcore-pcfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-pcfd/src/sbi_path.rs
@@ -632,8 +632,12 @@ pub async fn pcf_discover_endpoint(
 /// Build a bounded-timeout SBI client for a discovered endpoint. Attaches an
 /// NRF-issued Bearer token scoped to `target` when OAuth2 enforcement is on
 /// (Wave-6 H8 Phase A, TS 33.501 §13.4.1); a no-op otherwise so the matched-sim
-/// default path is byte-unchanged.
-fn client_for(ep: &DiscoveredEndpoint, target: NfType) -> nextgcore_sbi::client::SbiClient {
+/// default path is byte-unchanged. `pub(crate)`: also used by the feature-gated
+/// intent-loop controller (issue #24) for its PCF→NWDAF analytics poll.
+pub(crate) fn client_for(
+    ep: &DiscoveredEndpoint,
+    target: NfType,
+) -> nextgcore_sbi::client::SbiClient {
     use nextgcore_sbi::client::{SbiClient, SbiClientConfig};
     use std::time::Duration;
     crate::app::attach_oauth2(


### PR DESCRIPTION
Closes #24

## What

Feature-gated (`intent-loop`, **off by default**) intent-driven closed-loop policy demonstrator in `nextgcore-pcfd`, connecting the pre-existing but dead scaffolding into one running monitor→decide→act loop for one declared outcome: **keep slice X latency below N ms**.

- **Intent input**: new `pcf.intent` YAML block (slice SST/SD + `max_latency_ms` + tuning knobs), deserialized into the existing `PolicyIntent { MinLatency, MaxLatencyMs(N) }` — no new intent type. Kept as a raw `serde_yaml::Value` in the typed `PcfYaml` so a malformed intent block can never break SBI-address/NRF-URI seeding (lenient conversion + warn under the feature).
- **Monitor**: controller task (`intent_loop.rs`, spawned from `app::run`, udmd `nes_driver` idiom) discovers an NWDAF via the NRF (`pcf_discover_endpoint`) and GETs `nnwdaf-analyticsinfo/v1/analytics` — `QOS_SUSTAINABILITY` first (the analytic the intent semantically wants), falling back to the one analytic today's nwdafd actually serves (`NF_LOAD`; `SUPPORTED_EVENTS = [NF_LOAD]`, QoS-sustainability answers 204 forever). Observed latency is a **documented synthetic proxy** (`load% × nf_load_latency_ms_per_pct`), same honesty rule as the NES synthetic power model.
- **Decide**: populates the previously never-populated `AnalyticsState`, runs `AnalyticsPolicyEngine::evaluate` (observability-only; its congestion/throttle verdict is logged, not applied) and feeds the latency reading into the existing `SlaPolicyAdapter::adapt`.
- **Act**: rebuilds an updated `SmPolicyDecision` through the production `build_sm_policy_decision` and emits the structured `monitor → observed=… target=… action=…` log line each iteration. Steady-state violations at the adapter's 5 ms DRX floor report `none(no-headroom…)` instead of a false `adapt`.
- `intent_policy` is no longer blanket-`#[allow(dead_code)]` (now `cfg_attr`-conditional, documented against the workspace-wide `dead_code = "allow"`).
- Design note: `docs/intent-driven-policy-loop.md` (non-normative caveat: no frozen Rel-20 Stage-3; nearest anchor TS 28.312) + README link; `pcf.yaml` ships the block with `enabled: false`.

## Acceptance criteria

- [x] `cargo build -p nextgcore-pcfd` (default) unchanged — controller fully compiled out; `--features intent-loop` builds clean
- [x] Workspace clippy + tests green; new end-to-end test drives one loop iteration: reading above target → adjusted decision (reduced DRX, intent 5QI/ARP in the rebuilt decision) vs no adjustment within target (plus no-data and no-headroom paths)
- [x] With the feature enabled against a running NWDAF, PCF logs `intent-loop: monitor → observed=… target=… action=…` per poll (first tick fires at startup)
- [x] `intent_policy` no longer `#[allow(dead_code)]`; no new dead-code warnings in either config
- [x] Design doc under `docs/` states the non-normative / research-prototype scope

## Out of scope (per issue)

General intent engine, multi-intent conflict resolution, `Nnwdaf_EventsSubscription` subscribe/notify (polling GET), NWDAF ML retraining, delivery of the rebuilt decision to an SMF (today's `…update_notify` re-derives from UDR; a parts-taking variant is a follow-up), and any change to default (loop-off) behavior.

## Review

Adversarial 4-dimension review (correctness / async-integration / spec-honesty / conventions): 15 raw findings → 10 confirmed (1 MEDIUM doc-accuracy, 9 LOW), all fixed — notably the malformed-`pcf.intent`-kills-config-parse hazard, NaN aggressiveness escaping the clamp, and the no-headroom action taxonomy.

## Verification

```sh
cargo build -p nextgcore-pcfd                                  # default unchanged
cargo test -p nextgcore-pcfd --features intent-loop intent_loop # 7 loop tests
cargo clippy --workspace && cargo test --workspace              # gate green
```

Signed-off-by: Murat Parlakisik <parlakisik@gmail.com>
