### PR TITLE
feat(app): aggregate read-only network-state snapshot, 6g-extensions-gated (issue #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ cargo audit
 - [docs/sba-transport-evaluation.md](docs/sba-transport-evaluation.md) — HTTP/2 vs HTTP/3 SBI transport benchmark and evaluation (non-normative 6G research)
 - [docs/isac-sensing-pipeline.md](docs/isac-sensing-pipeline.md) — ISAC sensing data pipeline design note (non-normative 6G research)
 - [docs/intent-driven-policy-loop.md](docs/intent-driven-policy-loop.md) — intent-driven closed-loop policy design note (non-normative 6G research)
+- [docs/network-state-snapshot.md](docs/network-state-snapshot.md) — aggregate network-state snapshot / digital-twin export design note (non-normative 6G research)
 - [docker/rust/CI.md](docker/rust/CI.md) — the one-command matched-sim end-to-end suite (`e2e.sh`)
 - [docs/](docs/) — per-component gap analyses and architecture notes
 

--- a/docs/network-state-snapshot.md
+++ b/docs/network-state-snapshot.md
@@ -1,0 +1,86 @@
+# Aggregate Network-State Snapshot (Design Note)
+
+> **Non-normative 6G research.** A "network digital twin" export has no
+> frozen Rel-20/6G Stage-3 specification; this aggregate format is
+> **project-defined**. The underlying data models are TS 29.510 (NRF
+> NFProfile) and TS 29.536 (NSACF slice quotas), which the source snapshots
+> already follow. Research shape for education, not a conformance target.
+> Tracking issue: [#25](https://github.com/NextgCoreLab/nextgcore/issues/25).
+
+## What it is
+
+A digital twin needs one coherent, read-only export of network state as its
+substrate. `nextgcore_app::state_export` (feature `6g-extensions`, off by
+default) is an **offline aggregator**: it composes the state the NRF and
+NSACF *already persist to JSON on disk* into one `NetworkStateSnapshot`
+document. No live SBI plumbing, no new listening socket, no always-on task.
+
+```
+nrfd  --state-file nrf_state.json    ─┐  (persisted on every registry mutation)
+                                      ├─► NetworkStateSnapshot::from_persisted
+nsacfd --state-file nsacf_state.json ─┘      │
+                                             ▼
+      { captured_at_ms, nf_registrations, slice_quotas, session_summary }
+```
+
+## Snapshot format
+
+- `captured_at_ms` — capture wall-clock, ms since Unix epoch.
+- `nf_registrations[]` — one entry per persisted NRF NFProfile: distilled
+  `nf_instance_id` / `nf_type` / `nf_status` / `fqdn` / `ipv4_addresses` /
+  `service_names`, plus the **verbatim persisted profile document** under
+  `profile` (camelCase TS 29.510 keys) so nothing is lost. Profiles missing
+  the mandatory `nfInstanceId`/`nfType`/`nfStatus` trio are skipped, exactly
+  like the NRF's own lenient restore path.
+- `slice_quotas[]` — one entry per NSACF slice: `sst`/`sd` (raw number, as
+  persisted), `max_ues`/`max_pdu_sessions`, live `current_ues` /
+  `current_pdu_sessions` (lengths of the persisted admission membership
+  sets), `eac_active`.
+- `session_summary` — totals across slices plus a documented **`note`**
+  field stating the limitation: counts are NSACF per-slice admission
+  counters; **live SMF/UPF per-session enumeration is a follow-up and is
+  not included** — no session list is fabricated.
+
+Optional/empty fields — `fqdn`, `ipv4_addresses`, `service_names`, and
+`sd` — are omitted from the serialized JSON entirely when absent or empty
+(the NSACF state doc itself persists an explicit `"sd": null`, but the
+export drops the key; deserialization accepts either form). Malformed
+source entries are skipped with a `log::warn!`, and a skipped quota row's
+UE/PDU counts are consequently absent from the `session_summary` totals.
+
+The `nf_hooks` digital-twin types (`NfStateSnapshot`, `NfStatus`,
+`NfStateDelta`, `SnapshotHistoryEntry`) now derive serde
+Serialize/Deserialize, so per-NF twin snapshots can travel as JSON too.
+
+## Invocation
+
+No NF binary changes. A cargo example (skipped entirely by default builds
+via `required-features`) does the export:
+
+```sh
+cargo run -p nextgcore-app --features 6g-extensions \
+  --example export_network_state -- nrf_state.json nsacf_state.json out.json
+```
+
+The source files come from `nextgcore-nrfd --state-file <path>` (or env
+`NEXTGCORE_NRF_STATE_FILE`) and `nextgcore-nsacfd --state-file <path>`;
+both NFs persist on every mutation, so the files are current as of the last
+registry/admission change.
+
+## Scope limits
+
+- **Offline, read-only, point-in-time.** No live cross-process SBI
+  collection (the NWDAF `nrf_collector` is the seed for later live work).
+- **No SMF/UPF session registry exists** to read — hence the honest
+  `session_summary.note` instead of invented per-session data.
+- Snapshot ordering follows the source docs; NRF profile order, NSACF
+  quota-row order, and NSACF membership-set order are all nondeterministic
+  (HashMap/HashSet iteration).
+
+## Verification
+
+```sh
+cargo build -p nextgcore-app                                  # default unchanged
+cargo test  -p nextgcore-app --features 6g-extensions          # incl. state_export
+cargo build -p nextgcore-app --features 6g-extensions --example export_network_state
+```

--- a/src/libs/nextgcore-app/Cargo.toml
+++ b/src/libs/nextgcore-app/Cargo.toml
@@ -7,9 +7,17 @@ license.workspace = true
 description = "NextGCore Application Framework Library"
 
 [features]
-## Gate 6G research modules (intent engine, cross-NF AI/ML hooks).
+## Gate 6G research modules (intent engine, cross-NF AI/ML hooks, and the
+## issue #25 aggregate network-state snapshot / digital-twin export).
 ## Enable with: cargo build -p nextgcore-app --features 6g-extensions
 6g-extensions = []
+
+# Issue #25: offline network-state export example. required-features keeps
+# every default-features workspace build/test byte-unchanged — cargo skips
+# the example unless 6g-extensions is enabled.
+[[example]]
+name = "export_network_state"
+required-features = ["6g-extensions"]
 
 [dependencies]
 nextgcore-core = { workspace = true }

--- a/src/libs/nextgcore-app/examples/export_network_state.rs
+++ b/src/libs/nextgcore-app/examples/export_network_state.rs
@@ -1,0 +1,63 @@
+//! Offline aggregate network-state export (issue #25, non-normative 6G
+//! research). Merges the state files persisted by `nextgcore-nrfd
+//! --state-file` and `nextgcore-nsacfd --state-file` into one
+//! `NetworkStateSnapshot` JSON document. No listener, no live SBI calls.
+//!
+//! Usage:
+//!   cargo run -p nextgcore-app --features 6g-extensions \
+//!     --example export_network_state -- <nrf_state.json> <nsacf_state.json> [out.json]
+//!
+//! With no `out.json` the pretty JSON is written to stdout.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use nextgcore_app::NetworkStateSnapshot;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    let (nrf_path, nsacf_path, out_path) = match args.as_slice() {
+        [_, nrf, nsacf] => (PathBuf::from(nrf), PathBuf::from(nsacf), None),
+        [_, nrf, nsacf, out] => (
+            PathBuf::from(nrf),
+            PathBuf::from(nsacf),
+            Some(PathBuf::from(out)),
+        ),
+        _ => {
+            eprintln!("usage: export_network_state <nrf_state.json> <nsacf_state.json> [out.json]");
+            return ExitCode::from(2);
+        }
+    };
+
+    let snapshot = match NetworkStateSnapshot::from_persisted(&nrf_path, &nsacf_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("export_network_state: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let json = match serde_json::to_string_pretty(&snapshot) {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("export_network_state: serialize failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match out_path {
+        Some(path) => {
+            if let Err(e) = std::fs::write(&path, format!("{json}\n")) {
+                eprintln!("export_network_state: write {} failed: {e}", path.display());
+                return ExitCode::FAILURE;
+            }
+            eprintln!(
+                "wrote {} ({} NF registrations, {} slice quotas)",
+                path.display(),
+                snapshot.nf_registrations.len(),
+                snapshot.slice_quotas.len()
+            );
+        }
+        None => println!("{json}"),
+    }
+    ExitCode::SUCCESS
+}

--- a/src/libs/nextgcore-app/src/intent.rs
+++ b/src/libs/nextgcore-app/src/intent.rs
@@ -438,7 +438,7 @@ impl IntentTranslator {
 
         // Sort by priority
         let mut sorted_intents = intents.to_vec();
-        sorted_intents.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sorted_intents.sort_by_key(|i| std::cmp::Reverse(i.priority));
 
         // Translate highest priority first
         let mut merged_config = self.translate(&sorted_intents[0])?;

--- a/src/libs/nextgcore-app/src/lib.rs
+++ b/src/libs/nextgcore-app/src/lib.rs
@@ -12,6 +12,8 @@ pub mod init;
 pub mod intent; // B3.2: Intent-based configuration translation
 #[cfg(feature = "6g-extensions")]
 pub mod nf_hooks;
+#[cfg(feature = "6g-extensions")]
+pub mod state_export; // issue #25: aggregate read-only network-state snapshot
 pub mod yaml; // #197: Cross-NF AI/ML hooks, digital twin, energy, intent API
 
 #[cfg(test)]
@@ -106,6 +108,13 @@ pub use nf_hooks::{
     SnapshotHistoryEntry,
     // B6.6: Digital twin scenario simulator
     WhatIfScenario,
+};
+// Issue #25: aggregate read-only network-state snapshot (digital-twin
+// foundation) — offline merge of the persisted NRF + NSACF state docs.
+#[cfg(feature = "6g-extensions")]
+pub use state_export::{
+    registrations_by_type, NetworkStateSnapshot, NfRegistrationEntry, SessionSummary,
+    SliceQuotaEntry, StateExportError,
 };
 
 // Macros are automatically exported via #[macro_export]

--- a/src/libs/nextgcore-app/src/nf_hooks.rs
+++ b/src/libs/nextgcore-app/src/nf_hooks.rs
@@ -141,7 +141,9 @@ impl AiMlHookRegistry {
 // ============================================================================
 
 /// NF state snapshot for digital twin synchronization.
-#[derive(Debug, Clone)]
+/// Serde derives (issue #25): serializable so twin snapshots can be exported
+/// as JSON by the `state_export` aggregator.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NfStateSnapshot {
     /// NF instance ID.
     pub nf_instance_id: String,
@@ -164,7 +166,7 @@ pub struct NfStateSnapshot {
 }
 
 /// NF operational status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum NfStatus {
     /// NF is registered and operational.
     Registered,
@@ -527,7 +529,7 @@ impl CrossNfIntentCoordinator {
 // ============================================================================
 
 /// Delta between two NF state snapshots for efficient sync.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NfStateDelta {
     /// NF instance ID.
     pub nf_instance_id: String,
@@ -544,7 +546,7 @@ pub struct NfStateDelta {
 }
 
 /// Snapshot history entry with sequence number for ordering.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnapshotHistoryEntry {
     /// Monotonic sequence number.
     pub sequence: u64,
@@ -1248,7 +1250,7 @@ mod tests {
     fn test_aiml_hook_registry() {
         let mut registry = AiMlHookRegistry::new();
         let id1 = registry.register(AiMlHookPoint::PreRequest, "AMF", 1);
-        let id2 = registry.register(AiMlHookPoint::PreRequest, "SMF", 2);
+        let _id2 = registry.register(AiMlHookPoint::PreRequest, "SMF", 2);
         assert_eq!(registry.hook_count(), 2);
 
         let hooks = registry.get_hooks(AiMlHookPoint::PreRequest);

--- a/src/libs/nextgcore-app/src/state_export.rs
+++ b/src/libs/nextgcore-app/src/state_export.rs
@@ -1,0 +1,491 @@
+//! Aggregate read-only network-state snapshot (issue #25, `6g-extensions`).
+//!
+//! Digital-twin foundation: composes the state the NRF and NSACF **already
+//! persist to JSON on disk** into one project-defined
+//! [`NetworkStateSnapshot`] document. Non-normative: no frozen Rel-20/6G
+//! Stage-3 "network digital twin" spec exists; the underlying data models
+//! are TS 29.510 (NRF NFProfile) and TS 29.536 (NSACF slice quotas), which
+//! the source snapshots already follow.
+//!
+//! Offline aggregator only: it reads the files written by
+//! `nextgcore-nrfd --state-file` (or `NEXTGCORE_NRF_STATE_FILE`) and
+//! `nextgcore-nsacfd --state-file`. No live SBI plumbing, no SMF/UPF
+//! session enumeration (see [`SessionSummary::note`]), no listening socket.
+//! See `docs/network-state-snapshot.md`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// The documented `session_summary.note` limitation text.
+const SESSION_SUMMARY_NOTE: &str = "UE and PDU-session counts are per-slice \
+    admission counters from the persisted NSACF state doc; live per-session \
+    SMF/UPF enumeration is a follow-up and is NOT included — no session list \
+    is fabricated.";
+
+/// Error building a [`NetworkStateSnapshot`] from persisted state files.
+#[derive(Debug, thiserror::Error)]
+pub enum StateExportError {
+    /// A state file could not be read.
+    #[error("failed to read {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    /// A state file was not valid JSON.
+    #[error("failed to parse {path}: {source}")]
+    Parse {
+        path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// One registered NF instance, distilled from a persisted NRF NFProfile
+/// (TS 29.510). `profile` carries the full persisted document verbatim
+/// (camelCase wire keys) so nothing is lost by the distillation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NfRegistrationEntry {
+    pub nf_instance_id: String,
+    pub nf_type: String,
+    /// Live status as persisted (e.g. `REGISTERED`, `SUSPENDED`).
+    pub nf_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fqdn: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ipv4_addresses: Vec<String>,
+    /// `serviceName`s collected from the profile's `nfServices`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub service_names: Vec<String>,
+    /// The persisted NFProfile document, verbatim.
+    pub profile: serde_json::Value,
+}
+
+/// One slice quota row from the persisted NSACF state doc (TS 29.536 data).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SliceQuotaEntry {
+    pub sst: u8,
+    /// Slice differentiator as the NSACF persists it (raw number, not the
+    /// 6-hex-digit wire string).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sd: Option<u32>,
+    pub max_ues: u64,
+    pub max_pdu_sessions: u64,
+    /// Live admitted-UE count (length of the persisted `ues` membership set).
+    pub current_ues: u64,
+    /// Live PDU-session count (length of the persisted `pduSessions` set).
+    pub current_pdu_sessions: u64,
+    pub eac_active: bool,
+}
+
+/// Per-slice session counters distilled from the NSACF admission state,
+/// plus the honest limitation note.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionSummary {
+    /// Sum of admitted UEs across all slices.
+    pub total_ues: u64,
+    /// Sum of active PDU sessions across all slices.
+    pub total_pdu_sessions: u64,
+    /// Documented limitation of this first cut (no live SMF/UPF data).
+    pub note: String,
+}
+
+/// The aggregate, read-only, project-defined network-state snapshot.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NetworkStateSnapshot {
+    /// Capture wall-clock time, ms since the Unix epoch.
+    pub captured_at_ms: u64,
+    /// Registered NF instances from the persisted NRF snapshot doc.
+    pub nf_registrations: Vec<NfRegistrationEntry>,
+    /// Slice quotas + live admission counters from the NSACF state doc.
+    pub slice_quotas: Vec<SliceQuotaEntry>,
+    /// Session counters derived from the slice quotas (see `note`).
+    pub session_summary: SessionSummary,
+}
+
+impl NetworkStateSnapshot {
+    /// Build a snapshot from the two persisted state files
+    /// (`nextgcore-nrfd --state-file`, `nextgcore-nsacfd --state-file`).
+    pub fn from_persisted(
+        nrf_state_path: &Path,
+        nsacf_state_path: &Path,
+    ) -> Result<Self, StateExportError> {
+        let nrf_doc = read_json(nrf_state_path)?;
+        let nsacf_doc = read_json(nsacf_state_path)?;
+        Ok(Self::from_docs(&nrf_doc, &nsacf_doc))
+    }
+
+    /// Pure merge of an already-parsed NRF snapshot doc and NSACF state doc
+    /// (the testable core; malformed entries are skipped, mirroring the
+    /// NRF's own lenient `restore_from`).
+    pub fn from_docs(nrf_doc: &serde_json::Value, nsacf_doc: &serde_json::Value) -> Self {
+        let nf_registrations = parse_nrf_profiles(nrf_doc);
+        let slice_quotas = parse_nsacf_quotas(nsacf_doc);
+        let session_summary = SessionSummary {
+            total_ues: slice_quotas.iter().map(|q| q.current_ues).sum(),
+            total_pdu_sessions: slice_quotas.iter().map(|q| q.current_pdu_sessions).sum(),
+            note: SESSION_SUMMARY_NOTE.to_string(),
+        };
+        Self {
+            captured_at_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+            nf_registrations,
+            slice_quotas,
+            session_summary,
+        }
+    }
+}
+
+fn read_json(path: &Path) -> Result<serde_json::Value, StateExportError> {
+    let content = std::fs::read_to_string(path).map_err(|source| StateExportError::Io {
+        path: path.display().to_string(),
+        source,
+    })?;
+    serde_json::from_str(&content).map_err(|source| StateExportError::Parse {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+/// Distill `{ "version", "profiles": [NFProfile...] }` (the doc
+/// `NfInstanceManager::persist` writes). Profiles missing the mandatory
+/// `nfInstanceId`/`nfType`/`nfStatus` string trio are skipped, like the
+/// NRF's own restore path.
+fn parse_nrf_profiles(nrf_doc: &serde_json::Value) -> Vec<NfRegistrationEntry> {
+    let Some(profiles) = nrf_doc.get("profiles").and_then(|p| p.as_array()) else {
+        return Vec::new();
+    };
+    profiles
+        .iter()
+        .filter_map(|p| {
+            let get_str = |k: &str| {
+                p.get(k)
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+            };
+            let (Some(nf_instance_id), Some(nf_type), Some(nf_status)) = (
+                get_str("nfInstanceId"),
+                get_str("nfType"),
+                get_str("nfStatus"),
+            ) else {
+                log::warn!(
+                    "state_export: skipping malformed persisted NFProfile \
+                     (missing nfInstanceId/nfType/nfStatus)"
+                );
+                return None;
+            };
+            let entry = NfRegistrationEntry {
+                nf_instance_id,
+                nf_type,
+                nf_status,
+                fqdn: get_str("fqdn"),
+                ipv4_addresses: str_array(p.get("ipv4Addresses")),
+                service_names: p
+                    .get("nfServices")
+                    .and_then(|s| s.as_array())
+                    .map(|svcs| {
+                        svcs.iter()
+                            .filter_map(|s| s.get("serviceName").and_then(|n| n.as_str()))
+                            .map(str::to_string)
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                profile: p.clone(),
+            };
+            Some(entry)
+        })
+        .collect()
+}
+
+/// Distill `{ "nextQuotaId", "quotas": [...] }` (the doc the NSACF's
+/// `save_state` writes). Counters are membership-derived: `ues` /
+/// `pduSessions` array lengths.
+fn parse_nsacf_quotas(nsacf_doc: &serde_json::Value) -> Vec<SliceQuotaEntry> {
+    let Some(quotas) = nsacf_doc.get("quotas").and_then(|q| q.as_array()) else {
+        return Vec::new();
+    };
+    quotas
+        .iter()
+        .filter_map(|q| {
+            let Some(sst) = q
+                .get("sst")
+                .and_then(|v| v.as_u64())
+                .and_then(|v| u8::try_from(v).ok())
+            else {
+                log::warn!(
+                    "state_export: skipping malformed NSACF quota row (missing/invalid \
+                     sst); its UE/PDU counts are excluded from session_summary totals"
+                );
+                return None;
+            };
+            let entry = SliceQuotaEntry {
+                sst,
+                // try_from, not `as`: an out-of-range sd from a corrupted file
+                // must become None, never a silently wrapped wrong value.
+                sd: q
+                    .get("sd")
+                    .and_then(|v| v.as_u64())
+                    .and_then(|v| u32::try_from(v).ok()),
+                max_ues: q.get("maxUes").and_then(|v| v.as_u64()).unwrap_or(0),
+                max_pdu_sessions: q
+                    .get("maxPduSessions")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0),
+                current_ues: array_len(q.get("ues")),
+                current_pdu_sessions: array_len(q.get("pduSessions")),
+                eac_active: q
+                    .get("eacActive")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            };
+            Some(entry)
+        })
+        .collect()
+}
+
+fn str_array(v: Option<&serde_json::Value>) -> Vec<String> {
+    v.and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|s| s.as_str())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn array_len(v: Option<&serde_json::Value>) -> u64 {
+    v.and_then(|v| v.as_array())
+        .map(|a| a.len() as u64)
+        .unwrap_or(0)
+}
+
+/// Group registrations by NF type (convenience for consumers/UIs).
+pub fn registrations_by_type(
+    snapshot: &NetworkStateSnapshot,
+) -> BTreeMap<String, Vec<&NfRegistrationEntry>> {
+    let mut map: BTreeMap<String, Vec<&NfRegistrationEntry>> = BTreeMap::new();
+    for r in &snapshot.nf_registrations {
+        map.entry(r.nf_type.clone()).or_default().push(r);
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fixture_nrf_doc() -> serde_json::Value {
+        json!({
+            "version": 1,
+            "profiles": [
+                {
+                    "nfInstanceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    "nfType": "AMF",
+                    "nfStatus": "REGISTERED",
+                    "heartBeatTimer": 10,
+                    "plmnList": [{"mcc": "001", "mnc": "01"}],
+                    "ipv4Addresses": ["10.0.0.3"],
+                    "fqdn": "amf.example.com",
+                    "nfServices": [{
+                        "serviceInstanceId": "amf-svc-1",
+                        "serviceName": "namf-comm",
+                        "versions": [{"apiVersionInUri": "v1"}],
+                        "scheme": "http",
+                        "ipEndPoints": [{"ipv4Address": "10.0.0.3", "port": 7777}]
+                    }]
+                },
+                {
+                    "nfInstanceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "nfType": "SMF",
+                    "nfStatus": "SUSPENDED",
+                    "ipv4Addresses": ["10.0.0.5"],
+                    "nfServices": [{
+                        "serviceInstanceId": "smf-svc-1",
+                        "serviceName": "nsmf-pdusession",
+                        "versions": ["v1"],
+                        "scheme": "http"
+                    }]
+                },
+                { "nfType": "UPF", "nfStatus": "REGISTERED" }
+            ],
+            "subscriptions": []
+        })
+    }
+
+    fn fixture_nsacf_doc() -> serde_json::Value {
+        json!({
+            "nextQuotaId": 3,
+            "quotas": [
+                {
+                    "id": 1,
+                    "sst": 1,
+                    "sd": 66051,
+                    "maxUes": 100,
+                    "maxPduSessions": 500,
+                    "maxUes3gpp": 80,
+                    "maxUesN3gpp": 20,
+                    "maxPdu3gpp": null,
+                    "maxPduN3gpp": null,
+                    "ues": ["imsi-001010000000001", "imsi-001010000000002"],
+                    "pduSessions": ["imsi-001010000000001:1"],
+                    "uesAccess": {
+                        "imsi-001010000000001": "3GPP_ACCESS",
+                        "imsi-001010000000002": "NON_3GPP_ACCESS"
+                    },
+                    "pduSessionsAccess": {"imsi-001010000000001:1": "3GPP_ACCESS"},
+                    "eacActive": false
+                },
+                {
+                    "id": 2,
+                    "sst": 2,
+                    "sd": null,
+                    "maxUes": 10,
+                    "maxPduSessions": 20,
+                    "maxUes3gpp": null,
+                    "maxUesN3gpp": null,
+                    "maxPdu3gpp": null,
+                    "maxPduN3gpp": null,
+                    "ues": [],
+                    "pduSessions": [],
+                    "uesAccess": {},
+                    "pduSessionsAccess": {},
+                    "eacActive": true
+                }
+            ]
+        })
+    }
+
+    /// Issue #25 acceptance: fixture NRF + NSACF docs yield the expected NF
+    /// instances and slice quotas; session_summary carries the honest note.
+    #[test]
+    fn from_docs_merges_fixture_state() {
+        let snap = NetworkStateSnapshot::from_docs(&fixture_nrf_doc(), &fixture_nsacf_doc());
+
+        // Malformed third profile (no nfInstanceId) is skipped, like the
+        // NRF's own restore path.
+        assert_eq!(snap.nf_registrations.len(), 2);
+        let amf = &snap.nf_registrations[0];
+        assert_eq!(amf.nf_instance_id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        assert_eq!(amf.nf_type, "AMF");
+        assert_eq!(amf.nf_status, "REGISTERED");
+        assert_eq!(amf.fqdn.as_deref(), Some("amf.example.com"));
+        assert_eq!(amf.ipv4_addresses, vec!["10.0.0.3"]);
+        assert_eq!(amf.service_names, vec!["namf-comm"]);
+        assert_eq!(amf.profile["heartBeatTimer"], 10);
+        let smf = &snap.nf_registrations[1];
+        assert_eq!(smf.nf_type, "SMF");
+        assert_eq!(smf.nf_status, "SUSPENDED");
+        assert_eq!(smf.service_names, vec!["nsmf-pdusession"]);
+
+        assert_eq!(snap.slice_quotas.len(), 2);
+        let s1 = &snap.slice_quotas[0];
+        assert_eq!((s1.sst, s1.sd), (1, Some(66051)));
+        assert_eq!((s1.max_ues, s1.max_pdu_sessions), (100, 500));
+        assert_eq!((s1.current_ues, s1.current_pdu_sessions), (2, 1));
+        assert!(!s1.eac_active);
+        let s2 = &snap.slice_quotas[1];
+        assert_eq!((s2.sst, s2.sd), (2, None));
+        assert!(s2.eac_active);
+
+        assert_eq!(snap.session_summary.total_ues, 2);
+        assert_eq!(snap.session_summary.total_pdu_sessions, 1);
+        assert!(snap.session_summary.note.contains("follow-up"));
+        assert!(snap.session_summary.note.contains("NOT included"));
+
+        let by_type = registrations_by_type(&snap);
+        assert_eq!(by_type["AMF"].len(), 1);
+        assert_eq!(by_type["SMF"].len(), 1);
+    }
+
+    /// Issue #25 acceptance: NetworkStateSnapshot round-trips through serde.
+    #[test]
+    fn network_state_snapshot_serde_round_trip() {
+        let snap = NetworkStateSnapshot::from_docs(&fixture_nrf_doc(), &fixture_nsacf_doc());
+        let text = serde_json::to_string_pretty(&snap).expect("serialize");
+        let back: NetworkStateSnapshot = serde_json::from_str(&text).expect("deserialize");
+        assert_eq!(snap, back);
+    }
+
+    /// Issue #25 acceptance: NfStateSnapshot (nf_hooks) round-trips through
+    /// serde now that the derives exist.
+    #[test]
+    fn nf_state_snapshot_serde_round_trip() {
+        let snap = crate::nf_hooks::NfStateSnapshot {
+            nf_instance_id: "amf-1".to_string(),
+            nf_type: "AMF".to_string(),
+            timestamp_ms: 1_700_000_000_000,
+            status: crate::nf_hooks::NfStatus::Registered,
+            load: 0.6,
+            active_sessions: 100,
+            cpu_utilization: 0.4,
+            memory_utilization: 0.5,
+            kpis: std::collections::HashMap::from([("ue_count".to_string(), 42.0)]),
+        };
+        let text = serde_json::to_string(&snap).expect("serialize");
+        let back: crate::nf_hooks::NfStateSnapshot = serde_json::from_str(&text).expect("parse");
+        assert_eq!(back.nf_instance_id, snap.nf_instance_id);
+        assert_eq!(back.status, snap.status);
+        assert_eq!(back.kpis["ue_count"], 42.0);
+    }
+
+    #[test]
+    fn missing_or_empty_sections_yield_empty_snapshot() {
+        let snap = NetworkStateSnapshot::from_docs(&json!({}), &json!({}));
+        assert!(snap.nf_registrations.is_empty());
+        assert!(snap.slice_quotas.is_empty());
+        assert_eq!(snap.session_summary.total_ues, 0);
+        assert!(snap.session_summary.note.contains("follow-up"));
+    }
+
+    #[test]
+    fn corrupt_rows_are_skipped_not_wrapped() {
+        let doc = json!({ "quotas": [
+            { "id": 9, "sst": 300, "maxUes": 5, "maxPduSessions": 5,
+              "ues": ["imsi-x"], "pduSessions": [], "eacActive": false },
+            { "id": 10, "sst": 3, "sd": 4_294_967_297u64, "maxUes": 5, "maxPduSessions": 5,
+              "ues": [], "pduSessions": [], "eacActive": false }
+        ]});
+        let snap = NetworkStateSnapshot::from_docs(&json!({}), &doc);
+        // The sst-300 row is skipped wholesale (its UE count excluded from
+        // the totals); an out-of-range sd becomes None, never a silently
+        // wrapped wrong value.
+        assert_eq!(snap.slice_quotas.len(), 1);
+        assert_eq!(snap.slice_quotas[0].sst, 3);
+        assert_eq!(snap.slice_quotas[0].sd, None);
+        assert_eq!(snap.session_summary.total_ues, 0);
+    }
+
+    #[test]
+    fn from_persisted_reads_fixture_files() {
+        // Unique-per-test temp names (same-pid parallel tests race on a
+        // shared name — the pqc-tls lesson), cleaned up at the end.
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let nrf_path = dir.join(format!("nextgcore-app-issue25-nrf-{pid}.json"));
+        let nsacf_path = dir.join(format!("nextgcore-app-issue25-nsacf-{pid}.json"));
+        std::fs::write(&nrf_path, fixture_nrf_doc().to_string()).expect("write nrf");
+        std::fs::write(&nsacf_path, fixture_nsacf_doc().to_string()).expect("write nsacf");
+
+        let snap = NetworkStateSnapshot::from_persisted(&nrf_path, &nsacf_path).expect("build");
+        assert_eq!(snap.nf_registrations.len(), 2);
+        assert_eq!(snap.slice_quotas.len(), 2);
+        assert!(snap.captured_at_ms > 0);
+
+        let err = NetworkStateSnapshot::from_persisted(
+            &dir.join(format!("nextgcore-app-issue25-missing-{pid}.json")),
+            &nsacf_path,
+        )
+        .expect_err("missing file must error");
+        assert!(matches!(err, StateExportError::Io { .. }));
+
+        let _ = std::fs::remove_file(&nrf_path);
+        let _ = std::fs::remove_file(&nsacf_path);
+    }
+}


### PR DESCRIPTION
Closes #25

## What

Digital-twin foundation: an **offline, read-only aggregate network-state snapshot**, gated behind the existing `6g-extensions` feature of `nextgcore-app` (off by default, no new listener, no NF binary changes).

- **Serde derives** added to the previously non-serializable twin types in `nf_hooks.rs`: `NfStateSnapshot`, `NfStatus`, `NfStateDelta`, `SnapshotHistoryEntry` (all fields already std/serde-friendly — no `Instant`, no skips needed).
- **New `state_export.rs`**: project-defined `NetworkStateSnapshot { captured_at_ms, nf_registrations, slice_quotas, session_summary }` with `from_persisted(nrf_state_path, nsacf_state_path)` (file IO + `Result`) and the pure, testable `from_docs(...)` merge. Parsers are written against what the NFs **actually persist**: the NRF `{version, profiles[], subscriptions[]}` doc (`NfInstanceManager::persist`; verbatim TS 29.510 profile kept under `profile`, malformed entries skipped like the NRF's own lenient restore) and the NSACF `{nextQuotaId, quotas[]}` state doc (`save_state`; live counters derived from the `ues`/`pduSessions` membership-set lengths, `sd` as the raw persisted number).
- **`session_summary`** carries totals plus an honest `note`: counts are NSACF per-slice admission counters; live SMF/UPF per-session enumeration is a follow-up — **no session list is fabricated**.
- **Invocation**: cargo example `export_network_state` with `required-features = ["6g-extensions"]` (first `[[example]]` in the workspace — default-features builds/tests skip it entirely). No always-on process.
- Design note `docs/network-state-snapshot.md` (non-normative banner: no frozen Rel-20/6G Stage-3 "network digital twin" spec; data models are TS 29.510 / TS 29.536) + README link.
- Drive-by: fixed the two pre-existing feature-build clippy warnings in the crate (`intent.rs` `sort_by`→`sort_by_key`, `nf_hooks.rs` unused `id2`) so `--features 6g-extensions` clippy is now 0.

## Acceptance criteria

- [x] `cargo build -p nextgcore-app --features 6g-extensions` clean; default build unchanged (feature-gated `mod` + `required-features` example)
- [x] `NfStateSnapshot` and `NetworkStateSnapshot` serde round-trip tests pass
- [x] `from_persisted` with fixture NRF + NSACF docs yields the fixture NF instances (ids/types/services, verbatim profile) and slice quotas (`maxUes`/`maxPduSessions` + live counters)
- [x] `session_summary.note` states the SMF/UPF live-session limitation; no invented session data
- [x] `cargo test -p nextgcore-app --features 6g-extensions` passes (97 tests, incl. 6 new state_export tests)
- [x] Feature off by default; no new listening socket anywhere

## Review

Adversarial 3-dimension review (format-fidelity vs the real NRF/NSACF emitters / correctness-API / honesty-conventions): 5 raw findings → 4 confirmed (all LOW), all fixed — out-of-range `sd` now becomes `None` instead of a silently wrapped value, malformed source rows skip with a `log::warn!` (and the doc notes their counts are excluded from totals), plus two doc-accuracy amendments.

## Verification

```sh
cargo build -p nextgcore-app                                   # default unchanged
cargo test  -p nextgcore-app --features 6g-extensions           # 97 pass, clippy 0
cargo run -p nextgcore-app --features 6g-extensions \
  --example export_network_state -- nrf_state.json nsacf_state.json out.json
```

Signed-off-by: Murat Parlakisik <parlakisik@gmail.com>
