### PR TITLE
fix(docker): track the build-context exclusions via a Dockerfile-scoped ignore

### DIFF
--- a/docker/rust/Dockerfile.builder
+++ b/docker/rust/Dockerfile.builder
@@ -11,6 +11,15 @@
 # Build (multi-platform with buildx):
 #   docker buildx build --platform linux/amd64,linux/arm64 \
 #     -f Dockerfile.builder -t nextg-builder .
+#
+# BUILD CONTEXT: the nextg PARENT directory (one level above this repo), since
+# the COPY lines below need both nextgcore/src and the sibling nextgsim tree.
+# Exclusions therefore live in Dockerfile.builder.dockerignore next to this
+# file -- a Dockerfile-scoped ignore file -- because the context root is not
+# part of any git repository and an ignore file there could not be committed.
+# That file requires BuildKit; under DOCKER_BUILDKIT=0 it is silently ignored
+# and ~39GB of cargo target/ ships to the daemon. preflight.sh refuses in that
+# case.
 
 # Use buildplatform for faster cross-compilation.
 # Pin matches the `channel` in nextgcore/src/rust-toolchain.toml and

--- a/docker/rust/Dockerfile.builder.dockerignore
+++ b/docker/rust/Dockerfile.builder.dockerignore
@@ -1,0 +1,79 @@
+# Build-context exclusions for Dockerfile.builder.
+#
+# WHY THIS FILE IS HERE AND NOT AT THE CONTEXT ROOT
+#
+# build.sh and build-multiarch.sh pass $PROJECT_ROOT -- the nextg PARENT
+# directory, one level above this repository -- as the build context, because
+# Dockerfile.builder COPYs both nextgcore/src and nextgsim. Docker normally
+# reads .dockerignore from the root of the CONTEXT, and that directory is not
+# part of any git repository, so an ignore file placed there cannot be
+# committed, reviewed, or cloned: every fresh checkout would silently lose it.
+#
+# BuildKit also honours a Dockerfile-scoped ignore file named
+# <dockerfile>.dockerignore, resolved next to the Dockerfile rather than at the
+# context root. That lets this file live INSIDE the repo -- tracked and
+# reviewable -- while still governing a context that sits above it. Its patterns
+# are still interpreted relative to the CONTEXT root (hence the nextgcore/ and
+# nextgsim/ prefixes below), not relative to this directory.
+#
+# WHAT IT PREVENTS
+#
+# Without it, both cargo target/ trees ship to the daemon on every build:
+# nextgcore/src/target (~27GB) and nextgsim/target (~12GB). Measured on a real
+# build: the context went from 39GB to 26.83MB. preflight.sh cannot catch this
+# because it checks free space BEFORE the transfer that consumes it.
+#
+# TWO CAVEATS
+#
+# 1. Requires BuildKit. Docker >= 23 uses it by default; with DOCKER_BUILDKIT=0
+#    the legacy builder ignores this file and the full 39GB transfers again.
+# 2. A Dockerfile-scoped ignore file REPLACES the context-root .dockerignore
+#    rather than merging with it, so this file must be complete on its own.
+#
+# Dockerfile.builder COPYs exactly two paths:
+#   COPY nextgcore/src /build/nextgcore/src
+#   COPY nextgsim      /build/nextgsim
+# Keep nextgsim/config/ue.yaml: it is include_str!'d by
+# nextgsim-common/src/config.rs and the build fails without it.
+
+# Rust build artifacts -- the whole reason this file exists
+target/
+**/target/
+
+# Git metadata (never COPYed; hundreds of MB across the sibling repos)
+.git/
+**/.git/
+.gitignore
+.gitmodules
+
+# Sibling repo: 3GPP specs and audit notes, never COPYed by any Dockerfile
+6g_docs/
+
+# Staged build outputs -- regenerated per build. The images that consume them
+# (Dockerfile.nf, Dockerfile.gnb-local) use a narrower context of their own.
+nextgcore/binaries/
+nextgcore/docker/rust/binaries/
+nextgsim/binaries/
+nextgsim/docker/binaries/
+nextgcore/docker/rust/build-cache/
+
+# Agent/context tooling and local editor state
+.context/
+.claude/
+ideas/
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Local development noise
+*.log
+*.tmp
+.env
+.env.local
+.DS_Store
+
+# Test and coverage artifacts
+*.profraw
+*.profdata

--- a/docker/rust/build.sh
+++ b/docker/rust/build.sh
@@ -56,7 +56,15 @@ if [ "$SKIP_RUST" = false ]; then
     echo "(This builds both nextgcore and nextgsim inside a Rust container)"
     echo ""
 
-    # Build using Docker builder
+    # Build using Docker builder.
+    #
+    # The context is PROJECT_ROOT (the nextg parent dir) because
+    # Dockerfile.builder COPYs both nextgcore/src and the sibling nextgsim.
+    # Exclusions come from Dockerfile.builder.dockerignore next to the
+    # Dockerfile, NOT from a .dockerignore at the context root -- that
+    # directory is outside any git repo, so a file there could not be
+    # committed. BuildKit is required to honour it (preflight.sh refuses when
+    # DOCKER_BUILDKIT=0); without it ~39GB of cargo target/ transfers.
     docker build \
         -f "$SCRIPT_DIR/Dockerfile.builder" \
         -t nextg-builder:latest \

