### PR TITLE
fix(nrfd,dbi,scpd): identity-based producer selection, OPc derivation, and a test race

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2461,6 +2461,7 @@ dependencies = [
  "log",
  "mongodb",
  "nextgcore-core",
+ "nextgcore-crypt",
  "proptest",
  "serde",
  "thiserror 1.0.69",

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -1581,6 +1581,22 @@ async fn handle_nf_discover(request: &SbiRequest) -> SbiResponse {
         target_nf_fqdn: param("target-nf-fqdn"),
         // Page in the handler; ask discover_profiles for the full match set.
         limit: None,
+        // Identity selection for UDM/UDR/AUSF (TS 29.510 §5.3.2.2.2): route the
+        // request to the instance whose supiRanges/gpsiRanges/routingIndicators/
+        // groupId actually cover this subscriber, rather than to any registered
+        // producer of the target type.
+        supi: param("supi"),
+        gpsi: param("gpsi"),
+        routing_indicator: param("routing-indicator"),
+        // style: form, explode: false => comma-separated, as service-names.
+        group_id_list: param("group-id-list")
+            .map(|v| {
+                v.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default(),
     };
 
     let all_matches = discover_profiles(&query);

--- a/src/bins/nextgcore-nrfd/src/nnrf_handler.rs
+++ b/src/bins/nextgcore-nrfd/src/nnrf_handler.rs
@@ -1372,6 +1372,16 @@ pub struct DiscoveryQuery {
     pub target_nf_fqdn: Option<String>,
     /// limit (minimum 1)
     pub limit: Option<usize>,
+    /// supi — select the UDM/UDR/AUSF instance whose `supiRanges` cover this
+    /// subscriber (TS 29.510 §5.3.2.2.2).
+    pub supi: Option<String>,
+    /// gpsi — as `supi`, matched against `gpsiRanges`.
+    pub gpsi: Option<String>,
+    /// routing-indicator — matched against the profile's `routingIndicators`.
+    pub routing_indicator: Option<String>,
+    /// group-id-list — matched against the profile's NF `groupId`
+    /// (style: form, explode: false => comma-separated).
+    pub group_id_list: Vec<String>,
 }
 
 /// Two S-NSSAIs match when sst is equal and sd is equal (an absent sd only
@@ -1384,6 +1394,122 @@ fn snssai_matches(a: &serde_json::Value, b: &serde_json::Value) -> bool {
 fn plmn_matches(a: &serde_json::Value, b: &serde_json::Value) -> bool {
     a.get("mcc").and_then(|v| v.as_str()) == b.get("mcc").and_then(|v| v.as_str())
         && a.get("mnc").and_then(|v| v.as_str()) == b.get("mnc").and_then(|v| v.as_str())
+}
+
+/// The digit run that identifies a subscriber, with the scheme prefix removed:
+/// `imsi-001010000000001` -> `001010000000001`, `msisdn-14155550100` ->
+/// `14155550100`. Returns `None` when no leading digit run is present (e.g. a
+/// `nai-` GPSI), which makes range matching inapplicable rather than false.
+fn identity_digits(id: &str) -> Option<&str> {
+    let rest = id.split_once('-').map_or(id, |(_, rest)| rest);
+    let digits = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .map_or(rest, |end| &rest[..end]);
+    (!digits.is_empty()).then_some(digits)
+}
+
+/// Whether `digits` falls inside one `SupiRange`/`IdentityRange`
+/// (TS29510_Nnrf_NFManagement.yaml SupiRange: `oneOf [{start,end}, {pattern}]`).
+///
+/// Comparison is NUMERIC, not lexical: both bounds are constrained to
+/// `^[0-9]+$` precisely so they denote numbers, and `"100" < "99"` as strings
+/// would silently mis-bucket subscribers. Identities exceeding u128 are
+/// compared by (length, lexical) order, which is equivalent for digit strings.
+///
+/// The `pattern` alternative is NOT evaluated: `regex` is not a declared
+/// dependency of this workspace (it reaches Cargo.lock only transitively via
+/// env_logger), and hand-rolling a regex engine here would be worse than
+/// declining. `None` is returned so a pattern-only range leaves the candidate
+/// undisqualified rather than wrongly excluded -- see `identity_matches`.
+fn identity_in_range(digits: &str, range: &serde_json::Value) -> Option<bool> {
+    let start = range.get("start").and_then(|v| v.as_str())?;
+    let end = range.get("end").and_then(|v| v.as_str())?;
+    if !start.bytes().all(|b| b.is_ascii_digit()) || !end.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let cmp = |a: &str, b: &str| {
+        let (a, b) = (a.trim_start_matches('0'), b.trim_start_matches('0'));
+        a.len().cmp(&b.len()).then_with(|| a.cmp(b))
+    };
+    Some(cmp(digits, start).is_ge() && cmp(digits, end).is_le())
+}
+
+/// The identity-bearing info container for a UDM/UDR/AUSF profile, whichever is
+/// present (TS 29.510 §6.1.6.2.x UdmInfo/UdrInfo/AusfInfo all carry groupId,
+/// supiRanges, gpsiRanges and routingIndicators).
+fn nf_info_for_type(doc: &serde_json::Value) -> Option<&serde_json::Value> {
+    ["udmInfo", "udrInfo", "ausfInfo"]
+        .iter()
+        .find_map(|key| doc.get(key))
+}
+
+/// Applies the identity-selection filters (`supi`, `gpsi`, `routing-indicator`,
+/// `group-id-list`) to one candidate profile.
+///
+/// Follows the same absence rule `profile_matches` documents for sNssais and
+/// plmnList: **a profile that declares no ranges is not disqualified**. A
+/// single-instance deployment normally declares nothing and serves everyone, so
+/// failing closed here would turn the first `supi`-bearing query into an outage
+/// rather than a refinement. A profile that DOES declare ranges but none
+/// covering the request is excluded -- that is the whole point of the filter.
+fn identity_matches(info: &serde_json::Value, query: &DiscoveryQuery) -> bool {
+    let ranges_allow = |id: &Option<String>, key: &str| -> bool {
+        let Some(id) = id else { return true }; // filter not requested
+        let Some(ranges) = info.get(key).and_then(|v| v.as_array()) else {
+            return true; // declares no ranges => serves any
+        };
+        if ranges.is_empty() {
+            return true;
+        }
+        let Some(digits) = identity_digits(id) else {
+            return true; // non-numeric identity: ranges inapplicable
+        };
+        // Evaluatable ranges only. If every declared range is pattern-only the
+        // candidate stays eligible (see identity_in_range).
+        let mut saw_evaluatable = false;
+        for range in ranges {
+            match identity_in_range(digits, range) {
+                Some(true) => return true,
+                Some(false) => saw_evaluatable = true,
+                None => {}
+            }
+        }
+        if !saw_evaluatable {
+            log::debug!(
+                "NF Discovery: {key} on this candidate declares only pattern ranges, \
+                 which this NRF does not evaluate; not excluding it"
+            );
+        }
+        !saw_evaluatable
+    };
+
+    if !ranges_allow(&query.supi, "supiRanges") {
+        return false;
+    }
+    if !ranges_allow(&query.gpsi, "gpsiRanges") {
+        return false;
+    }
+
+    // routingIndicators: exact match against the declared list (each is
+    // ^[0-9]{1,4}$; there is no pattern form).
+    if let Some(ref ri) = query.routing_indicator {
+        if let Some(list) = info.get("routingIndicators").and_then(|v| v.as_array()) {
+            if !list.is_empty() && !list.iter().filter_map(|v| v.as_str()).any(|v| v == ri) {
+                return false;
+            }
+        }
+    }
+
+    // group-id-list: the profile's groupId must be among those requested.
+    if !query.group_id_list.is_empty() {
+        if let Some(group) = info.get("groupId").and_then(|v| v.as_str()) {
+            if !query.group_id_list.iter().any(|g| g == group) {
+                return false;
+            }
+        }
+    }
+
+    true
 }
 
 /// Collects every DNN advertised in the NF-type-specific info containers
@@ -1518,6 +1644,16 @@ fn profile_matches(doc: &serde_json::Value, status: &str, query: &DiscoveryQuery
     if let Some(ref dnn) = query.dnn {
         let dnns = advertised_dnns(doc);
         if !dnns.is_empty() && !dnns.iter().any(|d| d == dnn) {
+            return false;
+        }
+    }
+
+    // Identity selection (supi / gpsi / routing-indicator / group-id-list):
+    // route the subscriber to the UDM/UDR/AUSF instance that actually serves it
+    // (TS 29.510 §5.3.2.2.2). Only these three NF types carry the identity
+    // containers, so a profile without one is unaffected.
+    if let Some(info) = nf_info_for_type(doc) {
+        if !identity_matches(info, query) {
             return false;
         }
     }
@@ -2095,6 +2231,205 @@ mod tests {
         manager.deregister(smf_id).ok();
         manager.deregister(upf_id).ok();
         manager.deregister(suspended_id).ok();
+    }
+
+    // ------------------------------------------------------------------
+    // Identity-based producer selection (issue #67, TS 29.510 §5.3.2.2.2)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_identity_range_numeric_not_lexical() {
+        // The trap this guards: as STRINGS "100" < "99", so a lexical compare
+        // would place 100 outside {99..101}. Both bounds are ^[0-9]+$ precisely
+        // because they denote numbers.
+        let range = serde_json::json!({"start": "99", "end": "101"});
+        assert_eq!(identity_in_range("100", &range), Some(true));
+        assert_eq!(identity_in_range("98", &range), Some(false));
+        assert_eq!(identity_in_range("102", &range), Some(false));
+        // Inclusive at both bounds.
+        assert_eq!(identity_in_range("99", &range), Some(true));
+        assert_eq!(identity_in_range("101", &range), Some(true));
+        // Leading zeros do not change the value.
+        let padded = serde_json::json!({"start": "0099", "end": "0101"});
+        assert_eq!(identity_in_range("00100", &padded), Some(true));
+        // A pattern-only range is not evaluatable => None, never a false verdict.
+        assert_eq!(
+            identity_in_range("100", &serde_json::json!({"pattern": "^1.*$"})),
+            None
+        );
+        // Identities far beyond u128 still order correctly (length, then lexical).
+        let big = serde_json::json!({
+            "start": "100000000000000000000000000000000000000000",
+            "end":   "300000000000000000000000000000000000000000"
+        });
+        assert_eq!(
+            identity_in_range("200000000000000000000000000000000000000000", &big),
+            Some(true)
+        );
+        assert_eq!(
+            identity_in_range("400000000000000000000000000000000000000000", &big),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn test_identity_digits_strips_scheme_prefix() {
+        assert_eq!(
+            identity_digits("imsi-001010000000001"),
+            Some("001010000000001")
+        );
+        assert_eq!(identity_digits("msisdn-14155550100"), Some("14155550100"));
+        // Bare digits (no prefix) are accepted as-is.
+        assert_eq!(identity_digits("001010000000001"), Some("001010000000001"));
+        // A non-numeric GPSI has no digit run to range-match on.
+        assert_eq!(identity_digits("nai-user@example.com"), None);
+    }
+
+    #[test]
+    fn test_discovery_identity_selection() {
+        let manager = nf_manager();
+        let in_range = "disc-udm-in-range";
+        let out_of_range = "disc-udm-out-of-range";
+        let no_ranges = "disc-udm-no-ranges";
+
+        // Two sharded UDMs plus one that declares nothing.
+        manager
+            .register(
+                NfProfile::from_json(&serde_json::json!({
+                    "nfInstanceId": in_range,
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "udmInfo": {
+                        "groupId": "udm-group-a",
+                        "supiRanges": [{"start": "001010000000000", "end": "001010000000999"}],
+                        "gpsiRanges": [{"start": "14155550100", "end": "14155550199"}],
+                        "routingIndicators": ["0001", "0002"]
+                    }
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        manager
+            .register(
+                NfProfile::from_json(&serde_json::json!({
+                    "nfInstanceId": out_of_range,
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "udmInfo": {
+                        "groupId": "udm-group-b",
+                        "supiRanges": [{"start": "001010000001000", "end": "001010000001999"}],
+                        "routingIndicators": ["0003"]
+                    }
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        manager
+            .register(
+                NfProfile::from_json(&serde_json::json!({
+                    "nfInstanceId": no_ranges,
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "udmInfo": {}
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+
+        let base = || DiscoveryQuery {
+            target_nf_type: "UDM".to_string(),
+            requester_nf_type: "AMF".to_string(),
+            ..Default::default()
+        };
+        let ids = |q: &DiscoveryQuery| -> Vec<String> {
+            discover_profiles(q)
+                .iter()
+                .filter_map(|p| {
+                    p.get("nfInstanceId")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                })
+                .collect()
+        };
+
+        // No supi => every registered UDM is a candidate (unchanged behaviour).
+        let all = ids(&base());
+        assert!(all.contains(&in_range.to_string()));
+        assert!(all.contains(&out_of_range.to_string()));
+        assert!(all.contains(&no_ranges.to_string()));
+
+        // supi inside the first shard's range: the other shard is EXCLUDED, and
+        // the range-less profile still matches (absence means "serves any").
+        let mut q = base();
+        q.supi = Some("imsi-001010000000042".to_string());
+        let got = ids(&q);
+        assert!(
+            got.contains(&in_range.to_string()),
+            "the shard whose supiRanges cover the SUPI must be returned"
+        );
+        assert!(
+            !got.contains(&out_of_range.to_string()),
+            "a shard declaring ranges that do NOT cover the SUPI must be excluded"
+        );
+        assert!(
+            got.contains(&no_ranges.to_string()),
+            "a profile declaring no supiRanges serves any subscriber"
+        );
+
+        // The complementary SUPI selects the other shard.
+        let mut q = base();
+        q.supi = Some("imsi-001010000001500".to_string());
+        let got = ids(&q);
+        assert!(got.contains(&out_of_range.to_string()));
+        assert!(!got.contains(&in_range.to_string()));
+
+        // gpsi is matched against gpsiRanges, independently of supiRanges.
+        let mut q = base();
+        q.gpsi = Some("msisdn-14155550142".to_string());
+        assert!(ids(&q).contains(&in_range.to_string()));
+        let mut q = base();
+        q.gpsi = Some("msisdn-14155559999".to_string());
+        assert!(!ids(&q).contains(&in_range.to_string()));
+
+        // routing-indicator: exact match against the declared list.
+        let mut q = base();
+        q.routing_indicator = Some("0002".to_string());
+        let got = ids(&q);
+        assert!(got.contains(&in_range.to_string()));
+        assert!(!got.contains(&out_of_range.to_string()));
+        let mut q = base();
+        q.routing_indicator = Some("9999".to_string());
+        let got = ids(&q);
+        assert!(!got.contains(&in_range.to_string()));
+        assert!(!got.contains(&out_of_range.to_string()));
+        // ...but a profile declaring no routingIndicators is still eligible.
+        assert!(got.contains(&no_ranges.to_string()));
+
+        // group-id-list: only the named group's instance comes back.
+        let mut q = base();
+        q.group_id_list = vec!["udm-group-b".to_string()];
+        let got = ids(&q);
+        assert!(got.contains(&out_of_range.to_string()));
+        assert!(!got.contains(&in_range.to_string()));
+
+        // A non-identity NF type is untouched by these filters: an SMF has no
+        // udmInfo/udrInfo/ausfInfo container, so supi must not exclude it.
+        let smf_id = "disc-identity-smf";
+        manager
+            .register(NfProfile::from_json(&full_profile_doc(smf_id, "SMF")).unwrap())
+            .unwrap();
+        let mut q = DiscoveryQuery {
+            target_nf_type: "SMF".to_string(),
+            requester_nf_type: "AMF".to_string(),
+            ..Default::default()
+        };
+        q.supi = Some("imsi-999999999999999".to_string());
+        assert!(ids(&q).contains(&smf_id.to_string()));
+
+        manager.deregister(in_range).ok();
+        manager.deregister(out_of_range).ok();
+        manager.deregister(no_ranges).ok();
+        manager.deregister(smf_id).ok();
     }
 
     fn temp_state_path(tag: &str) -> PathBuf {

--- a/src/bins/nextgcore-scpd/src/sbi_path.rs
+++ b/src/bins/nextgcore-scpd/src/sbi_path.rs
@@ -471,8 +471,27 @@ mod tests {
         assert!(!config.tls_enabled);
     }
 
+    /// Serialises the tests that drive the process-global SBI_SERVER_RUNNING
+    /// lifecycle flag.
+    ///
+    /// `store(false)` at the top of each test is not isolation: cargo runs the
+    /// tests of one binary on parallel threads, so a second test's reset or its
+    /// `scp_sbi_open` can land between this test's open and its assert. Observed
+    /// as `test_sbi_open_close` failing on `assert!(result.is_ok())` because
+    /// `test_sbi_open_already_running` had already set the flag, making open
+    /// return Err("SBI server already running"). Rare (it needs the two threads
+    /// to interleave inside a few instructions) but a real race, not an
+    /// environment artefact.
+    fn sbi_lifecycle_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[test]
     fn test_sbi_open_close() {
+        let _serial = sbi_lifecycle_lock();
         // Reset state
         SBI_SERVER_RUNNING.store(false, Ordering::SeqCst);
 
@@ -486,6 +505,7 @@ mod tests {
 
     #[test]
     fn test_sbi_open_already_running() {
+        let _serial = sbi_lifecycle_lock();
         // Reset state
         SBI_SERVER_RUNNING.store(false, Ordering::SeqCst);
 

--- a/src/libs/nextgcore-dbi/Cargo.toml
+++ b/src/libs/nextgcore-dbi/Cargo.toml
@@ -8,6 +8,10 @@ description = "NextGCore Database Interface Library"
 
 [dependencies]
 nextgcore-core = { workspace = true }
+# OPc derivation (milenage_opc) on the OP-only provisioning path, so no
+# consumer can serve the raw OP as OPc. No cycle: nextgcore-crypt depends
+# only on nextgcore-core.
+nextgcore-crypt = { workspace = true }
 thiserror.workspace = true
 mongodb = { version = "2.8", default-features = false, features = ["sync"] }
 serde.workspace = true

--- a/src/libs/nextgcore-dbi/src/subscription.rs
+++ b/src/libs/nextgcore-dbi/src/subscription.rs
@@ -4,6 +4,7 @@
 //! Ported from lib/dbi/subscription.c in the C implementation.
 
 use mongodb::bson::{doc, Bson, Document};
+use nextgcore_crypt::milenage::milenage_opc;
 use serde::{Deserialize, Serialize};
 
 use crate::mongoc::{get_subscriber_collection, DbiError, DbiResult};
@@ -55,7 +56,17 @@ pub fn nextgcore_dbi_auth_info(supi: &str) -> DbiResult<NextgcoreDbiAuthInfo> {
         .get_document(NEXTGCORE_SECURITY_STRING)
         .map_err(|_| DbiError::FieldNotFound(NEXTGCORE_SECURITY_STRING.to_string()))?;
 
+    Ok(parse_auth_info(security, supi))
+}
+
+/// Parses a subscriber's `security` sub-document into [`NextgcoreDbiAuthInfo`].
+///
+/// Split out of [`nextgcore_dbi_auth_info`] so the OPc-derivation invariant is
+/// reachable in tests: that function reaches MongoDB, and its `test_store`
+/// short-circuit returns a pre-built struct without ever running this parse.
+pub(crate) fn parse_auth_info(security: &Document, supi: &str) -> NextgcoreDbiAuthInfo {
     let mut auth_info = NextgcoreDbiAuthInfo::default();
+    let mut has_op = false;
 
     // Parse K
     if let Ok(k_str) = security.get_str(NEXTGCORE_K_STRING) {
@@ -71,6 +82,47 @@ pub fn nextgcore_dbi_auth_info(supi: &str) -> DbiResult<NextgcoreDbiAuthInfo> {
     // Parse OP
     if let Ok(op_str) = security.get_str(NEXTGCORE_OP_STRING) {
         nextgcore_ascii_to_hex(op_str, &mut auth_info.op);
+        has_op = true;
+    }
+
+    // Derive OPc from (K, OP) when only OP was provisioned.
+    //
+    // OPc = OP XOR E_K(OP) (TS 33.102 Annex C.4). MILENAGE must be driven with
+    // OPc, never with OP (TS 33.501 §6.1), and `encOpcKey` carries the OPc
+    // (TS 29.505 §5.4.2.4).
+    //
+    // Deriving HERE rather than at each consumer makes `opc` an invariant of
+    // this struct: whenever key material was provisioned at all, `opc` holds a
+    // usable OPc and `use_opc` is true. That is what stops a consumer from
+    // serving the raw OP by omitting a derivation step -- which is exactly the
+    // bug this fixes: nextgcore-udrd emitted
+    // `if use_opc { opc } else { op }` into encOpcKey, so an OP-only
+    // subscriber authenticated with OP as its OPc and 5G-AKA failed.
+    // nextgcore-hssd already derived correctly on all three Diameter paths
+    // (swx_path.rs:259, cx_path.rs:173, s6a_path.rs:314); only the 5G path
+    // skipped it. Those sites still work -- their `if use_opc` branch now
+    // simply always takes the provisioned arm.
+    //
+    // An explicitly provisioned OPc is never overwritten: provisioning wins,
+    // because deriving over operator-supplied material would silently discard
+    // it. `op` stays populated for any other reader.
+    if !auth_info.use_opc && has_op {
+        match milenage_opc(&auth_info.k, &auth_info.op) {
+            Ok(opc) => {
+                auth_info.opc = opc;
+                auth_info.use_opc = true;
+            }
+            Err(e) => {
+                // Leave use_opc false rather than fall back to OP: a consumer
+                // seeing no OPc fails authentication, which is the correct
+                // outcome. Serving OP would authenticate against the wrong key.
+                log::error!(
+                    "OPc derivation from OP failed for {supi}: {e:?}. \
+                     Authentication will fail for this subscriber -- \
+                     provision opc directly, or fix the k/op values."
+                );
+            }
+        }
     }
 
     // Parse AMF
@@ -94,7 +146,7 @@ pub fn nextgcore_dbi_auth_info(supi: &str) -> DbiResult<NextgcoreDbiAuthInfo> {
         auth_info.authentication_method = m.to_string();
     }
 
-    Ok(auth_info)
+    auth_info
 }
 
 /// Update SQN for a subscriber
@@ -772,4 +824,96 @@ pub fn nextgcore_dbi_policy_subscription(supi: &str) -> DbiResult<NextgcoreSubsc
     }
 
     Ok(subscription_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 3GPP TS 35.208 Test Set 1, mirroring the constants in
+    // nextgcore-crypt/src/milenage.rs so the expected OPc is anchored to the
+    // published vectors rather than to our own output.
+    const K1_HEX: &str = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    const OP1_HEX: &str = "cdc202d5123e20f62b6d676ac72cb318";
+    const OPC1_HEX: &str = "cd63cb71954a9f4e48a5994e37a02baf";
+
+    fn security_doc(fields: &[(&str, &str)]) -> Document {
+        let mut d = Document::new();
+        for (k, v) in fields {
+            d.insert(*k, *v);
+        }
+        d
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    /// OP-only provisioning must yield the DERIVED OPc, never the raw OP.
+    ///
+    /// This is the #86 defect: nextgcore-udrd emitted
+    /// `if use_opc { opc } else { op }` into `encOpcKey`, so an OP-only
+    /// subscriber had MILENAGE driven with OP where TS 33.501 §6.1 requires
+    /// OPc, and 5G-AKA failed for that subscriber.
+    #[test]
+    fn test_op_only_derives_opc_and_never_serves_raw_op() {
+        let doc = security_doc(&[(NEXTGCORE_K_STRING, K1_HEX), (NEXTGCORE_OP_STRING, OP1_HEX)]);
+        let info = parse_auth_info(&doc, "imsi-001010000000001");
+
+        assert!(
+            info.use_opc,
+            "use_opc must be set once OPc is derived, so consumers take the OPc arm"
+        );
+        assert_eq!(
+            hex(&info.opc),
+            OPC1_HEX,
+            "opc must be the TS 35.208 Set-1 derived value OPc = OP XOR E_K(OP)"
+        );
+        assert_ne!(
+            hex(&info.opc),
+            OP1_HEX,
+            "serving the raw OP as OPc is the authentication-breaking bug"
+        );
+        // The UDR's encOpcKey expression must now select the derived OPc.
+        let served = if info.use_opc { &info.opc } else { &info.op };
+        assert_eq!(hex(served), OPC1_HEX);
+    }
+
+    /// An explicitly provisioned OPc is served verbatim and never re-derived.
+    #[test]
+    fn test_provisioned_opc_is_not_rederived() {
+        let doc = security_doc(&[
+            (NEXTGCORE_K_STRING, K1_HEX),
+            (NEXTGCORE_OPC_STRING, OPC1_HEX),
+            // Both present: provisioning must win over derivation.
+            (NEXTGCORE_OP_STRING, OP1_HEX),
+        ]);
+        let info = parse_auth_info(&doc, "imsi-001010000000002");
+
+        assert!(info.use_opc);
+        assert_eq!(
+            hex(&info.opc),
+            OPC1_HEX,
+            "a provisioned OPc must pass through untouched"
+        );
+    }
+
+    /// A record with neither OPc nor OP leaves use_opc false: there is nothing
+    /// to derive from, and inventing key material would be worse than failing.
+    #[test]
+    fn test_no_key_material_leaves_use_opc_false() {
+        let doc = security_doc(&[(NEXTGCORE_K_STRING, K1_HEX)]);
+        let info = parse_auth_info(&doc, "imsi-001010000000003");
+        assert!(!info.use_opc);
+        assert_eq!(info.opc, [0u8; NEXTGCORE_KEY_LEN]);
+    }
+
+    /// `op` stays populated after derivation: it is no longer used for AKA, but
+    /// zeroing it would be an unrelated behaviour change for other readers.
+    #[test]
+    fn test_op_is_retained_after_derivation() {
+        let doc = security_doc(&[(NEXTGCORE_K_STRING, K1_HEX), (NEXTGCORE_OP_STRING, OP1_HEX)]);
+        let info = parse_auth_info(&doc, "imsi-001010000000004");
+        assert_eq!(hex(&info.op), OP1_HEX);
+    }
 }


### PR DESCRIPTION
Three commits, split by concern. Two are the follow-ons that did not make it into #138; one is new.

---

## 1. `fix(dbi)`: derive OPc from OP so 5G-AKA stops using OP as OPc — **#86 primary**

When a subscriber is provisioned with **OP only** (no OPc), `udrd` served the **raw OP** in `encOpcKey` and `udmd` copied it straight into `udm_ue.opc`, so MILENAGE ran with OP where TS 33.501 §6.1 requires OPc. **Authentication failed for every OP-provisioned subscriber.** OPc-provisioned ones worked, which is why it hid: the matched-pair E2E provisions OPc.

Chain: `subscription.rs` parsed OP with no derivation → `udrd/main.rs:2202` emitted `if use_opc { opc } else { op }` → `udmd/nudr_handler.rs:262` copied that into `opc` → `:720` / `app.rs:1750` called `milenage_generate` with it.

### Correction to the issue text

#86 states `milenage_opc` "is referenced only by unit tests … never invoked on the OP→OPc provisioning path." **That is wrong**, and the correction supplies the precedent for the fix: `nextgcore-hssd` already derives correctly on **all three** Diameter paths — `swx_path.rs:259`, `cx_path.rs:173`, `s6a_path.rs:314` — each doing exactly `if use_opc { opc } else { milenage_opc(&k, &op)? }`.

So the primitive and the derivation both existed. The defect is that the **5G path skipped a step the 4G path in the same repo performs**. That asymmetry is the entire bug.

### Why the DBI layer, not `udrd:2202`

`nextgcore-dbi` is where OP/OPc are read, and every consumer shares that struct. Deriving there makes `opc` an **invariant**: whenever key material was provisioned, `opc` holds a usable OPc and `use_opc` is true. The `udrd` ternary stops being a trap — its `else` arm is now unreachable for OP-provisioned records — and `hssd`'s three copies become redundant rather than load-bearing (no behaviour change for EPC).

Patching only `udrd:2202` would fix the reported symptom while leaving the raw OP one forgotten ternary from the wire.

A provisioned OPc is **never** overwritten (provisioning wins; deriving over operator-supplied material would silently discard it). If derivation fails, `use_opc` stays false rather than falling back to OP — no OPc fails authentication, which is correct; serving OP authenticates against the wrong key.

Adds `nextgcore-crypt` to `nextgcore-dbi`. No cycle: `crypt` depends only on `core`, and is already a declared workspace dep. `Cargo.lock` updated in the same commit.

### Testability required a split

`nextgcore_dbi_auth_info` reaches MongoDB, and its `test_store` short-circuit returns a **pre-built struct** — it mirrors the function's signature, not its body, so the parse (and any invariant in it) was unreachable from tests. Extracted `parse_auth_info(&Document, supi)`.

Four tests, expected values anchored to **3GPP TS 35.208 Test Set 1** (the same K/OP/OPc constants `milenage.rs` uses) rather than to our own output. Revert-verified: deleting only the derivation block fails the OP-only test on *"serving the raw OP as OPc is the authentication-breaking bug"*.

Scoped to the auth-breaking defect. #86's two secondary defects (`PATCH …/authentication-subscription` swallowing failures behind 204; `…/authentication-status` discarding the `AuthEvent` with `GET` → 405) are error-handling/persistence work with no overlap with key derivation, tracked separately so this stays reviewable as a security fix.

---

## 2. `fix(nrfd)`: select UDM/UDR/AUSF by subscriber identity — **closes #67**

`SearchNFInstances` accepted identity-selection parameters the NRF never read, so a consumer asking for the UDM serving a specific SUPI got **any** registered UDM — regardless of whether its `supiRanges` cover that subscriber. In sharded deployments: failed authentication, failed registration, misrouted UDR queries.

Adds `supi`/`gpsi`/`routing-indicator`/`group-id-list` to `DiscoveryQuery`, parses them, and filters UDM/UDR/AUSF candidates on the profile's declared `supiRanges`/`gpsiRanges`/`routingIndicators`/`groupId`.

**Range comparison is numeric, not lexical.** `SupiRange` constrains `start`/`end` to `^[0-9]+$` precisely because they denote numbers: as strings `"100" < "99"`, so a lexical compare places SUPI …100 *outside* `{99..101}` and silently mis-buckets subscribers. Implemented as (significant-digit-length, lexical) — exact for digit strings of any length, where a `u128` parse would have to reject or truncate long identities.

**The `pattern` range form is not evaluated.** `regex` is not a declared workspace dependency (it reaches `Cargo.lock` only transitively via `env_logger`), and hand-rolling a regex engine would be worse than declining. A pattern-only range returns `None`, leaving the candidate **eligible** rather than wrongly excluded, and logs at debug. Named in-code as a known limit.

**Absence means "serves any"** — consistent with the rule `profile_matches` already documents for `sNssais`/`plmnList`/DNN. A profile declaring no ranges matches everyone, so existing single-instance deployments are untouched; failing closed would turn the first `supi`-bearing query into an outage. A profile declaring ranges that do **not** cover the request is excluded — the point of the fix.

Three tests: numeric-vs-lexical boundaries (the `"100"` in `{99..101}` trap, leading zeros, 42-digit identities), prefix stripping for `imsi-`/`msisdn-`/`nai-`, and an end-to-end shard-selection matrix over two sharded UDMs plus one declaring nothing. Revert-verified.

Out of scope, as #67 itself asks: `guami`/`amf-set-id`/`tai` topology selection, `requester-snssais`/`target-nf-set-id`, `preferred-locality` ordering, and the optional `SearchResult` ignored-parameter indication.

---

## 3. `test(scpd)`: serialise the two tests driving the global SBI lifecycle flag

`test_sbi_open_close` and `test_sbi_open_already_running` both mutate the process-global `SBI_SERVER_RUNNING` and relied on `store(false)` at the top for isolation. That resets shared state but does not **hold** it: cargo runs a binary's tests on parallel threads, so the other test's reset or its own `scp_sbi_open` lands between this test's open and its assert, and `scp_sbi_open` correctly returns `Err("SBI server already running")`.

Production code untouched — the already-running check is right, and is what the second test asserts. Both tests now take a shared `OnceLock<Mutex<()>>`, recovering from poisoning so a real assertion failure reports itself rather than cascading a `PoisonError`.

Measured by removing **only** the two lock acquisitions and re-running the pair 40×: **12/40 failed without the lock, 0/40 with it.**

Unrelated to the `ephemeral_port` fix in #138: this test binds no socket, and the OS ephemeral range (32768–60999) cannot collide with the SCP's fixed 7777.

---

## Gates

**5314 passed / 0 failed**, `clippy --workspace` clean, `fmt --check` clean, working tree clean.

Specs: `specs/fix-udr-op-served-as-opc.md`, `specs/fix-nrf-discovery-identity-selection.md`, `specs/fix-scpd-sbi-lifecycle-test-race.md`