### PR TITLE
feat(nwdafd): real analytics-plus-inference path, ONNX subset feature-gated (issue #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ cargo audit
 - [docs/isac-sensing-pipeline.md](docs/isac-sensing-pipeline.md) — ISAC sensing data pipeline design note (non-normative 6G research)
 - [docs/intent-driven-policy-loop.md](docs/intent-driven-policy-loop.md) — intent-driven closed-loop policy design note (non-normative 6G research)
 - [docs/network-state-snapshot.md](docs/network-state-snapshot.md) — aggregate network-state snapshot / digital-twin export design note (non-normative 6G research)
+- [docs/nwdaf-inference.md](docs/nwdaf-inference.md) — NWDAF analytics inference abstraction and ONNX-subset backend design note (non-normative 6G research)
 - [docker/rust/CI.md](docker/rust/CI.md) — the one-command matched-sim end-to-end suite (`e2e.sh`)
 - [docs/](docs/) — per-component gap analyses and architecture notes
 

--- a/docs/nwdaf-inference.md
+++ b/docs/nwdaf-inference.md
@@ -1,0 +1,70 @@
+# NWDAF Analytics Inference (Design Note)
+
+> **Non-normative 6G research.** NWDAF analytics are TS 23.288 / TS 29.520
+> functionality; the ML-serving abstraction and model backends here are
+> prototype-level — **no frozen Stage-3 specification covers model
+> internals**. Research shape for education, not a conformance target.
+> Tracking issue: [#26](https://github.com/NextgCoreLab/nextgcore/issues/26).
+
+## The inference abstraction
+
+`nextgcore-nwdafd`'s `ml_service` now defines a minimal load-by-id +
+predict surface (issue #26):
+
+```rust
+pub trait InferenceModel: Send + Sync {
+    fn model_id(&self) -> &str;
+    fn predict_series(&self, series: &[f64]) -> Option<(f64, f64)>; // (prediction, confidence)
+}
+pub fn load_model(model_id: &str) -> Result<Box<dyn InferenceModel>, String>;
+```
+
+The `NF_LOAD` analytics path is wired through it end to end:
+`nrf_collector` (samples from NRF NFStatusNotify) → `AnalyticsEngine`
+(`compute_nf_load` calls the **active model**) → `Nnwdaf_AnalyticsInfo`
+GET / EventsSubscription Notify (the emitted `confidence` member — the
+TS 29.520 prediction-confidence Uinteger — is the model's output; the wire
+shape is unchanged and stays spec-pure: the vendor `predictedLoad` key
+removed in G2-1 stays removed, so the numeric prediction surfaces via the
+engine API (`NfLoadAnalytics.predicted_load`), not as an invented wire
+member).
+
+## Models
+
+| id | file needed | prediction | confidence semantics |
+|---|---|---|---|
+| `ols-linear` (default) | no | OLS fit over last ≤5 samples, one step ahead | R² of the fit (byte-identical to the pre-#26 inline math) |
+| `ewma[:<alpha>]` | no | exponentially weighted moving average | `1 − mean abs one-step error` (heuristic) |
+| `onnx:<path>` | yes | linear model applied to the last *n* samples | backtest R² of the loaded model over the observed series |
+
+Selection: set `NWDAF_PREDICTION_MODEL` (e.g. `ewma:0.5`,
+`onnx:/etc/nextgcore/nfload.onnx`) before starting `nextgcore-nwdafd`;
+unset = `ols-linear`, behavior-identical to before issue #26. An invalid
+value logs a warning and keeps the default.
+
+## The ONNX backend (feature `onnx-model`, off by default)
+
+Zero-dependency by design: a hand-rolled reader for a **minimal, explicitly
+documented ONNX subset** — exactly one `ai.onnx.ml` `LinearRegressor` node
+(`coefficients` + `intercepts`), the class `skl2onnx` exports for sklearn
+`LinearRegression`. Anything else in the graph is a **hard error**, never a
+silent approximation. Rationale: no C-linked runtime (repo rule), zero
+Cargo.lock growth (the pqc-tls precedent), and hand-rolled wire codecs are
+the house style. Test models are built as protobuf bytes in test source —
+no binary fixtures (per the never-commit-binaries decision).
+
+## Federation status
+
+`federation.rs` keeps its **real, tested local FedAvg** aggregation
+(`FlAggregationRound::aggregate`, element-wise mean) and peer registry as an
+internal library; the genuinely dead scaffolding (`FederatedRequest`, the
+never-touched `requests` map) was removed. Honesty note: nothing federates
+over the wire — there is no cross-NWDAF protocol here.
+
+## Verification
+
+```sh
+cargo test -p nextgcore-nwdafd                          # default: OLS baseline, no model file
+cargo test -p nextgcore-nwdafd --features onnx-model    # + ONNX subset reader tests
+NWDAF_PREDICTION_MODEL=ewma cargo run -p nextgcore-nwdafd   # live model swap
+```

--- a/src/bins/nextgcore-nwdafd/Cargo.toml
+++ b/src/bins/nextgcore-nwdafd/Cargo.toml
@@ -15,6 +15,12 @@ path = "src/main.rs"
 ## bounded in-memory store, Isac pub-sub event + ingest metric. Off by default.
 ## Enable with: cargo build -p nextgcore-nwdafd --features sensing
 sensing = ["dep:nextgcore-proto", "nextgcore-sbi/6g-extensions"]
+## Issue #26: ONNX-backed NF_LOAD prediction (non-normative). Zero-dependency
+## hand-rolled reader for a minimal ONNX subset — exactly one ai.onnx.ml
+## LinearRegressor node; anything else is a hard error. Off by default; the
+## default build keeps the OLS baseline and needs no model file.
+## Enable with: cargo build -p nextgcore-nwdafd --features onnx-model
+onnx-model = []
 
 [dependencies]
 nextgcore-core = { workspace = true }

--- a/src/bins/nextgcore-nwdafd/src/analytics.rs
+++ b/src/bins/nextgcore-nwdafd/src/analytics.rs
@@ -9,8 +9,10 @@
 //!
 //! # OPERATIONAL ALGORITHM
 //!
-//! **All analytics in this module use ordinary least-squares linear regression
-//! on the last N samples.** The `confidence` field is the regression R² (the
+//! **NF_LOAD prediction is routed through the pluggable
+//! `ml_service::InferenceModel` (issue #26); the default model is ordinary
+//! least-squares linear regression on the last N samples, and the other
+//! analytics in this module use the same OLS approach inline.** The `confidence` field is the regression R² (the
 //! fraction of variance the linear fit explains, nwafd-10) — it reflects how
 //! well the predictor fits the observed data, NOT trained-model accuracy. No ML
 //! model is used. When `Nnwdaf_MLModelProvision` models are integrated, the
@@ -134,9 +136,12 @@ pub struct AnalyticsEngine {
     ue_cells: HashMap<String, Vec<(u64, u64)>>, // (cell_id, timestamp)
     /// Anomaly scores per SUPI
     anomaly_scores: HashMap<String, Vec<AbnormalBehaviourRecord>>,
+    /// Active prediction model for NF_LOAD (issue #26): defaults to the OLS
+    /// baseline, swappable via `set_predictor` / NWDAF_PREDICTION_MODEL.
+    predictor: crate::ml_service::Predictor,
 }
 
-const MAX_SAMPLES: usize = 100;
+pub(crate) const MAX_SAMPLES: usize = 100;
 
 impl AnalyticsEngine {
     pub fn new() -> Self {
@@ -151,6 +156,16 @@ impl AnalyticsEngine {
             buf.remove(0);
         }
         buf.push(sample);
+    }
+
+    /// Swap the active NF_LOAD prediction model (issue #26).
+    pub fn set_predictor(&mut self, model: Box<dyn crate::ml_service::InferenceModel>) {
+        self.predictor = crate::ml_service::Predictor(model);
+    }
+
+    /// Identifier of the active prediction model.
+    pub fn predictor_id(&self) -> &str {
+        self.predictor.0.model_id()
     }
 
     /// Upsert the cached NRF profile metadata for an NF instance (G2-1).
@@ -190,14 +205,15 @@ impl AnalyticsEngine {
     /// last N samples (up to 5). `predicted_load` is the fitted value projected
     /// one step ahead, clamped to [0, 1].
     ///
-    /// `confidence` (nwafd-10) is the regression **coefficient of determination
-    /// (R²)** — the fraction of the window's CPU variance explained by the
-    /// linear fit — clamped to [0, 1]. It therefore reflects how well the
-    /// straight-line predictor actually fits the observed samples (high for a
-    /// clean trend, low for noisy input), instead of the previous synthetic
-    /// sample-count ratio. HONESTY NOTE: this remains linear regression, NOT a
-    /// trained ML model; when `Nnwdaf_MLModelProvision` models are integrated
-    /// this should switch to model-accuracy metrics (TS 23.288 §6.14).
+    /// `predicted_load` and `confidence` are produced by the active
+    /// `ml_service::InferenceModel` (issue #26). The default model is the OLS
+    /// baseline whose confidence (nwafd-10) is the regression **R²** — the
+    /// fraction of the window's CPU variance explained by the linear fit,
+    /// clamped to [0, 1] — byte-identical to the math this method previously
+    /// inlined. HONESTY NOTE: the baselines are statistical predictors, NOT
+    /// trained ML models; the feature-gated `onnx-model` backend loads real
+    /// (linear) model files, and each model documents its own confidence
+    /// semantics (TS 23.288 §6.14).
     pub fn compute_nf_load(&self, nf_instance_id: &str) -> Option<NfLoadAnalytics> {
         let samples = self.nf_samples.get(nf_instance_id)?;
         if samples.is_empty() {
@@ -206,48 +222,16 @@ impl AnalyticsEngine {
         let mean_cpu = samples.iter().map(|s| s.cpu_usage).sum::<f64>() / samples.len() as f64;
         let peak_cpu = samples.iter().map(|s| s.cpu_usage).fold(0.0f64, f64::max);
 
-        // Least-squares linear fit y = a + b·x over the last N (≤5) samples,
-        // with x = 0..N-1. `predicted_load` projects to x = N; `confidence` is
-        // the R² of the fit.
-        let n = samples.len().min(5);
-        let (predicted_load, confidence) = if n >= 2 {
-            let last = &samples[samples.len() - n..];
-            let nf = n as f64;
-            let sum_x: f64 = (0..n).map(|i| i as f64).sum();
-            let sum_y: f64 = last.iter().map(|s| s.cpu_usage).sum();
-            let sum_xx: f64 = (0..n).map(|i| (i as f64).powi(2)).sum();
-            let sum_xy: f64 = last
-                .iter()
-                .enumerate()
-                .map(|(i, s)| i as f64 * s.cpu_usage)
-                .sum();
-
-            // denom = N·Σx² − (Σx)² is strictly positive for N ≥ 2 distinct x.
-            let denom = nf * sum_xx - sum_x * sum_x;
-            let b = (nf * sum_xy - sum_x * sum_y) / denom;
-            let a = (sum_y - b * sum_x) / nf;
-            let predicted = (a + b * nf).clamp(0.0, 1.0);
-
-            // R² = 1 − SS_res / SS_tot.
-            let mean_y = sum_y / nf;
-            let ss_tot: f64 = last.iter().map(|s| (s.cpu_usage - mean_y).powi(2)).sum();
-            let ss_res: f64 = last
-                .iter()
-                .enumerate()
-                .map(|(i, s)| (s.cpu_usage - (a + b * i as f64)).powi(2))
-                .sum();
-            let r_squared = if ss_tot <= f64::EPSILON {
-                // Flat series: the predictor reproduces it exactly → R² = 1.
-                1.0
-            } else {
-                (1.0 - ss_res / ss_tot).clamp(0.0, 1.0)
-            };
-
-            (predicted, r_squared)
-        } else {
-            // A single sample yields no residual basis; report no confidence.
-            (mean_cpu, 0.0)
-        };
+        // Issue #26: route the prediction through the active inference model
+        // (default: the OLS baseline, byte-identical to the formerly inline
+        // least-squares fit). A model that declines (window too short) falls
+        // back to (mean, no-confidence), preserving the pre-#26 contract.
+        let values: Vec<f64> = samples.iter().map(|s| s.cpu_usage).collect();
+        let (predicted_load, confidence) = self
+            .predictor
+            .0
+            .predict_series(&values)
+            .unwrap_or((mean_cpu, 0.0));
 
         Some(NfLoadAnalytics {
             nf_type: samples[0].nf_type.clone(),
@@ -415,5 +399,48 @@ mod tests {
             engine.ingest_nf_load(NfLoadSample::now("SMF", "smf-01", 0.5, 0.5, 0));
         }
         assert!(engine.nf_samples["smf-01"].len() <= MAX_SAMPLES);
+    }
+}
+
+#[cfg(test)]
+mod inference_wiring_tests {
+    use super::*;
+
+    /// Issue #26 acceptance: the NF_LOAD analytics values are produced by the
+    /// active `ml_service::InferenceModel` — a swapped model changes the
+    /// computed prediction/confidence.
+    struct FixedModel;
+    impl crate::ml_service::InferenceModel for FixedModel {
+        fn model_id(&self) -> &str {
+            "fixed-test"
+        }
+        fn predict_series(&self, _series: &[f64]) -> Option<(f64, f64)> {
+            Some((0.87, 0.42))
+        }
+    }
+
+    #[test]
+    fn compute_nf_load_uses_active_model() {
+        let mut engine = AnalyticsEngine::new();
+        for i in 0..6 {
+            engine.ingest_nf_load(NfLoadSample::now(
+                "AMF",
+                "amf-01",
+                0.1 + 0.05 * f64::from(i),
+                0.0,
+                0,
+            ));
+        }
+        assert_eq!(engine.predictor_id(), "ols-linear");
+        let default_result = engine.compute_nf_load("amf-01").unwrap();
+
+        engine.set_predictor(Box::new(FixedModel));
+        assert_eq!(engine.predictor_id(), "fixed-test");
+        let r = engine.compute_nf_load("amf-01").unwrap();
+        assert!((r.predicted_load - 0.87).abs() < 1e-9);
+        assert!((r.confidence - 0.42).abs() < 1e-9);
+        // mean/peak are engine statistics, unaffected by the model swap.
+        assert!((r.mean_cpu - default_result.mean_cpu).abs() < 1e-9);
+        assert!((r.peak_cpu - default_result.peak_cpu).abs() < 1e-9);
     }
 }

--- a/src/bins/nextgcore-nwdafd/src/federation.rs
+++ b/src/bins/nextgcore-nwdafd/src/federation.rs
@@ -4,7 +4,8 @@
 //! - DCCF (Data Collection Co-ordination Function) consumer interface
 //! - MFAF (Messaging Framework Adaptor Function) forwarding
 //! - Cross-PLMN analytics federation for roaming scenarios
-//! - Model federated learning aggregation stubs
+//! - Local FedAvg aggregation rounds (element-wise mean of participant
+//!   updates) — real, tested computation, kept as an internal library
 
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -73,21 +74,6 @@ impl FederationPeer {
     }
 }
 
-/// Federated analytics request: forward analytics query to a peer
-#[derive(Debug, Clone)]
-pub struct FederatedRequest {
-    /// Local subscription or query ID
-    pub local_ref: String,
-    /// Target peer instance ID
-    pub peer_instance_id: String,
-    /// Analytics IDs requested
-    pub analytics_ids: Vec<AnalyticsId>,
-    /// Request timestamp
-    pub sent_at: u64,
-    /// Whether a response has been received
-    pub completed: bool,
-}
-
 /// FL (Federated Learning) aggregation round
 ///
 /// NWDAF acts as aggregator for distributed model updates from UPFs/gNBs.
@@ -99,7 +85,7 @@ pub struct FlAggregationRound {
     pub analytics_id: AnalyticsId,
     /// Expected number of participant updates
     pub expected_participants: u32,
-    /// Received gradient updates (participant ID → update vector hash)
+    /// Received gradient updates (participant ID → raw update vector)
     pub received_updates: HashMap<String, Vec<f64>>,
     /// Aggregated global model update (FedAvg result)
     pub aggregated_update: Option<Vec<f64>>,
@@ -151,8 +137,6 @@ impl FlAggregationRound {
 pub struct FederationManager {
     /// Known federation peers
     peers: HashMap<String, FederationPeer>,
-    /// Active federated requests
-    requests: HashMap<String, FederatedRequest>,
     /// Active FL rounds
     fl_rounds: HashMap<u32, FlAggregationRound>,
 }

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -24,6 +24,8 @@ pub mod federation;
 pub mod ml_service;
 pub mod notification_dispatcher;
 pub mod nrf_collector;
+#[cfg(feature = "onnx-model")]
+pub mod onnx_model; // issue #26: zero-dep ONNX LinearRegressor subset backend
 mod sbi_handler;
 
 pub use context::*;
@@ -197,6 +199,22 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| format!("nwdaf-{}", uuid::Uuid::new_v4()));
 
     nwdaf_context_init(nf_instance_id.clone(), args.max_subscriptions);
+
+    // Issue #26: optional prediction-model selection. Default (env unset) is
+    // the OLS baseline — behavior-identical to the pre-#26 inline math.
+    if let Ok(model_id) = std::env::var("NWDAF_PREDICTION_MODEL") {
+        match ml_service::load_model(&model_id) {
+            Ok(model) => {
+                let ctx = nwdaf_self();
+                let guard = ctx.read().unwrap_or_else(|e| e.into_inner());
+                guard.lock_engine().set_predictor(model);
+                log::info!("NF_LOAD prediction model set to {model_id}");
+            }
+            Err(e) => {
+                log::warn!("NWDAF_PREDICTION_MODEL={model_id} ignored ({e}); keeping ols-linear");
+            }
+        }
+    }
 
     let shutdown = Arc::new(AtomicBool::new(false));
     setup_signal_handlers(shutdown.clone());

--- a/src/bins/nextgcore-nwdafd/src/ml_service.rs
+++ b/src/bins/nextgcore-nwdafd/src/ml_service.rs
@@ -710,3 +710,247 @@ mod tests {
         assert!(notif.get("accuracy").is_none());
     }
 }
+
+// ============================================================================
+// Issue #26: inference abstraction (load-by-id + predict)
+// ============================================================================
+
+/// A loaded prediction model: one-step-ahead forecasting over a numeric
+/// series (issue #26). `Send + Sync` because the analytics engine that owns
+/// the active model lives behind a shared `Mutex` in the NWDAF context.
+///
+/// Non-normative: TS 23.288 does not specify model internals; the baselines
+/// here need no model file so the default build and E2E path are unchanged.
+pub trait InferenceModel: Send + Sync {
+    /// Stable identifier (also what `load_model` resolves).
+    fn model_id(&self) -> &str;
+    /// Predict the next value of `series` (values in 0.0..=1.0).
+    /// Returns `(prediction clamped to 0..=1, confidence 0..=1)`, or `None`
+    /// when the series is empty or shorter than the model's input window.
+    fn predict_series(&self, series: &[f64]) -> Option<(f64, f64)>;
+}
+
+/// Default baseline: ordinary-least-squares linear fit over the last ≤5
+/// samples — byte-for-byte the math `AnalyticsEngine::compute_nf_load`
+/// used inline before issue #26 (confidence = R² of the fit; single sample
+/// → (value, 0.0)).
+#[derive(Debug, Clone, Default)]
+pub struct OlsLinearModel;
+
+impl InferenceModel for OlsLinearModel {
+    fn model_id(&self) -> &str {
+        "ols-linear"
+    }
+
+    fn predict_series(&self, series: &[f64]) -> Option<(f64, f64)> {
+        if series.is_empty() {
+            return None;
+        }
+        let n = series.len().min(5);
+        if n < 2 {
+            // A single sample yields no residual basis; report no confidence.
+            return Some((series[series.len() - 1].clamp(0.0, 1.0), 0.0));
+        }
+        let last = &series[series.len() - n..];
+        let nf = n as f64;
+        let sum_x: f64 = (0..n).map(|i| i as f64).sum();
+        let sum_y: f64 = last.iter().sum();
+        let sum_xx: f64 = (0..n).map(|i| (i as f64).powi(2)).sum();
+        let sum_xy: f64 = last.iter().enumerate().map(|(i, y)| i as f64 * y).sum();
+        // denom = N·Σx² − (Σx)² is strictly positive for N ≥ 2 distinct x.
+        let denom = nf * sum_xx - sum_x * sum_x;
+        let b = (nf * sum_xy - sum_x * sum_y) / denom;
+        let a = (sum_y - b * sum_x) / nf;
+        let predicted = (a + b * nf).clamp(0.0, 1.0);
+        // R² = 1 − SS_res / SS_tot.
+        let mean_y = sum_y / nf;
+        let ss_tot: f64 = last.iter().map(|y| (y - mean_y).powi(2)).sum();
+        let ss_res: f64 = last
+            .iter()
+            .enumerate()
+            .map(|(i, y)| (y - (a + b * i as f64)).powi(2))
+            .sum();
+        let r_squared = if ss_tot <= f64::EPSILON {
+            // Flat series: the predictor reproduces it exactly → R² = 1.
+            1.0
+        } else {
+            (1.0 - ss_res / ss_tot).clamp(0.0, 1.0)
+        };
+        Some((predicted, r_squared))
+    }
+}
+
+/// EWMA baseline: exponentially weighted moving average as the next-step
+/// prediction; confidence is `1 − mean(|one-step EWMA error|)` over the
+/// series (a documented heuristic, NOT a goodness-of-fit statistic).
+#[derive(Debug, Clone)]
+pub struct EwmaModel {
+    alpha: f64,
+}
+
+impl EwmaModel {
+    pub fn new(alpha: f64) -> Self {
+        Self {
+            alpha: if alpha.is_finite() {
+                alpha.clamp(0.01, 1.0)
+            } else {
+                0.3
+            },
+        }
+    }
+
+    pub fn alpha(&self) -> f64 {
+        self.alpha
+    }
+}
+
+impl Default for EwmaModel {
+    fn default() -> Self {
+        Self::new(0.3)
+    }
+}
+
+impl InferenceModel for EwmaModel {
+    fn model_id(&self) -> &str {
+        "ewma"
+    }
+
+    fn predict_series(&self, series: &[f64]) -> Option<(f64, f64)> {
+        let (first, rest) = series.split_first()?;
+        if rest.is_empty() {
+            return Some((first.clamp(0.0, 1.0), 0.0));
+        }
+        let mut ewma = *first;
+        let mut abs_err_sum = 0.0;
+        for y in rest {
+            // The pre-update EWMA is the one-step prediction for `y`.
+            abs_err_sum += (y - ewma).abs();
+            ewma = self.alpha * y + (1.0 - self.alpha) * ewma;
+        }
+        let confidence = (1.0 - abs_err_sum / rest.len() as f64).clamp(0.0, 1.0);
+        Some((ewma.clamp(0.0, 1.0), confidence))
+    }
+}
+
+/// Wrapper giving the boxed active model `Debug` + `Default` (the analytics
+/// engine derives both; the default is the OLS baseline, keeping default
+/// builds behavior-identical).
+pub struct Predictor(pub Box<dyn InferenceModel>);
+
+impl std::fmt::Debug for Predictor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Predictor")
+            .field(&self.0.model_id())
+            .finish()
+    }
+}
+
+impl Default for Predictor {
+    fn default() -> Self {
+        Self(Box::new(OlsLinearModel))
+    }
+}
+
+/// Load a prediction model by id (issue #26 "load-by-id" surface):
+/// - `"ols-linear"` — the default OLS baseline (no model file)
+/// - `"ewma"` or `"ewma:<alpha>"` — EWMA baseline (no model file)
+/// - `"onnx:<path>"` — ONNX-backed linear model, only with the off-by-default
+///   `onnx-model` cargo feature (zero-dependency minimal subset reader)
+pub fn load_model(model_id: &str) -> Result<Box<dyn InferenceModel>, String> {
+    if model_id == "ols-linear" {
+        return Ok(Box::new(OlsLinearModel));
+    }
+    if model_id == "ewma" {
+        return Ok(Box::new(EwmaModel::default()));
+    }
+    if let Some(alpha) = model_id.strip_prefix("ewma:") {
+        let alpha: f64 = alpha
+            .parse()
+            .map_err(|e| format!("invalid ewma alpha {alpha:?}: {e}"))?;
+        return Ok(Box::new(EwmaModel::new(alpha)));
+    }
+    if let Some(path) = model_id.strip_prefix("onnx:") {
+        #[cfg(feature = "onnx-model")]
+        {
+            return crate::onnx_model::OnnxLinearRegressor::load(std::path::Path::new(path))
+                .map(|m| Box::new(m) as Box<dyn InferenceModel>);
+        }
+        #[cfg(not(feature = "onnx-model"))]
+        {
+            return Err(format!(
+                "model {path:?} requires the off-by-default `onnx-model` cargo feature"
+            ));
+        }
+    }
+    Err(format!(
+        "unknown model id {model_id:?} (expected ols-linear, ewma[:<alpha>], or onnx:<path>)"
+    ))
+}
+
+#[cfg(test)]
+mod inference_tests {
+    use super::*;
+
+    #[test]
+    fn ols_matches_legacy_inline_math() {
+        // Clean rising trend → high R² (mirrors test_confidence_reflects_fit_quality).
+        let clean: Vec<f64> = (0..10).map(|i| 0.1 + 0.05 * i as f64).collect();
+        let (pred, conf) = OlsLinearModel.predict_series(&clean).unwrap();
+        assert!(conf > 0.9, "clean trend must have high confidence ({conf})");
+        assert!(
+            pred > *clean.last().unwrap(),
+            "rising trend projects upward"
+        );
+
+        // Zig-zag → poor fit.
+        let zigzag = [0.3, 0.7, 0.3, 0.7, 0.3, 0.7, 0.3, 0.7];
+        let (_, zconf) = OlsLinearModel.predict_series(&zigzag).unwrap();
+        assert!(zconf < 0.5, "zig-zag must have low confidence ({zconf})");
+        assert!(zconf < conf);
+
+        // Single sample → (value, 0.0); empty → None.
+        assert_eq!(OlsLinearModel.predict_series(&[0.4]), Some((0.4, 0.0)));
+        assert!(OlsLinearModel.predict_series(&[]).is_none());
+
+        // Flat series → R² = 1.
+        let (fp, fc) = OlsLinearModel.predict_series(&[0.5; 6]).unwrap();
+        assert!((fp - 0.5).abs() < 1e-9);
+        assert!((fc - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ewma_predicts_and_scores() {
+        let m = EwmaModel::default();
+        assert_eq!(m.model_id(), "ewma");
+        let (pred, conf) = m.predict_series(&[0.5; 8]).unwrap();
+        assert!((pred - 0.5).abs() < 1e-9, "flat series predicts itself");
+        assert!((conf - 1.0).abs() < 1e-9, "no error → full confidence");
+        let (_, noisy_conf) = m.predict_series(&[0.1, 0.9, 0.1, 0.9]).unwrap();
+        assert!(noisy_conf < 0.5);
+        assert!(m.predict_series(&[]).is_none());
+        // Alpha clamping.
+        assert!((EwmaModel::new(f64::NAN).alpha() - 0.3).abs() < 1e-9);
+        assert!((EwmaModel::new(7.0).alpha() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn load_model_resolves_ids() {
+        assert_eq!(load_model("ols-linear").unwrap().model_id(), "ols-linear");
+        assert_eq!(load_model("ewma").unwrap().model_id(), "ewma");
+        assert_eq!(load_model("ewma:0.5").unwrap().model_id(), "ewma");
+        assert!(load_model("ewma:x").is_err());
+        assert!(load_model("bogus").is_err());
+        #[cfg(not(feature = "onnx-model"))]
+        assert!(load_model("onnx:/tmp/m.onnx")
+            .err()
+            .expect("onnx must fail without the feature")
+            .contains("onnx-model"));
+    }
+
+    #[test]
+    fn predictor_wrapper_debug_and_default() {
+        let p = Predictor::default();
+        assert_eq!(p.0.model_id(), "ols-linear");
+        assert!(format!("{p:?}").contains("ols-linear"));
+    }
+}

--- a/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
+++ b/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
@@ -223,9 +223,12 @@ fn nf_status_json(status: &str) -> Value {
 /// (`round(R² × 100)`). The former non-spec vendor keys `predictedLoad` and
 /// float `confidence` are dropped (documented per the G2-1 spec item).
 ///
-/// T5.4 HONESTY NOTE: `compute_nf_load` is linear regression on the last N
-/// samples, not a trained ML model; `confidence` is the regression R², not
-/// model accuracy (TS 23.288 §6.14).
+/// T5.4/issue #26 HONESTY NOTE: `compute_nf_load` routes prediction and
+/// `confidence` through the active `ml_service::InferenceModel`. The default
+/// is the OLS baseline (confidence = regression R², byte-identical to the
+/// formerly inline math); the feature-gated `onnx-model` backend loads real
+/// linear model files, and each model documents its own confidence
+/// semantics (TS 23.288 §6.14).
 pub fn compute_event_infos(
     engine: &AnalyticsEngine,
     event: AnalyticsId,
@@ -1072,6 +1075,38 @@ mod tests {
     /// 0..=100 (never the old float R²), the non-spec `predictedLoad` vendor
     /// key is gone, and `nfStatus` is the TS 29.520 object form sourced from
     /// the cached NRF profile (never a bare string literal).
+    /// Issue #26 acceptance: a swapped inference model's output reaches the
+    /// wire — the emitted `confidence` Uinteger is the model's confidence.
+    #[test]
+    fn swapped_model_output_reaches_wire_confidence() {
+        struct FixedModel;
+        impl crate::ml_service::InferenceModel for FixedModel {
+            fn model_id(&self) -> &str {
+                "fixed-test"
+            }
+            fn predict_series(&self, _series: &[f64]) -> Option<(f64, f64)> {
+                Some((0.87, 0.42))
+            }
+        }
+        let mut engine = AnalyticsEngine::new();
+        for v in [0.1_f64, 0.2, 0.3] {
+            engine.ingest_nf_load(crate::analytics::NfLoadSample::now(
+                "AMF",
+                "amf-fixed-01",
+                v,
+                0.0,
+                0,
+            ));
+        }
+        engine.set_predictor(Box::new(FixedModel));
+        let infos = compute_event_infos(&engine, AnalyticsId::NfLoad, &EventInfoFilter::none());
+        assert_eq!(infos[0]["nfInstanceId"], "amf-fixed-01");
+        assert_eq!(
+            infos[0]["confidence"], 42,
+            "wire confidence = model output x100"
+        );
+    }
+
     #[test]
     fn test_nf_load_info_spec_shape() {
         use crate::analytics::NfProfileMeta;

--- a/src/bins/nextgcore-nwdafd/src/onnx_model.rs
+++ b/src/bins/nextgcore-nwdafd/src/onnx_model.rs
@@ -1,0 +1,526 @@
+//! ONNX-backed inference for the NWDAF prediction path (issue #26, feature
+//! `onnx-model`, off by default).
+//!
+//! Zero-dependency by design: instead of pulling an ONNX runtime crate, this
+//! is a hand-rolled reader for a **minimal, explicitly documented subset** of
+//! the ONNX protobuf format — a single `ai.onnx.ml` `LinearRegressor` node
+//! (`coefficients` + `intercepts` attributes), i.e. exactly the model class
+//! sklearn's `skl2onnx` exports for `LinearRegression`. Anything else in the
+//! graph is a hard error, never a silent approximation. Hand-rolled wire
+//! codecs are this repo's house style (NAS/NGAP/LPP), and the lock stays
+//! byte-identical (the pqc-tls precedent).
+//!
+//! The model maps the last `coefficients.len()` samples of the series to the
+//! next value: `y = intercept + Σ coef[i]·window[i]`. `confidence` is the
+//! R² of a backtest of the loaded model over the observed series (documented
+//! semantics; an ONNX file itself carries no goodness-of-fit). The reader
+//! accepts `AttributeProto.floats` in both the packed and the per-element
+//! proto2 encodings (real exporter files use the latter); multi-output
+//! models (`targets` > 1 / multiple intercepts) are rejected at load.
+
+use crate::ml_service::InferenceModel;
+
+/// Protobuf wire types used by the subset reader.
+const WT_VARINT: u64 = 0;
+const WT_I64: u64 = 1;
+const WT_LEN: u64 = 2;
+const WT_I32: u64 = 5;
+
+/// A loaded `ai.onnx.ml` LinearRegressor.
+#[derive(Debug, Clone)]
+pub struct OnnxLinearRegressor {
+    model_id: String,
+    coefficients: Vec<f64>,
+    intercept: f64,
+}
+
+impl OnnxLinearRegressor {
+    /// Load from an `.onnx` file (see module doc for the supported subset).
+    pub fn load(path: &std::path::Path) -> Result<Self, String> {
+        let bytes = std::fs::read(path)
+            .map_err(|e| format!("failed to read ONNX model {}: {e}", path.display()))?;
+        Self::from_bytes(&bytes, &format!("onnx:{}", path.display()))
+    }
+
+    /// Parse a serialized `ModelProto`. Errors on anything outside the
+    /// single-LinearRegressor subset.
+    pub fn from_bytes(bytes: &[u8], model_id: &str) -> Result<Self, String> {
+        let mut graph: Option<&[u8]> = None;
+        walk_fields(bytes, |field, payload| {
+            if field == 7 {
+                // ModelProto.graph
+                if graph.is_some() {
+                    return Err("duplicate ModelProto.graph field (split/merged \
+                                ModelProto is outside the supported subset)"
+                        .to_string());
+                }
+                graph = Some(payload.require_len()?);
+            }
+            Ok(())
+        })?;
+        let graph = graph.ok_or("ONNX ModelProto has no graph")?;
+
+        let mut nodes: Vec<&[u8]> = Vec::new();
+        walk_fields(graph, |field, payload| {
+            if field == 1 {
+                // GraphProto.node
+                nodes.push(payload.require_len()?);
+            }
+            Ok(())
+        })?;
+        if nodes.is_empty() {
+            return Err("ONNX graph has no nodes".to_string());
+        }
+        if nodes.len() > 1 {
+            return Err(format!(
+                "unsupported ONNX graph: {} nodes (subset supports exactly one \
+                 ai.onnx.ml LinearRegressor node)",
+                nodes.len()
+            ));
+        }
+
+        let mut op_type = String::new();
+        let mut attrs: Vec<&[u8]> = Vec::new();
+        walk_fields(nodes[0], |field, payload| {
+            match field {
+                4 => op_type = payload.require_str()?,   // NodeProto.op_type
+                5 => attrs.push(payload.require_len()?), // NodeProto.attribute
+                _ => {}
+            }
+            Ok(())
+        })?;
+        if op_type != "LinearRegressor" {
+            return Err(format!(
+                "unsupported ONNX op {op_type:?}: this build supports only the \
+                 ai.onnx.ml LinearRegressor subset (see docs/nwdaf-inference.md)"
+            ));
+        }
+
+        let mut coefficients: Vec<f64> = Vec::new();
+        let mut intercepts: Vec<f64> = Vec::new();
+        for attr in attrs {
+            let mut name = String::new();
+            let mut floats: Vec<f64> = Vec::new();
+            let mut int_value: Option<u64> = None;
+            walk_fields(attr, |field, payload| {
+                match field {
+                    1 => name = payload.require_str()?, // AttributeProto.name
+                    3 => {
+                        // AttributeProto.i (e.g. the LinearRegressor `targets`
+                        // attribute for multi-output models)
+                        if let Payload::Varint(v) = payload {
+                            int_value = Some(v);
+                        }
+                    }
+                    7 => {
+                        // AttributeProto.floats: packed (LEN) or unpacked (I32)
+                        match payload {
+                            Payload::Len(b) => {
+                                if b.len() % 4 != 0 {
+                                    return Err("packed floats not 4-byte aligned".into());
+                                }
+                                for chunk in b.chunks_exact(4) {
+                                    floats.push(f64::from(f32::from_le_bytes(
+                                        chunk.try_into().expect("chunks_exact(4)"),
+                                    )));
+                                }
+                            }
+                            Payload::I32(v) => {
+                                floats.push(f64::from(f32::from_le_bytes(v.to_le_bytes())));
+                            }
+                            _ => return Err("unexpected wire type for floats".into()),
+                        }
+                    }
+                    _ => {}
+                }
+                Ok(())
+            })?;
+            match name.as_str() {
+                "coefficients" => coefficients = floats,
+                "intercepts" => intercepts = floats,
+                // Multi-output regressors ravel their coefficient matrix into
+                // the same attribute; evaluating that as a longer lag window
+                // would be silent garbage — hard-error per the module
+                // contract.
+                "targets" => {
+                    if int_value.is_some_and(|t| t != 1) {
+                        return Err(format!(
+                            "unsupported LinearRegressor: targets={} (only \
+                             single-output models are in the subset)",
+                            int_value.unwrap_or(0)
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+        if coefficients.is_empty() {
+            return Err("LinearRegressor has no coefficients attribute".to_string());
+        }
+        if intercepts.len() > 1 {
+            return Err(format!(
+                "unsupported LinearRegressor: {} intercepts (multi-output \
+                 models are outside the subset)",
+                intercepts.len()
+            ));
+        }
+        // [issue #26 review] A window wider than the engine's bounded sample
+        // history could never fire — reject at load so the operator gets the
+        // existing warn + safe default instead of a silent mean-fallback.
+        if coefficients.len() > crate::analytics::MAX_SAMPLES {
+            return Err(format!(
+                "LinearRegressor input window ({} coefficients) exceeds the \
+                 engine's history cap of {} samples — the model could never run",
+                coefficients.len(),
+                crate::analytics::MAX_SAMPLES
+            ));
+        }
+        Ok(Self {
+            model_id: model_id.to_string(),
+            coefficients,
+            intercept: intercepts.first().copied().unwrap_or(0.0),
+        })
+    }
+
+    /// Apply the linear function to one input window (len == coefficients).
+    fn apply(&self, window: &[f64]) -> f64 {
+        self.intercept
+            + self
+                .coefficients
+                .iter()
+                .zip(window)
+                .map(|(c, x)| c * x)
+                .sum::<f64>()
+    }
+}
+
+impl InferenceModel for OnnxLinearRegressor {
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    fn predict_series(&self, series: &[f64]) -> Option<(f64, f64)> {
+        let n = self.coefficients.len();
+        if n == 0 || series.len() < n {
+            return None;
+        }
+        let prediction = self.apply(&series[series.len() - n..]).clamp(0.0, 1.0);
+
+        // Backtest R² of the loaded model over the observed series: predict
+        // each sample from the window preceding it. Fewer than 2 backtest
+        // points → confidence 0.0 (unknown).
+        let backtests: Vec<(f64, f64)> = (n..series.len())
+            .map(|t| (self.apply(&series[t - n..t]), series[t]))
+            .collect();
+        if backtests.len() < 2 {
+            return Some((prediction, 0.0));
+        }
+        let mean_actual = backtests.iter().map(|(_, a)| a).sum::<f64>() / backtests.len() as f64;
+        let ss_tot: f64 = backtests
+            .iter()
+            .map(|(_, a)| (a - mean_actual).powi(2))
+            .sum();
+        let ss_res: f64 = backtests.iter().map(|(p, a)| (a - p).powi(2)).sum();
+        let confidence = if ss_tot <= f64::EPSILON {
+            if ss_res <= f64::EPSILON {
+                1.0
+            } else {
+                0.0
+            }
+        } else {
+            (1.0 - ss_res / ss_tot).clamp(0.0, 1.0)
+        };
+        Some((prediction, confidence))
+    }
+}
+
+/// One decoded field payload.
+enum Payload<'a> {
+    Varint(u64),
+    I64(u64),
+    Len(&'a [u8]),
+    I32(u32),
+}
+
+impl<'a> Payload<'a> {
+    fn require_len(&self) -> Result<&'a [u8], String> {
+        match self {
+            Payload::Len(b) => Ok(b),
+            _ => Err("expected length-delimited field".to_string()),
+        }
+    }
+
+    fn require_str(&self) -> Result<String, String> {
+        let b = self.require_len()?;
+        String::from_utf8(b.to_vec()).map_err(|e| format!("invalid UTF-8 string field: {e}"))
+    }
+}
+
+/// Walk every top-level field of a protobuf message, invoking `visit` with
+/// the field number and payload; unknown fields are skipped structurally.
+fn walk_fields<'a>(
+    mut buf: &'a [u8],
+    mut visit: impl FnMut(u64, Payload<'a>) -> Result<(), String>,
+) -> Result<(), String> {
+    while !buf.is_empty() {
+        let (tag, rest) = read_varint(buf)?;
+        let field = tag >> 3;
+        let wire_type = tag & 0x7;
+        buf = rest;
+        let payload = match wire_type {
+            WT_VARINT => {
+                let (v, rest) = read_varint(buf)?;
+                buf = rest;
+                Payload::Varint(v)
+            }
+            WT_I64 => {
+                if buf.len() < 8 {
+                    return Err("truncated 64-bit field".to_string());
+                }
+                let v = u64::from_le_bytes(buf[..8].try_into().expect("len checked"));
+                buf = &buf[8..];
+                Payload::I64(v)
+            }
+            WT_LEN => {
+                let (len, rest) = read_varint(buf)?;
+                let len = usize::try_from(len).map_err(|_| "field length overflow")?;
+                if rest.len() < len {
+                    return Err("truncated length-delimited field".to_string());
+                }
+                buf = &rest[len..];
+                Payload::Len(&rest[..len])
+            }
+            WT_I32 => {
+                if buf.len() < 4 {
+                    return Err("truncated 32-bit field".to_string());
+                }
+                let v = u32::from_le_bytes(buf[..4].try_into().expect("len checked"));
+                buf = &buf[4..];
+                Payload::I32(v)
+            }
+            other => return Err(format!("unsupported protobuf wire type {other}")),
+        };
+        visit(field, payload)?;
+    }
+    Ok(())
+}
+
+fn read_varint(buf: &[u8]) -> Result<(u64, &[u8]), String> {
+    let mut value: u64 = 0;
+    for (i, byte) in buf.iter().enumerate() {
+        if i >= 10 {
+            return Err("varint too long".to_string());
+        }
+        value |= u64::from(byte & 0x7f) << (7 * i);
+        if byte & 0x80 == 0 {
+            return Ok((value, &buf[i + 1..]));
+        }
+    }
+    Err("truncated varint".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- minimal protobuf ENCODER, test-only: builds known-good model bytes
+    //    in source (no binary fixtures, per the never-commit-binaries rule) --
+
+    fn put_varint(buf: &mut Vec<u8>, mut v: u64) {
+        loop {
+            let byte = (v & 0x7f) as u8;
+            v >>= 7;
+            if v == 0 {
+                buf.push(byte);
+                break;
+            }
+            buf.push(byte | 0x80);
+        }
+    }
+
+    fn put_len_field(buf: &mut Vec<u8>, field: u64, payload: &[u8]) {
+        put_varint(buf, (field << 3) | WT_LEN);
+        put_varint(buf, payload.len() as u64);
+        buf.extend_from_slice(payload);
+    }
+
+    fn attr_floats(name: &str, values: &[f32]) -> Vec<u8> {
+        let mut attr = Vec::new();
+        put_len_field(&mut attr, 1, name.as_bytes()); // AttributeProto.name
+        let mut packed = Vec::new();
+        for v in values {
+            packed.extend_from_slice(&v.to_le_bytes());
+        }
+        put_len_field(&mut attr, 7, &packed); // AttributeProto.floats (packed)
+        attr
+    }
+
+    fn model_bytes(op_type: &str, coefficients: &[f32], intercepts: &[f32]) -> Vec<u8> {
+        let mut node = Vec::new();
+        put_len_field(&mut node, 4, op_type.as_bytes()); // NodeProto.op_type
+        put_len_field(&mut node, 7, b"ai.onnx.ml"); // NodeProto.domain
+        put_len_field(&mut node, 5, &attr_floats("coefficients", coefficients));
+        put_len_field(&mut node, 5, &attr_floats("intercepts", intercepts));
+        let mut graph = Vec::new();
+        put_len_field(&mut graph, 1, &node); // GraphProto.node
+        let mut model = Vec::new();
+        put_len_field(&mut model, 7, &graph); // ModelProto.graph
+        model
+    }
+
+    #[test]
+    fn parses_and_predicts_linear_regressor() {
+        // y = 2·x[1] − x[0]: exact one-step extrapolation of any arithmetic
+        // series, so the backtest R² must be 1.0 on a clean ramp.
+        let bytes = model_bytes("LinearRegressor", &[-1.0, 2.0], &[0.0]);
+        let m = OnnxLinearRegressor::from_bytes(&bytes, "onnx:test").unwrap();
+        assert_eq!(m.model_id(), "onnx:test");
+        let series = [0.1, 0.15, 0.2, 0.25, 0.3];
+        let (pred, conf) = m.predict_series(&series).unwrap();
+        assert!((pred - 0.35).abs() < 1e-6, "ramp extrapolation ({pred})");
+        assert!((conf - 1.0).abs() < 1e-6, "perfect backtest ({conf})");
+        // Window (2) longer than history → None.
+        assert!(m.predict_series(&[0.4]).is_none());
+    }
+
+    #[test]
+    fn rejects_unsupported_ops_and_malformed_bytes() {
+        let gemm = model_bytes("Gemm", &[1.0], &[0.0]);
+        let err = OnnxLinearRegressor::from_bytes(&gemm, "x").unwrap_err();
+        assert!(err.contains("unsupported ONNX op"), "{err}");
+
+        let empty_graph = {
+            let mut model = Vec::new();
+            put_len_field(&mut model, 7, &[]);
+            model
+        };
+        assert!(OnnxLinearRegressor::from_bytes(&empty_graph, "x")
+            .unwrap_err()
+            .contains("no nodes"));
+
+        let mut truncated = model_bytes("LinearRegressor", &[1.0], &[0.0]);
+        truncated.truncate(truncated.len() - 3);
+        assert!(OnnxLinearRegressor::from_bytes(&truncated, "x").is_err());
+
+        assert!(OnnxLinearRegressor::from_bytes(&[], "x")
+            .unwrap_err()
+            .contains("no graph"));
+
+        let no_coefs = model_bytes("LinearRegressor", &[], &[0.1]);
+        assert!(OnnxLinearRegressor::from_bytes(&no_coefs, "x")
+            .unwrap_err()
+            .contains("no coefficients"));
+    }
+
+    fn attr_int(name: &str, v: u64) -> Vec<u8> {
+        let mut attr = Vec::new();
+        put_len_field(&mut attr, 1, name.as_bytes()); // AttributeProto.name
+        put_varint(&mut attr, (3 << 3) | WT_VARINT); // AttributeProto.i
+        put_varint(&mut attr, v);
+        attr
+    }
+
+    fn attr_floats_unpacked(name: &str, values: &[f32]) -> Vec<u8> {
+        let mut attr = Vec::new();
+        put_len_field(&mut attr, 1, name.as_bytes());
+        for v in values {
+            // proto2 default (no [packed=true]): one I32 record per element —
+            // the form real exporter files use.
+            put_varint(&mut attr, (7 << 3) | WT_I32);
+            attr.extend_from_slice(&v.to_le_bytes());
+        }
+        attr
+    }
+
+    fn model_from_attrs(op_type: &str, attrs: &[Vec<u8>]) -> Vec<u8> {
+        let mut node = Vec::new();
+        put_len_field(&mut node, 4, op_type.as_bytes());
+        put_len_field(&mut node, 7, b"ai.onnx.ml");
+        for a in attrs {
+            put_len_field(&mut node, 5, a);
+        }
+        let mut graph = Vec::new();
+        put_len_field(&mut graph, 1, &node);
+        let mut model = Vec::new();
+        put_len_field(&mut model, 7, &graph);
+        model
+    }
+
+    #[test]
+    fn unpacked_floats_parse_identically_to_packed() {
+        let packed = model_bytes("LinearRegressor", &[-1.0, 2.0], &[0.0]);
+        let unpacked = model_from_attrs(
+            "LinearRegressor",
+            &[
+                attr_floats_unpacked("coefficients", &[-1.0, 2.0]),
+                attr_floats_unpacked("intercepts", &[0.0]),
+            ],
+        );
+        let a = OnnxLinearRegressor::from_bytes(&packed, "x").unwrap();
+        let b = OnnxLinearRegressor::from_bytes(&unpacked, "x").unwrap();
+        let series = [0.1, 0.15, 0.2, 0.25];
+        assert_eq!(a.predict_series(&series), b.predict_series(&series));
+    }
+
+    #[test]
+    fn rejects_multi_output_and_oversized_models() {
+        // skl2onnx multi-output shape: raveled 2x3 coefficients + 2 intercepts
+        // + targets=2 → hard error, never a silent 6-lag misread.
+        let multi = model_from_attrs(
+            "LinearRegressor",
+            &[
+                attr_floats("coefficients", &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+                attr_floats("intercepts", &[0.05, 0.9]),
+                attr_int("targets", 2),
+            ],
+        );
+        let err = OnnxLinearRegressor::from_bytes(&multi, "x").unwrap_err();
+        assert!(err.contains("targets=2"), "{err}");
+
+        // Two intercepts even without a targets attribute → rejected.
+        let two_intercepts = model_bytes("LinearRegressor", &[1.0], &[0.1, 0.2]);
+        assert!(OnnxLinearRegressor::from_bytes(&two_intercepts, "x")
+            .unwrap_err()
+            .contains("intercepts"));
+
+        // targets=1 (single-output export) stays accepted.
+        let single = model_from_attrs(
+            "LinearRegressor",
+            &[
+                attr_floats("coefficients", &[-1.0, 2.0]),
+                attr_floats("intercepts", &[0.0]),
+                attr_int("targets", 1),
+            ],
+        );
+        assert!(OnnxLinearRegressor::from_bytes(&single, "x").is_ok());
+
+        // Window wider than the engine's 100-sample history cap → load error.
+        let oversized = model_bytes("LinearRegressor", &[0.01f32; 101], &[0.0]);
+        assert!(OnnxLinearRegressor::from_bytes(&oversized, "x")
+            .unwrap_err()
+            .contains("history cap"));
+
+        // Duplicate ModelProto.graph → rejected, not last-wins.
+        let mut dup = model_bytes("LinearRegressor", &[1.0], &[0.0]);
+        let second = model_bytes("LinearRegressor", &[1.0], &[0.0]);
+        dup.extend_from_slice(&second);
+        assert!(OnnxLinearRegressor::from_bytes(&dup, "x")
+            .unwrap_err()
+            .contains("duplicate ModelProto.graph"));
+    }
+
+    #[test]
+    fn load_model_via_ml_service_roundtrips_a_file() {
+        let bytes = model_bytes("LinearRegressor", &[-1.0, 2.0], &[0.0]);
+        let path = std::env::temp_dir().join(format!(
+            "nextgcore-nwdafd-issue26-{}.onnx",
+            std::process::id()
+        ));
+        std::fs::write(&path, &bytes).expect("write model");
+        let m = crate::ml_service::load_model(&format!("onnx:{}", path.display()))
+            .expect("load via ml_service");
+        assert!(m.model_id().starts_with("onnx:"));
+        assert!(m.predict_series(&[0.1, 0.2, 0.3]).is_some());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
+++ b/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
@@ -180,9 +180,11 @@ fn parse_event_filter(raw: Option<&String>) -> Result<EventInfoFilter, String> {
 /// cannot exist. Only tokens outside the `NwdafEvent` enum are 400
 /// `INVALID_ANALYTICS_TYPE`. The former non-spec `tgtUe` echo is removed.
 ///
-/// T5.4 HONESTY NOTE: the analytics engine uses linear regression (slope on
-/// the last N samples), NOT a trained ML model. `confidence` is the regression
-/// R² scaled to a Uinteger, not model accuracy (TS 23.288 §6.14).
+/// T5.4/issue #26 HONESTY NOTE: the analytics engine routes prediction and
+/// `confidence` through the active `ml_service::InferenceModel` (default: the
+/// OLS linear-regression baseline, whose confidence is the regression R²
+/// scaled to a Uinteger; the feature-gated `onnx-model` backend loads real
+/// linear model files — TS 23.288 §6.14).
 pub async fn handle_analytics_info_query_with_ctx(
     ctx: &Arc<RwLock<NwdafContext>>,
     request: &SbiRequest,


### PR DESCRIPTION
Closes #26

## What

Turns the NWDAF ML-serving scaffolding into a **real, minimal analytics-plus-inference path**, with the default build byte-behavior-identical and no model file needed.

- **Inference abstraction** (`ml_service.rs`): `InferenceModel` trait (`model_id` + `predict_series → (prediction, confidence)`) and `load_model(id)` — the issue's load-by-id/predict surface. Baselines ship in-tree: `ols-linear` (the exact OLS math `compute_nf_load` previously inlined, R² confidence — default) and `ewma[:<alpha>]` (documented error-based confidence heuristic).
- **End-to-end wiring**: `nrf_collector` → `AnalyticsEngine` (`compute_nf_load` now calls the **active model**) → `Nnwdaf_AnalyticsInfo` GET / EventsSubscription Notify. The emitted TS 29.520 `confidence` member is the model's output; the wire shape is deliberately unchanged (the G2-1 decision dropping the vendor `predictedLoad` key stands — the numeric prediction surfaces via the engine API, not an invented wire member; documented in the design note). Model selection via `NWDAF_PREDICTION_MODEL` env (unset = identical-to-before default; invalid = warn + default).
- **ONNX backend** (new `onnx_model.rs`, feature `onnx-model = []`, off by default): **zero-dependency** hand-rolled reader for a minimal, explicitly documented ONNX protobuf subset — exactly one `ai.onnx.ml` `LinearRegressor` node; anything else is a hard error. No C-linked runtime, zero `Cargo.lock` growth (pqc-tls precedent), test models built as protobuf bytes in test source (no binary fixtures, per the never-commit-binaries decision). Confidence = backtest R² of the loaded model over the observed series.
- **Federation**: kept the real, tested local FedAvg (`FlAggregationRound::aggregate`) and peer registry as a documented internal library; **removed the genuinely dead scaffolding** (`FederatedRequest`, the never-read `requests` map) and fixed misleading docs. Honesty note added: nothing federates over the wire.
- Honesty-note doc comments refreshed at all four anchors (analytics/sbi_handler/dispatcher module docs); design note `docs/nwdaf-inference.md` + README link.

## Acceptance criteria

- [x] `Nnwdaf_AnalyticsInfo`'s NF_LOAD analytics are produced by `ml_service` — exercised by tests (engine-level model-swap wiring test + a dispatcher-level test pinning the wire `confidence` member to a swapped model's output)
- [x] Default build needs no external model file; ONNX path is feature-gated and tested when enabled (114 tests with `--features onnx-model`)
- [x] No `TODO`/`unimplemented!` in the touched modules (grep-verified); `cargo clippy` clean in both configs

## Review

Adversarial 3-dimension review (numeric equivalence vs the removed inline math / ONNX wire-format vs real exporter output / wiring+honesty): 7 raw findings → 6 confirmed (2 MEDIUM, 4 LOW), all fixed — multi-output `LinearRegressor` exports (`targets` > 1, multiple intercepts) now hard-error instead of silently misreading the raveled coefficient matrix; a window wider than the engine's 100-sample history cap errors at load (routing into the existing warn + safe-default arm); duplicate `ModelProto.graph` rejected; proto2 per-element (unpacked) float encoding covered by a parity test; a wire-level test pins a swapped model's output on the emitted `confidence` member; one doc overclaim amended.

## Verification

```sh
cargo test -p nextgcore-nwdafd                        # 109 pass (OLS default, no model file)
cargo test -p nextgcore-nwdafd --features onnx-model  # 114 pass, clippy 0 both configs
NWDAF_PREDICTION_MODEL=ewma:0.5 cargo run -p nextgcore-nwdafd
```

Signed-off-by: Murat Parlakisik <parlakisik@gmail.com>
