### PR TITLE
fix(pfcp): complete the Cause table and stop failing whole messages on unknown values

### DIFF
--- a/src/bins/nextgcore-smfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-smfd/src/pfcp_path.rs
@@ -177,25 +177,16 @@ pub mod pfcp_cause {
 }
 
 /// Human-readable PFCP cause name for error reporting
+///
+/// Delegates to `nextgcore_pfcp::types::PfcpCause` rather than carrying a second
+/// copy of TS 29.244 Table 8.2.1-1. The local copy this replaced had drifted
+/// from the library enum in a way that mattered: it listed cause 78
+/// ("Redirection requested") while the enum did not, so the SMF could *name* a
+/// cause its own decoder rejected outright.
 pub fn cause_name(cause: u8) -> &'static str {
-    match cause {
-        1 => "Request accepted",
-        64 => "Request rejected",
-        65 => "Session context not found",
-        66 => "Mandatory IE missing",
-        67 => "Conditional IE missing",
-        68 => "Invalid length",
-        69 => "Mandatory IE incorrect",
-        70 => "Invalid Forwarding Policy",
-        71 => "Invalid F-TEID allocation option",
-        72 => "No established PFCP Association",
-        73 => "Rule creation/modification failure",
-        74 => "PFCP entity in congestion",
-        75 => "No resources available",
-        76 => "Service not supported",
-        77 => "System failure",
-        78 => "Redirection requested",
-        _ => "Unknown cause",
+    match nextgcore_pfcp::types::PfcpCause::try_from(cause) {
+        Ok(c) => c.name(),
+        Err(_) => "Unknown cause",
     }
 }
 

