### PR TITLE
WIP: fix(helm): render a working 5GC control plane (closes #124)

### DIFF
--- a/deploy/eks/README.md
+++ b/deploy/eks/README.md
@@ -92,10 +92,11 @@ Two consequences worth stating plainly:
 - **A third-party RAN cannot attach.** Real gNBs speak SCTP over IP proto 132.
   Interop needs binaries rebuilt with `--features kernel-sctp` and
   `--sctp-backend kernel`, plus SCTP support on the node and load balancer.
-- The Helm chart at `nextgcore/deploy/helm/` declares 38412 as
-  `protocol: SCTP`, which contradicts this and does not work with the current
-  binaries. The chart has other gaps too (8 of 10 NFs get no config
-  ConfigMap). **Prefer this overlay over the chart.**
+- The Helm chart at `nextgcore/deploy/helm/` declares 38412 as `protocol: UDP`
+  for the same reason, and mounts a real config for all 10 NFs. Both gaps this
+  section used to warn about are fixed (see #124). The chart deploys the
+  **control plane only** — no gNB/UE, no monitoring — so prefer this overlay
+  for a full EKS bring-up, and the chart when you want just a 5GC.
 
 ## Prerequisites
 

--- a/deploy/helm/nextgcore/Chart.yaml
+++ b/deploy/helm/nextgcore/Chart.yaml
@@ -1,9 +1,13 @@
-# Item 126: Helm chart for NextGCore 5G Core
+# Helm chart for the NextGCore 5G Core control plane.
+#
+# Scope: control plane only (10 NFs + MongoDB). The gNB/UE simulator and
+# the monitoring stack are deliberately NOT here -- use nextgsim/k8s/ and
+# k8s/monitoring/. See specs/fix-helm-chart-control-plane.md.
 apiVersion: v2
 name: nextgcore
-description: NextGCore 5G Core Network Functions
+description: NextGCore 5G Core Network Functions (control plane)
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.1.0"
 keywords:
   - 5g
@@ -15,8 +19,10 @@ sources:
   - https://github.com/nextgsim/nextgcore
 maintainers:
   - name: NextGCore Contributors
-dependencies:
-  - name: mongodb
-    version: "14.x.x"
-    repository: https://charts.bitnami.com/bitnami
-    condition: mongodb.enabled
+# No dependencies on purpose. This chart previously declared
+# mongodb 14.x.x from charts.bitnami.com, which was never vendored into
+# charts/ -- so EVERY `helm template` and `helm install` failed offline with
+# "found in Chart.yaml, but missing in charts/ directory: mongodb", even with
+# --set mongodb.enabled=false. A floating remote dependency also makes renders
+# non-reproducible. MongoDB is now templated directly from
+# templates/mongodb.yaml, mirroring k8s/manifests/mongodb.yaml.

--- a/deploy/helm/nextgcore/README.md
+++ b/deploy/helm/nextgcore/README.md
@@ -1,0 +1,70 @@
+# NextGCore 5G Core — Helm chart
+
+Deploys the **control plane**: 10 NFs (NRF, AMF, SMF, UPF, AUSF, UDM, UDR, PCF,
+NSSF, BSF) plus MongoDB and its subscriber-seeding Job.
+
+## Scope
+
+| Included | Not included |
+|---|---|
+| 10 control-plane NFs | gNB / UE simulator (`nextgsim/k8s/`) |
+| MongoDB + subscriber seed Job | Prometheus / Grafana / Jaeger (`k8s/monitoring/`) |
+| UPF data plane (TUN + NAT) | The 16 non-core NFs (SCP, SEPP, NWDAF, LMF, …) |
+
+For a full stack including the simulator, use `k8s/` (Kind) or `deploy/eks/`
+(EKS). Those are the paths the E2E suite targets directly.
+
+## Install
+
+```bash
+# The UPF needs a privileged pod for its TUN device.
+kubectl create namespace nextg-system
+kubectl label namespace nextg-system \
+  pod-security.kubernetes.io/enforce=privileged --overwrite
+
+helm install nextg deploy/helm/nextgcore -n nextg-system --wait
+```
+
+Then follow the `NOTES.txt` output — it prints the one out-of-band step (the
+SUCI de-concealment Secret) and the checks worth running.
+
+No `helm dependency build` is needed: the chart vendors nothing and renders
+offline.
+
+## Verifying it actually works
+
+Rendering is not evidence. Two checks catch the failures that hide behind a
+green `helm install`:
+
+```bash
+# 1. Every NF must advertise a routable pod IP, never 0.0.0.0.
+kubectl exec -n nextg-system deploy/nextg-nrf -- \
+  curl -s --http2-prior-knowledge \
+  http://127.0.0.1:7777/nnrf-nfm/v1/nf-instances
+
+# 2. No NF may have fallen back to built-in defaults. This is a WARN, and the
+#    pod still reports Ready, so it is easy to miss.
+for nf in nrf amf smf ausf udm udr pcf nssf bsf; do
+  kubectl logs -n nextg-system deploy/nextg-$nf --tail=80 2>&1 \
+    | grep -H --label="$nf" 'Using defaults'
+done
+```
+
+## Values worth knowing
+
+| Key | Default | Why you would change it |
+|---|---|---|
+| `upf.dataPlane.enabled` | `true` | `false` for control-plane-only where the node cannot provide `/dev/net/tun` (Kind on macOS). No user plane: a UE ping will not work. |
+| `mongodb.persistence.enabled` | `true` | `false` on clusters with no CSI driver, where a PVC stays Pending. Data is lost on restart. |
+| `mongodb.enabled` / `mongodb.externalUri` | `true` / `""` | Point at an existing MongoDB. The seed Job still runs against it. |
+| `global.plmn` | 999-70 | Must match the simulator's PLMN. |
+| `subscriber.*` | test IMSI | Must match the UE's USIM config. |
+| `amf.service.headless`, `upf.service.headless` | `true` | Leave alone. NGAP and GTP-U are UDP; kube-proxy's per-flow balancing plus a conntrack timeout breaks both. |
+
+## Verified
+
+Against Kind, `helm install --wait` then the simulator from `nextgsim/k8s/`
+pointed at the release: **74 passed / 0 failed / 6 skipped** on
+`k8s/e2e-test.sh`, and 0% packet loss from the UE to 8.8.8.8 through the GTP-U
+tunnel. Design notes and the full defect list are in
+`specs/fix-helm-chart-control-plane.md`.

--- a/deploy/helm/nextgcore/templates/NOTES.txt
+++ b/deploy/helm/nextgcore/templates/NOTES.txt
@@ -1,0 +1,49 @@
+NextGCore 5G Core control plane — release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+This chart deploys the CONTROL PLANE ONLY (10 NFs + MongoDB).
+It does NOT ship the gNB/UE simulator or the monitoring stack.
+  simulator:  nextgsim/k8s/
+  monitoring: k8s/monitoring/
+
+Check the rollout:
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/part-of=nextgcore
+
+Confirm every NF registered with a ROUTABLE address (never 0.0.0.0):
+  kubectl exec -n {{ .Release.Namespace }} deploy/{{ .Release.Name }}-nrf -- \
+    curl -s --http2-prior-knowledge http://127.0.0.1:{{ .Values.global.sbi.port }}/nnrf-nfm/v1/nf-instances
+{{ if not .Values.hnetKeys.existingSecret }}
+ACTION REQUIRED — SUCI de-concealment keys are not installed.
+
+The UDM mounts Secret "{{ .Release.Name }}-udm-hnet-keys" (optional), which this
+chart cannot create: the keys live outside the chart directory and Helm's
+.Files.Get cannot read above the chart root. Until it exists the null
+protection scheme works but ECIES profile A/B fails to de-conceal a SUCI.
+
+From the repo root, using the DEVELOPMENT keys (replace for real use):
+
+  kubectl create secret generic {{ .Release.Name }}-udm-hnet-keys \
+    --namespace {{ .Release.Namespace }} \
+    --from-file=curve25519-1.key=docker/rust/configs/5gc/hnet/curve25519-1.key \
+    --from-file=secp256r1-2.key=docker/rust/configs/5gc/hnet/secp256r1-2.key
+
+  kubectl rollout restart deploy/{{ .Release.Name }}-udm -n {{ .Release.Namespace }}
+{{- end }}
+{{- if and .Values.upf.enabled .Values.upf.dataPlane.enabled }}
+
+The UPF runs privileged with runAsUser 0 and hostPath {{ .Values.upf.dataPlane.hostPathTun }}.
+That requires a namespace at pod-security enforce=privileged:
+
+  kubectl label namespace {{ .Release.Namespace }} \
+    pod-security.kubernetes.io/enforce=privileged --overwrite
+
+If the UPF crash-loops with "refusing to start without a data plane", the node
+cannot give it a TUN device (common on Kind/Docker Desktop macOS). To run
+control-plane-only ON PURPOSE — no user plane, a UE ping will not work:
+
+  helm upgrade {{ .Release.Name }} <chart> --set upf.dataPlane.enabled=false
+{{- end }}
+{{- if not .Values.mongodb.persistence.enabled }}
+
+WARNING: mongodb.persistence.enabled=false — MongoDB is on an emptyDir and
+subscriber data is LOST on pod restart.
+{{- end }}

--- a/deploy/helm/nextgcore/templates/_helpers.tpl
+++ b/deploy/helm/nextgcore/templates/_helpers.tpl
@@ -27,3 +27,183 @@ NF image reference
 {{ .nf.image.repository }}:{{ .nf.image.tag }}
 {{- end -}}
 {{- end }}
+
+{{/*
+Name of the ConfigMap carrying every NF config.
+*/}}
+{{- define "nextgcore.configMapName" -}}
+{{ .Release.Name }}-configs
+{{- end }}
+
+{{/*
+In-cluster host of the NRF Service. Release-scoped, so two releases in one
+namespace do not cross-register.
+*/}}
+{{- define "nextgcore.nrfHost" -}}
+{{ .Release.Name }}-nrf.{{ .Release.Namespace }}.svc.cluster.local
+{{- end }}
+
+{{- define "nextgcore.nrfUri" -}}
+{{ .Values.global.sbi.scheme }}://{{ include "nextgcore.nrfHost" . }}:{{ .Values.global.sbi.port }}
+{{- end }}
+
+{{/*
+MongoDB connection URI. Points at the in-chart StatefulSet unless the operator
+overrides mongodb.externalUri.
+*/}}
+{{- define "nextgcore.dbUri" -}}
+{{- if .Values.mongodb.externalUri -}}
+{{ .Values.mongodb.externalUri }}
+{{- else -}}
+mongodb://{{ .Release.Name }}-mongodb.{{ .Release.Namespace }}.svc.cluster.local:27017/{{ .Values.mongodb.database }}
+{{- end -}}
+{{- end }}
+
+{{/*
+initContainer that rewrites the NF's advertised SBI address from 0.0.0.0 to the
+pod IP.
+
+WHY: configmap.yaml sets sbi.server[0].address to 0.0.0.0, and that one value
+feeds BOTH the listen socket and the ipv4Addresses registered with the NRF. The
+bind address must stay 0.0.0.0 inside a pod, but an NFProfile advertising
+0.0.0.0 hands every consumer an address it cannot dial -- discovery "succeeds"
+and the call fails. A ConfigMap mount is read-only and the pod IP is unknown
+until scheduling, so the rewritten copy lands in an emptyDir.
+
+Call with a dict: {{ include "nextgcore.advertiseInit" (dict "nf" "ausf") }}
+The AMF does NOT use this -- it reads AMF_SBI_ADDR from the environment
+(amfd/src/lib.rs:811) and never consults its YAML for the profile.
+*/}}
+{{- define "nextgcore.advertiseInit" -}}
+- name: rewrite-advertise-addr
+  image: busybox:1.36
+  env:
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: NF_NAME
+      value: {{ .nf }}
+  command:
+    - sh
+    - -c
+    - |
+      set -eu
+      echo "[advertise] pod IP: $POD_IP"
+      case "$POD_IP" in
+        *[0-9].[0-9]*) ;;
+        *) echo "[advertise] FATAL: POD_IP is not IPv4: '$POD_IP'" >&2; exit 1 ;;
+      esac
+      cp "/tmp/config-template/${NF_NAME}.yaml" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+      sed -i "s|^\( *- address:\) *0\.0\.0\.0 *$|\1 $POD_IP|" "/etc/nextgcore-resolved/${NF_NAME}.yaml"
+      if grep -qE '^ *- address: *0\.0\.0\.0 *$' "/etc/nextgcore-resolved/${NF_NAME}.yaml"; then
+        echo "[advertise] FATAL: a 0.0.0.0 advertise address survived" >&2
+        exit 1
+      fi
+      echo "[advertise] ${NF_NAME}.yaml advertise address set to $POD_IP"
+  volumeMounts:
+    - name: config
+      mountPath: /tmp/config-template
+      readOnly: true
+    - name: config-resolved
+      mountPath: /etc/nextgcore-resolved
+{{- end }}
+
+{{/*
+initContainer that blocks until the NRF SBI port accepts a connection. Every NF
+registers with the NRF at startup, and a failed registration is not retried.
+*/}}
+{{- define "nextgcore.waitForNrf" -}}
+- name: wait-nrf
+  image: busybox:1.36
+  command:
+    - sh
+    - -c
+    - |
+      until nc -z {{ include "nextgcore.nrfHost" . }} {{ .Values.global.sbi.port }}; do
+        echo "waiting for nrf"
+        sleep 2
+      done
+{{- end }}
+
+{{/*
+initContainer that blocks until MongoDB accepts a connection.
+*/}}
+{{- define "nextgcore.waitForMongo" -}}
+- name: wait-mongodb
+  image: busybox:1.36
+  command:
+    - sh
+    - -c
+    - |
+      until nc -z {{ .Release.Name }}-mongodb.{{ .Release.Namespace }}.svc.cluster.local 27017; do
+        echo "waiting for mongodb"
+        sleep 2
+      done
+{{- end }}
+
+{{/*
+The two volumes every config-driven NF needs: the ConfigMap template and the
+emptyDir the rewritten copy lands in.
+*/}}
+{{- define "nextgcore.configVolumes" -}}
+- name: config
+  configMap:
+    name: {{ include "nextgcore.configMapName" . }}
+- name: config-resolved
+  emptyDir: {}
+- name: logs
+  emptyDir: {}
+{{- end }}
+
+{{/*
+Config + log mounts for an NF container. The config mount points at the
+REWRITTEN copy, never the raw ConfigMap.
+*/}}
+{{- define "nextgcore.configMounts" -}}
+{{/*
+`rewritten` selects the source volume and MUST match whether this NF has the
+rewrite-advertise-addr initContainer:
+
+  rewritten=true  -> config-resolved (the emptyDir the initContainer fills)
+  rewritten=false -> config          (the ConfigMap itself)
+
+Getting this wrong fails silently and confusingly: mounting config-resolved
+with a subPath when nothing populated the emptyDir makes kubelet create an
+empty DIRECTORY at that path, and the NF logs
+"Could not read config file: Is a directory (os error 21). Using defaults."
+then runs on defaults and never registers. Observed on the AMF.
+*/}}
+{{- if .rewritten }}
+- name: config-resolved
+{{- else }}
+- name: config
+{{- end }}
+  mountPath: /etc/nextgcore/{{ .nf }}.yaml
+  subPath: {{ .nf }}.yaml
+  readOnly: true
+- name: logs
+  mountPath: /var/log/nextgcore
+{{- end }}
+
+{{/*
+tcpSocket probes on the SBI port.
+
+NEVER httpGet: nextgcore-sbi builds its server with hyper's http2::Builder only
+(h2c prior knowledge, no HTTP/1.1 fallback, no ALPN), so kubelet's HTTP/1.1
+probe can never succeed. /health and /ready exist but are unreachable from
+kubelet, and the failing liveness probe SIGKILLs a healthy NF roughly every
+90s. The chart used to do exactly this on 9 of its NFs.
+*/}}
+{{- define "nextgcore.sbiProbes" -}}
+readinessProbe:
+  tcpSocket:
+    port: sbi
+  initialDelaySeconds: 5
+  periodSeconds: 10
+livenessProbe:
+  tcpSocket:
+    port: sbi
+  initialDelaySeconds: 15
+  periodSeconds: 30
+{{- end }}

