### PR TITLE
fix(nrfd): stop minting AMF-audience OAuth2 tokens for unrecognised NF types

### DIFF
--- a/src/bins/nextgcore-nrfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-nrfd/src/sbi_path.rs
@@ -44,24 +44,15 @@ fn attach_oauth2(client: SbiClient, target: NfType) -> SbiClient {
     }
 }
 
-/// Best-effort map of an NF type string (TS 29.510 NFType) to [`NfType`] for
-/// OAuth2 token scoping. Only the common NRF-notification consumers are
-/// recognised; unknown values fall back to the caller's default.
+/// Map an NF type string (TS 29.510 NFType) to [`NfType`] for OAuth2 token
+/// scoping.
+///
+/// Delegates to [`NfType::from_nf_type_str`], which covers all 41 spec variants.
+/// This used to be a local 11-entry table, so the 30 unlisted NF types — SEPP,
+/// UPF, NWDAF, CHF, EASDF, TSCTSF and the rest — all returned `None` and were
+/// then silently coerced to `AMF` by the caller.
 fn nf_type_from_str(s: &str) -> Option<NfType> {
-    Some(match s.to_uppercase().as_str() {
-        "AMF" => NfType::Amf,
-        "SMF" => NfType::Smf,
-        "PCF" => NfType::Pcf,
-        "UDM" => NfType::Udm,
-        "UDR" => NfType::Udr,
-        "AUSF" => NfType::Ausf,
-        "NSSF" => NfType::Nssf,
-        "NEF" => NfType::Nef,
-        "BSF" => NfType::Bsf,
-        "SCP" => NfType::Scp,
-        "NRF" => NfType::Nrf,
-        _ => return None,
-    })
+    NfType::from_nf_type_str(s)
 }
 
 /// SBI server configuration
@@ -223,10 +214,45 @@ async fn dispatch_notify_request_async(
 
     let client_config = SbiClientConfig::new(&host, port).with_scheme(scheme);
     let client = SbiClient::new(client_config);
-    let target = req_nf_type
-        .and_then(nf_type_from_str)
-        .unwrap_or(NfType::Amf);
-    let client = attach_oauth2(client, target);
+
+    // OAuth2 audience must be the ACTUAL subscriber NF type (TS 33.501 §13.4.1:
+    // the access token's `audience` claim identifies the NF service producer the
+    // token is valid for).
+    //
+    // This previously did `.unwrap_or(NfType::Amf)`, so any NF type the local
+    // table did not recognise — every one of SEPP, UPF, NWDAF, CHF, EASDF,
+    // TSCTSF, ... — silently received a token minted for an AMF audience. Two
+    // consequences, both bad: a conformant consumer rejects the token on an
+    // audience mismatch (so the notification is lost for a reason the log does
+    // not explain), and an AMF-audience token is handed to a party that never
+    // asked for one.
+    //
+    // Now: send the notification WITHOUT a token rather than with a wrong one.
+    // The subscriber rejects an unauthenticated notify with 401, which is a
+    // truthful and debuggable failure, unlike a plausible token for the wrong
+    // audience.
+    let client = match req_nf_type {
+        Some(raw) => match nf_type_from_str(raw) {
+            Some(target) => attach_oauth2(client, target),
+            None => {
+                log::warn!(
+                    "NF status notify to {notification_uri}: unrecognised subscriber NFType \
+                     '{raw}' (TS 29.510 NFType); sending WITHOUT an OAuth2 token rather than \
+                     minting one for the wrong audience"
+                );
+                client
+            }
+        },
+        None => {
+            // No reqNfType on the subscription: nothing identifies the audience,
+            // so there is no correct token to mint.
+            log::debug!(
+                "NF status notify to {notification_uri}: subscription carries no reqNfType; \
+                 sending without an OAuth2 token"
+            );
+            client
+        }
+    };
 
     let sbi_request = SbiRequest::post(&path)
         .with_header("Content-Type", &notify_request.content_type)
@@ -862,9 +888,41 @@ mod tests {
         assert_eq!(nf_type_from_str("smf"), Some(NfType::Smf));
         assert_eq!(nf_type_from_str("Pcf"), Some(NfType::Pcf));
         assert_eq!(nf_type_from_str("UDR"), Some(NfType::Udr));
-        // Unknown / non-NF strings fall through to None so the caller can
-        // pick a default.
+        // Genuinely unknown values stay None. The caller must NOT substitute a
+        // default: for OAuth2 scoping a default means a token minted for the
+        // wrong audience.
         assert_eq!(nf_type_from_str("WHATEVER"), None);
         assert_eq!(nf_type_from_str(""), None);
+    }
+
+    #[test]
+    fn test_nf_type_from_str_covers_types_beyond_the_old_local_table() {
+        // Regression: this mapping used to be a local 11-entry table, so every
+        // other TS 29.510 NFType returned None and was then coerced to
+        // NfType::Amf by dispatch_notify_request_async's `.unwrap_or`. Those
+        // subscribers got an AMF-audience OAuth2 token.
+        //
+        // Each of these is a legitimate NRF subscriber that the old table missed.
+        assert_eq!(nf_type_from_str("SEPP"), Some(NfType::Sepp));
+        assert_eq!(nf_type_from_str("UPF"), Some(NfType::Upf));
+        assert_eq!(nf_type_from_str("NWDAF"), Some(NfType::Nwdaf));
+        assert_eq!(nf_type_from_str("CHF"), Some(NfType::Chf));
+        assert_eq!(nf_type_from_str("EASDF"), Some(NfType::Easdf));
+        assert_eq!(nf_type_from_str("TSCTSF"), Some(NfType::Tsctsf));
+        assert_eq!(nf_type_from_str("NSACF"), Some(NfType::Nsacf));
+        assert_eq!(nf_type_from_str("MBSMF"), Some(NfType::Mbsmf));
+        // Underscored spellings from TS 29.510 must parse too.
+        assert_eq!(nf_type_from_str("5G_EIR"), Some(NfType::FiveGEir));
+        assert_eq!(nf_type_from_str("SMSF_5G"), Some(NfType::Smsf5G));
+        // None of them may resolve to AMF.
+        for raw in [
+            "SEPP", "UPF", "NWDAF", "CHF", "EASDF", "TSCTSF", "NSACF", "MBSMF", "5G_EIR", "SMSF_5G",
+        ] {
+            assert_ne!(
+                nf_type_from_str(raw),
+                Some(NfType::Amf),
+                "{raw} must not be scoped as AMF"
+            );
+        }
     }
 }

