### PR TITLE
WIP: fix(upfd): scope PFCP peer-failure teardown to the peer that failed

### DIFF
--- a/specs/fix-upf-peer-failure-wrong-peer.md
+++ b/specs/fix-upf-peer-failure-wrong-peer.md
@@ -1,0 +1,117 @@
+# Fix: UPF peer-failure teardown ignores which peer failed
+
+## Problem
+
+`PfcpServer::declare_peer_failure` (`bins/nextgcore-upfd/src/pfcp_path.rs:574`)
+takes a `peer: SocketAddr` but uses it only for the log line. It then
+unconditionally drops the single stored association and clears **every**
+session:
+
+```rust
+async fn declare_peer_failure(&self, peer: SocketAddr, reason: &str) {
+    log::warn!("PFCP peer {peer} failure ({reason}): clearing association and sessions");
+    *self.association.write().await = None;   // <-- no check of `peer`
+    ...
+}
+```
+
+Both call sites can fire for a peer that does **not** hold the current
+association:
+
+- `handle_association_release_request` (line 857) — any host may send an
+  Association Release Request; it is acknowledged with `RequestAccepted`
+  and then tears down whoever *is* associated.
+- `check_peer_recovery` (line 723) — compares an incoming Recovery Time
+  Stamp against the stored association without first confirming the
+  sender owns it, so a heartbeat from a different address whose RTS
+  happens to differ declares failure for the real peer.
+
+### Observed failure
+
+Reproduced on Kind and again on EKS devtest1 during this session. A
+rolling `kubectl rollout restart deployment/smf` briefly runs two SMF
+pods. The new pod associates; the old pod then sends its Association
+Release on shutdown; the UPF wipes the **new** pod's association. Every
+subsequent Session Establishment is rejected:
+
+```
+PFCP Association established with 10.244.0.60:8805 (peer RTS=...)
+PFCP peer 10.244.0.52:8805 failure (association released by peer): clearing association and sessions
+Session Establishment from 10.244.0.60:8805 without PFCP association
+```
+
+The SMF surfaces this as `cause 72 (No Established PFCP Association)`,
+which fails PDU session establishment and black-holes the user plane.
+The only workaround was scaling the SMF to 0, restarting the UPF, then
+scaling back to 1 — done manually for both E2E runs.
+
+This also means any multi-SMF deployment is broken: one SMF's shutdown
+drops every other SMF's sessions.
+
+## Fix
+
+Make the teardown peer-aware. `declare_peer_failure` returns early
+unless the failing peer is the one currently associated:
+
+- Compare `peer` against `association.peer_addr` under the read lock.
+- If it does not match, log at `warn` and return without touching the
+  association, the session table, or emitting `PeerFailure`.
+- If there is no association at all, likewise return without clearing.
+
+`check_peer_recovery` additionally gates its RTS comparison on the
+sender being the associated peer, so a stray datagram cannot trigger the
+path at all.
+
+Non-goal: making the UPF support multiple concurrent associations. The
+field stays `Option<PfcpAssociation>`. This change only stops a
+non-owning peer from tearing down the owner's state; issue #66 tracks
+durable multi-peer state.
+
+TS 29.244 §6.2.6 scopes an association to the CP/UP function pair, and
+§7.4.4.2 scopes Association Release to the requesting peer's own
+association. TS 23.527 §4.2 scopes stale-session cleanup to the failed
+peer's sessions. Clearing another peer's state is non-conformant on all
+three counts.
+
+## Verification
+
+Two new tests in `pfcp_path.rs`, each verified to FAIL when the fix is
+reverted:
+
+1. `test_association_release_from_other_peer_is_ignored` — peer A
+   associates, peer B sends an Association Release. Assert A's
+   association survives, no `PeerFailure` event is emitted, and B still
+   receives its `ASSOCIATION_RELEASE_RESPONSE`.
+2. `test_recovery_timestamp_change_from_other_peer_is_ignored` — peer A
+   associates with RTS=100, peer B heartbeats with RTS=200. Assert A's
+   association survives and no `PeerFailure` is emitted.
+
+Existing `test_heartbeat_rts_change_drops_association` and
+`test_association_release_clears_state` must still pass: the owning
+peer's failure path is unchanged.
+
+Full-workspace `cargo test --release --workspace`, `cargo fmt --check`,
+and `cargo clippy` must be clean.
+
+Result: 5290 passed / 0 failed (up from 5288 — the two new tests), fmt
+clean, clippy clean. Two pre-existing clippy warnings unrelated to this
+change were also fixed under "own the whole branch": an unused
+`OsStrExt` import in `nextgcore-tun/src/linux.rs` and an
+`io::Error::new(ErrorKind::Other, ...)` in `upfd/src/data_plane.rs`.
+Both were confirmed present on clean `HEAD` first.
+
+Verified live on Kind with the rebuilt UPF image: a rolling
+`kubectl rollout restart deployment/smf` — which previously produced
+cause 72 every time — now logs
+
+```
+ignoring PFCP peer failure from 10.244.0.82:8805 (association released
+by peer): the association belongs to 10.244.0.90:8805 -- not clearing it
+```
+
+and the E2E stays at 74 passed / 0 failed / 6 skipped with 0% packet
+loss to 8.8.8.8.
+
+The base-manifest, deploy.sh and Helm changes made in the same session are
+separate concerns and ship separately; see `specs/fix-k8s-base-deployment.md`
+and `specs/fix-helm-chart-control-plane.md`.

