### PR TITLE
WIP: fix(k8s): advertise pod IPs, unblock deploy.sh, and seed idempotently

### DIFF
--- a/deploy/eks/deploy-eks.sh
+++ b/deploy/eks/deploy-eks.sh
@@ -100,8 +100,13 @@ kubectl kustomize "${SCRIPT_DIR}" > "${RENDERED}" || die "kustomize render faile
 # Done post-render rather than as 9 near-identical kustomize patches: each NF
 # needs its own container name, config filename and volumeMount set preserved
 # (the UDM additionally mounts hnet keys, which a blanket volumeMounts replace
-# would drop). Kind is unaffected -- there 0.0.0.0 happens to be reachable on a
-# single node, so the base manifests are not wrong for their target.
+# would drop).
+#
+# Kind is NOT unaffected, contrary to what this comment used to claim: on a
+# single-node Kind cluster the AMF resolved its peers through discovery, dialled
+# 0.0.0.0:7777 -- itself -- and got 404 from its own SBI router, so every
+# registration failed. The base manifests now carry an equivalent
+# rewrite-advertise-addr initContainer plus AMF_SBI_ADDR from status.podIP.
 log "rewriting NF advertise addresses to the pod IP..."
 python3 - "${RENDERED}" <<'PY' > "${RENDERED}.tmp" || die "advertise-address rewrite failed"
 import sys, yaml
@@ -136,6 +141,35 @@ for d in yaml.safe_load_all(open(sys.argv[1])):
     if d.get('kind') == 'Deployment' and d['metadata']['name'] in NFS:
         nf = d['metadata']['name']
         pod = d['spec']['template']['spec']
+
+        # The base manifests now carry this initContainer themselves. Applying
+        # it twice yields duplicate initContainer and volume names, which the
+        # API server rejects, so do not re-add it.
+        #
+        # But a kustomize patch that REPLACES a container's volumeMounts (the
+        # UDM's hnet-keys patch does) drops the base manifest's redirect to
+        # config-resolved, leaving the container reading the un-rewritten
+        # template while the initContainer writes the rewritten copy nobody
+        # reads -- so the UDM silently advertised 0.0.0.0 again. Re-assert the
+        # redirect here rather than trusting the render.
+        if any(c.get('name') == 'rewrite-advertise-addr'
+               for c in pod.get('initContainers', [])):
+            cont = next((c for c in pod['containers'] if c['name'] == nf), None)
+            if cont is None:
+                sys.exit(f'{nf}: container not found')
+            cfg_mount = next(
+                (m for m in cont.get('volumeMounts', [])
+                 if m.get('subPath') == f'{nf}.yaml'), None)
+            if cfg_mount is None:
+                sys.exit(f'{nf}: no {nf}.yaml config mount to redirect')
+            cfg_mount['name'] = 'config-resolved'
+            if not any(v.get('name') == 'config-resolved'
+                       for v in pod.get('volumes', [])):
+                pod.setdefault('volumes', []).append(
+                    {'name': 'config-resolved', 'emptyDir': {}})
+            patched.append(nf)
+            out.append(d)
+            continue
 
         # Find the container's existing config mount so we can redirect just it.
         cont = next((c for c in pod['containers'] if c['name'] == nf), None)

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -79,6 +79,25 @@ echo ""
 echo "[4/9] Deploying nextgcore configuration"
 kubectl apply -f "${SCRIPT_DIR}/manifests/configmap.yaml"
 