--- a/src/libs/nextgcore-pfcp/src/message.rs
+++ b/src/libs/nextgcore-pfcp/src/message.rs
@@ -275,7 +275,7 @@ impl AssociationSetupResponse {
                 }
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::RecoveryTimeStamp as u16 => {
@@ -381,7 +381,7 @@ impl AssociationReleaseResponse {
                 }
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 _ => {}
@@ -611,7 +611,7 @@ impl SessionEstablishmentResponse {
                 }
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::FSeid as u16 => {
@@ -688,7 +688,7 @@ impl SessionDeletionResponse {
         while buf.remaining() >= IeHeader::LEN {
             let ie = RawIe::decode(buf)?;
             if ie.ie_type == IeType::Cause as u16 && !ie.data.is_empty() {
-                cause = Some(PfcpCause::try_from(ie.data[0])?);
+                cause = Some(PfcpCause::from_wire(ie.data[0]));
             }
         }
 
@@ -927,7 +927,7 @@ impl SessionModificationResponse {
             match ie.ie_type {
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::OffendingIe as u16 => {
@@ -1122,7 +1122,7 @@ impl SessionReportResponse {
             match ie.ie_type {
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::OffendingIe as u16 => {
@@ -1250,7 +1250,7 @@ impl NodeReportResponse {
                 }
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::OffendingIe as u16 => {
@@ -1407,7 +1407,7 @@ impl AssociationUpdateResponse {
                 }
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::UpFunctionFeatures as u16 => {
@@ -1538,7 +1538,7 @@ impl PfdManagementResponse {
             match ie.ie_type {
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::OffendingIe as u16 => {
@@ -1654,7 +1654,7 @@ impl SessionSetDeletionResponse {
                 }
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::OffendingIe as u16 => {
@@ -1760,7 +1760,7 @@ impl SessionSetModificationResponse {
                 }
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 t if t == IeType::OffendingIe as u16 => {
@@ -2026,6 +2026,61 @@ mod tests {
         let mut bytes = buf.freeze();
         let decoded = HeartbeatRequest::decode(&mut bytes).unwrap();
 
+        assert_eq!(decoded.recovery_time_stamp, 1234567890);
+    }
+
+    /// Build an Association Setup Response body carrying an arbitrary Cause
+    /// octet, so a cause value the encoder cannot express can still be fed to
+    /// the decoder the way a third-party UPF would send it.
+    ///
+    /// Encoded with the real encoder and then patched in place, rather than
+    /// hand-assembled: `NodeId::encode` writes only the IE payload (the header
+    /// is added by the caller), so a hand-built body is easy to get subtly
+    /// wrong and would test the fixture instead of the decoder.
+    fn assoc_setup_response_with_raw_cause(cause: u8) -> Bytes {
+        let msg = AssociationSetupResponse::new(
+            NodeId::new_ipv4([10, 45, 0, 1]),
+            PfcpCause::RequestAccepted,
+            1234567890,
+        );
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf);
+        let mut body = buf.to_vec();
+
+        // Overwrite the Cause IE value with the raw octet under test. Layout is
+        // [IE header 4B][value 1B], so find the header and step over it.
+        let cause_ie = (IeType::Cause as u16).to_be_bytes();
+        let pos = body
+            .windows(4)
+            .position(|w| w[0..2] == cause_ie && w[2..4] == 1u16.to_be_bytes())
+            .expect("encoded response must contain a 1-octet Cause IE");
+        body[pos + 4] = cause;
+
+        Bytes::from(body)
+    }
+
+    #[test]
+    fn test_message_with_cause_78_is_parseable() {
+        // Regression for the real interop failure: a UPF answering with cause
+        // 78 ("Redirection Requested") used to make the ENTIRE response
+        // unparseable, because the Cause decode propagated its error with `?`.
+        // The whole message must now decode, not just the cause.
+        let mut body = assoc_setup_response_with_raw_cause(78);
+        let decoded = AssociationSetupResponse::decode(&mut body)
+            .expect("a response carrying cause 78 must parse");
+        assert_eq!(decoded.cause, PfcpCause::RedirectionRequested);
+        assert_eq!(decoded.recovery_time_stamp, 1234567890);
+    }
+
+    #[test]
+    fn test_message_with_unknown_cause_still_parses() {
+        // The Cause ranges are extendable. An unrecognised rejection value must
+        // degrade to Request Rejected and leave the rest of the message intact
+        // rather than discarding a well-formed response.
+        let mut body = assoc_setup_response_with_raw_cause(201);
+        let decoded = AssociationSetupResponse::decode(&mut body)
+            .expect("an unknown cause must not fail the message");
+        assert_eq!(decoded.cause, PfcpCause::RequestRejected);
         assert_eq!(decoded.recovery_time_stamp, 1234567890);
     }
 

--- a/src/libs/nextgcore-pfcp/src/types.rs
+++ b/src/libs/nextgcore-pfcp/src/types.rs
@@ -23,7 +23,18 @@ pub const IPV6_LEN: usize = 16;
 /// PFCP bitrate length (5 bytes uplink + 5 bytes downlink)
 pub const PFCP_BITRATE_LEN: usize = 10;
 
-/// PFCP Cause Values (TS 29.244 Section 8.2.1)
+/// PFCP Cause Values (TS 29.244 Table 8.2.1-1)
+///
+/// The full set of values defined up to Rel-20 (TS 29.244 V20.0.0). Values
+/// 2..=63 are the acceptance range and 64..=255 the rejection range; both are
+/// declared extendable by the spec, so a peer may legitimately send a value
+/// this enum does not name. Decode unknown values with [`PfcpCause::from_wire`]
+/// rather than `try_from` so an unrecognised cause degrades to its range
+/// semantics instead of failing the whole message.
+///
+/// This stays a fieldless `#[repr(u8)]` enum on purpose: the encode path casts
+/// `self.cause as u8` in eleven places, so an `Unknown(u8)` variant would
+/// silently serialise a discriminant rather than the original byte.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum PfcpCause {
@@ -42,6 +53,21 @@ pub enum PfcpCause {
     NoResourcesAvailable = 75,
     ServiceNotSupported = 76,
     SystemFailure = 77,
+    RedirectionRequested = 78,
+    AllDynamicAddressesAreOccupied = 79,
+    UnknownPredefinedRule = 80,
+    UnknownApplicationId = 81,
+    L2tpTunnelEstablishmentFailure = 82,
+    L2tpSessionEstablishmentFailure = 83,
+    L2tpTunnelRelease = 84,
+    L2tpSessionRelease = 85,
+    PfcpSessionRestorationFailure = 86,
+    L2tpTunnelAuthFailure = 87,
+    L2tpSessionAuthFailure = 88,
+    L2tpLnsNotReachable = 89,
+    PfdContentsSyntaxError = 90,
+    PfdContentsSemanticsError = 91,
+    PfdApplicationIdUnknown = 92,
 }
 
 impl TryFrom<u8> for PfcpCause {
@@ -64,12 +90,52 @@ impl TryFrom<u8> for PfcpCause {
             75 => Ok(Self::NoResourcesAvailable),
             76 => Ok(Self::ServiceNotSupported),
             77 => Ok(Self::SystemFailure),
+            78 => Ok(Self::RedirectionRequested),
+            79 => Ok(Self::AllDynamicAddressesAreOccupied),
+            80 => Ok(Self::UnknownPredefinedRule),
+            81 => Ok(Self::UnknownApplicationId),
+            82 => Ok(Self::L2tpTunnelEstablishmentFailure),
+            83 => Ok(Self::L2tpSessionEstablishmentFailure),
+            84 => Ok(Self::L2tpTunnelRelease),
+            85 => Ok(Self::L2tpSessionRelease),
+            86 => Ok(Self::PfcpSessionRestorationFailure),
+            87 => Ok(Self::L2tpTunnelAuthFailure),
+            88 => Ok(Self::L2tpSessionAuthFailure),
+            89 => Ok(Self::L2tpLnsNotReachable),
+            90 => Ok(Self::PfdContentsSyntaxError),
+            91 => Ok(Self::PfdContentsSemanticsError),
+            92 => Ok(Self::PfdApplicationIdUnknown),
             _ => Err(PfcpError::InvalidCause(value)),
         }
     }
 }
 
 impl PfcpCause {
+    /// Decode a Cause octet off the wire without failing on unknown values.
+    ///
+    /// TS 29.244 §8.2.1 splits the Cause space into an acceptance range
+    /// (2..=63) and a rejection range (64..=255), and declares both
+    /// extendable. A future release can therefore add a value this build does
+    /// not know, and a strict `try_from` would reject the entire enclosing
+    /// message rather than the one IE — which is how a peer sending cause 78
+    /// ("Redirection Requested", added before Rel-20 but absent here until
+    /// now) made every N4 response unparseable.
+    ///
+    /// An unrecognised value is mapped to the generic outcome for its range so
+    /// the accept/reject decision is still correct. Callers that want to report
+    /// the unmapped octet should pair this with [`PfcpCause::try_from`], which
+    /// still returns [`PfcpError::InvalidCause`] carrying the raw value. This
+    /// crate deliberately takes no logging dependency — it is a codec.
+    pub fn from_wire(value: u8) -> Self {
+        match Self::try_from(value) {
+            Ok(cause) => cause,
+            // TS 29.244 §8.2.1: 64..=255 is the rejection range, 2..=63 the
+            // acceptance range. Both are extendable.
+            Err(_) if value >= 64 => Self::RequestRejected,
+            Err(_) => Self::RequestAccepted,
+        }
+    }
+
     /// Get the name of the cause
     pub fn name(&self) -> &'static str {
         match self {
@@ -88,10 +154,36 @@ impl PfcpCause {
             Self::NoResourcesAvailable => "No Resources Available",
             Self::ServiceNotSupported => "Service Not Supported",
             Self::SystemFailure => "System Failure",
+            Self::RedirectionRequested => "Redirection Requested",
+            Self::AllDynamicAddressesAreOccupied => "All dynamic addresses are occupied",
+            Self::UnknownPredefinedRule => "Unknown Pre-defined Rule",
+            Self::UnknownApplicationId => "Unknown Application ID",
+            Self::L2tpTunnelEstablishmentFailure => "L2TP tunnel Establishment failure",
+            Self::L2tpSessionEstablishmentFailure => "L2TP session Establishment failure",
+            Self::L2tpTunnelRelease => "L2TP tunnel release",
+            Self::L2tpSessionRelease => "L2TP session release",
+            Self::PfcpSessionRestorationFailure => {
+                "PFCP session restoration failure due to requested resource not available"
+            }
+            Self::L2tpTunnelAuthFailure => {
+                "L2TP tunnel Establishment failure - Tunnel Auth Failure"
+            }
+            Self::L2tpSessionAuthFailure => {
+                "L2TP Session Establishment failure - Session Auth Failure"
+            }
+            Self::L2tpLnsNotReachable => "L2TP tunnel Establishment failure - LNS not reachable",
+            Self::PfdContentsSyntaxError => "PFD Contents Syntax Error",
+            Self::PfdContentsSemanticsError => "PFD Contents Semantics Error",
+            Self::PfdApplicationIdUnknown => "PFD Application Id Unknown",
         }
     }
 
     /// Check if cause indicates success
+    ///
+    /// Only value 1 is a positive acknowledgement; every other named value is
+    /// in the rejection range. Note `RedirectionRequested` (78) is *not* a
+    /// success — the request was not carried out, the peer is being asked to
+    /// re-target a different SMF.
     pub fn is_success(&self) -> bool {
         matches!(self, Self::RequestAccepted)
     }
@@ -3432,7 +3524,7 @@ impl PfdPartialFailureInformation {
                 }
                 t if t == IeType::Cause as u16 => {
                     if !ie.data.is_empty() {
-                        failure_cause = Some(PfcpCause::try_from(ie.data[0])?);
+                        failure_cause = Some(PfcpCause::from_wire(ie.data[0]));
                     }
                 }
                 _ => {}
@@ -3861,6 +3953,50 @@ mod tests {
         let mut bytes = encoded.clone();
         let decoded = FTeid::decode(&mut bytes).unwrap();
         (encoded, decoded)
+    }
+
+    #[test]
+    fn test_cause_78_redirection_requested_decodes() {
+        // Regression: cause 78 is defined in TS 29.244 Table 8.2.1-1 and was
+        // already named in smfd's local table, but was absent from this enum.
+        // Because every decode site propagated the error with `?`, a real UPF
+        // returning 78 made the whole enclosing N4 response unparseable.
+        let cause = PfcpCause::try_from(78).expect("cause 78 must decode");
+        assert_eq!(cause, PfcpCause::RedirectionRequested);
+        assert_eq!(cause.name(), "Redirection Requested");
+        // 78 asks the UPF to re-target another SMF: the request was NOT carried out.
+        assert!(!cause.is_success());
+    }
+
+    #[test]
+    fn test_all_ts29244_table_8_2_1_1_causes_decode() {
+        // Every value the spec defines up to Rel-20 must round-trip through
+        // both TryFrom and the u8 discriminant used by the encode path.
+        for value in [
+            1u8, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83,
+            84, 85, 86, 87, 88, 89, 90, 91, 92,
+        ] {
+            let cause = PfcpCause::try_from(value)
+                .unwrap_or_else(|_| panic!("TS 29.244 cause {value} must decode"));
+            assert_eq!(cause as u8, value, "discriminant must equal the wire value");
+            assert_ne!(cause.name(), "", "cause {value} needs a name");
+        }
+    }
+
+    #[test]
+    fn test_from_wire_maps_unknown_causes_to_range_semantics() {
+        // Both Cause ranges are extendable, so a newer peer may send a value
+        // this build does not name. from_wire must keep the accept/reject
+        // decision correct instead of failing the message.
+        assert_eq!(PfcpCause::from_wire(200), PfcpCause::RequestRejected);
+        assert_eq!(PfcpCause::from_wire(64), PfcpCause::RequestRejected);
+        assert_eq!(PfcpCause::from_wire(2), PfcpCause::RequestAccepted);
+        assert_eq!(PfcpCause::from_wire(63), PfcpCause::RequestAccepted);
+        // Known values must still decode exactly, not via the range fallback.
+        assert_eq!(PfcpCause::from_wire(78), PfcpCause::RedirectionRequested);
+        assert_eq!(PfcpCause::from_wire(1), PfcpCause::RequestAccepted);
+        // An unknown rejection value must not be mistaken for success.
+        assert!(!PfcpCause::from_wire(200).is_success());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`PfcpCause` named only 15 of the values in TS 29.244 Table 8.2.1-1 and returned `InvalidCause` for the rest. That error was propagated with `?` at **13 decode sites** (12 in `message.rs`, 1 in `types.rs`), so an unrecognised Cause octet did not degrade the one IE — it made the **entire enclosing PFCP message unparseable**.

Cause **78 "Redirection Requested"** shows how this bit: it is defined in the spec and was already listed in smfd's own name table at `pfcp_path.rs:197`, while being absent from the library enum. The SMF could *name* a cause its own decoder rejected, and a real UPF answering with 78 lost every N4 response.

Fourteen further spec values (79–92: dynamic-address exhaustion, unknown pre-defined rule, the L2TP set, PFCP session restoration failure, the PFD errors) were missing on the same footing.

## Why completing the table is not sufficient on its own

TS 29.244 §8.2.1 splits the Cause space into an acceptance range (2..=63) and a rejection range (64..=255), and declares **both extendable**. A conformant peer on a newer release may legitimately send a value this build does not name, so a decoder that discards the whole message on an unknown Cause is structurally wrong, not merely incomplete — the same break would recur on the next release.

## Changes

- **Complete the enum** to all 30 values defined through Rel-20, verified against TS 29.244 V20.0.0 Table 8.2.1-1.
- **Add `PfcpCause::from_wire`** — a non-fatal decode mapping an unknown value to its range outcome (`>= 64` → rejected, else accepted) so the accept/reject decision stays correct and the message survives. All 13 decode sites now use it; `try_from` is unchanged for callers that need the raw unmapped octet.
- **Make smfd's `cause_name` delegate** to `PfcpCause::name()` instead of keeping a second copy of the spec table. That duplicate was the mechanism of the drift.

### Design notes

The enum stays a fieldless `#[repr(u8)]`. An `Unknown(u8)` variant was rejected because the encode path casts `self.cause as u8` in eleven places, so a fieldful variant would silently serialise a discriminant rather than the byte received.

`RedirectionRequested` is deliberately **not** treated as success by `is_success()` — the request was not carried out; the peer is being asked to re-target a different SMF.

## Testing

Five regression tests, **each confirmed to fail when the fix is reverted** (verified by removing the 78/79 `TryFrom` arms and re-running: 4 of 5 failed, including the end-to-end message test; the fifth covers only the range fallback, which is independent of the table):

| Test | Covers |
|---|---|
| `test_cause_78_redirection_requested_decodes` | the specific regression |
| `test_all_ts29244_table_8_2_1_1_causes_decode` | all 30 values decode; discriminant equals the wire octet |
| `test_from_wire_maps_unknown_causes_to_range_semantics` | range fallback; unknown rejection value is not mistaken for success |
| `test_message_with_cause_78_is_parseable` | full `AssociationSetupResponse` carrying cause 78 — proves the original failure mode is gone |
| `test_message_with_unknown_cause_still_parses` | same for an unnamed value |

The two message-level tests build their fixture with the real encoder and then patch the Cause octet in place. Hand-assembling the body was tried first and was wrong: `NodeId::encode` emits only the IE payload (the header is written by the caller), so the hand-built version tested the fixture rather than the decoder.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — zero errors, zero warnings in the touched files (workspace holds at its 20-warning pre-existing baseline)
- `cargo test --workspace` — **5280 passed / 0 failed**, up from 5275 by exactly the 5 new tests

Unrelated pre-existing flake seen once during the run: `nextgcore-scpd proxy::tests::test_model_c_forwarding_end_to_end` can fail under parallel test threads with "Address already in use" because the SCP tests bind fixed `127.0.0.1:<port>` numbers. It passes in isolation and on re-run, and touches no PFCP code.

## Scope

Decode-side only — no emitted Cause value changes. Does not add a logging dependency to `nextgcore-pfcp` (it is a codec crate). Does not address the other fail-closed decoders found alongside this one (NGAP cause extensions, NAS TLV-E IEI allowlist, PFCP message type, GTPv1 TV table, SUCI protection scheme); each needs its own change.