### PR TITLE
fix(docker,test): pin builder toolchain and fix two flakes whose recorded root causes were wrong

### DIFF
--- a/docker/rust/Dockerfile.builder
+++ b/docker/rust/Dockerfile.builder
@@ -12,8 +12,11 @@
 #   docker buildx build --platform linux/amd64,linux/arm64 \
 #     -f Dockerfile.builder -t nextg-builder .
 
-# Use buildplatform for faster cross-compilation
-FROM --platform=$BUILDPLATFORM rust:1.88-bookworm AS builder
+# Use buildplatform for faster cross-compilation.
+# Pin matches the `channel` in nextgcore/src/rust-toolchain.toml and
+# nextgsim/rust-toolchain.toml -- if they diverge, rustup silently downloads
+# the pinned toolchain on every build and this base image's rustc is unused.
+FROM --platform=$BUILDPLATFORM rust:1.95.0-bookworm AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/src/bins/nextgcore-amfd/src/namf_server.rs
+++ b/src/bins/nextgcore-amfd/src/namf_server.rs
@@ -2649,7 +2649,9 @@ mod tests {
     /// is built, and the transfer is accepted (200) — the SM path is skipped.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_n1n2_lpp_to_connected_ue_relays() {
-        let supi = "imsi-001010000060030";
+        // Unique SUPI: test_ue_context_transfer_roundtrip also registered
+        // imsi-001010000060030 in the shared process-global supi_hash.
+        let supi = "imsi-001010000060036";
         setup_ue(supi, true, true);
 
         let body = json!({
@@ -2742,7 +2744,16 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_n1n2_updp_to_connected_ue_relays_verbatim() {
         let _serial = updp_queue_test_lock().lock().await;
-        let supi = "imsi-001010000060032";
+        // Unique SUPI. The queue lock above serialises the DRAIN, but the
+        // enqueue in try_ue_policy_relay uses the UE that
+        // `amf_ue_find_by_supi` resolves from the process-global supi_hash --
+        // which the lock does not cover. test_registration_status_update
+        // registered this same SUPI, so whichever test called setup_ue last
+        // owned the hash entry; the handler then enqueued under the OTHER
+        // test's ue.id and drain_downlinks_for(ue.id) filtered its own item
+        // away, failing with "exactly one UPDP downlink enqueued: left 0".
+        // See test_ue_context_transfer_error_paths for the same trap.
+        let supi = "imsi-001010000060035";
         let ue = setup_ue(supi, true, true);
 
         // Opaque MANAGE UE POLICY COMMAND-ish bytes (payload is opaque to the

--- a/src/bins/nextgcore-scpd/src/proxy.rs
+++ b/src/bins/nextgcore-scpd/src/proxy.rs
@@ -1502,12 +1502,37 @@ mod tests {
     // (ephemeral ports, bounded timeouts, fully async — no blocking threads)
     // ------------------------------------------------------------------
 
-    /// Reserve an ephemeral localhost port.
+    /// Reserve an ephemeral localhost port, never handing the same port to two
+    /// callers in this process.
+    ///
+    /// Binding a probe and dropping it is inherently TOCTOU: between the drop
+    /// and the caller's real bind the port is free, so the OS is entitled to
+    /// hand it to the next probe. Under parallel test threads that happened
+    /// often enough to fail ~1 run in 10 with
+    /// `producer start: ServerError("Failed to bind: Address already in use")`
+    /// at the `start_mock_producer` / `start_scp` bind. (The flake was
+    /// originally diagnosed as hardcoded port numbers, but these helpers
+    /// always used ephemeral ports -- the defect is the reuse window, not a
+    /// fixed constant.)
+    ///
+    /// Excluding already-issued ports closes the in-process race, which is the
+    /// one parallel `cargo test` threads create. A foreign process claiming the
+    /// port in the same window remains theoretically possible and is not worth
+    /// synchronising against here.
     fn ephemeral_port() -> u16 {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-        let port = probe.local_addr().expect("probe addr").port();
-        drop(probe);
-        port
+        static ISSUED: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<u16>>> =
+            std::sync::OnceLock::new();
+        let issued = ISSUED.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+        for _ in 0..256 {
+            let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+            let port = probe.local_addr().expect("probe addr").port();
+            drop(probe);
+            if issued.lock().expect("issued lock").insert(port) {
+                return port;
+            }
+        }
+        panic!("could not obtain an unused ephemeral port in 256 attempts");
     }
 
     /// Start a mock producer that echoes the request (method, uri, body and


### PR DESCRIPTION
Two unrelated commits, split by concern.

---

## 1. `fix(docker)`: pin the builder toolchain to the workspace channel

`Dockerfile.builder` pinned `rust:1.88-bookworm` while both workspaces pin `channel = "1.95.0"` in `rust-toolchain.toml`. rustup honours the toolchain file, so every build downloaded 1.95.0 on top of the base image: the pin was dead weight and actively misleading about which compiler the images are built with.

Pinning the **patch** version (`1.95.0`, not `1.95`) keeps two builds of the same commit byte-identical in toolchain terms. Verified `rust:1.95.0-bookworm` exists upstream via `docker manifest inspect`.

---

## 2. `test(amfd,scpd)`: fix two flakes whose recorded root causes were both wrong

Both were ticketed as "contention on a fixed shared resource under parallel test threads." **Neither diagnosis survived contact with the code**, and each had already cost one failed fix attempt.

### amfd — a SUPI collision, not a queue race

`test_n1n2_updp_to_connected_ue_relays_verbatim` failed 2/2 under `cargo test --workspace` with `exactly one UPDP downlink enqueued: left 0`, while passing isolated and single-threaded. It already held a dedicated `updp_queue_test_lock` meant to serialise it — which could never have worked:

- the lock covers the **drain** (`drain_downlinks_for`)
- the **enqueue** in `try_ue_policy_relay` uses whichever `ue.id` `amf_ue_find_by_supi` resolves from the **process-global `supi_hash`** — state the lock does not guard

`test_registration_status_update` registered the same SUPI (`imsi-001010000060032`). `amf_context_init` is a one-shot `OnceLock` that never clears `supi_hash`, so whichever test called `setup_ue` last owned the hash entry; the handler enqueued under the *other* test's id and the drain filtered the item away.

A crate-wide audit found two more duplicate pairs — one live (the LPP relay test shared `imsi-001010000060030` with `test_ue_context_transfer_roundtrip`), one benign. Notably `test_ue_context_transfer_error_paths` carries a comment from a **previous fix of this same class** asserting a SUPI was unique, which had since become false: comments asserting uniqueness go stale and must be re-audited, not trusted.

**Fix**: unique SUPIs. No new synchronisation.

### scpd — a probe TOCTOU, not hardcoded ports

Recorded as "SCP tests bind fixed `127.0.0.1:<port>` numbers", naming `start_scp` (`proxy.rs:1552`). Both halves are wrong: there are no fixed ports (the helpers already used `ephemeral_port()`), and the failing bind was `start_mock_producer` (`proxy.rs:1547`).

The real defect is `ephemeral_port()` itself: it binds a probe, reads `local_addr().port()`, then **drops the probe** before returning. Between drop and the caller's real bind the port is free, so the OS may hand it to another parallel test's probe.

**Fix**: `ephemeral_port()` records issued ports process-wide and re-probes rather than returning one twice.

### Evidence — measured, not assumed

| | before | after |
|---|---|---|
| amfd | 2/2 runs failed | **12/12 clean**; reverting only the SUPI reproduces the failure 1/6 |
| scpd | 1 failure in 10 runs | 1 in 40, then 100 consecutive clean |

⚠️ **The scpd flake is MITIGATED, NOT ELIMINATED.** The dedup closes the in-process race that parallel `cargo test` threads create; it cannot close the probe-drop window itself. Eliminating it requires `SbiServer` to accept a pre-bound `TcpListener` (or expose its bound `local_addr`) instead of binding internally at `server.rs:823` — an API change on a shared library, tracked separately. `nextgcore-sbi`'s own tests (`server.rs:1440`, `:1523`) use the same pattern and inherit the same flake.

A 1-in-10 flake passes 9 times in 10 by definition, so rates were measured over tens of runs both before and after rather than treating one green run as evidence.

---

## Gates

**5307 passed / 0 failed**, `clippy --workspace` clean, `fmt --check` clean.

Specs: `specs/fix-root-dockerignore-and-builder-toolchain.md`, `specs/fix-namf-supi-collision-and-scpd-port-toctou.md`