+# udm.yaml mounts the Secret udm-hnet-keys at /etc/nextgcore/hnet, which is
+# where configmap.yaml points the UDM for SUCI de-concealment. The mount is
+# `optional: true`, so without this the UDM starts with NO key material and
+# silently cannot de-conceal a SUCI -- deploy-eks.sh creates the Secret but
+# this path never did.
+HNET_DIR="${SCRIPT_DIR}/../docker/rust/configs/5gc/hnet"
+if [ -f "${HNET_DIR}/curve25519-1.key" ] && [ -f "${HNET_DIR}/secp256r1-2.key" ]; then
+  echo "  Creating udm-hnet-keys Secret (repo DEVELOPMENT keys - replace for real use)"
+  kubectl create secret generic udm-hnet-keys \
+    --namespace "${NAMESPACE}" \
+    --from-file="curve25519-1.key=${HNET_DIR}/curve25519-1.key" \
+    --from-file="secp256r1-2.key=${HNET_DIR}/secp256r1-2.key" \
+    --dry-run=client -o yaml | kubectl apply -f -
+else
+  echo "ERROR: hnet keys not found under ${HNET_DIR}." >&2
+  echo "       The UDM cannot de-conceal a SUCI without them." >&2
+  exit 1
+fi
+
 # --- Step 5: Deploy nextgcore NFs in dependency order ---
 echo ""
 echo "[5/9] Deploying nextgcore 5G Core Network Functions"
@@ -120,12 +139,16 @@ echo "  Deploying AMF..."
 kubectl apply -f "${SCRIPT_DIR}/manifests/amf.yaml"
 kubectl rollout status deployment/amf -n "${NAMESPACE}" --timeout=120s
 
-echo "  Deploying SMF..."
+# The UPF is applied BEFORE waiting on the SMF: the SMF's resolve-upf
+# initContainer blocks until upf.<ns>.svc.cluster.local resolves, so waiting
+# for the SMF first deadlocks -- the SMF can never become ready and the UPF is
+# never applied. Only the UPF *Service* has to exist for DNS to resolve, not a
+# ready UPF pod, so applying both and then waiting is enough.
+echo "  Deploying SMF and UPF..."
 kubectl apply -f "${SCRIPT_DIR}/manifests/smf.yaml"
-kubectl rollout status deployment/smf -n "${NAMESPACE}" --timeout=120s
-
-echo "  Deploying UPF..."
 kubectl apply -f "${SCRIPT_DIR}/manifests/upf.yaml"
+
+kubectl rollout status deployment/smf -n "${NAMESPACE}" --timeout=120s
 kubectl rollout status deployment/upf -n "${NAMESPACE}" --timeout=120s
 
 # --- Step 8: Deploy monitoring stack ---

--- a/k8s/manifests/amf.yaml
+++ b/k8s/manifests/amf.yaml
@@ -68,8 +68,19 @@ spec:
               value: info
             - name: RUST_BACKTRACE
               value: "1"
+            # The pod IP, NOT 0.0.0.0. Unlike every other NF, the AMF takes its
+            # SBI address from this env var (nextgcore-amfd/src/lib.rs:811) and
+            # uses it for BOTH the listen socket and the ipv4Addresses it
+            # registers with the NRF -- it never reads sbi.server[0].address
+            # from its YAML, so a ConfigMap rewrite cannot fix the NFProfile.
+            # With 0.0.0.0 the AMF advertised an unusable endpoint and, when it
+            # resolved its own peers through discovery, dialled 0.0.0.0:7777 --
+            # itself -- getting 404 from its own SBI router and failing every
+            # registration. Binding to the pod IP is correct inside a pod.
             - name: AMF_SBI_ADDR
-              value: "0.0.0.0"
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: SMF_SBI_ADDR
               value: "smf.nextg-system.svc.cluster.local"
             - name: SMF_SBI_PORT

--- a/k8s/manifests/ausf.yaml
+++ b/k8s/manifests/ausf.yaml
@@ -34,6 +34,43 @@ spec:
         app.kubernetes.io/part-of: nextgcore
     spec:
       initContainers:
+        # Rewrite sbi.server[0].address from 0.0.0.0 to the pod IP. That single
+        # config value is used for BOTH the listen socket and the ipv4Addresses
+        # registered with the NRF, so 0.0.0.0 made discovery hand consumers an
+        # address they cannot dial. A ConfigMap mount is read-only and the pod
+        # IP is unknown until scheduling, so the rewrite lands in an emptyDir.
+        - name: rewrite-advertise-addr
+          image: busybox:1.36
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NF_NAME
+              value: ausf
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[advertise] pod IP: $POD_IP"
+              case "$POD_IP" in
+                *[0-9].[0-9]*) ;;
+                *) echo "[advertise] FATAL: POD_IP is not IPv4: '$POD_IP'" >&2; exit 1 ;;
+              esac
+              cp "/tmp/config-template/${NF_NAME}.yaml" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              sed -i "s|^\( *- address:\) *0\.0\.0\.0 *$|\1 $POD_IP|" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              if grep -qE '^ *- address: *0\.0\.0\.0 *$' "/etc/nextgcore-resolved/${NF_NAME}.yaml"; then
+                echo "[advertise] FATAL: a 0.0.0.0 advertise address survived" >&2
+                exit 1
+              fi
+              echo "[advertise] ${NF_NAME}.yaml advertise address set to $POD_IP"
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config-template
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgcore-resolved
         - name: wait-nrf
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
@@ -62,7 +99,7 @@ spec:
               cpu: 200m
               memory: 128Mi
           volumeMounts:
-            - name: config
+            - name: config-resolved
               mountPath: /etc/nextgcore/ausf.yaml
               subPath: ausf.yaml
               readOnly: true
@@ -82,5 +119,7 @@ spec:
         - name: config
           configMap:
             name: nextgcore-configs
+        - name: config-resolved
+          emptyDir: {}
         - name: logs
           emptyDir: {}

--- a/k8s/manifests/bsf.yaml
+++ b/k8s/manifests/bsf.yaml
@@ -34,6 +34,43 @@ spec:
         app.kubernetes.io/part-of: nextgcore
     spec:
       initContainers:
+        # Rewrite sbi.server[0].address from 0.0.0.0 to the pod IP. That single
+        # config value is used for BOTH the listen socket and the ipv4Addresses
+        # registered with the NRF, so 0.0.0.0 made discovery hand consumers an
+        # address they cannot dial. A ConfigMap mount is read-only and the pod
+        # IP is unknown until scheduling, so the rewrite lands in an emptyDir.
+        - name: rewrite-advertise-addr
+          image: busybox:1.36
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NF_NAME
+              value: bsf
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[advertise] pod IP: $POD_IP"
+              case "$POD_IP" in
+                *[0-9].[0-9]*) ;;
+                *) echo "[advertise] FATAL: POD_IP is not IPv4: '$POD_IP'" >&2; exit 1 ;;
+              esac
+              cp "/tmp/config-template/${NF_NAME}.yaml" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              sed -i "s|^\( *- address:\) *0\.0\.0\.0 *$|\1 $POD_IP|" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              if grep -qE '^ *- address: *0\.0\.0\.0 *$' "/etc/nextgcore-resolved/${NF_NAME}.yaml"; then
+                echo "[advertise] FATAL: a 0.0.0.0 advertise address survived" >&2
+                exit 1
+              fi
+              echo "[advertise] ${NF_NAME}.yaml advertise address set to $POD_IP"
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config-template
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgcore-resolved
         - name: wait-nrf
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
@@ -61,7 +98,7 @@ spec:
               cpu: 200m
               memory: 128Mi
           volumeMounts:
-            - name: config
+            - name: config-resolved
               mountPath: /etc/nextgcore/bsf.yaml
               subPath: bsf.yaml
               readOnly: true
@@ -81,5 +118,7 @@ spec:
         - name: config
           configMap:
             name: nextgcore-configs
+        - name: config-resolved
+          emptyDir: {}
         - name: logs
           emptyDir: {}

--- a/k8s/manifests/mongodb-init.yaml
+++ b/k8s/manifests/mongodb-init.yaml
@@ -18,13 +18,22 @@ data:
     db.sessions.createIndex({ "dnn": 1 });
     db.policyData.createIndex({ "supi": 1 });
     db.accounts.createIndex({ "username": 1 }, { unique: true });
