### PR TITLE
fix(amfd): derive T3512 from config instead of hardcoding it

### DIFF
--- a/src/bins/nextgcore-amfd/src/context.rs
+++ b/src/bins/nextgcore-amfd/src/context.rs
@@ -436,9 +436,16 @@ pub struct AmfContext {
     pub ngap_port: u16,
 
     // Timers
-    /// T3502 timer value
+    /// T3502 timer value, in **seconds**.
+    ///
+    /// Not currently emitted: `build_registration_accept` sends
+    /// `t3502_value: None`, so this is carried for future use.
     pub t3502_value: u64,
-    /// T3512 timer value
+    /// T3512 periodic registration update timer, in **seconds**.
+    ///
+    /// Encoded into every Registration Accept as GPRS Timer 3 (IEI 0x5E) by
+    /// `gmm_build::encode_gprs_timer3_seconds`, which requires the value to be
+    /// exactly representable as `n x unit` with `n <= 31`.
     pub t3512_value: u64,
 
     // ID generators
@@ -651,7 +658,15 @@ impl AmfContext {
             supi_hash: RwLock::new(HashMap::new()),
             ngap_port: 38412,
             t3502_value: 720,
-            t3512_value: 3240,
+            // 540 s = 9 minutes, matching both the wire value the AMF has
+            // always emitted and `time.t3512.value: 540` in
+            // docker/rust/configs/5gc/amf.yaml.
+            //
+            // Was 3240 (54 minutes) while nothing read the field and
+            // gmm_build.rs hardcoded 9 minutes. Now that the field feeds the
+            // emitted IE, a stale default would silently change the timer every
+            // UE receives, so it is corrected to the value actually in use.
+            t3512_value: 540,
             next_gnb_id: AtomicUsize::new(1),
             next_ran_ue_id: AtomicUsize::new(1),
             next_amf_ue_id: AtomicUsize::new(1),

--- a/src/bins/nextgcore-amfd/src/gmm_build.rs
+++ b/src/bins/nextgcore-amfd/src/gmm_build.rs
@@ -335,6 +335,62 @@ impl Default for NasMessageBuilder {
 ///
 /// Includes: 5GS registration result (mandatory), 5G-GUTI (0x77),
 /// TAI list (0x54), Allowed NSSAI (0x15) and T3512 (0x5E).
+/// Encode a duration in seconds as a GPRS Timer 3 IE (TS 24.008 §10.5.7.4a,
+/// Table 10.5.163b).
+///
+/// The IE carries a 3-bit unit and a 5-bit value (0..=31), so it can only
+/// express `value × unit`. This picks the *coarsest* unit that represents the
+/// requested duration exactly and fits in 5 bits, so a configured value is
+/// either encoded faithfully or rejected — never silently rounded to something
+/// the operator did not ask for.
+///
+/// Coarsest-first is deliberate. A duration is often expressible in several
+/// units (540 s is both 18 × 30 s and 9 × 1 min), and the conventional
+/// encoding — the one peers and packet captures expect, and the one this AMF has
+/// always emitted — is the coarser 9 × 1 min (wire octet 0xA9). Choosing the
+/// finest unit instead would silently change the bytes on the wire for the exact
+/// same configured duration.
+///
+/// Units, coarsest first: 320 h, 10 h, 1 h, 10 min, 1 min, 30 s, 2 s.
+///
+/// Returns the deactivated encoding (unit 111) for 0, per the spec's
+/// "timer is deactivated" row. Falls back to 9 minutes — the historical
+/// hardcoded default — for a duration no unit can express exactly, logging a
+/// warning rather than emitting a wrong timer.
+fn encode_gprs_timer3_seconds(seconds: u64) -> nextgcore_types::GprsTimer3 {
+    use nextgcore_types::GprsTimer3 as T3;
+
+    if seconds == 0 {
+        return T3::new(T3::UNIT_DEACTIVATED, 0);
+    }
+
+    // (unit code, seconds per tick), coarsest granularity first.
+    const UNITS: [(u8, u64); 7] = [
+        (T3::UNIT_320_HOURS, 1_152_000),
+        (T3::UNIT_10_HOURS, 36_000),
+        (T3::UNIT_1_HOUR, 3600),
+        (T3::UNIT_10_MINUTES, 600),
+        (T3::UNIT_1_MINUTE, 60),
+        (T3::UNIT_30_SECONDS, 30),
+        (T3::UNIT_2_SECONDS, 2),
+    ];
+
+    for (unit, tick) in UNITS {
+        if seconds.is_multiple_of(tick) {
+            let ticks = seconds / tick;
+            if (1..=31).contains(&ticks) {
+                return T3::new(unit, ticks as u8);
+            }
+        }
+    }
+
+    log::warn!(
+        "T3512 value {seconds}s is not representable as a GPRS Timer 3 \
+         (value x unit, value <= 31); falling back to 9 minutes"
+    );
+    T3::new(T3::UNIT_1_MINUTE, 9)
+}
+
 pub fn build_registration_accept(amf_ue: &AmfUe) -> Option<Vec<u8>> {
     // nas-06 Phase 2 (Tier C, REGISTRATION-CRITICAL): encoded via nextgcore-nas. Byte-
     // identical to the prior hand-rolled output — 5GS registration result LV
@@ -410,12 +466,23 @@ pub fn build_registration_accept(amf_ue: &AmfUe) -> Option<Vec<u8>> {
     };
 
     // T3512 value (IEI 0x5E, GPRS timer 3 — TS 24.501 §9.11.3.44 / TS 24.008
-    // §10.5.7.4a Table 10.5.163b): 9 minutes — unit 101 (multiples of
-    // 1 minute), value 9 → 9 min, wire octet 0xA9.
-    let t3512_value = Some(nextgcore_types::GprsTimer3::new(
-        nextgcore_types::GprsTimer3::UNIT_1_MINUTE,
-        9,
-    ));
+    // §10.5.7.4a Table 10.5.163b).
+    //
+    // Derived from the AMF context's t3512_value (seconds) rather than
+    // hardcoded. Previously this was a literal 9 minutes while
+    // `context.rs` carried `t3512_value: 3240` — 54 minutes — with no reader,
+    // and `docker/rust/configs/5gc/amf.yaml` declared `time.t3512.value: 540`
+    // (9 min) which `parse_time` silently drops into its `_ => {}` arm. Three
+    // values, two of them dead, and the live one agreeing with the YAML only by
+    // coincidence.
+    //
+    // A poisoned context lock falls back to the historical 9 minutes rather
+    // than dropping a mandatory-for-this-message IE.
+    let t3512_seconds = crate::context::amf_self()
+        .read()
+        .map(|ctx| ctx.t3512_value)
+        .unwrap_or(540);
+    let t3512_value = Some(encode_gprs_timer3_seconds(t3512_seconds));
 
     let msg =
         nextgcore_msg::FiveGmmMessage::RegistrationAccept(nextgcore_msg::RegistrationAccept {
@@ -905,6 +972,79 @@ fn get_pdu_session_status(amf_ue: &AmfUe) -> u16 {
 mod tests {
     use super::*;
     use crate::context::{PlmnId, NEXTGCORE_RAND_LEN};
+
+    #[test]
+    fn test_gprs_timer3_encodes_the_coarsest_exact_unit() {
+        use nextgcore_types::GprsTimer3 as T3;
+
+        // The value the AMF has always emitted: 9 min -> unit 101, value 9,
+        // wire octet 0xA9. This is what the golden vectors pin.
+        //
+        // 540 s is ALSO exactly 18 x 30 s. Coarsest-exact is what keeps the
+        // conventional 9 x 1 min encoding; a finest-first rule would emit
+        // (unit 100, value 18) here and silently change the wire bytes for the
+        // same configured duration.
+        let t = encode_gprs_timer3_seconds(540);
+        assert_eq!((t.unit, t.value), (T3::UNIT_1_MINUTE, 9));
+        assert_eq!((t.unit << 5) | t.value, 0xA9);
+
+        // Sub-minute durations still reach the finer units, because no coarser
+        // one represents them exactly.
+        assert_eq!(
+            encode_gprs_timer3_seconds(30),
+            T3::new(T3::UNIT_30_SECONDS, 1)
+        );
+        assert_eq!(
+            encode_gprs_timer3_seconds(4),
+            T3::new(T3::UNIT_2_SECONDS, 2)
+        );
+
+        // 3240 s = 54 min. Not a whole number of 10-minute ticks, and 54 > 31 so
+        // 1-minute units cannot hold it either -- NOT representable. This was
+        // the stale context default, which is why the field could not simply be
+        // wired through as-is.
+        assert_eq!(
+            encode_gprs_timer3_seconds(3240),
+            T3::new(T3::UNIT_1_MINUTE, 9),
+            "an unrepresentable value must fall back, not encode something wrong"
+        );
+
+        // Coarser units for longer durations.
+        assert_eq!(
+            encode_gprs_timer3_seconds(3600),
+            T3::new(T3::UNIT_1_HOUR, 1)
+        );
+        assert_eq!(
+            encode_gprs_timer3_seconds(7200),
+            T3::new(T3::UNIT_1_HOUR, 2)
+        );
+        // 1800 s = 30 min: exact in 10-minute units (3).
+        assert_eq!(
+            encode_gprs_timer3_seconds(1800),
+            T3::new(T3::UNIT_10_MINUTES, 3)
+        );
+
+        // Zero means deactivated, not "fire immediately".
+        assert_eq!(
+            encode_gprs_timer3_seconds(0),
+            T3::new(T3::UNIT_DEACTIVATED, 0)
+        );
+    }
+
+    #[test]
+    fn test_t3512_context_default_matches_the_emitted_timer() {
+        // Regression: context.rs carried t3512_value: 3240 (54 min) with no
+        // reader while gmm_build hardcoded 9 min, and amf.yaml declared 540.
+        // Now that the field feeds the wire, its default must equal what the
+        // AMF has always sent -- otherwise wiring it up silently changes the
+        // timer every UE receives.
+        let ctx_default = crate::context::AmfContext::new();
+        assert_eq!(ctx_default.t3512_value, 540, "9 minutes, matching amf.yaml");
+        assert_eq!(
+            encode_gprs_timer3_seconds(ctx_default.t3512_value),
+            nextgcore_types::GprsTimer3::new(nextgcore_types::GprsTimer3::UNIT_1_MINUTE, 9)
+        );
+    }
 
     fn create_test_amf_ue() -> AmfUe {
         AmfUe {


### PR DESCRIPTION
## Problem

Three T3512 values existed, **two of them dead**, and the live one agreed with the config only by coincidence:

| Location | Value | Status |
|---|---|---|
| `gmm_build.rs:415` | 9 min hardcoded into every Registration Accept | **LIVE** |
| `context.rs:654` | `t3512_value: 3240` (54 min) | no reader |
| `amf.yaml:72` | `time.t3512.value: 540` (9 min) | never parsed |

`parse_time` in `nextgcore-app` handles `nf_instance`, `subscription`, `message` and `handover` — so `t3512` falls into its `_ => {}` arm and is silently dropped.

## Changes

`build_registration_accept` now encodes the AMF context's `t3512_value`, and the context default is corrected from **3240 → 540** so it equals the value the AMF has always emitted and the shipped `amf.yaml` declares. Wiring the field through while leaving 3240 in place would have silently changed the timer every UE receives.

Added `encode_gprs_timer3_seconds`, converting seconds to the IE's 3-bit unit + 5-bit value (TS 24.008 §10.5.7.4a Table 10.5.163b). It picks the **coarsest** unit representing the duration exactly.

**That choice is load-bearing.** 540 s is *both* 18 × 30 s and 9 × 1 min, and only the coarser form gives the conventional wire octet `0xA9` that peers and the golden vectors expect. A finest-first rule encodes the same configured duration as different bytes — I hit exactly that while writing the tests.

Edge cases: a duration no unit represents exactly falls back to 9 minutes **with a warning** rather than emitting a rounded timer; `0` encodes as deactivated (unit 111) per the spec, not as immediate expiry.

## Correction to the finding that prompted this

`CONFORMANCE-REAUDIT-2026-07-01` lists *"amfd T3512 timer 90h-not-9min"*. **That is incorrect.**

The code used `GprsTimer3::UNIT_1_MINUTE`, which is `5`, and unit `101` is "multiples of 1 minute" per Table 10.5.163b — so `0xA9` has always decoded as 9 minutes. I verified the unit encoding against `24008-k00.txt`.

The confusion is understandable: there are **two** `UNIT_1_MINUTE` constants in `nextgcore-nas/common/types.rs` — `GprsTimer`'s (`= 1`) and `GprsTimer3`'s (`= 5`) — but the call site used the right one. **No wire value was ever wrong**; the defect was purely the dead config.

## Verification

All four Registration Accept golden vectors and the `nextgcore-nas` drift test pass **unchanged**, confirming this is byte-identical and a pure hardcoded-to-config refactor:

```
golden_registration_accept_full ... ok
golden_registration_accept_no_guti_no_nssai ... ok
golden_registration_accept_3digit_mnc ... ok
drift_registration_accept_minimal_through_nextgcore_nas ... ok
```

Two new tests cover the unit-selection rule (including the 540 s ambiguity and the 3240 s unrepresentable case) and assert the context default still equals the emitted timer.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — zero errors, 20-warning baseline held (fixed the one `manual_is_multiple_of` this introduced)
- `cargo test --workspace` — **5288 passed / 0 failed**

The pre-existing `namf_server` UPDP downlink-queue flake surfaced once and passes in isolation; it involves no T3512 or `gmm_build` code.

## Follow-up not done here

`time.t3512.value` in `amf.yaml` is **still unparsed** — this PR makes the context field authoritative, but the YAML key remains inert. Teaching `parse_time` to read it belongs with the other unparsed timer keys (T3502, T3346, T3396 and friends), which is a larger change to the shared `nextgcore-app` config. Worth its own issue.