--- a/src/libs/nextgcore-sbi/src/types.rs
+++ b/src/libs/nextgcore-sbi/src/types.rs
@@ -336,6 +336,62 @@ impl NfType {
     pub fn as_server_token(&self) -> &'static str {
         self.to_str()
     }
+
+    /// Parse a TS 29.510 NFType enumeration value.
+    ///
+    /// The exact inverse of [`NfType::to_str`], covering every variant, so the
+    /// two cannot drift. Comparison is case-insensitive because the NFType
+    /// string arrives over the wire from a peer.
+    ///
+    /// Returns `None` for an unrecognised value. Callers must **not** substitute
+    /// a default: when the value feeds OAuth2 token scoping, defaulting means
+    /// minting a token for the wrong audience (see `nextgcore-nrfd`'s notify
+    /// path, which previously fell back to `AMF`).
+    pub fn from_nf_type_str(s: &str) -> Option<Self> {
+        let upper = s.to_ascii_uppercase();
+        Some(match upper.as_str() {
+            "NRF" => Self::Nrf,
+            "UDM" => Self::Udm,
+            "AMF" => Self::Amf,
+            "SMF" => Self::Smf,
+            "AUSF" => Self::Ausf,
+            "NEF" => Self::Nef,
+            "PCF" => Self::Pcf,
+            "SMSF" => Self::Smsf,
+            "NSSF" => Self::Nssf,
+            "UDR" => Self::Udr,
+            "LMF" => Self::Lmf,
+            "GMLC" => Self::Gmlc,
+            "5G_EIR" => Self::FiveGEir,
+            "SEPP" => Self::Sepp,
+            "UPF" => Self::Upf,
+            "N3IWF" => Self::N3iwf,
+            "AF" => Self::Af,
+            "UDSF" => Self::Udsf,
+            "BSF" => Self::Bsf,
+            "CHF" => Self::Chf,
+            "NWDAF" => Self::Nwdaf,
+            "PCSCF" => Self::Pcscf,
+            "CBCF" => Self::Cbcf,
+            "HSS" => Self::Hss,
+            "UCMF" => Self::Ucmf,
+            "SCP" => Self::Scp,
+            "NSSAAF" => Self::Nssaaf,
+            "MFAF" => Self::Mfaf,
+            "MBSMF" => Self::Mbsmf,
+            "MBSTF" => Self::Mbstf,
+            "PANF" => Self::Panf,
+            "TSCTSF" => Self::Tsctsf,
+            "EASDF" => Self::Easdf,
+            "EES" => Self::Ees,
+            "DCCF" => Self::Dccf,
+            "NSACF" => Self::Nsacf,
+            "PKMF" => Self::Pkmf,
+            "MNPF" => Self::Mnpf,
+            "SMSF_5G" => Self::Smsf5G,
+            _ => return None,
+        })
+    }
 }
 
 /// URI Scheme - matches OpenAPI_uri_scheme_e