-    db.accounts.insertOne({
-        username: "admin",
-        password: "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy",
-        roles: ["admin"],
-        created: new Date()
-    });
-    db.subscribers.insertOne({
+    // updateOne+upsert rather than insertOne: this Job is re-applied by every
+    // deploy.sh run, and insertOne against the existing unique index aborted
+    // the script with "E11000 duplicate key error ... username: admin",
+    // CrashLoopBackOff-ing the Job even though the seed data was already
+    // correct. $setOnInsert so a re-run never overwrites a changed password.
+    db.accounts.updateOne(
+        { username: "admin" },
+        { $setOnInsert: {
+            username: "admin",
+            password: "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy",
+            roles: ["admin"],
+            created: new Date()
+        } },
+        { upsert: true }
+    );
+    db.subscribers.updateOne({ imsi: "999700000000001" }, { $setOnInsert: {
         imsi: "999700000000001",
         msisdn: ["821000000001"],
         security: {
@@ -51,8 +60,8 @@ data:
         network_access_mode: 0,
         subscribed_rau_tau_timer: 12,
         created: new Date()
-    });
-    db.subscribers.insertOne({
+    } }, { upsert: true });
+    db.subscribers.updateOne({ imsi: "001010123456789" }, { $setOnInsert: {
         imsi: "001010123456789",
         msisdn: ["821012345678"],
         security: {
@@ -79,7 +88,7 @@ data:
         network_access_mode: 0,
         subscribed_rau_tau_timer: 12,
         created: new Date()
-    });
+    } }, { upsert: true });
     print("NextGCore MongoDB initialization completed.");
 ---
 apiVersion: batch/v1

--- a/k8s/manifests/nssf.yaml
+++ b/k8s/manifests/nssf.yaml
@@ -34,6 +34,43 @@ spec:
         app.kubernetes.io/part-of: nextgcore
     spec:
       initContainers:
+        # Rewrite sbi.server[0].address from 0.0.0.0 to the pod IP. That single
+        # config value is used for BOTH the listen socket and the ipv4Addresses
+        # registered with the NRF, so 0.0.0.0 made discovery hand consumers an
+        # address they cannot dial. A ConfigMap mount is read-only and the pod
+        # IP is unknown until scheduling, so the rewrite lands in an emptyDir.
+        - name: rewrite-advertise-addr
+          image: busybox:1.36
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NF_NAME
+              value: nssf
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[advertise] pod IP: $POD_IP"
+              case "$POD_IP" in
+                *[0-9].[0-9]*) ;;
+                *) echo "[advertise] FATAL: POD_IP is not IPv4: '$POD_IP'" >&2; exit 1 ;;
+              esac
+              cp "/tmp/config-template/${NF_NAME}.yaml" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              sed -i "s|^\( *- address:\) *0\.0\.0\.0 *$|\1 $POD_IP|" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              if grep -qE '^ *- address: *0\.0\.0\.0 *$' "/etc/nextgcore-resolved/${NF_NAME}.yaml"; then
+                echo "[advertise] FATAL: a 0.0.0.0 advertise address survived" >&2
+                exit 1
+              fi
+              echo "[advertise] ${NF_NAME}.yaml advertise address set to $POD_IP"
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config-template
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgcore-resolved
         - name: wait-nrf
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
@@ -58,7 +95,7 @@ spec:
               cpu: 200m
               memory: 128Mi
           volumeMounts:
-            - name: config
+            - name: config-resolved
               mountPath: /etc/nextgcore/nssf.yaml
               subPath: nssf.yaml
               readOnly: true
@@ -78,5 +115,7 @@ spec:
         - name: config
           configMap:
             name: nextgcore-configs
+        - name: config-resolved
+          emptyDir: {}
         - name: logs
           emptyDir: {}

--- a/k8s/manifests/pcf.yaml
+++ b/k8s/manifests/pcf.yaml
@@ -37,6 +37,43 @@ spec:
         app.kubernetes.io/part-of: nextgcore
     spec:
       initContainers:
+        # Rewrite sbi.server[0].address from 0.0.0.0 to the pod IP. That single
+        # config value is used for BOTH the listen socket and the ipv4Addresses
+        # registered with the NRF, so 0.0.0.0 made discovery hand consumers an
+        # address they cannot dial. A ConfigMap mount is read-only and the pod
+        # IP is unknown until scheduling, so the rewrite lands in an emptyDir.
+        - name: rewrite-advertise-addr
+          image: busybox:1.36
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NF_NAME
+              value: pcf
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[advertise] pod IP: $POD_IP"
+              case "$POD_IP" in
+                *[0-9].[0-9]*) ;;
+                *) echo "[advertise] FATAL: POD_IP is not IPv4: '$POD_IP'" >&2; exit 1 ;;
+              esac
+              cp "/tmp/config-template/${NF_NAME}.yaml" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              sed -i "s|^\( *- address:\) *0\.0\.0\.0 *$|\1 $POD_IP|" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              if grep -qE '^ *- address: *0\.0\.0\.0 *$' "/etc/nextgcore-resolved/${NF_NAME}.yaml"; then
+                echo "[advertise] FATAL: a 0.0.0.0 advertise address survived" >&2
+                exit 1
+              fi
+              echo "[advertise] ${NF_NAME}.yaml advertise address set to $POD_IP"
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config-template
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgcore-resolved
         - name: wait-nrf
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
@@ -66,7 +103,7 @@ spec:
               cpu: 200m
               memory: 128Mi
           volumeMounts:
-            - name: config
+            - name: config-resolved
               mountPath: /etc/nextgcore/pcf.yaml
               subPath: pcf.yaml
               readOnly: true
@@ -86,5 +123,7 @@ spec:
         - name: config
           configMap:
             name: nextgcore-configs
+        - name: config-resolved
+          emptyDir: {}
         - name: logs
           emptyDir: {}

--- a/k8s/manifests/smf.yaml
+++ b/k8s/manifests/smf.yaml
@@ -41,6 +41,43 @@ spec:
         app.kubernetes.io/part-of: nextgcore
     spec:
       initContainers:
+        # Rewrite sbi.server[0].address from 0.0.0.0 to the pod IP. That single
+        # config value is used for BOTH the listen socket and the ipv4Addresses
+        # registered with the NRF, so 0.0.0.0 made discovery hand consumers an
+        # address they cannot dial. A ConfigMap mount is read-only and the pod
+        # IP is unknown until scheduling, so the rewrite lands in an emptyDir.
+        - name: rewrite-advertise-addr
+          image: busybox:1.36
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NF_NAME
+              value: smf
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[advertise] pod IP: $POD_IP"
+              case "$POD_IP" in
+                *[0-9].[0-9]*) ;;
+                *) echo "[advertise] FATAL: POD_IP is not IPv4: '$POD_IP'" >&2; exit 1 ;;
+              esac
+              cp "/tmp/config-template/${NF_NAME}.yaml" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              sed -i "s|^\( *- address:\) *0\.0\.0\.0 *$|\1 $POD_IP|" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              if grep -qE '^ *- address: *0\.0\.0\.0 *$' "/etc/nextgcore-resolved/${NF_NAME}.yaml"; then
+                echo "[advertise] FATAL: a 0.0.0.0 advertise address survived" >&2
+                exit 1
+              fi
+              echo "[advertise] ${NF_NAME}.yaml advertise address set to $POD_IP"
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config-template
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgcore-resolved
         - name: wait-nrf
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
@@ -126,7 +163,7 @@ spec:
               cpu: 500m
               memory: 256Mi
           volumeMounts:
-            - name: config
+            - name: config-resolved
               mountPath: /etc/nextgcore/smf.yaml
               subPath: smf.yaml
               readOnly: true
@@ -149,6 +186,8 @@ spec:
         - name: config
           configMap:
             name: nextgcore-configs
+        - name: config-resolved
+          emptyDir: {}
         - name: logs
           emptyDir: {}
         # Carries the resolved UPF IP from the resolve-upf initContainer to the

--- a/k8s/manifests/udm.yaml
+++ b/k8s/manifests/udm.yaml
@@ -34,6 +34,43 @@ spec:
         app.kubernetes.io/part-of: nextgcore
     spec:
       initContainers:
+        # Rewrite sbi.server[0].address from 0.0.0.0 to the pod IP. That single
+        # config value is used for BOTH the listen socket and the ipv4Addresses
+        # registered with the NRF, so 0.0.0.0 made discovery hand consumers an
+        # address they cannot dial. A ConfigMap mount is read-only and the pod
+        # IP is unknown until scheduling, so the rewrite lands in an emptyDir.
+        - name: rewrite-advertise-addr
+          image: busybox:1.36
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NF_NAME
+              value: udm
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[advertise] pod IP: $POD_IP"
+              case "$POD_IP" in
+                *[0-9].[0-9]*) ;;
+                *) echo "[advertise] FATAL: POD_IP is not IPv4: '$POD_IP'" >&2; exit 1 ;;
+              esac
+              cp "/tmp/config-template/${NF_NAME}.yaml" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              sed -i "s|^\( *- address:\) *0\.0\.0\.0 *$|\1 $POD_IP|" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              if grep -qE '^ *- address: *0\.0\.0\.0 *$' "/etc/nextgcore-resolved/${NF_NAME}.yaml"; then
+                echo "[advertise] FATAL: a 0.0.0.0 advertise address survived" >&2
+                exit 1
+              fi
+              echo "[advertise] ${NF_NAME}.yaml advertise address set to $POD_IP"
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config-template
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgcore-resolved
         - name: wait-nrf
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
@@ -62,7 +99,7 @@ spec:
               cpu: 200m
               memory: 128Mi
           volumeMounts:
-            - name: config
+            - name: config-resolved
               mountPath: /etc/nextgcore/udm.yaml
               subPath: udm.yaml
               readOnly: true
@@ -89,6 +126,8 @@ spec:
         - name: config
           configMap:
             name: nextgcore-configs
+        - name: config-resolved
+          emptyDir: {}
         - name: logs
           emptyDir: {}
         # Created by k8s/deploy.sh and deploy/eks/deploy-eks.sh from the repo's

--- a/k8s/manifests/udr.yaml
+++ b/k8s/manifests/udr.yaml
@@ -34,6 +34,43 @@ spec:
         app.kubernetes.io/part-of: nextgcore
     spec:
       initContainers:
+        # Rewrite sbi.server[0].address from 0.0.0.0 to the pod IP. That single
+        # config value is used for BOTH the listen socket and the ipv4Addresses
+        # registered with the NRF, so 0.0.0.0 made discovery hand consumers an
+        # address they cannot dial. A ConfigMap mount is read-only and the pod
+        # IP is unknown until scheduling, so the rewrite lands in an emptyDir.
+        - name: rewrite-advertise-addr
+          image: busybox:1.36
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NF_NAME
+              value: udr
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[advertise] pod IP: $POD_IP"
+              case "$POD_IP" in
+                *[0-9].[0-9]*) ;;
+                *) echo "[advertise] FATAL: POD_IP is not IPv4: '$POD_IP'" >&2; exit 1 ;;
+              esac
+              cp "/tmp/config-template/${NF_NAME}.yaml" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              sed -i "s|^\( *- address:\) *0\.0\.0\.0 *$|\1 $POD_IP|" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+              if grep -qE '^ *- address: *0\.0\.0\.0 *$' "/etc/nextgcore-resolved/${NF_NAME}.yaml"; then
+                echo "[advertise] FATAL: a 0.0.0.0 advertise address survived" >&2
+                exit 1
+              fi
+              echo "[advertise] ${NF_NAME}.yaml advertise address set to $POD_IP"
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config-template
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgcore-resolved
         - name: wait-nrf
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z nrf.nextg-system.svc.cluster.local 7777; do echo waiting for nrf; sleep 2; done']
@@ -61,7 +98,7 @@ spec:
               cpu: 200m
               memory: 128Mi
           volumeMounts:
-            - name: config
+            - name: config-resolved
               mountPath: /etc/nextgcore/udr.yaml
               subPath: udr.yaml
               readOnly: true
@@ -81,5 +118,7 @@ spec:
         - name: config
           configMap:
             name: nextgcore-configs
+        - name: config-resolved
+          emptyDir: {}
         - name: logs
           emptyDir: {}

