### PR TITLE
fix(webui,dbi): store SQN as BSON Int64 and validate provisioning input

### DIFF
--- a/specs/fix-webui-sqn-type-and-validation.md
+++ b/specs/fix-webui-sqn-type-and-validation.md
@@ -1,0 +1,126 @@
+# Fix: WebUI writes SQN as a BSON String, breaking post-AKA maintenance
+
+Resolves nextgcore #119.
+
+## Problem
+
+All cites verified against merged `main` (`36f0247`).
+
+### 1. SQN type mismatch (the core bug)
+
+`SecurityContext.sqn` is typed `String` (`bins/nextgcore-webui/src/main.rs:81`)
+and serialised verbatim into BSON via `bson::to_document` (`main.rs:298`
+create, `main.rs:310` update). The rest of the stack treats that field as a
+64-bit integer:
+
+- read: `security.get_i64(NEXTGCORE_SQN_STRING)`
+  (`libs/nextgcore-dbi/src/subscription.rs:87`) — a String yields `Err`, so
+  `auth_info.sqn` silently stays `0`;
+- maintenance: `$inc: 32` then `$bit … "and": NEXTGCORE_MAX_SQN`
+  (`subscription.rs:147-162`) — both are numeric-only Mongo operators and
+  error against a String field.
+
+The Node model gets it right (`webui/server/models/subscriber.js:26`,
+`Schema.Types.Long`), so the two shipped UIs disagree on the same field.
+
+TS 33.102 §6.3 makes SQN a 48-bit counter the home network advances per
+successful authentication; TS 29.505 carries it as a `SequenceNumber` subject
+to arithmetic maintenance. A String is not a counter.
+
+**Impact:** a subscriber provisioned through the Rust WebUI cannot have its
+SQN advanced. After the first authentication SQN_HE cannot move, which
+de-synchronises AKA, causes repeated AUTS re-sync failures, and can block
+attach. This is the replay protection of 5G-AKA.
+
+### 2. Standalone WebUI defaults to the wrong database
+
+`--db-name` defaults to `open5gs` (`main.rs:41`), while the dbi connection
+falls back to `nextgcore` (`mongoc.rs:104-107`) and the seed script writes
+`nextgcore` (`docs/assets/webui/mongo-init.js:5`). An operator running the
+standalone UI without `--db-name` provisions into a database the UDR never
+reads — presenting as "subscriber not found" after an apparently successful
+create.
+
+### 3. No server-side validation, and silent key corruption
+
+`create_subscriber` only checks that `imsi` and `security.k` are non-empty
+(`main.rs:216-218`). Worse, `nextgcore_ascii_to_hex` (`types.rs:434-447`)
+`filter_map`s over 2-char windows, **silently dropping** any pair that is not
+valid hex, then truncates to the buffer length. A malformed K is persisted
+wrong with no diagnostic, and authentication then fails for no visible reason.
+
+## Fix
+
+1. **`sqn` becomes `i64`.** Serialises to BSON Int64, matching `get_i64` and
+   the `$inc`/`$bit` maintenance path. A custom `Deserialize` accepts Int64,
+   Int32, **and** String, so legacy documents carrying a String `sqn` still
+   load rather than failing the whole read — the compat path is required, not
+   optional, because the on-disk schema is already populated in existing
+   deployments.
+2. **Default `--db-name` to `nextgcore`**, agreeing with the dbi fallback and
+   the seed. Asserted by a test against the dbi constant so the two cannot
+   drift again.
+3. **Validate on create and update**, returning HTTP 400 rather than writing:
+   IMSI 5–15 digits, K and OPc/OP 32 hex chars, AMF 4 hex, SD 6 hex.
+4. **`nextgcore_ascii_to_hex` gains a checked sibling.** A new
+   `nextgcore_ascii_to_hex_checked` returns `Result` and rejects odd-length or
+   non-hex input; the lenient function keeps its signature and delegates, so
+   the 6 existing call sites are unchanged. Chosen over changing the existing
+   signature because those call sites read already-persisted data where a hard
+   error would turn a corrupt record into a failed read; validation belongs at
+   the ingress, which is what (3) adds.
+
+## Non-goals
+
+- Migrating stored String `sqn` values. The compat deserialiser makes them
+  readable; a coercion migration is a separate, gated operation and the issue
+  explicitly says to split it.
+- UI consolidation and wiring a UI into `docker-compose.yml` with auth/TLS
+  (issue #118 territory, and port 3000 is already Grafana). Tracked separately.
+
+## Verification
+
+Tests in `bins/nextgcore-webui/src/main.rs` (the crate currently has none) and
+`libs/nextgcore-dbi/src/types.rs`:
+
+1. `sqn` serialises to `Bson::Int64` — asserts the stored BSON type, which is
+   the actual defect.
+2. A legacy document with `"sqn": "42"` (String) deserialises to `42i64`.
+3. Int64 and absent-field cases both deserialise.
+4. The WebUI's default db name equals the dbi fallback constant.
+5. Validation rejects: short IMSI, non-digit IMSI, 31-char K, non-hex K,
+   3-char AMF — and accepts a known-good subscriber.
+6. `nextgcore_ascii_to_hex_checked` errors on odd-length and on non-hex input,
+   and agrees with the lenient function on valid input.
+
+Each new test must be verified to FAIL when its fix is reverted. Full
+workspace `cargo test`, `cargo fmt --check` and CI-equivalent
+`cargo clippy --workspace` must be clean.
+
+### Revert-check results
+
+Reverting each fix in isolation, so one change at a time is under test:
+
+| Reverted | Tests that failed |
+|---|---|
+| `--db-name` back to `open5gs` | `default_db_name_matches_dbi_fallback` (1) |
+| validation back to the non-empty check | `validation_rejects_malformed_{imsi,key,amf…,slice_sd}`, `validation_bounds_sqn_to_48_bits` (5) |
+| compat deserialiser removed (field stays `i64`) | `legacy_string_sqn_deserialises`, `empty_string_sqn_is_zero` (2) |
+| `nextgcore_ascii_to_hex_checked` delegating to the lenient fn | `test_ascii_to_hex_checked_rejects_malformed_input` (1) |
+
+`validation_accepts_a_good_subscriber` correctly keeps passing under the
+validation revert — it asserts the positive case.
+
+**The `sqn: String` → `i64` change itself cannot be revert-tested
+mechanically:** restoring the `String` type fails compilation in 9 places, so
+there is no build in which the old behaviour and the new tests coexist. The
+`i64`-dependent assertions (`sqn_serialises_as_bson_int64`,
+`stored_sqn_is_readable_via_get_i64`) are therefore *type-enforced* rather than
+revert-proven. That is weaker evidence and is stated rather than glossed: they
+still pin the exact property `$inc`/`$bit` require, which is what the defect
+was.
+
+Not covered: a live create → `increment_sqn` → read round-trip needs a real
+mongod, and this crate has no such harness. The BSON-type assertion is the
+proxy — it pins the exact property `$inc` requires. Stated plainly rather than
+claimed as integration coverage.

--- a/src/bins/nextgcore-webui/src/main.rs
+++ b/src/bins/nextgcore-webui/src/main.rs
@@ -5,7 +5,7 @@
 //!
 //! # Usage
 //! ```bash
-//! nextgcore-webui --db-uri mongodb://localhost:27017 --db-name open5gs --port 3000
+//! nextgcore-webui --db-uri mongodb://localhost:27017 --db-name nextgcore --port 3000
 //! ```
 
 use std::net::SocketAddr;
@@ -20,8 +20,13 @@ use axum::{
     Json, Router,
 };
 use clap::Parser;
+use nextgcore_dbi::types::NEXTGCORE_DEFAULT_DB_NAME;
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
+
+/// Default MongoDB database, taken from nextgcore-dbi so the WebUI and the UDR
+/// cannot disagree about where subscribers live.
+const DEFAULT_DB_NAME: &str = NEXTGCORE_DEFAULT_DB_NAME;
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -37,8 +42,14 @@ struct Args {
     #[arg(long, default_value = "mongodb://localhost:27017")]
     db_uri: String,
 
-    /// MongoDB database name
-    #[arg(long, default_value = "open5gs")]
+    /// MongoDB database name.
+    ///
+    /// Must match what the UDR reads. nextgcore-dbi falls back to "nextgcore"
+    /// (mongoc.rs) and docs/assets/webui/mongo-init.js seeds "nextgcore"; this
+    /// used to default to "open5gs", so provisioning through the standalone UI
+    /// without an explicit --db-name landed in a database the UDR never reads
+    /// and presented as "subscriber not found" after a successful create.
+    #[arg(long, default_value = DEFAULT_DB_NAME)]
     db_name: String,
 
     /// HTTP listen port
@@ -77,8 +88,101 @@ pub struct SecurityContext {
     pub op: String,
     #[serde(default = "default_amf")]
     pub amf: String,
-    #[serde(default)]
-    pub sqn: String,
+    /// AKA sequence number, a 48-bit counter (TS 33.102 6.3).
+    ///
+    /// i64, NOT String: this serialises to a BSON Int64, which is what the
+    /// rest of the stack requires. nextgcore-dbi reads it with `get_i64`
+    /// (subscription.rs) and advances it with `$inc` then a `$bit` 48-bit mask
+    /// -- both numeric-only Mongo operators. While this was a String, a
+    /// subscriber provisioned here read back as SQN 0 and the maintenance
+    /// operators errored, so SQN_HE could never advance: AKA de-synchronised,
+    /// AUTS re-sync failed repeatedly, and attach could block. The Node model
+    /// (webui/server/models/subscriber.js) always used Schema.Types.Long.
+    ///
+    /// Deserialisation accepts a String too, so documents written by the older
+    /// build still load instead of failing the whole read.
+    #[serde(default, deserialize_with = "deserialize_sqn")]
+    pub sqn: i64,
+}
+
+/// Accept Int64, Int32 or String for `sqn`.
+///
+/// Existing deployments already hold String values written by the previous
+/// build; rejecting them would turn a legacy record into a failed read rather
+/// than the recoverable one it is. A non-numeric string is the one case with
+/// no sensible reading, so it is an error.
+fn deserialize_sqn<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{Error as DeError, Unexpected, Visitor};
+    use std::fmt;
+
+    // A hand-written Visitor rather than an intermediate Value: this runs under
+    // BOTH bson::from_document (the Mongo read path) and serde_json (the HTTP
+    // request path), and an intermediate serde_json::Value cannot represent a
+    // BSON Int64, which is exactly the type this field now stores.
+    struct SqnVisitor;
+
+    impl<'de> Visitor<'de> for SqnVisitor {
+        type Value = i64;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("an integer sqn, or a numeric string from a legacy document")
+        }
+
+        fn visit_i64<E: DeError>(self, v: i64) -> Result<i64, E> {
+            Ok(v)
+        }
+
+        fn visit_i32<E: DeError>(self, v: i32) -> Result<i64, E> {
+            Ok(i64::from(v))
+        }
+
+        fn visit_u64<E: DeError>(self, v: u64) -> Result<i64, E> {
+            i64::try_from(v).map_err(|_| E::custom(format!("sqn {v} exceeds i64")))
+        }
+
+        fn visit_u32<E: DeError>(self, v: u32) -> Result<i64, E> {
+            Ok(i64::from(v))
+        }
+
+        fn visit_f64<E: DeError>(self, v: f64) -> Result<i64, E> {
+            // JSON numbers may arrive as f64. Accept only exact integers: a
+            // fractional SQN is a client bug, not something to round silently.
+            if v.fract() == 0.0 && v >= i64::MIN as f64 && v <= i64::MAX as f64 {
+                Ok(v as i64)
+            } else {
+                Err(E::custom(format!("sqn {v} is not an integer")))
+            }
+        }
+
+        fn visit_str<E: DeError>(self, v: &str) -> Result<i64, E> {
+            let t = v.trim();
+            if t.is_empty() {
+                return Ok(0);
+            }
+            t.parse::<i64>()
+                .map_err(|_| E::invalid_value(Unexpected::Str(v), &self))
+        }
+
+        fn visit_unit<E: DeError>(self) -> Result<i64, E> {
+            Ok(0)
+        }
+
+        fn visit_none<E: DeError>(self) -> Result<i64, E> {
+            Ok(0)
+        }
+
+        fn visit_some<D2>(self, d: D2) -> Result<i64, D2::Error>
+        where
+            D2: serde::Deserializer<'de>,
+        {
+            d.deserialize_any(self)
+        }
+    }
+
+    deserializer.deserialize_any(SqnVisitor)
 }
 
 fn default_amf() -> String {
@@ -180,6 +284,77 @@ fn default_priority() -> u8 {
 }
 
 // ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/// Reject a malformed subscriber before it reaches MongoDB.
+///
+/// Provisioning used to check only that `imsi` and `security.k` were non-empty.
+/// Everything downstream then trusted the record, and
+/// `nextgcore_ascii_to_hex` silently DROPS non-hex pairs and truncates -- so a
+/// mistyped K was persisted wrong with no diagnostic and authentication simply
+/// failed later for no visible reason. Catching it here is the cheap place.
+///
+/// Lengths follow TS 23.003 2.2 for the IMSI and the fixed widths the crypto
+/// layer expects: K/OPc/OP are 16 bytes, AMF 2, SD 3.
+fn validate_subscriber(sub: &Subscriber) -> Result<(), String> {
+    fn is_hex(s: &str, want: usize, field: &str) -> Result<(), String> {
+        if s.len() != want {
+            return Err(format!(
+                "{field} must be {want} hex characters, got {}",
+                s.len()
+            ));
+        }
+        if !s.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(format!("{field} must be hexadecimal"));
+        }
+        Ok(())
+    }
+
+    let imsi = sub.imsi.trim();
+    if !(5..=15).contains(&imsi.len()) {
+        return Err(format!(
+            "imsi must be 5-15 digits (TS 23.003 2.2), got {}",
+            imsi.len()
+        ));
+    }
+    if !imsi.chars().all(|c| c.is_ascii_digit()) {
+        return Err("imsi must be decimal digits only".to_string());
+    }
+
+    is_hex(&sub.security.k, 32, "security.k")?;
+    // OPc and OP are each optional, but a supplied value must be well formed.
+    // At least one is needed to derive an authentication vector.
+    if !sub.security.opc.is_empty() {
+        is_hex(&sub.security.opc, 32, "security.opc")?;
+    }
+    if !sub.security.op.is_empty() {
+        is_hex(&sub.security.op, 32, "security.op")?;
+    }
+    if sub.security.opc.is_empty() && sub.security.op.is_empty() {
+        return Err("one of security.opc or security.op is required".to_string());
+    }
+    is_hex(&sub.security.amf, 4, "security.amf")?;
+
+    if sub.security.sqn < 0 {
+        return Err("security.sqn must not be negative".to_string());
+    }
+    if sub.security.sqn as u64 > nextgcore_dbi::types::NEXTGCORE_MAX_SQN {
+        return Err("security.sqn exceeds the 48-bit range (TS 33.102 6.3)".to_string());
+    }
+
+    for slice in &sub.slice {
+        if let Some(sd) = slice.sd.as_deref() {
+            if !sd.is_empty() {
+                is_hex(sd, 6, "slice.sd")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Application state
 // ---------------------------------------------------------------------------
 
@@ -213,8 +388,8 @@ async fn create_subscriber(
     State(state): State<SharedState>,
     Json(sub): Json<Subscriber>,
 ) -> Response {
-    if sub.imsi.is_empty() || sub.security.k.is_empty() {
-        return (StatusCode::BAD_REQUEST, "imsi and security.k are required").into_response();
+    if let Err(e) = validate_subscriber(&sub) {
+        return (StatusCode::BAD_REQUEST, e).into_response();
     }
     match db_create_subscriber(&state.db_uri, &state.db_name, &sub) {
         Ok(()) => (StatusCode::CREATED, Json(sub)).into_response(),
@@ -227,6 +402,11 @@ async fn update_subscriber(
     Path(imsi): Path<String>,
     Json(sub): Json<Subscriber>,
 ) -> Response {
+    // Update validates too: an update writes the same document shape, so
+    // skipping it here would leave a hole straight to the create-path defect.
+    if let Err(e) = validate_subscriber(&sub) {
+        return (StatusCode::BAD_REQUEST, e).into_response();
+    }
     match db_update_subscriber(&state.db_uri, &state.db_name, &imsi, &sub) {
         Ok(true) => Json(sub).into_response(),
         Ok(false) => StatusCode::NOT_FOUND.into_response(),
@@ -596,4 +776,220 @@ async fn main() -> Result<()> {
     axum::serve(listener, app).await.context("server error")?;
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mongodb::bson::{doc, Bson};
+
+    fn good_subscriber() -> Subscriber {
+        Subscriber {
+            imsi: "999700000000001".to_string(),
+            msisdn: vec![],
+            security: SecurityContext {
+                k: "465B5CE8B199B49FAA5F0A2EE238A6BC".to_string(),
+                opc: "E8ED289DEBA952E4283B54E88E6D834D".to_string(),
+                op: String::new(),
+                amf: "8000".to_string(),
+                sqn: 0,
+            },
+            ambr: Ambr::default(),
+            slice: vec![],
+            status: 0,
+        }
+    }
+
+    /// The defect this issue is about: `$inc`/`$bit` are numeric-only Mongo
+    /// operators, so `sqn` must land in BSON as an Int64. While it was a
+    /// String the maintenance path errored and SQN_HE could never advance.
+    #[test]
+    fn sqn_serialises_as_bson_int64() {
+        let mut sub = good_subscriber();
+        sub.security.sqn = 42;
+        let doc = mongodb::bson::to_document(&sub).expect("serialize");
+        let security = doc.get_document("security").expect("security subdoc");
+        match security.get("sqn") {
+            Some(Bson::Int64(v)) => assert_eq!(*v, 42),
+            other => panic!("sqn must serialise to BSON Int64, got {other:?}"),
+        }
+    }
+
+    /// nextgcore-dbi reads the field with `get_i64`, so that exact call must
+    /// succeed against what we write.
+    #[test]
+    fn stored_sqn_is_readable_via_get_i64() {
+        let mut sub = good_subscriber();
+        sub.security.sqn = 1_234_567;
+        let doc = mongodb::bson::to_document(&sub).expect("serialize");
+        let security = doc.get_document("security").expect("security subdoc");
+        assert_eq!(security.get_i64("sqn").expect("get_i64"), 1_234_567);
+    }
+
+    /// Documents written by the previous build hold a String. They must still
+    /// load: refusing them would turn a legacy record into a failed read.
+    #[test]
+    fn legacy_string_sqn_deserialises() {
+        let legacy = doc! {
+            "imsi": "999700000000001",
+            "security": {
+                "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
+                "opc": "E8ED289DEBA952E4283B54E88E6D834D",
+                "amf": "8000",
+                "sqn": "42",
+            },
+        };
+        let sub: Subscriber = mongodb::bson::from_document(legacy).expect("legacy doc must load");
+        assert_eq!(sub.security.sqn, 42);
+    }
+
+    #[test]
+    fn int64_and_absent_sqn_deserialise() {
+        let with_i64 = doc! {
+            "imsi": "999700000000001",
+            "security": {
+                "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
+                "opc": "E8ED289DEBA952E4283B54E88E6D834D",
+                "amf": "8000",
+                "sqn": 99_i64,
+            },
+        };
+        let sub: Subscriber = mongodb::bson::from_document(with_i64).expect("int64 doc");
+        assert_eq!(sub.security.sqn, 99);
+
+        let absent = doc! {
+            "imsi": "999700000000001",
+            "security": {
+                "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
+                "opc": "E8ED289DEBA952E4283B54E88E6D834D",
+                "amf": "8000",
+            },
+        };
+        let sub: Subscriber = mongodb::bson::from_document(absent).expect("absent sqn defaults");
+        assert_eq!(sub.security.sqn, 0);
+    }
+
+    /// An empty legacy string is "unset", not an error.
+    #[test]
+    fn empty_string_sqn_is_zero() {
+        let d = doc! {
+            "imsi": "999700000000001",
+            "security": {
+                "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
+                "opc": "E8ED289DEBA952E4283B54E88E6D834D",
+                "amf": "8000",
+                "sqn": "",
+            },
+        };
+        let sub: Subscriber = mongodb::bson::from_document(d).expect("empty string sqn");
+        assert_eq!(sub.security.sqn, 0);
+    }
+
+    /// A non-numeric string has no sensible reading, so it must not be
+    /// silently coerced to 0 -- that would hide corruption.
+    #[test]
+    fn non_numeric_string_sqn_is_rejected() {
+        let d = doc! {
+            "imsi": "999700000000001",
+            "security": {
+                "k": "465B5CE8B199B49FAA5F0A2EE238A6BC",
+                "opc": "E8ED289DEBA952E4283B54E88E6D834D",
+                "amf": "8000",
+                "sqn": "not-a-number",
+            },
+        };
+        let r: Result<Subscriber, _> = mongodb::bson::from_document(d);
+        assert!(r.is_err(), "a non-numeric sqn string must be an error");
+    }
+
+    /// The WebUI and the UDR must agree on which database holds subscribers.
+    /// These drifted before: the WebUI defaulted to "open5gs" while dbi and the
+    /// seed script used "nextgcore", so provisioning silently went nowhere.
+    #[test]
+    fn default_db_name_matches_dbi_fallback() {
+        assert_eq!(DEFAULT_DB_NAME, "nextgcore");
+        assert_eq!(
+            DEFAULT_DB_NAME,
+            nextgcore_dbi::types::NEXTGCORE_DEFAULT_DB_NAME
+        );
+        let args = Args::parse_from(["nextgcore-webui"]);
+        assert_eq!(
+            args.db_name,
+            nextgcore_dbi::types::NEXTGCORE_DEFAULT_DB_NAME
+        );
+    }
+
+    #[test]
+    fn validation_accepts_a_good_subscriber() {
+        assert!(validate_subscriber(&good_subscriber()).is_ok());
+    }
+
+    #[test]
+    fn validation_rejects_malformed_imsi() {
+        let mut sub = good_subscriber();
+        sub.imsi = "9997".to_string();
+        assert!(validate_subscriber(&sub).is_err(), "4-digit imsi");
+
+        sub.imsi = "9997000000000012345".to_string();
+        assert!(validate_subscriber(&sub).is_err(), "19-digit imsi");
+
+        sub.imsi = "99970000000000X".to_string();
+        assert!(validate_subscriber(&sub).is_err(), "non-digit imsi");
+    }
+
+    /// The case that motivated this: a mistyped key used to be persisted with
+    /// the bad pairs dropped, and authentication then failed with no clue why.
+    #[test]
+    fn validation_rejects_malformed_key() {
+        let mut sub = good_subscriber();
+        sub.security.k = "465B5CE8B199B49FAA5F0A2EE238A6B".to_string(); // 31 chars
+        assert!(validate_subscriber(&sub).is_err(), "31-char k");
+
+        sub.security.k = "465B5CE8B199B49FAA5F0A2EE238A6ZZ".to_string(); // non-hex
+        assert!(validate_subscriber(&sub).is_err(), "non-hex k");
+    }
+
+    #[test]
+    fn validation_rejects_malformed_amf_and_requires_a_key_material() {
+        let mut sub = good_subscriber();
+        sub.security.amf = "800".to_string();
+        assert!(validate_subscriber(&sub).is_err(), "3-char amf");
+
+        let mut sub = good_subscriber();
+        sub.security.opc = String::new();
+        sub.security.op = String::new();
+        assert!(
+            validate_subscriber(&sub).is_err(),
+            "neither opc nor op supplied"
+        );
+    }
+
+    #[test]
+    fn validation_bounds_sqn_to_48_bits() {
+        let mut sub = good_subscriber();
+        sub.security.sqn = nextgcore_dbi::types::NEXTGCORE_MAX_SQN as i64;
+        assert!(validate_subscriber(&sub).is_ok(), "max 48-bit sqn is valid");
+
+        sub.security.sqn = nextgcore_dbi::types::NEXTGCORE_MAX_SQN as i64 + 1;
+        assert!(validate_subscriber(&sub).is_err(), "sqn beyond 48 bits");
+
+        sub.security.sqn = -1;
+        assert!(validate_subscriber(&sub).is_err(), "negative sqn");
+    }
+
+    #[test]
+    fn validation_rejects_malformed_slice_sd() {
+        let mut sub = good_subscriber();
+        sub.slice = vec![SliceConfig {
+            sst: 1,
+            sd: Some("ZZZZZZ".to_string()),
+            default_indicator: true,
+            session: vec![],
+        }];
+        assert!(validate_subscriber(&sub).is_err(), "non-hex sd");
+    }
 }

--- a/src/libs/nextgcore-dbi/src/mongoc.rs
+++ b/src/libs/nextgcore-dbi/src/mongoc.rs
@@ -104,7 +104,7 @@ pub fn nextgcore_mongoc_init(db_uri: &str) -> DbiResult<()> {
     let db_name = client_options
         .default_database
         .clone()
-        .unwrap_or_else(|| "nextgcore".to_string());
+        .unwrap_or_else(|| crate::types::NEXTGCORE_DEFAULT_DB_NAME.to_string());
 
     // Create client
     let client = Client::with_options(client_options)?;

--- a/src/libs/nextgcore-dbi/src/types.rs
+++ b/src/libs/nextgcore-dbi/src/types.rs
@@ -11,6 +11,14 @@ pub const NEXTGCORE_AMF_LEN: usize = 2;
 pub const NEXTGCORE_RAND_LEN: usize = 16;
 pub const NEXTGCORE_MAX_SQN: u64 = 0xFFFFFFFFFFFF; // 48-bit max
 
+/// Database used when the connection URI names none.
+///
+/// Single source of truth: mongoc.rs falls back to this, the WebUI's
+/// --db-name defaults to it, and docs/assets/webui/mongo-init.js seeds it.
+/// These drifted before -- the standalone WebUI defaulted to "open5gs" -- so
+/// provisioning landed in a database the UDR never read.
+pub const NEXTGCORE_DEFAULT_DB_NAME: &str = "nextgcore";
+
 // String lengths
 pub const NEXTGCORE_MAX_IMSI_LEN: usize = 15;
 pub const NEXTGCORE_MAX_IMSI_BCD_LEN: usize = 15;
@@ -430,7 +438,16 @@ pub fn nextgcore_id_get_value(supi: &str) -> Option<String> {
     }
 }
 
-/// Helper function to convert hex string to bytes
+/// Convert a hex string to bytes, lenient: non-hex pairs are DROPPED and the
+/// result is truncated to `buf`.
+///
+/// This silence is a trap for provisioning -- a mistyped key is written wrong
+/// with no diagnostic and authentication just fails later. The lenient
+/// behaviour is kept because the callers here parse already-persisted
+/// documents, where a hard error would turn one corrupt record into a failed
+/// read of the whole subscriber. Validate at the ingress instead (the WebUI
+/// does), or use [`nextgcore_ascii_to_hex_checked`] when the input is
+/// untrusted.
 pub fn nextgcore_ascii_to_hex(ascii: &str, buf: &mut [u8]) -> usize {
     let bytes: Vec<u8> = (0..ascii.len())
         .step_by(2)
@@ -444,6 +461,35 @@ pub fn nextgcore_ascii_to_hex(ascii: &str, buf: &mut [u8]) -> usize {
     let len = bytes.len().min(buf.len());
     buf[..len].copy_from_slice(&bytes[..len]);
     len
+}
+
+/// Convert a hex string to bytes, rejecting anything malformed.
+///
+/// Errors on an odd length, a non-hex character, or a value that does not fit
+/// `buf` -- the three cases [`nextgcore_ascii_to_hex`] hides. On success the
+/// two functions agree byte for byte.
+pub fn nextgcore_ascii_to_hex_checked(ascii: &str, buf: &mut [u8]) -> Result<usize, String> {
+    if !ascii.len().is_multiple_of(2) {
+        return Err(format!(
+            "hex string has odd length {} (expected an even number of characters)",
+            ascii.len()
+        ));
+    }
+    let want = ascii.len() / 2;
+    if want > buf.len() {
+        return Err(format!(
+            "hex string decodes to {want} bytes, which exceeds the {} byte buffer",
+            buf.len()
+        ));
+    }
+    for i in (0..ascii.len()).step_by(2) {
+        let pair = ascii
+            .get(i..i + 2)
+            .ok_or_else(|| format!("hex string is not valid UTF-8 at byte {i}"))?;
+        buf[i / 2] = u8::from_str_radix(pair, 16)
+            .map_err(|_| format!("'{pair}' at position {i} is not hexadecimal"))?;
+    }
+    Ok(want)
 }
 
 #[cfg(test)]
@@ -491,6 +537,62 @@ mod tests {
         assert_eq!(buf[0], 0x46);
         assert_eq!(buf[1], 0x5B);
         assert_eq!(buf[15], 0xBC);
+    }
+
+    /// Pins the lenient function's trap so it cannot be mistaken for safe: a
+    /// non-hex pair is DROPPED and the result silently shortens. A key
+    /// provisioned this way is wrong with no diagnostic.
+    #[test]
+    fn test_ascii_to_hex_silently_drops_bad_pairs() {
+        let mut buf = [0u8; 16];
+        // 'ZZ' in the middle: 32 chars in, only 15 bytes out.
+        let len = nextgcore_ascii_to_hex("465B5CE8B199B49FAA5F0A2EE238ZZBC", &mut buf);
+        assert_eq!(len, 15, "the bad pair is dropped rather than reported");
+    }
+
+    #[test]
+    fn test_ascii_to_hex_checked_accepts_valid_input() {
+        let mut buf = [0u8; 16];
+        let len = nextgcore_ascii_to_hex_checked("465B5CE8B199B49FAA5F0A2EE238A6BC", &mut buf)
+            .expect("valid hex must decode");
+        assert_eq!(len, 16);
+        assert_eq!(buf[0], 0x46);
+        assert_eq!(buf[15], 0xBC);
+
+        // Agrees byte for byte with the lenient function on valid input.
+        let mut lenient = [0u8; 16];
+        let llen = nextgcore_ascii_to_hex("465B5CE8B199B49FAA5F0A2EE238A6BC", &mut lenient);
+        assert_eq!((len, buf), (llen, lenient));
+    }
+
+    #[test]
+    fn test_ascii_to_hex_checked_rejects_malformed_input() {
+        let mut buf = [0u8; 16];
+
+        assert!(
+            nextgcore_ascii_to_hex_checked("465B5CE8B199B49FAA5F0A2EE238A6B", &mut buf).is_err(),
+            "odd length must be rejected"
+        );
+        assert!(
+            nextgcore_ascii_to_hex_checked("465B5CE8B199B49FAA5F0A2EE238ZZBC", &mut buf).is_err(),
+            "non-hex characters must be rejected, not dropped"
+        );
+        assert!(
+            nextgcore_ascii_to_hex_checked("465B5CE8B199B49FAA5F0A2EE238A6BCDD", &mut buf).is_err(),
+            "input longer than the buffer must be rejected, not truncated"
+        );
+        assert_eq!(
+            nextgcore_ascii_to_hex_checked("", &mut buf),
+            Ok(0),
+            "empty input decodes to zero bytes"
+        );
+    }
+
+    /// The WebUI's --db-name default and the mongoc fallback must agree, or
+    /// provisioning lands in a database the UDR never reads.
+    #[test]
+    fn test_default_db_name_is_nextgcore() {
+        assert_eq!(NEXTGCORE_DEFAULT_DB_NAME, "nextgcore");
     }
 
     #[test]


### PR DESCRIPTION
Closes #119.

## The core bug: SQN stored as a String

`SecurityContext.sqn` was typed `String` and serialised verbatim into BSON, but the rest of the stack treats that field as a 64-bit integer:

- **read** — `security.get_i64(NEXTGCORE_SQN_STRING)` (`subscription.rs:87`) returns `Err` on a String, so `auth_info.sqn` silently stayed `0`
- **maintenance** — `$inc: 32` then `$bit … "and": NEXTGCORE_MAX_SQN` (`subscription.rs:147-162`); both are **numeric-only** Mongo operators and error against a String

So a subscriber provisioned through the Rust WebUI could never have its SQN advanced. After the first authentication SQN_HE cannot move: AKA de-synchronises, AUTS re-sync fails repeatedly, attach can block. That counter is the replay protection of 5G-AKA/EPS-AKA (TS 33.102 §6.3, TS 29.505 `SequenceNumber`).

The Node model always had this right (`Schema.Types.Long`), so the two shipped UIs disagreed on the same field.

**Fix:** `sqn` is now `i64`. Deserialisation goes through a hand-written `Visitor` that *also* accepts `Int32` and a numeric `String` — existing deployments already hold String values written by the previous build, and rejecting them would turn a legacy record into a failed read of the whole subscriber. A `Visitor` rather than an intermediate `Value` because this runs under **both** `bson::from_document` and `serde_json`, and `serde_json::Value` cannot represent a BSON Int64. A non-numeric string has no sensible reading, so it errors rather than silently becoming 0.

## Wrong default database

The standalone WebUI defaulted `--db-name` to `open5gs` while `nextgcore-dbi` falls back to `nextgcore` and `mongo-init.js` seeds `nextgcore`. Provisioning without an explicit `--db-name` landed in a database the UDR never reads — presenting as "subscriber not found" after an apparently successful create. Both sides now reference a new `NEXTGCORE_DEFAULT_DB_NAME` constant so they cannot drift again, asserted by a test.

## No validation, and silent key corruption

`create_subscriber` checked only that `imsi` and `security.k` were non-empty. Worse, `nextgcore_ascii_to_hex` **silently drops** non-hex pairs and truncates — a mistyped K was persisted wrong with no diagnostic and authentication simply failed later for no visible reason.

Provisioning now validates IMSI (5–15 digits, TS 23.003 §2.2), K/OPc/OP (32 hex), AMF (4 hex), slice SD (6 hex) and the 48-bit SQN range, returning **400** instead of writing. `update_subscriber` validates too — it writes the same document shape, so skipping it would leave a hole straight back to the defect.

Adds `nextgcore_ascii_to_hex_checked`, which returns `Result` and rejects odd length, non-hex input, and input exceeding the buffer. The lenient function keeps its signature and behaviour on purpose: its 6 callers parse *already-persisted* documents, where a hard error would turn one corrupt field into a failed read. Validation belongs at the ingress. A test pins the lenient trap so it cannot be mistaken for safe.

## Verification

**17 new tests** — this crate had none before.

Each fix was reverted **in isolation** to confirm its tests actually fail:

| Reverted | Tests that failed |
|---|---|
| `--db-name` → `open5gs` | 1 |
| validation → non-empty check | 5 |
| compat deserialiser removed | 2 |
| checked hex → lenient | 1 |

`validation_accepts_a_good_subscriber` correctly keeps passing under the validation revert — it asserts the positive case.

**One honest gap:** the `String` → `i64` change itself cannot be revert-tested mechanically — restoring the type fails compilation in 9 places, so no build exists where the old behaviour and the new tests coexist. Those two assertions are *type-enforced* rather than revert-proven. They still pin the exact property `$inc`/`$bit` require, which is what the defect was.

**Also not covered:** a live `create → increment_sqn → read` round-trip needs a real mongod and this crate has no such harness. The BSON-type assertion is the proxy.

Gates: **5307 passed / 0 failed** (up from 5290), fmt clean, CI-equivalent clippy clean.

## Deliberately out of scope

Migrating stored String `sqn` values (the compat deserialiser makes them readable; a coercion migration is a separate gated operation), and UI consolidation plus wiring a UI into `docker-compose.yml` with auth/TLS — the issue asks for that to be split out, and port 3000 is already Grafana.

Spec: `specs/fix-webui-sqn-type-and-validation.md`