@@ -535,6 +591,77 @@ impl fmt::Display for SbiAppError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every `NfType` variant round-trips through `to_str` -> `from_nf_type_str`.
+    ///
+    /// This is the guard that keeps the two mappings from drifting. A partial
+    /// reverse map is not a cosmetic problem: `nextgcore-nrfd` used a local
+    /// 11-entry table for OAuth2 audience scoping and coerced every unmatched
+    /// type to `AMF`, so 30 NF types received tokens for the wrong audience.
+    #[test]
+    fn test_nf_type_str_round_trip_is_total() {
+        const ALL: &[NfType] = &[
+            NfType::Nrf,
+            NfType::Udm,
+            NfType::Amf,
+            NfType::Smf,
+            NfType::Ausf,
+            NfType::Nef,
+            NfType::Pcf,
+            NfType::Smsf,
+            NfType::Nssf,
+            NfType::Udr,
+            NfType::Lmf,
+            NfType::Gmlc,
+            NfType::FiveGEir,
+            NfType::Sepp,
+            NfType::Upf,
+            NfType::N3iwf,
+            NfType::Af,
+            NfType::Udsf,
+            NfType::Bsf,
+            NfType::Chf,
+            NfType::Nwdaf,
+            NfType::Pcscf,
+            NfType::Cbcf,
+            NfType::Hss,
+            NfType::Ucmf,
+            NfType::Scp,
+            NfType::Nssaaf,
+            NfType::Mfaf,
+            NfType::Mbsmf,
+            NfType::Mbstf,
+            NfType::Panf,
+            NfType::Tsctsf,
+            NfType::Easdf,
+            NfType::Ees,
+            NfType::Dccf,
+            NfType::Nsacf,
+            NfType::Pkmf,
+            NfType::Mnpf,
+            NfType::Smsf5G,
+        ];
+
+        for nf in ALL {
+            let s = nf.to_str();
+            assert_eq!(
+                NfType::from_nf_type_str(s),
+                Some(*nf),
+                "{s} must parse back to the same variant"
+            );
+            // The NFType string arrives from a peer, so parsing is
+            // case-insensitive.
+            assert_eq!(
+                NfType::from_nf_type_str(&s.to_ascii_lowercase()),
+                Some(*nf),
+                "{s} must parse case-insensitively"
+            );
+        }
+
+        // Unrecognised values must stay None rather than resolving to anything.
+        assert_eq!(NfType::from_nf_type_str("NOT_AN_NF"), None);
+        assert_eq!(NfType::from_nf_type_str(""), None);
+    }
 
     /// Issue #23: the TSCTSF service name round-trips through the enum
     /// (acceptance criterion; the SCP routes by this wire string).


### PR DESCRIPTION
## Problem

`dispatch_notify_request_async` scoped its OAuth2 token with:

```rust
req_nf_type.and_then(nf_type_from_str).unwrap_or(NfType::Amf)
```

…and `nf_type_from_str` was a **local 11-entry table**. The `NfType` enum has **41 variants**, so 30 legitimate NRF subscribers — SEPP, UPF, NWDAF, CHF, EASDF, TSCTSF, NSACF, MBSMF and the rest — fell through to `None` and were then **silently coerced to `AMF`**.

TS 33.501 §13.4.1 makes the access token's `audience` claim identify the producer the token is valid for. So this had two bad outcomes:

1. A conformant subscriber **rejects the token** on an audience mismatch — the notification is lost for a reason the log never explains.
2. An **AMF-audience token is handed to a party that never asked for one**.

## Changes

**1. Add `NfType::from_nf_type_str` in `nextgcore-sbi`** — the exact inverse of `to_str` across all 41 variants, including the underscored `5G_EIR` and `SMSF_5G` spellings. `nf_type_from_str` now delegates to it, so the NRF cannot carry a partial copy that drifts again.

**2. Fail closed instead of defaulting.** An unrecognised or absent `reqNfType` now sends the notification with **no token** and logs why, rather than attaching a wrong one. An unauthenticated notify is rejected with 401 — truthful and debuggable. A plausible token for the wrong audience is neither.

Absent `reqNfType` is handled separately from unrecognised: nothing identifies the audience either way, so there is no correct token to mint, but it is a config gap rather than a parse failure and logs at `debug` not `warn`.

## Testing

- **Library totality test** — every `NfType` variant round-trips `to_str` → `from_nf_type_str`, case-insensitively. This is the guard that keeps the two mappings from drifting.
- **NRF-side coverage** — asserts the eight most likely previously-broken subscriber types resolve correctly, and that **none of them resolves to `AMF`**. Verified to fail against the old 11-entry table:

```
test sbi_path::tests::test_nf_type_from_str_covers_types_beyond_the_old_local_table ... FAILED
```

An existing test comment claimed unknown values fall through *"so the caller can pick a default"* — that was documenting the bug, and is corrected.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — zero errors, no new warnings (workspace holds at its 20-warning pre-existing baseline)
- `cargo test --workspace` — **5277 passed / 0 failed**

## Note for review

The behaviour change is deliberate: subscribers whose NF type was previously coerced to AMF will now receive **no** token instead of a wrong one. If any deployment currently depends on that accidental AMF token being accepted, this surfaces it as a 401 rather than continuing to paper over it. That seems clearly preferable for a security control, but it is a visible change worth knowing about before merge.