--- a/specs/fix-k8s-base-deployment.md
+++ b/specs/fix-k8s-base-deployment.md
@@ -1,0 +1,98 @@
+# Fix: base k8s manifests cannot reach a passing E2E unattended
+
+## Problem
+
+Four defects, each verified live on Kind at `0cfb1fe`. Together they meant
+`k8s/deploy.sh` could not complete without manual intervention, and even once
+running, registration failed.
+
+### 1. Every NF advertised `0.0.0.0` to the NRF
+
+`k8s/manifests/configmap.yaml` sets each NF's `sbi.server[0].address` to
+`0.0.0.0`. That single value feeds **both** the listen socket and the
+`ipv4Addresses` in the NFProfile registered with the NRF. `0.0.0.0` is correct
+for a listen socket inside a pod and useless as an advertised endpoint:
+discovery "succeeds" and hands consumers an address they cannot dial.
+
+Observed: the AMF resolved its peers through discovery, dialled `0.0.0.0:7777`
+— itself — and got 404 from its own SBI router. Every registration failed.
+
+This needs **two** mechanisms, not one:
+
+- The 7 config-driven NFs (`ausf`, `bsf`, `nssf`, `pcf`, `smf`, `udm`, `udr`)
+  take the address from YAML, so rewriting the mounted config fixes them.
+- The **AMF does not**. `nextgcore-amfd/src/lib.rs:811` reads
+  `AMF_SBI_ADDR` from the environment and passes it straight to
+  `amf_nrf_register` (line 831); its YAML address is used for the listen
+  socket only. `k8s/manifests/amf.yaml` hardcoded that env var to `0.0.0.0`,
+  so a ConfigMap rewrite is a no-op for its profile.
+
+`deploy/eks/deploy-eks.sh` already solved the first half post-render. Its
+comment claimed "Kind is unaffected — there 0.0.0.0 happens to be reachable on
+a single node"; this session disproved that.
+
+### 2. `deploy.sh` deadlocked on UPF/SMF ordering
+
+`deploy.sh` ran `kubectl rollout status deployment/smf` **before** applying
+`upf.yaml`. The SMF's `resolve-upf` initContainer blocks until UPF DNS
+resolves, so neither could proceed and the script exited 1. Only the UPF
+*Service* has to exist for DNS to resolve — not a ready UPF pod.
+
+### 3. The UDM had no SUCI de-concealment keys
+
+`udm.yaml` mounts Secret `udm-hnet-keys` at `/etc/nextgcore/hnet`, which is
+where `configmap.yaml` points the UDM. The mount is `optional: true` and base
+`deploy.sh` never created the Secret — so the UDM started with no key material
+and silently could not de-conceal a profile A/B SUCI. `deploy-eks.sh` creates
+it; this path did not. (Issue #125.)
+
+### 4. `mongodb-init` was not idempotent
+
+The Job used `insertOne` against a unique `username` index, so a second
+`deploy.sh` run aborted with
+`E11000 duplicate key error ... username: "admin"` and CrashLoopBackOff'd —
+even though the seed data was already correct.
+
+## Fix
+
+1. Add a `rewrite-advertise-addr` initContainer to the 7 config-driven NFs:
+   copy the mounted ConfigMap into an emptyDir and `sed` the advertise address
+   to `status.podIP`, failing closed if a `0.0.0.0` survives or `POD_IP` is not
+   IPv4. A ConfigMap mount is read-only and the pod IP is unknown until
+   scheduling, hence the emptyDir. Anchored on `- address:` so client URIs are
+   untouched.
+2. Set `AMF_SBI_ADDR` from a `fieldRef` on `status.podIP`.
+3. Apply `upf.yaml` before waiting on the SMF; wait on both afterwards.
+4. Create `udm-hnet-keys` in `deploy.sh` from the repo development keys, and
+   fail loudly if they are missing.
+5. Convert the three `insertOne` calls to
+   `updateOne` + `$setOnInsert` + `upsert`, so a re-run never overwrites a
+   changed password and never aborts.
+6. Make the EKS overlay's post-render rewrite idempotent now that the base
+   manifests carry the initContainer, and correct the "Kind is unaffected"
+   comment.
+
+## Non-goals
+
+Multi-replica NFs, and durable NF state across restarts (issue #66). Every NF
+keeps `replicas: 1` and memory-only state.
+
+## Verification
+
+`./k8s/deploy.sh` from a **deleted** namespace must exit 0 with no manual
+steps, then:
+
+- all 8 registered NFs advertise routable pod IPs (0 × `0.0.0.0`) on the first
+  attempt, verified against the live NRF;
+- no NF logs `Using defaults` — a soft WARN that leaves the pod Ready while it
+  runs on built-in config;
+- `k8s/e2e-test.sh` reports the 74/0/6 baseline;
+- a manual `ping 8.8.8.8` from the UE, which the harness does not cover.
+
+Result: exit 0, all 8 NFs on pod IPs, **74 passed / 0 failed / 6 skipped**, 0%
+packet loss to 8.8.8.8.
+
+The EKS overlay additionally needs its *rendered* output asserted, not merely a
+successful render: the UDM's hnet kustomize patch replaces `volumeMounts`
+wholesale, which silently dropped the redirect and restored the `0.0.0.0` bug
+while `helm`/kustomize validation stayed green.


### PR DESCRIPTION
Four defects that together stopped `k8s/deploy.sh` reaching a passing E2E without manual intervention. All verified live on Kind.

## 1. Every NF advertised `0.0.0.0` to the NRF

`configmap.yaml` sets `sbi.server[0].address` to `0.0.0.0`, and that single value feeds **both** the listen socket and the `ipv4Addresses` in the registered NFProfile. Correct for a listen socket in a pod, useless as an advertised endpoint — discovery "succeeds" and hands consumers an address they cannot dial. The AMF resolved its peers through discovery, dialled `0.0.0.0:7777` (itself), got 404 from its own SBI router, and every registration failed.

This needs **two** mechanisms, not one:

- The 7 config-driven NFs take the address from YAML → a `rewrite-advertise-addr` initContainer copies the mounted ConfigMap into an emptyDir and rewrites the address to `status.podIP`, failing closed if a `0.0.0.0` survives or `POD_IP` is not IPv4. Anchored on `- address:` so client URIs are untouched.
- The **AMF does not read its YAML for the profile** — `amfd/src/lib.rs:811` takes `AMF_SBI_ADDR` from the environment — so that env var now comes from a `fieldRef` on `status.podIP`. A ConfigMap rewrite is a no-op for it.

## 2. `deploy.sh` deadlocked

It waited on the SMF rollout *before* applying `upf.yaml`, but the SMF's `resolve-upf` initContainer blocks on UPF DNS. Only the UPF **Service** must exist for that to resolve, so apply both and then wait.

## 3. The UDM had no SUCI de-concealment keys (#125)

`udm.yaml` mounts `udm-hnet-keys` `optional: true` and base `deploy.sh` never created it, so the UDM started with no key material and silently could not de-conceal a profile A/B SUCI.

## 4. `mongodb-init` was not idempotent

`insertOne` against the unique username index aborted a second run with `E11000 duplicate key` and CrashLoopBackOff'd even though the seed was already correct. Now `updateOne` + `$setOnInsert` + `upsert`. Verified against a real mongod: the old script reproduces E11000, the new one holds at 1 account / 2 subscribers.

## Also

Makes `deploy-eks.sh`'s post-render rewrite idempotent now that base manifests carry the initContainer, and **re-asserts the `config-resolved` mount for already-patched Deployments** — the UDM's hnet kustomize patch replaces `volumeMounts` wholesale, which dropped the redirect and silently restored the `0.0.0.0` bug while validation stayed green. Corrects the comment claiming "Kind is unaffected — there 0.0.0.0 happens to be reachable", which this work disproved.

## Verification

`./k8s/deploy.sh` from a **deleted** namespace now exits 0 with no manual steps:

- all 8 NFs advertise routable pod IPs on the first attempt (verified against the live NRF)
- no NF logs `Using defaults`
- E2E: **74 passed / 0 failed / 6 skipped**, 0% packet loss to 8.8.8.8

Spec: `specs/fix-k8s-base-deployment.md`