--- a/src/bins/nextgcore-upfd/src/data_plane.rs
+++ b/src/bins/nextgcore-upfd/src/data_plane.rs
@@ -292,10 +292,9 @@ impl TunDevice {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Failed to bring up interface: {}", stderr),
-            ));
+            return Err(io::Error::other(format!(
+                "Failed to bring up interface: {stderr}"
+            )));
         }
 
         // Set MTU

--- a/src/bins/nextgcore-upfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-upfd/src/pfcp_path.rs
@@ -571,7 +571,33 @@ impl PfcpServer {
 
     /// Handle a peer restart or association teardown: drop the association,
     /// clear all sessions, and tell the data plane to flush its state.
+    ///
+    /// Only the peer that currently HOLDS the association may tear it down.
+    /// An association is scoped to one CP/UP function pair (TS 29.244 6.2.6),
+    /// Association Release is scoped to the requesting peer's own association
+    /// (7.4.4.2), and stale-session cleanup is scoped to the failed peer's
+    /// sessions (TS 23.527 4.2). Without this guard a departing SMF's Release
+    /// wiped the association a NEWLY started SMF had just set up -- every
+    /// following Session Establishment was rejected with cause 72, which is
+    /// exactly what a rolling restart produces once two SMF pods overlap.
     async fn declare_peer_failure(&self, peer: SocketAddr, reason: &str) {
+        match self.association.read().await.as_ref() {
+            Some(a) if a.peer_addr == peer => {}
+            Some(a) => {
+                log::warn!(
+                    "ignoring PFCP peer failure from {peer} ({reason}): the association \
+                     belongs to {} -- not clearing it",
+                    a.peer_addr
+                );
+                return;
+            }
+            None => {
+                log::warn!(
+                    "ignoring PFCP peer failure from {peer} ({reason}): no association is up"
+                );
+                return;
+            }
+        }
         log::warn!("PFCP peer {peer} failure ({reason}): clearing association and sessions");
         *self.association.write().await = None;
         let count = {
@@ -711,11 +737,14 @@ impl PfcpServer {
 
     /// Compare a peer-reported Recovery Time Stamp against the stored
     /// association; a change means the peer restarted (TS 29.244 6.2.7.2).
+    /// Only the associated peer's own timestamp is meaningful here: a datagram
+    /// from any other address says nothing about whether THIS association's
+    /// peer restarted.
     async fn check_peer_recovery(&self, src_addr: SocketAddr, rts: u32) {
         let restarted = {
             let assoc = self.association.read().await;
             match assoc.as_ref() {
-                Some(a) => a.recovery_time_stamp != rts,
+                Some(a) => a.peer_addr == src_addr && a.recovery_time_stamp != rts,
                 None => false,
             }
         };
@@ -2062,6 +2091,70 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(matches!(evt, PfcpSessionEvent::PeerFailure { .. }));
+    }
+
+    /// A rolling SMF restart briefly runs two pods. The old one sends its
+    /// Association Release on shutdown, AFTER the new one has associated.
+    /// That Release must not touch the new peer's association -- otherwise
+    /// every following Session Establishment is rejected with cause 72.
+    #[tokio::test]
+    async fn test_association_release_from_other_peer_is_ignored() {
+        let (server, smf_a, addr, mut rx) = spawn_test_server().await;
+
+        // Peer A associates and owns the association.
+        let assoc = build_association_setup_request_payload(Some(100));
+        let _ = exchange(&smf_a, addr, &encode_pfcp(5, None, 1, &assoc)).await;
+        assert!(server.is_associated().await);
+
+        // Peer B (a different source address) releases ITS association.
+        let smf_b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let mut rel = crate::n4_build::PfcpMessageBuilder::new();
+        rel.add_node_id(&NodeId::Ipv4(Ipv4Addr::new(127, 0, 0, 9)));
+        let resp = exchange(&smf_b, addr, &encode_pfcp(9, None, 2, &rel.build())).await;
+
+        // B is still answered per TS 29.244 7.4.4.2 ...
+        assert_eq!(resp[1], pfcp_type::ASSOCIATION_RELEASE_RESPONSE);
+        assert_eq!(response_cause(&resp), PfcpCause::RequestAccepted as u8);
+        // ... but A's association and sessions survive.
+        assert!(
+            server.is_associated().await,
+            "a Release from a non-owning peer must not clear the association"
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(300), rx.recv())
+                .await
+                .is_err(),
+            "no PeerFailure may be raised for a peer that holds no association"
+        );
+    }
+
+    /// The same guard for the heartbeat path: another peer's Recovery Time
+    /// Stamp says nothing about whether THIS association's peer restarted.
+    #[tokio::test]
+    async fn test_recovery_timestamp_change_from_other_peer_is_ignored() {
+        let (server, smf_a, addr, mut rx) = spawn_test_server().await;
+
+        let assoc = build_association_setup_request_payload(Some(100));
+        let _ = exchange(&smf_a, addr, &encode_pfcp(5, None, 1, &assoc)).await;
+        assert!(server.is_associated().await);
+
+        // Peer B heartbeats with a DIFFERENT RTS.
+        let smf_b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let mut hb = crate::n4_build::PfcpMessageBuilder::new();
+        hb.add_u32(pfcp_ie::RECOVERY_TIME_STAMP, 200);
+        let resp = exchange(&smf_b, addr, &encode_pfcp(1, None, 2, &hb.build())).await;
+        assert_eq!(resp[1], pfcp_type::HEARTBEAT_RESPONSE);
+
+        assert!(
+            server.is_associated().await,
+            "another peer's RTS must not declare failure for the associated peer"
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(300), rx.recv())
+                .await
+                .is_err(),
+            "no PeerFailure may be raised from a non-owning peer's heartbeat"
+        );
     }
 
     #[tokio::test]

--- a/src/libs/nextgcore-tun/src/linux.rs
+++ b/src/libs/nextgcore-tun/src/linux.rs
@@ -3,7 +3,6 @@
 use crate::types::{IpSubnet, TunDevice, TunError, TunResult};
 use crate::IFNAMSIZ;
 use std::ffi::CString;
-use std::os::unix::ffi::OsStrExt;
 
 /// Linux TUN device path
 const TUN_DEV_PATH: &str = "/dev/net/tun";


### PR DESCRIPTION
## Problem

`declare_peer_failure` (`pfcp_path.rs:574`) took a `peer: SocketAddr` but used it only for the log line, then unconditionally dropped the single association and cleared **every** session. Both call sites can fire for a peer that does *not* hold the current association.

A rolling `kubectl rollout restart deployment/smf` briefly runs two SMF pods. The new pod associates, the old pod sends its Release on shutdown, and the UPF wipes the **new** pod's association:

```
PFCP Association established with 10.244.0.60:8805 (peer RTS=...)
PFCP peer 10.244.0.52:8805 failure (association released by peer): clearing association and sessions
Session Establishment from 10.244.0.60:8805 without PFCP association
```

The SMF reports `cause 72 (No Established PFCP Association)`, PDU session establishment fails and the user plane black-holes. Reproduced deterministically on Kind and on EKS devtest1 — the only workaround was scaling the SMF to 0, restarting the UPF, then scaling back.

**This also breaks any multi-SMF deployment**: one SMF's shutdown drops every other SMF's sessions.

## Fix

Return early from `declare_peer_failure` unless the failing peer owns the association, and gate `check_peer_recovery` on the sender owning it so a stray datagram cannot reach the path at all.

Per spec this is the conformant behaviour regardless of how many associations are supported: TS 29.244 §6.2.6 scopes an association to a CP/UP pair, §7.4.4.2 scopes Release to the requester's own association, TS 23.527 §4.2 scopes stale-session cleanup to the failed peer's sessions.

**Non-goal:** multiple concurrent associations. The field stays `Option<PfcpAssociation>`; that belongs with #66.

## Verification

- 2 new tests, **each verified to FAIL when the fix is reverted** (278 passed / 2 failed)
- Live on Kind with a rebuilt image — the rolling restart that previously failed every time now logs:
  `ignoring PFCP peer failure from 10.244.0.82:8805 (association released by peer): the association belongs to 10.244.0.90:8805 -- not clearing it`
- E2E holds at **74 passed / 0 failed / 6 skipped**, 0% loss to 8.8.8.8
- Gates: **5290 passed / 0 failed** (up from 5288), fmt clean, clippy clean

## Note for reviewers

Also fixes 2 pre-existing clippy warnings (unused `OsStrExt` import; `io::Error::new(ErrorKind::Other, ..)`), both confirmed present on clean `main` first. Say the word and I'll split them out.

Spec: `specs/fix-upf-peer-failure-wrong-peer.md`