--- a/docker/rust/preflight.sh
+++ b/docker/rust/preflight.sh
@@ -78,6 +78,29 @@ if ! docker info >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
+# 1b. BuildKit enabled?
+#
+# Dockerfile.builder.dockerignore is a DOCKERFILE-SCOPED ignore file, which
+# only BuildKit resolves. It is the sole thing keeping the two cargo target/
+# trees (~39GB combined) out of the build context, and it has to live next to
+# the Dockerfile rather than at the context root because the context is the
+# nextg parent directory, which is not in any git repository.
+#
+# Under the legacy builder (DOCKER_BUILDKIT=0) that file is silently ignored
+# and the full 39GB transfers to the daemon -- which is precisely the
+# image-store-wipe-under-disk-pressure hazard (#269) this script exists to
+# prevent, and which the disk checks below CANNOT catch because they run
+# before the transfer that consumes the space.
+# ---------------------------------------------------------------------------
+if [ "${DOCKER_BUILDKIT:-1}" = "0" ]; then
+    log_error "DOCKER_BUILDKIT=0: the legacy builder ignores"
+    log_error "docker/rust/Dockerfile.builder.dockerignore, so ~39GB of cargo"
+    log_error "target/ would ship to the daemon (hazard #269). Unset"
+    log_error "DOCKER_BUILDKIT or set it to 1, then re-run."
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
 # 2. Trim the BuildKit cache (keep recent layers), 3. usage snapshot
 # ---------------------------------------------------------------------------
 if [ "$DO_PRUNE" = true ]; then


### PR DESCRIPTION
## Problem

`build.sh` and `build-multiarch.sh` pass `$PROJECT_ROOT` — the **nextg parent directory, one level above this repository** — as the Docker build context, because `Dockerfile.builder` COPYs both `nextgcore/src` and the sibling `nextgsim` tree.

Docker reads `.dockerignore` from the root of the **context**, and that directory is not part of any git repository: no commits, no remote, and no `nextg` repo exists in the org. So an ignore file placed there cannot be committed or reviewed, is absent from every fresh clone, and lives only on the machine that created it.

One *was* created in an earlier session and verified to work (39GB context → 26.83MB), but it has been **untracked its entire life**. Any new checkout silently reintroduces the defect and ships both cargo `target/` trees — `nextgcore/src/target` (~27GB) plus `nextgsim/target` (~12GB) — to the daemon.

`preflight.sh` cannot catch it: it checks free space **before** the transfer that consumes it. That is exactly hazard #269 (the 2026-06-12 image-store wipe under disk pressure).

## Solution

BuildKit also resolves a **Dockerfile-scoped** ignore file named `<dockerfile>.dockerignore`, looked up next to the Dockerfile rather than at the context root. `docker/rust/Dockerfile.builder.dockerignore` therefore lives **inside this repo** — tracked, reviewable, cloned — while governing a context that sits above it.

## Verified twice, not assumed

1. **Synthetic probe** — a scoped ignore listing only `CI.md` excluded exactly that file and left `target/` present. Confirms the file is read, *and* that patterns resolve against the **context root** rather than the Dockerfile's directory (hence the `nextgcore/` / `nextgsim/` prefixes).
2. **Real layout** — with the untracked root `.dockerignore` moved aside, a probe replicating `Dockerfile.builder`'s exact COPY pair transferred **1.06MB**, leaked **no** `target/` directory, and preserved `nextgsim/config/ue.yaml` (which is `include_str!`'d by `nextgsim-common/src/config.rs` — the build fails without it). 16.1M + 12.8M copied instead of 39G.

## Two caveats, both handled

**It replaces rather than merges.** A Dockerfile-scoped ignore file does not combine with a context-root `.dockerignore`, so this is a complete standalone copy of the exclusion set, not a delta.

**It requires BuildKit.** Under `DOCKER_BUILDKIT=0` the legacy builder ignores it *silently* and the full 39GB transfers again. Since a single environment variable defeats the entire protection, `preflight.sh` now refuses with **exit 2** in that case, naming the file and the hazard. Verified: `DOCKER_BUILDKIT=0 ./preflight.sh` → exit 2; a normal run → exit 0, "preflight OK". Docker ≥ 23 uses BuildKit by default (local daemon is 25.0.16).

## Changes

| File | Change |
|---|---|
| `docker/rust/Dockerfile.builder.dockerignore` | **new** — full exclusion set, header explains why it is not at the context root and that patterns are context-root-relative |
| `docker/rust/preflight.sh` | new check 1b: refuse when `DOCKER_BUILDKIT=0` |
| `docker/rust/Dockerfile.builder` | header note: where exclusions live, BuildKit requirement |
| `docker/rust/build.sh` | same note at the `docker build` call site |

The notes exist so nobody has to rediscover why the exclusions are not where Docker's documentation says to look.

## On the untracked root file

Deliberately left in place. With BuildKit the scoped file takes precedence for `Dockerfile.builder`, so the root copy is now **redundant rather than load-bearing** — losing it no longer reintroduces the defect. It still covers any *other* build invoked with that context, and this change cannot commit a file outside its own repository. Removing a working protection from someone's disk is not this change's business; tracked as a follow-up instead.

## Verification

- `shellcheck preflight.sh build.sh` — no new findings
- `DOCKER_BUILDKIT=0 ./preflight.sh` → exit 2 with the explanatory message; `./preflight.sh` → exit 0
- Real-layout build probe as above
- Workspace unaffected: **5307 passed / 0 failed**, clippy and fmt clean

A full `build.sh` run is deliberately **not** part of verification: at ~88GB free a regression would refill the disk, which is the very failure this guards against. The probes exercise the same COPY pair and the same ignore file at a fraction of the cost.

Independent of #139 — disjoint files (`docker/rust/*` here vs `src/bins/*` and `src/libs/*` there), so the two merge in either order.

Spec: `specs/fix-dockerfile-scoped-build-context-ignore.md`