--- a/deploy/helm/nextgcore/templates/amf.yaml
+++ b/deploy/helm/nextgcore/templates/amf.yaml
@@ -19,11 +19,16 @@ spec:
       labels:
         app.kubernetes.io/name: amf
         app.kubernetes.io/instance: {{ .Release.Name }}-amf
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        {{- include "nextgcore.waitForNrf" . | nindent 8 }}
       containers:
         - name: amf
-          image: {{ .Values.amf.image.repository }}:{{ .Values.amf.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.amf) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args: ["-c", "/etc/nextgcore/amf.yaml"]
           ports:
             - name: sbi
               containerPort: {{ .Values.amf.service.sbiPort }}
@@ -42,25 +47,40 @@ spec:
               containerPort: {{ .Values.amf.metrics.port }}
               protocol: TCP
             {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "amf" "rewritten" false) | nindent 12 }}
           env:
             - name: RUST_LOG
-              value: info,nextgcore_amfd=debug
-            - name: NRF_SBI_ADDR
-              value: {{ .Release.Name }}-nrf
-            - name: NRF_SBI_PORT
-              value: "{{ .Values.global.sbi.port }}"
+              value: {{ .Values.global.logLevel }}
+            # The pod IP, NOT 0.0.0.0. The AMF is the one NF that takes its SBI
+            # address from the environment (nextgcore-amfd/src/lib.rs:811) and
+            # uses it for BOTH the listen socket and the ipv4Addresses it
+            # registers with the NRF -- it never reads sbi.server[0].address
+            # from its YAML, so the rewrite-advertise-addr initContainer the
+            # other NFs use cannot help it. With 0.0.0.0 the AMF advertised an
+            # unusable endpoint and, resolving peers through discovery, dialled
+            # 0.0.0.0:7777 -- itself -- getting 404 from its own SBI router and
+            # failing every registration.
+            - name: AMF_SBI_ADDR
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # Peer fallbacks for when discovery has not populated a peer yet.
+            # SMF_SBI_ADDR is not merely a fallback: the SM-context-update path
+            # reads it from env directly (ngap_path.rs:5054), so it must be a
+            # routable Service name or the gNB's downlink TEID never reaches
+            # the SMF.
+            - name: SMF_SBI_ADDR
+              value: {{ .Release.Name }}-smf.{{ .Release.Namespace }}.svc.cluster.local
+            - name: SMF_SBI_PORT
+              value: "{{ .Values.smf.service.sbiPort }}"
+            - name: AUSF_SBI_ADDR
+              value: {{ .Release.Name }}-ausf.{{ .Release.Namespace }}.svc.cluster.local
+            - name: AUSF_SBI_PORT
+              value: "{{ .Values.ausf.service.port }}"
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service
@@ -70,7 +90,15 @@ metadata:
     app.kubernetes.io/name: amf
     {{- include "nextgcore.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.amf.service.headless }}
+  # Headless: N2/NGAP is userspace SCTP over UDP. kube-proxy balances UDP
+  # per-flow with a conntrack timeout, which breaks a long-lived NGAP
+  # association, and the gNB must reach the specific pod holding its UE
+  # contexts. Matches deploy/eks/patches/headless-services.yaml.
+  clusterIP: None
+  {{- else }}
   type: {{ .Values.amf.service.type }}
+  {{- end }}
   ports:
     - port: {{ .Values.amf.service.sbiPort }}
       targetPort: sbi

--- a/deploy/helm/nextgcore/templates/ausf.yaml
+++ b/deploy/helm/nextgcore/templates/ausf.yaml
@@ -19,34 +19,36 @@ spec:
       labels:
         app.kubernetes.io/name: ausf
         app.kubernetes.io/instance: {{ .Release.Name }}-ausf
+      annotations:
+        # Roll the pods when the rendered config changes; without this a
+        # `helm upgrade` that only edits the ConfigMap leaves the old config
+        # running, since the Deployment spec is unchanged.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        {{- include "nextgcore.advertiseInit" (dict "nf" "ausf") | nindent 8 }}
+        {{- include "nextgcore.waitForNrf" . | nindent 8 }}
       containers:
         - name: ausf
-          image: {{ .Values.ausf.image.repository }}:{{ .Values.ausf.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.ausf) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args: ["-c", "/etc/nextgcore/ausf.yaml"]
           ports:
             - name: sbi
               containerPort: {{ .Values.ausf.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "ausf" "rewritten" true) | nindent 12 }}
           env:
             - name: RUST_LOG
-              value: info
-            - name: NRF_SBI_ADDR
-              value: {{ .Release.Name }}-nrf
-            - name: NRF_SBI_PORT
-              value: "{{ .Values.global.sbi.port }}"
+              value: {{ .Values.global.logLevel }}
+            - name: UDM_SBI_ADDR
+              value: {{ .Release.Name }}-udm.{{ .Release.Namespace }}.svc.cluster.local
+            - name: UDM_SBI_PORT
+              value: "{{ .Values.udm.service.port }}"
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/nextgcore/templates/bsf.yaml
+++ b/deploy/helm/nextgcore/templates/bsf.yaml
@@ -19,34 +19,33 @@ spec:
       labels:
         app.kubernetes.io/name: bsf
         app.kubernetes.io/instance: {{ .Release.Name }}-bsf
+      annotations:
+        # Roll the pods when the rendered config changes; without this a
+        # `helm upgrade` that only edits the ConfigMap leaves the old config
+        # running, since the Deployment spec is unchanged.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        {{- include "nextgcore.advertiseInit" (dict "nf" "bsf") | nindent 8 }}
+        {{- include "nextgcore.waitForNrf" . | nindent 8 }}
+        {{- include "nextgcore.waitForMongo" . | nindent 8 }}
       containers:
         - name: bsf
-          image: {{ .Values.bsf.image.repository }}:{{ .Values.bsf.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.bsf) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args: ["-c", "/etc/nextgcore/bsf.yaml"]
           ports:
             - name: sbi
               containerPort: {{ .Values.bsf.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "bsf" "rewritten" true) | nindent 12 }}
           env:
             - name: RUST_LOG
-              value: info
-            - name: NRF_SBI_ADDR
-              value: {{ .Release.Name }}-nrf
-            - name: NRF_SBI_PORT
-              value: "{{ .Values.global.sbi.port }}"
+              value: {{ .Values.global.logLevel }}
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/nextgcore/templates/configmap.yaml
+++ b/deploy/helm/nextgcore/templates/configmap.yaml
@@ -1,0 +1,287 @@
+{{/*
+Per-NF configuration, mirroring k8s/manifests/configmap.yaml.
+
+The chart previously mounted NOTHING, so every NF fell back to the image
+default `-c /etc/nextgcore/nf.yaml` (Dockerfile.nf:28) -- a path that does not
+exist in the image. Each Deployment now mounts its own key from here at
+/etc/nextgcore/<nf>.yaml and passes it explicitly via args.
+
+`address: 0.0.0.0` is the BIND address and is correct inside a pod. It is also
+what the NF registers with the NRF, which is NOT correct -- the
+rewrite-advertise-addr initContainer rewrites it to the pod IP before the NF
+starts. See _helpers.tpl "nextgcore.advertiseInit".
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nextgcore.configMapName" . }}
+  labels:
+    {{- include "nextgcore.labels" . | nindent 4 }}
+data:
+  nrf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/nrf.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    nrf:
+      serving:
+        - plmn_id:
+            mcc: {{ .Values.global.plmn.mcc }}
+            mnc: {{ .Values.global.plmn.mnc }}
+      sbi:
+        server:
+          - address: 0.0.0.0
+            advertise: {{ include "nextgcore.nrfHost" . }}
+            port: {{ .Values.global.sbi.port }}
+
+  amf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/amf.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    amf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.global.sbi.port }}
+        client:
+          nrf:
+            - uri: {{ include "nextgcore.nrfUri" . }}
+      ngap:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.amf.service.ngapPort }}
+      metrics:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.amf.metrics.port }}
+      guami:
+        - plmn_id:
+            mcc: {{ .Values.global.plmn.mcc }}
+            mnc: {{ .Values.global.plmn.mnc }}
+          amf_id:
+            region: {{ .Values.amf.config.amfId.region }}
+            set: {{ .Values.amf.config.amfId.set }}
+      tai:
+        - plmn_id:
+            mcc: {{ .Values.global.plmn.mcc }}
+            mnc: {{ .Values.global.plmn.mnc }}
+          tac: {{ .Values.amf.config.tai.tac }}
+      plmn_support:
+        - plmn_id:
+            mcc: {{ .Values.global.plmn.mcc }}
+            mnc: {{ .Values.global.plmn.mnc }}
+          s_nssai:
+            {{- toYaml .Values.amf.config.nssai | nindent 12 }}
+      security:
+        integrity_order: [NIA2, NIA1, NIA0]
+        ciphering_order: [NEA0, NEA1, NEA2]
+      network_name:
+        full: NextGCore
+        short: Next
+      amf_name: nextgcore-amf0
+      time:
+        t3512:
+          value: {{ .Values.amf.config.t3512 }}
+
+  smf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/smf.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    smf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.global.sbi.port }}
+        client:
+          nrf:
+            - uri: {{ include "nextgcore.nrfUri" . }}
+      pfcp:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.smf.service.pfcpPort }}
+        client:
+          upf:
+            - address: {{ .Release.Name }}-upf
+      gtpc:
+        server:
+          - address: 0.0.0.0
+      gtpu:
+        server:
+          - address: 0.0.0.0
+      metrics:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.smf.metrics.port }}
+      session:
+        {{- toYaml .Values.global.session | nindent 8 }}
+      dns:
+        {{- toYaml .Values.smf.config.dns | nindent 8 }}
+      mtu: {{ .Values.smf.config.mtu }}
+
+  upf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/upf.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    upf:
+      pfcp:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.upf.service.pfcpPort }}
+      gtpu:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.upf.service.gtpuPort }}
+      session:
+        {{- range .Values.global.session }}
+        - subnet: {{ .subnet }}
+          gateway: {{ .gateway }}
+          dev: {{ $.Values.upf.config.tunDevice }}
+        {{- end }}
+      metrics:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.upf.metrics.port }}
+
+  ausf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/ausf.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    ausf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.global.sbi.port }}
+        client:
+          nrf:
+            - uri: {{ include "nextgcore.nrfUri" . }}
+
+  udm.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/udm.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    udm:
+      hnet:
+        - id: 1
+          scheme: 1
+          key: /etc/nextgcore/hnet/curve25519-1.key
+        - id: 2
+          scheme: 2
+          key: /etc/nextgcore/hnet/secp256r1-2.key
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.global.sbi.port }}
+        client:
+          nrf:
+            - uri: {{ include "nextgcore.nrfUri" . }}
+
+  udr.yaml: |
+    db_uri: {{ include "nextgcore.dbUri" . }}
+    logger:
+      file:
+        path: /var/log/nextgcore/udr.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    udr:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.global.sbi.port }}
+        client:
+          nrf:
+            - uri: {{ include "nextgcore.nrfUri" . }}
+
+  pcf.yaml: |
+    db_uri: {{ include "nextgcore.dbUri" . }}
+    logger:
+      file:
+        path: /var/log/nextgcore/pcf.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    pcf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.global.sbi.port }}
+        client:
+          nrf:
+            - uri: {{ include "nextgcore.nrfUri" . }}
+      metrics:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.pcf.metrics.port }}
+
+  nssf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/nssf.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    nssf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.global.sbi.port }}
+        client:
+          nrf:
+            - uri: {{ include "nextgcore.nrfUri" . }}
+          nsi:
+            - uri: {{ include "nextgcore.nrfUri" . }}
+              s_nssai:
+                sst: 1
+
+  bsf.yaml: |
+    logger:
+      file:
+        path: /var/log/nextgcore/bsf.log
+      level: {{ .Values.global.logLevel }}
+    global:
+      max:
+        ue: {{ .Values.global.max.ue }}
+        peer: {{ .Values.global.max.peer }}
+    bsf:
+      sbi:
+        server:
+          - address: 0.0.0.0
+            port: {{ .Values.global.sbi.port }}
+        client:
+          nrf:
+            - uri: {{ include "nextgcore.nrfUri" . }}

--- a/deploy/helm/nextgcore/templates/mongodb-init.yaml
+++ b/deploy/helm/nextgcore/templates/mongodb-init.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.mongodb.init.enabled }}
+{{/*
+Gated on init.enabled ALONE, not on mongodb.enabled: an external MongoDB
+(mongodb.enabled=false + externalUri) still needs its subscribers seeded, and
+gating on both silently skipped the seed and left registration failing with an
+empty subscriber collection. The wait-for-mongo initContainer is only added for
+the in-chart StatefulSet, whose host this chart knows.
+*/}}
+{{/*
+Seeds subscribers and indexes. Without this the subscriber DB is empty and
+registration cannot succeed -- the chart previously pointed the UDR at MongoDB
+with no init Job at all.
+
+Every write is an upsert, not an insert: this Job is re-applied by every
+`helm upgrade`, and insertOne against the unique username index aborted the
+script with "E11000 duplicate key error ... username: admin", CrashLoopBackOff-
+ing the Job even though the seed data was already correct. $setOnInsert so a
+re-run never overwrites a changed password.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-mongodb-init-scripts
+  labels:
+    {{- include "nextgcore.labels" . | nindent 4 }}
+data:
+  mongo-init.js: |
+    db = db.getSiblingDB('{{ .Values.mongodb.database }}');
+    db.nfInstances.createIndex({ "nfInstanceId": 1 }, { unique: true });
+    db.nfInstances.createIndex({ "nfType": 1 });
+    db.nfInstances.createIndex({ "nfStatus": 1 });
+    db.subscribers.createIndex({ "imsi": 1 }, { unique: true });
+    db.sessions.createIndex({ "supi": 1 });
+    db.policyData.createIndex({ "supi": 1 });
+    db.accounts.createIndex({ "username": 1 }, { unique: true });
+    db.accounts.updateOne(
+        { username: "admin" },
+        { $setOnInsert: {
+            username: "admin",
+            password: "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy",
+            roles: ["admin"],
+            created: new Date()
+        } },
+        { upsert: true }
+    );
+    db.subscribers.updateOne({ imsi: "{{ .Values.subscriber.imsi }}" }, { $setOnInsert: {
+        imsi: "{{ .Values.subscriber.imsi }}",
+        security: {
+            k: "{{ .Values.subscriber.key }}",
+            opc: "{{ .Values.subscriber.opc }}",
+            amf: "{{ .Values.subscriber.amf }}"
+        },
+        ambr: {
+            uplink: { value: 1, unit: 3 },
+            downlink: { value: 1, unit: 3 }
+        },
+        slice: [{
+            sst: {{ .Values.subscriber.sst }},
+            default_indicator: true,
+            session: [{
+                name: "{{ .Values.subscriber.dnn }}",
+                type: 3,
+                qos: { index: 9, arp: { priority_level: 8, pre_emption_capability: 1, pre_emption_vulnerability: 1 } },
+                ambr: { uplink: { value: 1, unit: 3 }, downlink: { value: 1, unit: 3 } }
+            }]
+        }],
+        access_restriction_data: 32,
+        subscriber_status: 0,
+        network_access_mode: 0,
+        subscribed_rau_tau_timer: 12,
+        created: new Date()
+    } }, { upsert: true });
+    print("NextGCore MongoDB initialization completed.");
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-mongodb-init
+  labels:
+    {{- include "nextgcore.labels" . | nindent 4 }}
+  annotations:
+    # Runs on install AND upgrade: the seed is idempotent, and an upgrade that
+    # changes values.subscriber must reach the database.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "nextgcore.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      {{- if .Values.mongodb.enabled }}
+      initContainers:
+        {{- include "nextgcore.waitForMongo" . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: init
+          image: {{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}
+          command:
+            - mongosh
+            - {{ include "nextgcore.dbUri" . }}
+            - /scripts/mongo-init.js
+          volumeMounts:
+            - name: init-scripts
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: {{ .Release.Name }}-mongodb-init-scripts
+{{- end }}

--- a/deploy/helm/nextgcore/templates/mongodb.yaml
+++ b/deploy/helm/nextgcore/templates/mongodb.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.mongodb.enabled }}
+{{/*
+Templated directly rather than pulled from charts.bitnami.com: the chart must
+render offline (see Chart.yaml). Mirrors k8s/manifests/mongodb.yaml.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-mongodb
+  labels:
+    app.kubernetes.io/name: mongodb
+    {{- include "nextgcore.labels" . | nindent 4 }}
+spec:
+  # Headless: a StatefulSet needs stable per-pod DNS, and the NFs address
+  # MongoDB directly rather than through a load-balanced VIP.
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/instance: {{ .Release.Name }}-mongodb
+  ports:
+    - port: 27017
+      targetPort: 27017
+      protocol: TCP
+      name: mongodb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-mongodb
+  labels:
+    app.kubernetes.io/name: mongodb
+    {{- include "nextgcore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Release.Name }}-mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mongodb
+      app.kubernetes.io/instance: {{ .Release.Name }}-mongodb
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mongodb
+        app.kubernetes.io/instance: {{ .Release.Name }}-mongodb
+        {{- include "nextgcore.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: mongodb
+          image: {{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          ports:
+            - name: mongodb
+              containerPort: 27017
+          env:
+            - name: MONGO_INITDB_DATABASE
+              value: {{ .Values.mongodb.database }}
+          resources:
+            {{- toYaml .Values.mongodb.resources | nindent 12 }}
+          volumeMounts:
+            - name: mongodb-data
+              mountPath: /data/db
+          readinessProbe:
+            exec:
+              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+{{- if .Values.mongodb.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: mongodb-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.mongodb.persistence.storageClass }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.mongodb.persistence.size }}
+{{- else }}
+      # persistence.enabled=false: emptyDir, so DATA IS LOST on pod restart.
+      # Needed on clusters with no CSI driver, where a PVC would stay Pending.
+      volumes:
+        - name: mongodb-data
+          emptyDir: {}
+{{- end }}
+{{- end }}

--- a/deploy/helm/nextgcore/templates/nrf.yaml
+++ b/deploy/helm/nextgcore/templates/nrf.yaml
@@ -19,11 +19,18 @@ spec:
       labels:
         app.kubernetes.io/name: nrf
         app.kubernetes.io/instance: {{ .Release.Name }}-nrf
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.mongodb.enabled }}
+      initContainers:
+        {{- include "nextgcore.waitForMongo" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: nrf
-          image: {{ .Values.nrf.image.repository }}:{{ .Values.nrf.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.nrf) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args: ["-c", "/etc/nextgcore/nrf.yaml"]
           ports:
             - name: sbi
               containerPort: {{ .Values.nrf.service.port }}
@@ -33,21 +40,14 @@ spec:
               containerPort: {{ .Values.nrf.metrics.port }}
               protocol: TCP
             {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "nrf" "rewritten" false) | nindent 12 }}
           env:
             - name: RUST_LOG
-              value: info
+              value: {{ .Values.global.logLevel }}
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/nextgcore/templates/nssf.yaml
+++ b/deploy/helm/nextgcore/templates/nssf.yaml
@@ -19,34 +19,32 @@ spec:
       labels:
         app.kubernetes.io/name: nssf
         app.kubernetes.io/instance: {{ .Release.Name }}-nssf
+      annotations:
+        # Roll the pods when the rendered config changes; without this a
+        # `helm upgrade` that only edits the ConfigMap leaves the old config
+        # running, since the Deployment spec is unchanged.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        {{- include "nextgcore.advertiseInit" (dict "nf" "nssf") | nindent 8 }}
+        {{- include "nextgcore.waitForNrf" . | nindent 8 }}
       containers:
         - name: nssf
-          image: {{ .Values.nssf.image.repository }}:{{ .Values.nssf.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.nssf) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args: ["-c", "/etc/nextgcore/nssf.yaml"]
           ports:
             - name: sbi
               containerPort: {{ .Values.nssf.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "nssf" "rewritten" true) | nindent 12 }}
           env:
             - name: RUST_LOG
-              value: info
-            - name: NRF_SBI_ADDR
-              value: {{ .Release.Name }}-nrf
-            - name: NRF_SBI_PORT
-              value: "{{ .Values.global.sbi.port }}"
+              value: {{ .Values.global.logLevel }}
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/nextgcore/templates/pcf.yaml
+++ b/deploy/helm/nextgcore/templates/pcf.yaml
@@ -19,34 +19,36 @@ spec:
       labels:
         app.kubernetes.io/name: pcf
         app.kubernetes.io/instance: {{ .Release.Name }}-pcf
+      annotations:
+        # Roll the pods when the rendered config changes; without this a
+        # `helm upgrade` that only edits the ConfigMap leaves the old config
+        # running, since the Deployment spec is unchanged.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        {{- include "nextgcore.advertiseInit" (dict "nf" "pcf") | nindent 8 }}
+        {{- include "nextgcore.waitForNrf" . | nindent 8 }}
+        {{- include "nextgcore.waitForMongo" . | nindent 8 }}
       containers:
         - name: pcf
-          image: {{ .Values.pcf.image.repository }}:{{ .Values.pcf.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.pcf) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args: ["-c", "/etc/nextgcore/pcf.yaml"]
           ports:
             - name: sbi
               containerPort: {{ .Values.pcf.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            - name: metrics
+              containerPort: {{ .Values.pcf.metrics.port }}
+              protocol: TCP
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "pcf" "rewritten" true) | nindent 12 }}
           env:
             - name: RUST_LOG
-              value: info
-            - name: NRF_SBI_ADDR
-              value: {{ .Release.Name }}-nrf
-            - name: NRF_SBI_PORT
-              value: "{{ .Values.global.sbi.port }}"
+              value: {{ .Values.global.logLevel }}
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service
@@ -62,6 +64,10 @@ spec:
       targetPort: sbi
       protocol: TCP
       name: sbi
+    - port: {{ .Values.pcf.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
   selector:
     app.kubernetes.io/name: pcf
     app.kubernetes.io/instance: {{ .Release.Name }}-pcf

--- a/deploy/helm/nextgcore/templates/smf.yaml
+++ b/deploy/helm/nextgcore/templates/smf.yaml
@@ -19,11 +19,69 @@ spec:
       labels:
         app.kubernetes.io/name: smf
         app.kubernetes.io/instance: {{ .Release.Name }}-smf
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        {{- include "nextgcore.advertiseInit" (dict "nf" "smf") | nindent 8 }}
+        {{- include "nextgcore.waitForNrf" . | nindent 8 }}
+        {{- if .Values.upf.enabled }}
+        # The SMF needs the UPF's PFCP endpoint as an IP: PFCP is UDP and the
+        # SMF resolves its peer once at startup. Only the UPF *Service* has to
+        # exist for this to resolve -- not a ready UPF pod -- so this does not
+        # deadlock against the UPF's own startup.
+        - name: resolve-upf
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[resolve-upf] resolving UPF PFCP address..."
+              i=0
+              while [ "$i" -lt 60 ]; do
+                # busybox has no getent, so nslookup is the only resolver here.
+                # Anchoring on ^Name: first and only then taking the following
+                # Address: skips the "Server:/Address: <dns-ip>:53" preamble --
+                # a plain `grep Address` returns the DNS server's own IP.
+                IP=$(nslookup {{ .Release.Name }}-upf.{{ .Release.Namespace }}.svc.cluster.local 2>/dev/null \
+                     | awk '/^Name:/{n=1;next} n&&/^Address( 1)?:/{print $NF; exit}')
+                case "$IP" in
+                  *.*.*.*) break ;;
+                esac
+                i=$((i+1))
+                echo "[resolve-upf] waiting for UPF DNS ($i/60)"
+                sleep 2
+              done
+              case "$IP" in
+                *[0-9].[0-9]*) ;;
+                *) echo "[resolve-upf] FATAL: could not resolve UPF to an IPv4 address" >&2; exit 1 ;;
+              esac
+              echo "[resolve-upf] UPF=$IP"
+              printf '%s' "$IP" > /shared/upf-ip
+          volumeMounts:
+            - name: resolved
+              mountPath: /shared
+        {{- end }}
       containers:
         - name: smf
-          image: {{ .Values.smf.image.repository }}:{{ .Values.smf.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.smf) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- if .Values.upf.enabled }}
+          # UPF_PFCP_ADDR is overridden from the resolved file before exec.
+          # `exec` matters: the SMF must stay PID 1 so it receives SIGTERM
+          # directly and the container's exit status is the SMF's.
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              UPF_PFCP_ADDR="$(cat /shared/upf-ip)"
+              export UPF_PFCP_ADDR
+              echo "[smf] UPF_PFCP_ADDR=${UPF_PFCP_ADDR}"
+              exec /usr/local/bin/nf-binary -c /etc/nextgcore/smf.yaml
+          {{- else }}
+          args: ["-c", "/etc/nextgcore/smf.yaml"]
+          {{- end }}
           ports:
             - name: sbi
               containerPort: {{ .Values.smf.service.sbiPort }}
@@ -36,25 +94,28 @@ spec:
               containerPort: {{ .Values.smf.metrics.port }}
               protocol: TCP
             {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "smf" "rewritten" true) | nindent 12 }}
+            {{- if .Values.upf.enabled }}
+            - name: resolved
+              mountPath: /shared
+            {{- end }}
           env:
             - name: RUST_LOG
-              value: info,nextgcore_smfd=debug
-            - name: NRF_SBI_ADDR
-              value: {{ .Release.Name }}-nrf
-            - name: NRF_SBI_PORT
-              value: "{{ .Values.global.sbi.port }}"
+              value: {{ .Values.global.logLevel }}
+            - name: RUST_BACKTRACE
+              value: "1"
+            - name: SMF_PFCP_ADDR
+              value: "0.0.0.0"
+            - name: UPF_PFCP_PORT
+              value: "{{ .Values.upf.service.pfcpPort }}"
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
+        {{- if .Values.upf.enabled }}
+        - name: resolved
+          emptyDir: {}
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -83,22 +144,4 @@ spec:
   selector:
     app.kubernetes.io/name: smf
     app.kubernetes.io/instance: {{ .Release.Name }}-smf
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-smf-config
-  labels:
-    app.kubernetes.io/name: smf
-    {{- include "nextgcore.labels" . | nindent 4 }}
-data:
-  nf.yaml: |
-    smf:
-      sbi:
-        addr: 0.0.0.0
-        port: {{ .Values.smf.service.sbiPort }}
-      pfcp:
-        port: {{ .Values.smf.service.pfcpPort }}
-      subnet: {{ .Values.smf.config.subnet }}
-      dnn: {{ .Values.smf.config.dnn }}
 {{- end }}

--- a/deploy/helm/nextgcore/templates/udm.yaml
+++ b/deploy/helm/nextgcore/templates/udm.yaml
@@ -19,34 +19,46 @@ spec:
       labels:
         app.kubernetes.io/name: udm
         app.kubernetes.io/instance: {{ .Release.Name }}-udm
+      annotations:
+        # Roll the pods when the rendered config changes; without this a
+        # `helm upgrade` that only edits the ConfigMap leaves the old config
+        # running, since the Deployment spec is unchanged.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        {{- include "nextgcore.advertiseInit" (dict "nf" "udm") | nindent 8 }}
+        {{- include "nextgcore.waitForNrf" . | nindent 8 }}
       containers:
         - name: udm
-          image: {{ .Values.udm.image.repository }}:{{ .Values.udm.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.udm) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args: ["-c", "/etc/nextgcore/udm.yaml"]
           ports:
             - name: sbi
               containerPort: {{ .Values.udm.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "udm" "rewritten" true) | nindent 12 }}
+            # SUCI de-concealment keys. optional: the null scheme works without
+            # them; ECIES profile A/B does not. Secret is created out-of-band
+            # (see NOTES.txt) because it lives outside the chart directory.
+            - name: hnet-keys
+              mountPath: /etc/nextgcore/hnet
+              readOnly: true
           env:
             - name: RUST_LOG
-              value: info
-            - name: NRF_SBI_ADDR
-              value: {{ .Release.Name }}-nrf
-            - name: NRF_SBI_PORT
-              value: "{{ .Values.global.sbi.port }}"
+              value: {{ .Values.global.logLevel }}
+            - name: UDR_SBI_ADDR
+              value: {{ .Release.Name }}-udr.{{ .Release.Namespace }}.svc.cluster.local
+            - name: UDR_SBI_PORT
+              value: "{{ .Values.udr.service.port }}"
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
+        - name: hnet-keys
+          secret:
+            secretName: {{ .Values.hnetKeys.existingSecret | default (printf "%s-udm-hnet-keys" .Release.Name) }}
+            optional: true
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/nextgcore/templates/udr.yaml
+++ b/deploy/helm/nextgcore/templates/udr.yaml
@@ -19,36 +19,33 @@ spec:
       labels:
         app.kubernetes.io/name: udr
         app.kubernetes.io/instance: {{ .Release.Name }}-udr
+      annotations:
+        # Roll the pods when the rendered config changes; without this a
+        # `helm upgrade` that only edits the ConfigMap leaves the old config
+        # running, since the Deployment spec is unchanged.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        {{- include "nextgcore.advertiseInit" (dict "nf" "udr") | nindent 8 }}
+        {{- include "nextgcore.waitForNrf" . | nindent 8 }}
+        {{- include "nextgcore.waitForMongo" . | nindent 8 }}
       containers:
         - name: udr
-          image: {{ .Values.udr.image.repository }}:{{ .Values.udr.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.udr) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          args: ["-c", "/etc/nextgcore/udr.yaml"]
           ports:
             - name: sbi
               containerPort: {{ .Values.udr.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: sbi
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: sbi
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          {{- include "nextgcore.sbiProbes" . | nindent 10 }}
+          volumeMounts:
+            {{- include "nextgcore.configMounts" (dict "nf" "udr" "rewritten" true) | nindent 12 }}
           env:
             - name: RUST_LOG
-              value: info
-            - name: NRF_SBI_ADDR
-              value: {{ .Release.Name }}-nrf
-            - name: NRF_SBI_PORT
-              value: "{{ .Values.global.sbi.port }}"
-            - name: MONGODB_URI
-              value: "mongodb://{{ .Release.Name }}-mongodb:27017/nextgcore"
+              value: {{ .Values.global.logLevel }}
+      volumes:
+        {{- include "nextgcore.configVolumes" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/nextgcore/templates/upf.yaml
+++ b/deploy/helm/nextgcore/templates/upf.yaml
@@ -1,4 +1,105 @@
 {{- if .Values.upf.enabled }}
+{{- $gw := (index .Values.global.session 0).gateway }}
+{{- $subnet := (index .Values.global.session 0).subnet }}
+{{- $tun := .Values.upf.config.tunDevice }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-upf-wrapper
+  labels:
+    app.kubernetes.io/name: upf
+    {{- include "nextgcore.labels" . | nindent 4 }}
+data:
+  wrapper.sh: |
+    #!/bin/sh
+    set -e
+    # Creates the TUN device the user plane forwards through, then execs the
+    # UPF with the addressing it must advertise. Ported from
+    # k8s/manifests/upf.yaml; the reasoning below is load-bearing, not
+    # decoration.
+    #
+    # The fallback to --no-dataplane is OPT-IN via UPF_ALLOW_NO_DATAPLANE=true.
+    # Without that flag a TUN failure is fatal, because a UPF that silently
+    # drops its user plane and still reports Ready is worse than one that does
+    # not start: the E2E suite skips the data-plane assertions and reports a
+    # pass.
+    if [ "$(id -u)" != "0" ]; then
+      echo "[wrapper] WARNING: running as uid $(id -u), not root."
+      echo "[wrapper] ip/iptables/sysctl need uid 0 even with NET_ADMIN/SYS_ADMIN"
+      echo "[wrapper] in the bounding set. Set runAsUser: 0 on this container."
+    fi
+    # Every step below is idempotent, because this script must survive a
+    # CONTAINER restart as well as a pod restart. A container restart reuses the
+    # pod's network namespace, so {{ $tun }} and the nat rules are still there
+    # from the previous run. An unguarded `ip tuntap add` then fails with
+    # "ioctl(TUNSETIFF): Device or resource busy", turning a recoverable
+    # restart into a CrashLoopBackOff.
+    if ip link show {{ $tun }} >/dev/null 2>&1; then
+      echo "[wrapper] {{ $tun }} already exists (container restart, netns retained) - reusing it"
+      TUN_OK=true
+    elif ip tuntap add name {{ $tun }} mode tun; then
+      echo "[wrapper] TUN device created successfully"
+      TUN_OK=true
+    else
+      TUN_OK=false
+    fi
+
+    if [ "${TUN_OK}" = "true" ]; then
+      # `|| true` on each: the address may already be assigned and the link may
+      # already be up from the previous container.
+      ip addr add {{ $gw }}/{{ (splitList "/" $subnet) | last }} dev {{ $tun }} 2>/dev/null || true
+      sysctl -w net.ipv6.conf.all.disable_ipv6=1 >/dev/null 2>&1 || true
+      ip link set {{ $tun }} up
+      sysctl -w net.ipv4.ip_forward=1 >/dev/null 2>&1 || true
+      # -C before -A to avoid appending a duplicate MASQUERADE on a container
+      # restart (the pod netns, and so the nat table, survives one). Not a
+      # flush: POSTROUTING is shared with kube-proxy's chains.
+      iptables -t nat -C POSTROUTING -s {{ $subnet }} ! -o {{ $tun }} -j MASQUERADE 2>/dev/null \
+        || iptables -t nat -A POSTROUTING -s {{ $subnet }} ! -o {{ $tun }} -j MASQUERADE 2>/dev/null \
+        || true
+      ip link show {{ $tun }} >/dev/null 2>&1 || {
+        echo "[wrapper] FATAL: {{ $tun }} vanished after configuration" >&2
+        exit 1
+      }
+      echo "[wrapper] TUN configured: {{ $tun }} {{ $gw }}, NAT enabled"
+      # --gtpu-addr is BOTH the bind address and the N3 endpoint the UPF
+      # advertises to the SMF in the PFCP F-TEID, which the SMF relays to the
+      # gNB in the NGAP PDU Session Resource Setup transfer.
+      #
+      # With 0.0.0.0 the gNB was told "UPF addr=0.0.0.0" and sent uplink G-PDUs
+      # to 0.0.0.0:2152, looping back into its own GTP-U socket -- it
+      # decapsulated its own transmission, {{ $tun }} stayed at 0 bytes and a UE
+      # ping got 100% loss.
+      if [ -z "${POD_IP}" ]; then
+        echo "[wrapper] FATAL: POD_IP is not set. Inject it with a fieldRef on" >&2
+        echo "[wrapper] status.podIP, or the gNB will be told to send uplink to" >&2
+        echo "[wrapper] 0.0.0.0 and the user plane will silently loop back." >&2
+        exit 1
+      fi
+      # --pfcp-addr must ALSO be the pod IP. The UPF derives its PFCP Node ID
+      # from the pfcp bind address, and that Node ID -- NOT --gtpu-addr -- is
+      # what it writes into the N3 F-TEID's IPv4 field in the Created PDR. So a
+      # 0.0.0.0 pfcp-addr made the gNB send uplink to 0.0.0.0 even with
+      # --gtpu-addr set correctly.
+      echo "[wrapper] advertising N3 (GTP-U) endpoint ${POD_IP}:{{ .Values.upf.service.gtpuPort }}, PFCP node ${POD_IP}"
+      exec /usr/local/bin/nf-binary -c /etc/nextgcore/upf.yaml --pfcp-addr "${POD_IP}" --gtpu-addr "${POD_IP}"
+    else
+      echo "[wrapper] TUN device creation failed (see the error above)."
+      if [ "${UPF_ALLOW_NO_DATAPLANE}" = "true" ]; then
+        echo "[wrapper] UPF_ALLOW_NO_DATAPLANE=true: starting control-plane-only (--no-dataplane)"
+        echo "[wrapper] GTP-U forwarding is DISABLED. A UE ping will not work."
+        exec /usr/local/bin/nf-binary -c /etc/nextgcore/upf.yaml --pfcp-addr 0.0.0.0 --gtpu-addr 0.0.0.0 --no-dataplane
+      fi
+      echo "[wrapper] FATAL: refusing to start without a data plane."
+      echo "[wrapper] Common causes:"
+      echo "[wrapper]   * container not running as uid 0 (need runAsUser: 0)"
+      echo "[wrapper]   * /dev/net/tun not present on the node"
+      echo "[wrapper]   * Pod Security Admission rejecting privileged (need enforce=privileged)"
+      echo "[wrapper]   * nested containers (Kind/Docker Desktop on macOS)"
+      echo "[wrapper] To run control-plane-only on purpose, set UPF_ALLOW_NO_DATAPLANE=true."
+      exit 1
+    fi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,15 +120,22 @@ spec:
       labels:
         app.kubernetes.io/name: upf
         app.kubernetes.io/instance: {{ .Release.Name }}-upf
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      # No wait-smf initContainer, deliberately: the SMF initiates the PFCP
+      # Association Setup and retries on a timer, so the UPF only has to be
+      # listening. A wait here deadlocks -- the SMF's resolve-upf waits on UPF
+      # DNS, which a headless Service only publishes once a UPF pod is Ready.
+      {{- with .Values.upf.dataPlane.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: upf
-          image: {{ .Values.upf.image.repository }}:{{ .Values.upf.image.tag }}
+          image: {{ include "nextgcore.image" (dict "global" .Values.global "nf" .Values.upf) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- with .Values.upf.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          command: ["/bin/sh", "/scripts/wrapper.sh"]
           ports:
             - name: pfcp
               containerPort: {{ .Values.upf.service.pfcpPort }}
@@ -35,13 +143,87 @@ spec:
             - name: gtpu
               containerPort: {{ .Values.upf.service.gtpuPort }}
               protocol: UDP
+            {{- if .Values.upf.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.upf.metrics.port }}
+              protocol: TCP
+            {{- end }}
           env:
             - name: RUST_LOG
-              value: info,nextgcore_upfd=debug
-            - name: TUN_IP
-              value: "{{ .Values.upf.config.tunIp }}"
-            - name: TUN_PREFIX
-              value: "{{ .Values.upf.config.tunPrefix }}"
+              value: {{ .Values.global.logLevel }}
+            - name: RUST_BACKTRACE
+              value: "1"
+            # Consumed by wrapper.sh as --gtpu-addr AND --pfcp-addr: the N3
+            # endpoint the UPF advertises to the SMF, and thence to the gNB.
+            # Must be a routable address, not 0.0.0.0.
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: UPF_ALLOW_NO_DATAPLANE
+              value: "{{ not .Values.upf.dataPlane.enabled }}"
+          {{- if .Values.upf.dataPlane.enabled }}
+          securityContext:
+            privileged: true
+            # Required, not optional. Dockerfile.core ends with
+            # `USER nextgcore`, and capabilities in the bounding set are not
+            # usable by a non-root uid without file capabilities on the
+            # binaries -- so ip/iptables/sysctl all fail without this and
+            # wrapper.sh cannot create the TUN device. The chart used to grant
+            # privileged+NET_ADMIN while omitting runAsUser, the TUN device and
+            # the wrapper: all the privilege, none of the mechanism.
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_ADMIN
+          {{- end }}
+          # Asserts the data plane is actually up, not merely that the process
+          # exists. If the TUN device is missing the pod must not be Ready,
+          # otherwise dependents proceed against a UPF that cannot forward.
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - '[ "${UPF_ALLOW_NO_DATAPLANE}" = "true" ] || ip link show {{ $tun }} >/dev/null 2>&1'
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nextgcore/upf.yaml
+              subPath: upf.yaml
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/nextgcore
+            {{- if .Values.upf.dataPlane.enabled }}
+            - name: dev-tun
+              mountPath: /dev/net/tun
+            {{- end }}
+            - name: wrapper
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        # The UPF mounts the RAW ConfigMap, not the rewritten copy: it takes its
+        # advertise addresses from --pfcp-addr/--gtpu-addr on the command line
+        # (see wrapper.sh), so it needs no advertise-address rewrite.
+        - name: config
+          configMap:
+            name: {{ include "nextgcore.configMapName" . }}
+        - name: logs
+          emptyDir: {}
+        {{- if .Values.upf.dataPlane.enabled }}
+        - name: dev-tun
+          hostPath:
+            path: {{ .Values.upf.dataPlane.hostPathTun }}
+            type: CharDevice
+        {{- end }}
+        - name: wrapper
+          configMap:
+            name: {{ .Release.Name }}-upf-wrapper
+            defaultMode: 0755
 ---
 apiVersion: v1
 kind: Service
@@ -51,35 +233,31 @@ metadata:
     app.kubernetes.io/name: upf
     {{- include "nextgcore.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.upf.service.headless }}
+  # Headless is REQUIRED for GTP-U. kube-proxy balances UDP per-flow with a
+  # conntrack timeout, a poor fit for a long-lived N3 tunnel, and the gNB must
+  # reach the specific pod holding the PFCP session. The chart used to render
+  # ClusterIP here, reintroducing exactly what the EKS overlay removes.
+  clusterIP: None
+  {{- else }}
   type: {{ .Values.upf.service.type }}
+  {{- end }}
   ports:
-    - port: {{ .Values.upf.service.pfcpPort }}
-      targetPort: pfcp
-      protocol: UDP
-      name: pfcp
-    - port: {{ .Values.upf.service.gtpuPort }}
+    - name: gtpu
+      port: {{ .Values.upf.service.gtpuPort }}
       targetPort: gtpu
       protocol: UDP
-      name: gtpu
+    - name: pfcp
+      port: {{ .Values.upf.service.pfcpPort }}
+      targetPort: pfcp
+      protocol: UDP
+    {{- if .Values.upf.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.upf.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
   selector:
     app.kubernetes.io/name: upf
     app.kubernetes.io/instance: {{ .Release.Name }}-upf
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-upf-config
-  labels:
-    app.kubernetes.io/name: upf
-    {{- include "nextgcore.labels" . | nindent 4 }}
-data:
-  nf.yaml: |
-    upf:
-      pfcp:
-        port: {{ .Values.upf.service.pfcpPort }}
-      gtpu:
-        port: {{ .Values.upf.service.gtpuPort }}
-      tun:
-        ip: {{ .Values.upf.config.tunIp }}
-        prefix: {{ .Values.upf.config.tunPrefix }}
 {{- end }}

--- a/deploy/helm/nextgcore/values.yaml
+++ b/deploy/helm/nextgcore/values.yaml
@@ -1,5 +1,8 @@
-# Default values for NextGCore 5G Core Helm chart
-# Item 126: Helm charts from K8s YAML manifests
+# Default values for the NextGCore 5G Core control-plane chart.
+#
+# Scope: 10 control-plane NFs + MongoDB. The gNB/UE simulator and the
+# monitoring stack are NOT part of this chart -- see nextgsim/k8s/ and
+# k8s/monitoring/. Rationale in specs/fix-helm-chart-control-plane.md.
 
 global:
   image:
@@ -8,14 +11,70 @@ global:
   sbi:
     scheme: http
     port: 7777
+  logLevel: info
+  max:
+    ue: 1024
+    peer: 64
+  # Shared by amf/nrf guami, tai and plmn_support, and by the subscribers the
+  # mongodb-init Job seeds. Changing the PLMN here must match the simulator's.
+  plmn:
+    mcc: "999"
+    mnc: "70"
+  # UE address pools. Shared by the SMF (allocation) and the UPF (TUN routes),
+  # which must agree -- so they are defined once here.
+  session:
+    - subnet: "10.45.0.0/16"
+      gateway: "10.45.0.1"
+    - subnet: "2001:db8:cafe::/48"
+      gateway: "2001:db8:cafe::1"
 
-# MongoDB
+# MongoDB. Templated in-chart (templates/mongodb.yaml) rather than pulled from
+# charts.bitnami.com: the chart must render offline. See Chart.yaml.
 mongodb:
   enabled: true
-  auth:
-    enabled: false
+  image:
+    repository: mongo
+    tag: "6.0"
+  database: nextgcore
+  # Set to reuse an existing MongoDB instead of the in-chart StatefulSet.
+  externalUri: ""
   persistence:
-    size: 8Gi
+    enabled: true
+    size: 1Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  # Seeds subscribers + indexes. Registration cannot succeed without it.
+  init:
+    enabled: true
+
+# Subscriber seeded by the mongodb-init Job. Must match the UE's USIM config.
+subscriber:
+  imsi: "999700000000001"
+  key: "465B5CE8B199B49FAA5F0A2EE238A6BC"
+  opc: "E8ED289DEBA952E4283B54E88E6D834D"
+  amf: "8000"
+  dnn: "internet"
+  sst: 1
+
+# UDM home-network keys for SUCI de-concealment (ECIES profile A/B).
+#
+# The chart does NOT ship key material. The keys live outside the chart
+# directory (docker/rust/configs/5gc/hnet/), and Helm's .Files.Get cannot read
+# above the chart root -- so the Secret is created out-of-band and merely
+# mounted here. NOTES.txt prints the exact command after install.
+#
+# The mount is optional: without the Secret the UDM still starts and the
+# null protection scheme works, but a profile A/B SUCI fails to de-conceal.
+hnetKeys:
+  # Name of a Secret holding curve25519-1.key and secp256r1-2.key.
+  # Defaults to <release>-udm-hnet-keys.
+  existingSecret: ""
 
 # NRF - Network Repository Function
 nrf:
@@ -30,7 +89,6 @@ nrf:
   metrics:
     enabled: true
     port: 9090
-  config: {}
 
 # AMF - Access and Mobility Management Function
 amf:
@@ -40,24 +98,26 @@ amf:
     repository: nextgcore-rust/amf
     tag: latest
   service:
+    # Headless: NGAP is userspace SCTP over UDP and GTP-U-adjacent traffic
+    # tolerates kube-proxy per-flow UDP balancing poorly. Matches
+    # deploy/eks/patches/headless-services.yaml.
+    headless: true
     type: ClusterIP
     sbiPort: 7777
     ngapPort: 38412
-  ngap:
-    nodePort: null  # Set for NodePort service
   metrics:
     enabled: true
     port: 9090
   config:
-    plmn:
-      mcc: "999"
-      mnc: "70"
-    guami:
-      amfId: "cafe00"
+    amfId:
+      region: 2
+      set: 1
     tai:
       tac: 1
     nssai:
       - sst: 1
+    # T3512 periodic registration timer, seconds. 540 = 9 min.
+    t3512: 540
 
 # SMF - Session Management Function
 smf:
@@ -74,8 +134,12 @@ smf:
     enabled: true
     port: 9090
   config:
-    subnet: "10.45.0.0/16"
-    dnn: "internet"
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+      - 2001:4860:4860::8888
+      - 2001:4860:4860::8844
+    mtu: 1400
 
 # UPF - User Plane Function
 upf:
@@ -85,16 +149,27 @@ upf:
     repository: nextgcore-rust/upf
     tag: latest
   service:
+    # Headless is REQUIRED for GTP-U: kube-proxy's per-flow UDP balancing with a
+    # conntrack timeout is a poor fit for a long-lived N3 tunnel, and the gNB
+    # must reach the pod that holds the PFCP session. The chart used to render
+    # ClusterIP here, reintroducing what the EKS overlay removes.
+    headless: true
     type: ClusterIP
     pfcpPort: 8805
     gtpuPort: 2152
-  securityContext:
-    privileged: true
-    capabilities:
-      add: ["NET_ADMIN", "SYS_ADMIN"]
+  metrics:
+    enabled: true
+    port: 9090
+  # The data plane needs a real TUN device, which needs uid 0 and
+  # /dev/net/tun. Set enabled=false for a control-plane-only UPF (no user
+  # plane: PFCP sessions establish but no packets are forwarded).
+  dataPlane:
+    enabled: true
+    hostPathTun: /dev/net/tun
+    # Restrict to nodes prepared for the data plane, mirroring the EKS overlay.
+    nodeSelector: {}
   config:
-    tunIp: "10.45.0.1"
-    tunPrefix: 16
+    tunDevice: ogstun
 
 # AUSF - Authentication Server Function
 ausf:
@@ -139,6 +214,9 @@ pcf:
   service:
     type: ClusterIP
     port: 7777
+  metrics:
+    enabled: true
+    port: 9090
 
 # NSSF - Network Slice Selection Function
 nssf:
@@ -162,7 +240,8 @@ bsf:
     type: ClusterIP
     port: 7777
 
-# Observability
+# Not shipped by this chart. Left here so an operator overriding them sees
+# they are inert rather than silently ineffective. Use k8s/monitoring/.
 prometheus:
   enabled: false
 grafana:

--- a/specs/fix-helm-chart-control-plane.md
+++ b/specs/fix-helm-chart-control-plane.md
@@ -1,0 +1,95 @@
+# Fix: make the Helm chart render a working 5GC control plane
+
+Resolves nextgcore #124 (partially — see Non-goals).
+
+## Problem
+
+`deploy/helm/nextgcore/` renders Deployments that cannot start. Every
+claim in #124 was re-verified against the tree at `0cfb1fe`:
+
+| Claim | Verified |
+|---|---|
+| No template mounts config | `grep -c volumeMounts` = 0 across all 10 NF templates |
+| UPF ConfigMap uses a schema the binary cannot parse | emits `upf.tun.{ip,prefix}` + bare `pfcp.port`; binary wants `pfcp.server[].address/port`, `gtpu.server[]`, `session[].{subnet,gateway,dev}` |
+| `TUN_IP`/`TUN_PREFIX` are dead | no `env::var` for either in `upfd`; they are clap args |
+| UPF data plane cannot come up | no `/dev/net/tun`, no `hostPath`, no wrapper, no `runAsUser: 0` |
+| GTP-U on ClusterIP | `values.yaml:88` → `type: ClusterIP` for 2152/UDP |
+| Missing NFs / no seeded DB | 10 templates vs 13 workloads; no `mongodb-init` Job |
+
+Two further defects #124 did not list:
+
+- **The chart cannot render at all.** `Chart.yaml` declares a Bitnami
+  `mongodb` dependency that is not vendored, so *every* `helm template`
+  and `helm install` fails offline — including with
+  `--set mongodb.enabled=false`:
+  `Error: found in Chart.yaml, but missing in charts/ directory: mongodb`
+- **9 templates use `httpGet` probes.** `nextgcore-sbi` serves h2c
+  prior-knowledge only (no HTTP/1.1 fallback, no ALPN), so kubelet's
+  HTTP/1.1 probe can never succeed and the liveness probe SIGKILLs a
+  healthy NF roughly every 90s. This is the defect recorded in
+  LEARNINGS 2026-07-31; `k8s/manifests/` uses `tcpSocket` for exactly
+  this reason. The chart still carries the broken form.
+
+## Fix
+
+Bring the chart's **control plane** to parity with `k8s/manifests/`,
+reusing the mechanisms already proven there and in `deploy/eks/`:
+
+1. **Vendor the MongoDB dependency out.** Drop the Bitnami dependency
+   from `Chart.yaml` and template a minimal `mongodb` StatefulSet +
+   headless Service directly, mirroring `k8s/manifests/mongodb.yaml`.
+   Rationale: the chart must render offline and in air-gapped CI; a
+   remote 14.x.x floating dependency also makes renders
+   non-reproducible.
+2. **Mount real configs.** One ConfigMap carrying all 10 NF configs,
+   sourced from the same content as `k8s/manifests/configmap.yaml`, with
+   each NF mounting its own `<nf>.yaml` at `/etc/nextgcore/<nf>.yaml`
+   via `subPath` and passing `args: ["-c", "/etc/nextgcore/<nf>.yaml"]`.
+3. **Advertise the pod IP, not `0.0.0.0`.** Add the
+   `rewrite-advertise-addr` initContainer (7 config-driven NFs) and set
+   `AMF_SBI_ADDR` from `status.podIP` for the AMF, which reads that env
+   var rather than its YAML (`amfd/src/lib.rs:811`).
+4. **Correct the UPF.** Real config schema, the `wrapper.sh` ConfigMap,
+   `/dev/net/tun` hostPath, `runAsUser: 0`, `POD_IP` for the N3/PFCP
+   advertise address, and drop the dead `TUN_IP`/`TUN_PREFIX`.
+5. **`tcpSocket` probes** everywhere, replacing all 18 `httpGet` probes.
+6. **`clusterIP: None`** for the GTP-U/PFCP and NGAP Services, matching
+   `deploy/eks/patches/headless-services.yaml`.
+7. **Seed the subscriber DB.** Port the `mongodb-init` Job, using the
+   idempotent upsert form (not `insertOne`).
+8. **`udm-hnet-keys` Secret** from the repo development keys, so SUCI
+   de-concealment has key material.
+
+## Non-goals
+
+- gNB/UE templates and the monitoring stack. The chart stays a
+  *control-plane* deployment; the simulator remains on
+  `k8s/`/`deploy/eks/`. `values.yaml` keeps `prometheus/grafana/jaeger`
+  as disabled-by-default stubs rather than pretending to ship them.
+- Multi-replica or HA anything. `replicas` stays 1; NF state is
+  memory-only (issue #66).
+
+## Verification
+
+Each step below must pass, in order:
+
+1. `helm lint deploy/helm/nextgcore` — clean.
+2. `helm template` renders offline with no network access, and the
+   rendered output has: 0 `httpGet`, 10 NF `volumeMounts`, a UPF config
+   whose keys match `docker/rust/configs/5gc/upf.yaml`, and
+   `clusterIP: None` on the GTP-U and NGAP Services.
+3. `helm install` onto Kind, then `k8s/e2e-test.sh` against the release,
+   plus a manual `ping 8.8.8.8` from the UE. Because the chart ships no
+   gNB/UE, the simulator is supplied from `nextgsim/k8s/` pointed at the
+   Helm-released AMF. Target: registration and PDU session establish,
+   and the UPF gateway ping passes — i.e. the same control-plane
+   assertions the base path reaches, no `FAIL` attributable to the
+   chart.
+4. The parity check that matters: diff the rendered NF Deployment
+   pod-specs against `k8s/manifests/` for config mount, initContainers,
+   probes, and advertise address. Anything the chart omits must be a
+   documented non-goal, not an accident.
+
+Rendering successfully is not evidence of working — the UDM regression
+earlier in this session rendered `0 errors` while mounting the wrong
+volume. Assert the final rendered values, and then install.


### PR DESCRIPTION
Closes #124.

Every claim in #124 re-verified against the tree, plus **two defects it did not list**.

## Could not render at all

`Chart.yaml` declared `mongodb 14.x.x` from charts.bitnami.com but never vendored it, so *every* `helm template` and `helm install` failed offline — even with `--set mongodb.enabled=false`:

```
Error: found in Chart.yaml, but missing in charts/ directory: mongodb
```

MongoDB is now templated in-chart (mirroring `k8s/manifests/mongodb.yaml`) so the chart renders offline and reproducibly; a floating remote range also made two renders of one chart version non-identical. Use `mongodb.enabled=false` + `externalUri` for an existing instance.

## 18 `httpGet` probes across 9 NFs

`nextgcore-sbi` serves **h2c prior-knowledge only** (no HTTP/1.1 fallback, no ALPN), so kubelet's HTTP/1.1 probe can never succeed — `/health` and `/ready` exist but are unreachable, and the failing liveness probe SIGKILLs a healthy NF roughly every 90s. All probes are now `tcpSocket`, matching `k8s/manifests/`.

## From #124

- **No template mounted config** → every NF fell back to `-c /etc/nextgcore/nf.yaml`, absent from the image. One ConfigMap now carries all 10 real NF configs, each mounted with explicit `args`.
- **UPF config was a different schema** → emitted `upf.tun.{ip,prefix}` and bare `pfcp.port`; the binary wants `pfcp.server[].address/port`, `gtpu.server[]`, `session[].{subnet,gateway,dev}`. Fixed; the render is asserted against `docker/rust/configs/5gc/upf.yaml` and now has **zero** foreign keys.
- **`TUN_IP`/`TUN_PREFIX` were dead** → `upfd` reads neither (they're clap args). Removed.
- **UPF data plane could not come up** → the chart granted `privileged` + `NET_ADMIN`/`SYS_ADMIN` while omitting `/dev/net/tun`, `runAsUser: 0` and the wrapper: all of the privilege, none of the mechanism. Now has `wrapper.sh` with TUN/NAT setup, hostPath, `runAsUser 0`, and `POD_IP` for the N3/PFCP advertise addresses.
- **GTP-U on ClusterIP** → headless, as the EKS overlay requires.
- **No seeded DB** → the idempotent `mongodb-init` Job, without which registration cannot succeed.

Plus the `rewrite-advertise-addr` initContainer, `AMF_SBI_ADDR` from `status.podIP`, headless NGAP, and the `udm-hnet-keys` mount.

## Scope

**Control plane only.** gNB/UE and monitoring are deliberately absent — `values.yaml` keeps the observability keys as inert stubs rather than pretending to ship them. `README.md` and `NOTES.txt` say so.

## Verification

`helm install --wait` from a clean namespace on Kind, then the simulator from `nextgsim/k8s` pointed at the release:

- **74 passed / 0 failed / 6 skipped** on `k8s/e2e-test.sh`
- **0% packet loss** from the UE to 8.8.8.8
- all 8 NFs advertising routable pod IPs; no NF falling back to defaults
- `helm lint` clean; render asserted for 0 `httpGet`, UPF config shape, and mount/initContainer consistency across all 10 NFs

## Worth knowing

**Rendering successfully is not evidence.** A `subPath` mount from an emptyDir that nothing populates becomes an empty *directory*; the NF then logs `Is a directory ... Using defaults` at WARN and runs on built-in config **while reporting Ready**. That bug survived a clean render *and* a green `helm install --wait` — only querying the NRF caught it. The mount source and the populating initContainer are now a single explicit decision.

Also drops the stale warnings in `deploy/eks/README.md` telling readers to prefer the overlay over the chart because of the SCTP protocol and missing-ConfigMap gaps — both fixed here.

Spec: `specs/fix-helm-chart-control-plane.md`