### PR TITLE
fix(bsfd): Nbsf_Management wire conformance — all six defects (closes #97)

### DIFF
--- a/src/bins/nextgcore-bsfd/src/context.rs
+++ b/src/bins/nextgcore-bsfd/src/context.rs
@@ -64,8 +64,11 @@ pub struct PcfUeBinding {
     pub pcf_set_id: Option<String>,
     pub bind_level: Option<String>,
     pub recovery_time: Option<String>,
-    pub pcf_diam_host: Option<String>,
-    pub pcf_diam_realm: Option<String>,
+    // NOTE: no pcf_diam_host / pcf_diam_realm here. Those ARE valid members of
+    // PcfBinding (the PDU-session binding, TS29521_Nbsf_Management.yaml:1097)
+    // and PcfBindingPatch (:1176), and the PDU path stores them -- but
+    // PcfForUeBinding (:1390-1420) does not define them, so emitting them here
+    // polluted the resource representation.
     pub management_features: u64,
 }
 
@@ -2066,8 +2069,6 @@ mod tests {
             pcf_set_id: None,
             bind_level: None,
             recovery_time: None,
-            pcf_diam_host: None,
-            pcf_diam_realm: None,
             management_features: 0x1,
         };
         ctx.ue_binding_add(b.clone());

--- a/src/bins/nextgcore-bsfd/src/context.rs
+++ b/src/bins/nextgcore-bsfd/src/context.rs
@@ -441,10 +441,20 @@ pub struct BsfSess {
     /// DNN (Data Network Name)
     pub dnn: Option<String>,
 
-    /// PCF FQDN
+    /// PCF FQDN hosting Npcf_PolicyAuthorization (TS 29.521 PcfBinding.pcfFqdn)
     pub pcf_fqdn: Option<String>,
-    /// PCF IP endpoints
+    /// PCF IP endpoints (PcfBinding.pcfIpEndPoints)
     pub pcf_ip: Vec<PcfIpEndpoint>,
+    /// FQDN of the PCF hosting **Npcf_SMPolicyControl**
+    /// (PcfBinding.pcfSmFqdn, TS29521_Nbsf_Management.yaml:1101). This is a
+    /// DISTINCT endpoint from pcf_fqdn above, and it is what the SamePcf
+    /// duplicate-detection 403 must advertise -- BindingResp (the ExtProblemDetails
+    /// extension) defines pcfSmFqdn / pcfSmIpEndPoints, not the
+    /// PolicyAuthorization address.
+    pub pcf_sm_fqdn: Option<String>,
+    /// IP end points of the PCF hosting Npcf_SMPolicyControl
+    /// (PcfBinding.pcfSmIpEndPoints, :1104).
+    pub pcf_sm_ip: Vec<PcfIpEndpoint>,
     /// PCF instance ID (TS 29.512 NF instance ID, bsfd-08)
     pub pcf_id: Option<String>,
     /// PCF set ID (bsfd-08)
@@ -485,6 +495,8 @@ impl BsfSess {
             s_nssai: SNssai::default(),
             dnn: None,
             pcf_fqdn: None,
+            pcf_sm_fqdn: None,
+            pcf_sm_ip: Vec::new(),
             pcf_ip: Vec::new(),
             pcf_id: None,
             pcf_set_id: None,
@@ -1301,6 +1313,9 @@ pub fn sess_to_doc(sess: &BsfSess) -> nextgcore_dbi::mongodb::bson::Document {
     if let Some(sd) = sess.s_nssai.sd {
         d.insert("sd", sd as i64);
     }
+    if let Some(ref v) = sess.pcf_sm_fqdn {
+        d.insert("pcf_sm_fqdn", v);
+    }
     if let Some(ref pcf_fqdn) = sess.pcf_fqdn {
         d.insert("pcf_fqdn", pcf_fqdn);
     }
@@ -1382,6 +1397,9 @@ pub fn doc_to_sess(doc: &nextgcore_dbi::mongodb::bson::Document) -> BsfSess {
     }
     if let Ok(sd) = doc.get_i64("sd") {
         sess.s_nssai.sd = Some(sd as u32);
+    }
+    if let Ok(v) = doc.get_str("pcf_sm_fqdn") {
+        sess.pcf_sm_fqdn = Some(v.to_string());
     }
     if let Ok(pcf_fqdn) = doc.get_str("pcf_fqdn") {
         sess.pcf_fqdn = Some(pcf_fqdn.to_string());

--- a/src/bins/nextgcore-bsfd/src/context.rs
+++ b/src/bins/nextgcore-bsfd/src/context.rs
@@ -77,13 +77,79 @@ pub struct PcfUeBinding {
 #[derive(Debug, Clone)]
 pub struct PcfMbsBinding {
     pub binding_id: String,
-    /// Opaque MBS Session ID (TMGI or SSM form per TS 29.571).
-    pub mbs_session_id: String,
+    /// MBS Session ID as received. TS 29.571 `MbsSessionId` is an OBJECT
+    /// (`anyOf` tmgi / ssm, plus optional nid), not a scalar -- it is stored
+    /// verbatim so the create response and GET can echo the representation the
+    /// consumer sent, and matched via [`mbs_session_key`] rather than by text.
+    pub mbs_session_id: serde_json::Value,
     pub pcf_fqdn: Option<String>,
     pub pcf_ip: Vec<PcfIpEndpoint>,
     pub pcf_id: Option<String>,
     pub pcf_set_id: Option<String>,
+    pub bind_level: Option<String>,
+    pub recovery_time: Option<String>,
     pub management_features: u64,
+}
+
+/// Canonical comparison key for a TS 29.571 `MbsSessionId`.
+///
+/// Two objects can denote the SAME session yet differ byte-for-byte: JSON key
+/// order is not significant, and `Tmgi.mbsServiceId` is `^[A-Fa-f0-9]{6}$` so
+/// `0A1B2C` and `0a1b2c` are the same service. Comparing serialized text would
+/// therefore make discovery miss a binding the consumer had just created, and
+/// would let a duplicate registration slip past the EXISTING_BINDING_INFO_FOUND
+/// check. Reducing to an order-independent, case-folded key fixes both.
+///
+/// `None` when the value carries neither a usable `tmgi` nor `ssm`, so a
+/// malformed id never compares equal to anything (including another malformed
+/// one).
+pub fn mbs_session_key(v: &serde_json::Value) -> Option<String> {
+    let obj = v.as_object()?;
+    let nid = obj
+        .get("nid")
+        .and_then(|n| n.as_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if let Some(tmgi) = obj.get("tmgi").and_then(|t| t.as_object()) {
+        let svc = tmgi.get("mbsServiceId").and_then(|s| s.as_str())?;
+        let plmn = tmgi.get("plmnId").and_then(|p| p.as_object())?;
+        let mcc = plmn.get("mcc").and_then(|s| s.as_str())?;
+        let mnc = plmn.get("mnc").and_then(|s| s.as_str())?;
+        return Some(format!(
+            "tmgi:{}:{}:{}:{}",
+            svc.to_ascii_lowercase(),
+            mcc,
+            mnc,
+            nid
+        ));
+    }
+    if let Some(ssm) = obj.get("ssm").and_then(|s| s.as_object()) {
+        // IpAddr is itself a oneOf (ipv4Addr / ipv6Addr / ipv6Prefix); fold the
+        // whole address object to a stable string rather than assuming a form.
+        let fold = |k: &str| -> Option<String> {
+            let a = ssm.get(k)?;
+            match a {
+                serde_json::Value::String(s) => Some(s.to_ascii_lowercase()),
+                serde_json::Value::Object(m) => {
+                    let mut parts: Vec<String> = m
+                        .iter()
+                        .filter_map(|(k, v)| {
+                            v.as_str()
+                                .map(|s| format!("{k}={}", s.to_ascii_lowercase()))
+                        })
+                        .collect();
+                    parts.sort();
+                    Some(parts.join(","))
+                }
+                _ => None,
+            }
+        };
+        let src = fold("sourceIpAddr")?;
+        let dst = fold("destIpAddr")?;
+        return Some(format!("ssm:{src}:{dst}:{nid}"));
+    }
+    None
 }
 
 /// IPv6 prefix structure
@@ -1111,11 +1177,19 @@ impl BsfContext {
 
     /// Return all MBS bindings keyed by the given mbs_session_id.
     /// TS 29.521 §4.2.2.4: a duplicate is 403; multi-match is 400.
-    pub fn mbs_binding_find_by_mbs_session_id(&self, mbs_session_id: &str) -> Vec<PcfMbsBinding> {
+    pub fn mbs_binding_find_by_mbs_session_id(
+        &self,
+        mbs_session_id: &serde_json::Value,
+    ) -> Vec<PcfMbsBinding> {
+        // Semantic match on the canonical key, not on serialized text -- see
+        // mbs_session_key. An unusable query id matches nothing.
+        let Some(want) = mbs_session_key(mbs_session_id) else {
+            return Vec::new();
+        };
         match self.mbs_binding_list.read() {
             Ok(list) => list
                 .values()
-                .filter(|b| b.mbs_session_id == mbs_session_id)
+                .filter(|b| mbs_session_key(&b.mbs_session_id).as_deref() == Some(want.as_str()))
                 .cloned()
                 .collect(),
             Err(_) => Vec::new(),
@@ -2110,13 +2184,26 @@ mod tests {
         let mut ctx = BsfContext::new();
         ctx.init(100);
 
+        // A real TS 29.571 MbsSessionId object. This test previously used the
+        // string "TMGI-ABC", which is not a valid MbsSessionId in any form --
+        // that spelling only worked because the store compared raw strings.
+        let tmgi = |svc: &str| {
+            serde_json::json!({
+                "tmgi": {"mbsServiceId": svc, "plmnId": {"mcc": "001", "mnc": "01"}}
+            })
+        };
+        let id_abc = tmgi("0a1b2c");
+        let id_xyz = tmgi("ffeedd");
+
         let b1 = PcfMbsBinding {
             binding_id: "mbs-1".to_string(),
-            mbs_session_id: "TMGI-ABC".to_string(),
+            mbs_session_id: id_abc.clone(),
             pcf_fqdn: Some("pcf.example.com".to_string()),
             pcf_ip: Vec::new(),
             pcf_id: None,
             pcf_set_id: None,
+            bind_level: None,
+            recovery_time: None,
             management_features: 0x1,
         };
         ctx.mbs_binding_add(b1.clone());
@@ -2125,30 +2212,101 @@ mod tests {
         assert!(ctx.mbs_binding_find_by_id("mbs-1").is_some());
 
         // Find by mbs_session_id (single match).
-        let found = ctx.mbs_binding_find_by_mbs_session_id("TMGI-ABC");
+        let found = ctx.mbs_binding_find_by_mbs_session_id(&id_abc);
         assert_eq!(found.len(), 1);
 
         // Duplicate mbs_session_id: two bindings → caller detects multi-match.
         let b2 = PcfMbsBinding {
             binding_id: "mbs-2".to_string(),
-            mbs_session_id: "TMGI-ABC".to_string(),
+            mbs_session_id: id_abc.clone(),
             pcf_fqdn: Some("pcf2.example.com".to_string()),
             pcf_ip: Vec::new(),
             pcf_id: None,
             pcf_set_id: None,
+            bind_level: None,
+            recovery_time: None,
             management_features: 0x1,
         };
         ctx.mbs_binding_add(b2);
-        assert_eq!(ctx.mbs_binding_find_by_mbs_session_id("TMGI-ABC").len(), 2);
+        assert_eq!(ctx.mbs_binding_find_by_mbs_session_id(&id_abc).len(), 2);
 
         // Remove one; only one left.
         ctx.mbs_binding_remove("mbs-1");
-        assert_eq!(ctx.mbs_binding_find_by_mbs_session_id("TMGI-ABC").len(), 1);
+        assert_eq!(ctx.mbs_binding_find_by_mbs_session_id(&id_abc).len(), 1);
 
         // Different mbs_session_id: no match.
+        assert!(ctx.mbs_binding_find_by_mbs_session_id(&id_xyz).is_empty());
+
+        // Matching is SEMANTIC, not textual: mbsServiceId is ^[A-Fa-f0-9]{6}$,
+        // so hex case must not matter, and JSON key order is not significant.
+        // A textual == would miss both of these.
+        let upper = serde_json::json!({
+            "tmgi": {"mbsServiceId": "0A1B2C", "plmnId": {"mcc": "001", "mnc": "01"}}
+        });
+        assert_eq!(
+            ctx.mbs_binding_find_by_mbs_session_id(&upper).len(),
+            1,
+            "hex case in mbsServiceId must not affect matching"
+        );
+        let reordered = serde_json::json!({
+            "tmgi": {"plmnId": {"mnc": "01", "mcc": "001"}, "mbsServiceId": "0a1b2c"}
+        });
+        assert_eq!(
+            ctx.mbs_binding_find_by_mbs_session_id(&reordered).len(),
+            1,
+            "JSON key order must not affect matching"
+        );
+
+        // A different PLMN is a different session even with the same service id.
+        let other_plmn = serde_json::json!({
+            "tmgi": {"mbsServiceId": "0a1b2c", "plmnId": {"mcc": "999", "mnc": "99"}}
+        });
         assert!(ctx
-            .mbs_binding_find_by_mbs_session_id("TMGI-XYZ")
+            .mbs_binding_find_by_mbs_session_id(&other_plmn)
             .is_empty());
+
+        // An unusable id matches nothing rather than everything.
+        assert!(ctx
+            .mbs_binding_find_by_mbs_session_id(&serde_json::json!({}))
+            .is_empty());
+        assert!(ctx
+            .mbs_binding_find_by_mbs_session_id(&serde_json::json!("TMGI-ABC"))
+            .is_empty());
+    }
+
+    /// The canonical key folds representational differences and separates
+    /// genuinely different sessions (TS 29.571 MbsSessionId / Tmgi / Ssm).
+    #[test]
+    fn test_mbs_session_key_canonicalisation() {
+        let a = serde_json::json!({
+            "tmgi": {"mbsServiceId": "0A1B2C", "plmnId": {"mcc": "001", "mnc": "01"}}
+        });
+        let b = serde_json::json!({
+            "tmgi": {"plmnId": {"mnc": "01", "mcc": "001"}, "mbsServiceId": "0a1b2c"}
+        });
+        assert_eq!(mbs_session_key(&a), mbs_session_key(&b));
+        assert!(mbs_session_key(&a).is_some());
+
+        // nid disambiguates SNPN sessions.
+        let mut with_nid = a.clone();
+        with_nid["nid"] = serde_json::json!("000007ABCDE");
+        assert_ne!(mbs_session_key(&a), mbs_session_key(&with_nid));
+
+        // ssm form keys on both addresses.
+        let ssm = serde_json::json!({
+            "ssm": {"sourceIpAddr": {"ipv4Addr": "10.0.0.1"},
+                    "destIpAddr": {"ipv4Addr": "232.0.0.1"}}
+        });
+        assert!(mbs_session_key(&ssm).is_some());
+        assert_ne!(mbs_session_key(&ssm), mbs_session_key(&a));
+
+        // Neither tmgi nor ssm, and non-objects, are unusable.
+        assert!(mbs_session_key(&serde_json::json!({"nid": "000007ABCDE"})).is_none());
+        assert!(mbs_session_key(&serde_json::json!("TMGI-ABC")).is_none());
+        // tmgi missing plmnId is unusable.
+        assert!(
+            mbs_session_key(&serde_json::json!({"tmgi": {"mbsServiceId": "0a1b2c"}})).is_none()
+        );
     }
 
     #[test]

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -751,15 +751,36 @@ async fn handle_pcf_binding_create(request: &SbiRequest) -> SbiResponse {
                     "cause".to_string(),
                     serde_json::json!("EXISTING_BINDING_INFO_FOUND"),
                 );
-                if let Some(ref fqdn) = dup.pcf_fqdn {
+                // BindingResp (the ExtProblemDetails extension) defines
+                // pcfSmFqdn / pcfSmIpEndPoints: the Npcf_SMPolicyControl
+                // endpoint, NOT the PolicyAuthorization address. Emitting
+                // dup.pcf_fqdn here advertised the wrong service and routed
+                // SamePcf recovery to the wrong node. Fall back to the
+                // PolicyAuthorization address only when no SM address was
+                // registered, and say so rather than substituting silently.
+                let sm_fqdn = dup.pcf_sm_fqdn.as_ref().or_else(|| {
+                    if dup.pcf_fqdn.is_some() {
+                        log::warn!(
+                            "SamePcf 403: no pcfSmFqdn registered for this binding; \
+                             falling back to pcfFqdn, which may not host \
+                             Npcf_SMPolicyControl"
+                        );
+                    }
+                    dup.pcf_fqdn.as_ref()
+                });
+                if let Some(fqdn) = sm_fqdn {
                     ext.insert(
                         "pcfSmFqdn".to_string(),
                         serde_json::Value::String(fqdn.clone()),
                     );
                 }
-                if !dup.pcf_ip.is_empty() {
-                    let eps: Vec<serde_json::Value> = dup
-                        .pcf_ip
+                let sm_eps = if !dup.pcf_sm_ip.is_empty() {
+                    &dup.pcf_sm_ip
+                } else {
+                    &dup.pcf_ip
+                };
+                if !sm_eps.is_empty() {
+                    let eps: Vec<serde_json::Value> = sm_eps
                         .iter()
                         .map(|ep| {
                             let mut e = serde_json::Map::new();
@@ -789,9 +810,15 @@ async fn handle_pcf_binding_create(request: &SbiRequest) -> SbiResponse {
                         serde_json::Value::Array(eps),
                     );
                 }
-                return SbiResponse::with_status(403)
-                    .with_json_body(&serde_json::Value::Object(ext))
-                    .unwrap_or_else(|_| SbiResponse::with_status(403));
+                // TS 29.521 declares this 403 as application/problem+json with
+                // ExtProblemDetails. with_json_body hardcodes application/json
+                // (message.rs:553), and with_problem cannot be used because
+                // ExtProblemDetails is allOf [ProblemDetails, BindingResp] -- it
+                // carries members the typed ProblemDetails has no room for.
+                return SbiResponse::with_status(403).with_body(
+                    serde_json::Value::Object(ext).to_string(),
+                    "application/problem+json",
+                );
             }
         }
     }
@@ -830,6 +857,39 @@ async fn handle_pcf_binding_create(request: &SbiRequest) -> SbiResponse {
             }
             if let Some(endpoints) = binding_data.get("pcfIpEndPoints") {
                 sess.pcf_ip = parse_pcf_ip_endpoints(endpoints);
+            }
+            // The SM-PCF address is a DISTINCT PcfBinding member from the
+            // PolicyAuthorization one above (TS 29.521 :1101-1108) and is what the
+            // SamePcf 403 must advertise. It was never parsed, so that 403
+            // relabelled the PolicyAuthorization address as the SM one.
+            if let Some(v) = binding_data.get("pcfSmFqdn").and_then(|v| v.as_str()) {
+                sess.pcf_sm_fqdn = Some(v.to_string());
+            }
+            if let Some(endpoints) = binding_data.get("pcfSmIpEndPoints") {
+                sess.pcf_sm_ip = parse_pcf_ip_endpoints(endpoints);
+            }
+            // Framed routes (PcfBinding.ipv4FrameRouteList / ipv6FrameRouteList,
+            // :1126-1134). Only the PATCH path parsed these, yet discovery
+            // matching depends on them (context ipv4_in_frame_routes /
+            // ipv6_in_frame_routes), so a UE reachable only via a framed route was
+            // undiscoverable after a conformant registration.
+            if let Some(routes) = binding_data
+                .get("ipv4FrameRouteList")
+                .and_then(|v| v.as_array())
+            {
+                sess.ipv4_frame_route_list = routes
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
+            }
+            if let Some(routes) = binding_data
+                .get("ipv6FrameRouteList")
+                .and_then(|v| v.as_array())
+            {
+                sess.ipv6_frame_route_list = routes
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
             }
             if let Some(e) = expiry {
                 sess.set_expiry(e);
@@ -1525,10 +1585,9 @@ async fn handle_pcf_ue_binding_discovery(request: &SbiRequest) -> SbiResponse {
         .map(|g| g.ue_binding_find_matching(supi, gpsi))
         .unwrap_or_default();
 
-    if results.is_empty() {
-        return SbiResponse::with_status(204);
-    }
-
+    // TS 29.521 defines only a 200 whose schema is `type: array, minItems: 0`
+    // for this operation -- no 204 exists, so an empty result is an empty ARRAY.
+    // (The SM GET /pcfBindings legitimately defines 204 and keeps it.)
     let arr: Vec<serde_json::Value> = results.iter().map(ue_binding_json).collect();
     SbiResponse::with_status(200)
         .with_json_body(&serde_json::Value::Array(arr))
@@ -1802,15 +1861,48 @@ async fn handle_pcf_mbs_binding_create(request: &SbiRequest) -> SbiResponse {
             "cause".to_string(),
             serde_json::json!("EXISTING_BINDING_INFO_FOUND"),
         );
+        // MbsExtProblemDetails extends ProblemDetails with MbsBindingResp, whose
+        // members are pcfFqdn / pcfIpEndPoints (anyOf) -- NOT pcfSmFqdn. An MBS
+        // binding has no Npcf_SMPolicyControl notion at all.
         if let Some(ref fqdn) = first.pcf_fqdn {
             ext.insert(
-                "pcfSmFqdn".to_string(),
+                "pcfFqdn".to_string(),
                 serde_json::Value::String(fqdn.clone()),
             );
         }
-        return SbiResponse::with_status(403)
-            .with_json_body(&serde_json::Value::Object(ext))
-            .unwrap_or_else(|_| SbiResponse::with_status(403));
+        if !first.pcf_ip.is_empty() {
+            let eps: Vec<serde_json::Value> = first
+                .pcf_ip
+                .iter()
+                .map(|ep| {
+                    let mut e = serde_json::Map::new();
+                    if let Some(ref a) = ep.addr {
+                        e.insert(
+                            "ipv4Address".to_string(),
+                            serde_json::Value::String(a.clone()),
+                        );
+                    }
+                    if let Some(ref a6) = ep.addr6 {
+                        e.insert(
+                            "ipv6Address".to_string(),
+                            serde_json::Value::String(a6.clone()),
+                        );
+                    }
+                    if ep.is_port {
+                        e.insert(
+                            "port".to_string(),
+                            serde_json::Value::Number(ep.port.into()),
+                        );
+                    }
+                    serde_json::Value::Object(e)
+                })
+                .collect();
+            ext.insert("pcfIpEndPoints".to_string(), serde_json::Value::Array(eps));
+        }
+        return SbiResponse::with_status(403).with_body(
+            serde_json::Value::Object(ext).to_string(),
+            "application/problem+json",
+        );
     }
 
     let consumer_feat = data
@@ -1925,10 +2017,18 @@ async fn handle_pcf_mbs_binding_discovery(request: &SbiRequest) -> SbiResponse {
         .unwrap_or_default();
 
     match results.as_slice() {
-        [] => SbiResponse::with_status(204),
-        [b] => SbiResponse::with_status(200)
-            .with_json_body(&mbs_binding_json(b))
-            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        // As above: a 200 array with minItems 0, never a 204 and never a bare
+        // object -- a consumer following the array contract breaks on both.
+        [] | [_] => {
+            let arr: Vec<serde_json::Value> = results.iter().map(mbs_binding_json).collect();
+            SbiResponse::with_status(200)
+                .with_json_body(&serde_json::Value::Array(arr))
+                .unwrap_or_else(|_| SbiResponse::with_status(200))
+        }
+        // Multi-match now indicates corrupt state rather than a normal outcome:
+        // defect 3's canonical keying refuses a second binding for one session at
+        // create time with 403, and the spec's array response does not describe
+        // how to rank duplicates.
         _ => nextgcore_sbi::server::send_error(
             400,
             "Bad Request",
@@ -3304,14 +3404,22 @@ mod tests {
             .expect("GET deleted ue");
         assert_eq!(resp.status, 404);
 
-        // Discovery after delete → 204 (empty).
+        // Discovery after delete → 200 with an EMPTY ARRAY.
+        //
+        // This asserted 204, which is the #97 defect 5 non-conformance: TS 29.521
+        // defines only a 200 of `type: array, minItems: 0` for this operation.
+        // (The SM GET /pcfBindings legitimately defines 204 -- see the guard in
+        // test_discovery_success_shapes.)
         let mut req = SbiRequest::get("/nbsf-management/v1/pcf-ue-bindings");
         req.http.set_param("supi", "imsi-001019900111001");
         let resp = client
             .send_request(req)
             .await
             .expect("discover ue after delete");
-        assert_eq!(resp.status, 204);
+        assert_eq!(resp.status, 200);
+        let arr: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(arr, json!([]), "empty result is an empty array, not a 204");
 
         server.stop().await.expect("server stops");
     }
@@ -3597,6 +3705,229 @@ mod tests {
         assert_eq!(resp.status, 400);
     }
 
+    /// #97 defect 5: discovery success shapes.
+    ///
+    /// TS 29.521 defines for GET /pcf-ue-bindings and GET /pcf-mbs-bindings ONLY
+    /// a 200 whose schema is `type: array, minItems: 0` -- no 204 on either, and
+    /// never a bare object. The SM GET /pcfBindings DOES define 204 (:104-105),
+    /// and that asymmetry is deliberate: the fix must not make all three uniform.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_discovery_success_shapes() {
+        let (_srv, client) = start_bsf().await;
+
+        // UE: no match -> 200 [].
+        let mut req = SbiRequest::get("/nbsf-management/v1/pcf-ue-bindings");
+        req.http.set_param("supi", "imsi-001019900975001");
+        let resp = client.send_request(req).await.expect("ue discover empty");
+        assert_eq!(resp.status, 200, "no 204 is defined for this operation");
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body, json!([]));
+
+        // MBS: no match -> 200 [].
+        let id = json!({
+            "tmgi": {"mbsServiceId": "975002", "plmnId": {"mcc": "001", "mnc": "01"}}
+        });
+        let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
+        req.http
+            .set_param("mbs-session-id", &pct_encode_query(&id.to_string()));
+        let resp = client.send_request(req).await.expect("mbs discover empty");
+        assert_eq!(resp.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body, json!([]));
+
+        // MBS: ONE match -> a one-element ARRAY, not a bare object. A consumer
+        // iterating the array contract breaks on a bare object.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-mbs-bindings",
+                &json!({"mbsSessionId": id.clone(), "pcfFqdn": "pcf.shapes.example.com"}),
+            )
+            .await
+            .expect("POST mbs");
+        assert_eq!(resp.status, 201);
+        let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
+        req.http
+            .set_param("mbs-session-id", &pct_encode_query(&id.to_string()));
+        let resp = client.send_request(req).await.expect("mbs discover one");
+        assert_eq!(resp.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        let arr = body
+            .as_array()
+            .expect("must be an array, not a bare object");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["mbsSessionId"], id);
+
+        // ASYMMETRY GUARD: the SM GET /pcfBindings legitimately defines 204 and
+        // must keep it.
+        let mut req = SbiRequest::get("/nbsf-management/v1/pcfBindings");
+        req.http.set_param("ipv4Addr", "10.45.99.199");
+        let resp = client.send_request(req).await.expect("sm discover empty");
+        assert_eq!(
+            resp.status, 204,
+            "GET /pcfBindings DOES define 204; this must not be normalised away"
+        );
+    }
+
+    /// #97 defect 4: the SamePcf duplicate 403 media type and the SM-PCF address.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_same_pcf_403_problem_json_and_sm_address() {
+        let (_srv, client) = start_bsf().await;
+
+        // Register with DISTINCT PolicyAuthorization and SM-PCF addresses, plus
+        // paraCom so SamePcf detection can fire.
+        let body = json!({
+            "supi": "imsi-001019900974001",
+            "ipv4Addr": "10.45.0.174",
+            "dnn": "internet",
+            "snssai": {"sst": 1},
+            "pcfFqdn": "pcf-authz.example.com",
+            "pcfSmFqdn": "pcf-smpolicy.example.com",
+            "pcfSmIpEndPoints": [{"ipv4Address": "10.45.0.199", "port": 8888}],
+            "suppFeat": "4",
+            "paraCom": {"supi": "imsi-001019900974001", "dnn": "internet",
+                        "snssai": {"sst": 1}}
+        });
+        let resp = client
+            .post_json("/nbsf-management/v1/pcfBindings", &body)
+            .await
+            .expect("POST first");
+        assert_eq!(resp.status, 201);
+
+        // Duplicate -> 403.
+        let resp = client
+            .post_json("/nbsf-management/v1/pcfBindings", &body)
+            .await
+            .expect("POST duplicate");
+        assert_eq!(resp.status, 403);
+
+        // application/problem+json, not application/json: TS 29.521 declares the
+        // 403 as ExtProblemDetails. with_json_body hardcoded application/json.
+        let ct = resp
+            .http
+            .get_header("Content-Type")
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            ct.contains("application/problem+json"),
+            "403 must be application/problem+json, got {ct:?}"
+        );
+
+        let ext: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(ext["cause"], "EXISTING_BINDING_INFO_FOUND");
+        // BindingResp defines pcfSmFqdn as the Npcf_SMPolicyControl endpoint. The
+        // handler used to emit the PolicyAuthorization address under this name,
+        // routing SamePcf recovery to the wrong service.
+        assert_eq!(
+            ext["pcfSmFqdn"], "pcf-smpolicy.example.com",
+            "the 403 must advertise the SM-PCF address, not the PolicyAuthorization one"
+        );
+        assert_eq!(ext["pcfSmIpEndPoints"][0]["ipv4Address"], "10.45.0.199");
+        assert_eq!(ext["pcfSmIpEndPoints"][0]["port"], 8888);
+    }
+
+    /// #97 defect 4 (MBS half): MbsExtProblemDetails extends MbsBindingResp,
+    /// whose members are pcfFqdn / pcfIpEndPoints -- an MBS binding has no
+    /// Npcf_SMPolicyControl notion, so pcfSmFqdn is wrong there.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mbs_duplicate_403_uses_pcf_fqdn_and_problem_json() {
+        let (_srv, client) = start_bsf().await;
+        let id = json!({
+            "tmgi": {"mbsServiceId": "974100", "plmnId": {"mcc": "001", "mnc": "01"}}
+        });
+        let body = json!({
+            "mbsSessionId": id.clone(),
+            "pcfFqdn": "pcf.mbs974.example.com",
+            "pcfIpEndPoints": [{"ipv4Address": "10.45.0.174", "port": 7777}]
+        });
+
+        let resp = client
+            .post_json("/nbsf-management/v1/pcf-mbs-bindings", &body)
+            .await
+            .expect("POST mbs first");
+        assert_eq!(resp.status, 201);
+
+        let resp = client
+            .post_json("/nbsf-management/v1/pcf-mbs-bindings", &body)
+            .await
+            .expect("POST mbs duplicate");
+        assert_eq!(resp.status, 403);
+        let ct = resp
+            .http
+            .get_header("Content-Type")
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            ct.contains("application/problem+json"),
+            "MBS 403 must be application/problem+json, got {ct:?}"
+        );
+        let ext: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(ext["pcfFqdn"], "pcf.mbs974.example.com");
+        assert_eq!(ext["pcfIpEndPoints"][0]["ipv4Address"], "10.45.0.174");
+        assert!(
+            ext.get("pcfSmFqdn").is_none(),
+            "pcfSmFqdn is not an MbsBindingResp member"
+        );
+    }
+
+    /// #97 defect 6: framed-route lists must be stored on CREATE, not only on
+    /// PATCH -- discovery matching (context ipv4_in_frame_routes /
+    /// ipv6_in_frame_routes) depends on them, so a UE reachable only via a framed
+    /// route was undiscoverable after a conformant registration.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_framed_routes_stored_on_create() {
+        let (_srv, client) = start_bsf().await;
+
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcfBindings",
+                &json!({
+                    "supi": "imsi-001019900976001",
+                    "ipv4Addr": "10.45.0.176",
+                    "dnn": "internet",
+                    "snssai": {"sst": 1},
+                    "pcfFqdn": "pcf.routes.example.com",
+                    "ipv4FrameRouteList": ["10.76.0.0/24"],
+                    "ipv6FrameRouteList": ["2001:db8:76::/64"]
+                }),
+            )
+            .await
+            .expect("POST with framed routes");
+        assert_eq!(resp.status, 201);
+
+        // An address INSIDE the framed route resolves to this binding. Before the
+        // fix, create dropped the lists so this found nothing.
+        let mut req = SbiRequest::get("/nbsf-management/v1/pcfBindings");
+        req.http.set_param("ipv4Addr", "10.76.0.9");
+        let resp = client
+            .send_request(req)
+            .await
+            .expect("discover by framed route");
+        assert_eq!(
+            resp.status, 200,
+            "a UE inside an ipv4FrameRouteList must be discoverable"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body["supi"], "imsi-001019900976001");
+
+        // Same for the IPv6 framed route.
+        let mut req = SbiRequest::get("/nbsf-management/v1/pcfBindings");
+        req.http.set_param("ipv6Prefix", "2001:db8:76::5/128");
+        let resp = client
+            .send_request(req)
+            .await
+            .expect("discover by ipv6 route");
+        assert_eq!(resp.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body["supi"], "imsi-001019900976001");
+    }
+
     // bsfd-12: pcf-mbs-bindings lifecycle + duplicate 403 + multi-match 400
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_http_pcf_mbs_bindings_lifecycle() {
@@ -3693,7 +4024,11 @@ mod tests {
             &pct_encode_query(&mbs_id_other.to_string()),
         );
         let resp = client.send_request(req).await.expect("discover mbs miss");
-        assert_eq!(resp.status, 204);
+        // 200 with an empty array, not 204 (see the UE site above).
+        assert_eq!(resp.status, 200);
+        let arr: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(arr, json!([]));
 
         // PATCH → 200.
         let mut req = SbiRequest::patch(format!("/nbsf-management/v1/pcf-mbs-bindings/{mbs_id}"));

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -1619,6 +1619,71 @@ async fn handle_pcf_ue_binding_update(binding_id: &str, request: &SbiRequest) ->
 // bsfd-12: pcf-mbs-bindings resource (TS 29.521 §4.2.2.4/§4.2.4.4)
 // ---------------------------------------------------------------------------
 
+/// Validate a TS 29.571 `MbsSessionId` object.
+///
+/// Schema: `type: object`, `anyOf: [required: [tmgi], required: [ssm]]`, with
+/// `Tmgi` requiring `mbsServiceId` + `plmnId` and `Ssm` requiring
+/// `sourceIpAddr` + `destIpAddr`. Returns a human-readable detail on rejection.
+///
+/// A bare string is rejected explicitly rather than coerced, so the pre-fix
+/// spelling fails loudly instead of being accepted as a degenerate object.
+fn validate_mbs_session_id(v: &serde_json::Value) -> Result<(), String> {
+    let Some(obj) = v.as_object() else {
+        return Err(
+            "mbsSessionId must be an object with tmgi or ssm (TS 29.571 MbsSessionId), \
+             not a string"
+                .to_string(),
+        );
+    };
+    let has_tmgi = obj.contains_key("tmgi");
+    let has_ssm = obj.contains_key("ssm");
+    if !has_tmgi && !has_ssm {
+        return Err("mbsSessionId requires tmgi or ssm (TS 29.571 anyOf)".to_string());
+    }
+    if has_tmgi {
+        let Some(t) = obj.get("tmgi").and_then(|t| t.as_object()) else {
+            return Err("mbsSessionId.tmgi must be an object".to_string());
+        };
+        if !t
+            .get("mbsServiceId")
+            .and_then(|x| x.as_str())
+            .is_some_and(|s| s.len() == 6 && s.bytes().all(|b| b.is_ascii_hexdigit()))
+        {
+            return Err(
+                "mbsSessionId.tmgi.mbsServiceId must be 6 hex digits (TS 29.571 Tmgi)".to_string(),
+            );
+        }
+        let plmn_ok = t
+            .get("plmnId")
+            .and_then(|p| p.as_object())
+            .is_some_and(|p| {
+                p.get("mcc").and_then(|x| x.as_str()).is_some()
+                    && p.get("mnc").and_then(|x| x.as_str()).is_some()
+            });
+        if !plmn_ok {
+            return Err(
+                "mbsSessionId.tmgi.plmnId must carry mcc and mnc (TS 29.571 Tmgi)".to_string(),
+            );
+        }
+    }
+    if has_ssm {
+        let Some(m) = obj.get("ssm").and_then(|x| x.as_object()) else {
+            return Err("mbsSessionId.ssm must be an object".to_string());
+        };
+        if !m.contains_key("sourceIpAddr") || !m.contains_key("destIpAddr") {
+            return Err(
+                "mbsSessionId.ssm requires sourceIpAddr and destIpAddr (TS 29.571 Ssm)".to_string(),
+            );
+        }
+    }
+    // Belt-and-braces: the canonical key must be derivable, or discovery could
+    // never find what we are about to store.
+    if context::mbs_session_key(v).is_none() {
+        return Err("mbsSessionId is not usable as a binding key".to_string());
+    }
+    Ok(())
+}
+
 /// Build the PcfMbsBinding JSON representation.
 fn mbs_binding_json(b: &context::PcfMbsBinding) -> serde_json::Value {
     let mut m = serde_json::Map::new();
@@ -1626,10 +1691,9 @@ fn mbs_binding_json(b: &context::PcfMbsBinding) -> serde_json::Value {
         "pcfMbsBindingId".to_string(),
         serde_json::Value::String(b.binding_id.clone()),
     );
-    m.insert(
-        "mbsSessionId".to_string(),
-        serde_json::Value::String(b.mbs_session_id.clone()),
-    );
+    // Echoed verbatim: MbsSessionId is an object, and TS 29.521 requires the
+    // create response to carry the PcfMbsBinding that was stored.
+    m.insert("mbsSessionId".to_string(), b.mbs_session_id.clone());
     if let Some(ref v) = b.pcf_fqdn {
         m.insert("pcfFqdn".to_string(), serde_json::Value::String(v.clone()));
     }
@@ -1668,6 +1732,19 @@ fn mbs_binding_json(b: &context::PcfMbsBinding) -> serde_json::Value {
     if let Some(ref v) = b.pcf_set_id {
         m.insert("pcfSetId".to_string(), serde_json::Value::String(v.clone()));
     }
+    // PcfMbsBinding members that the MBS path previously dropped entirely.
+    if let Some(ref v) = b.bind_level {
+        m.insert(
+            "bindLevel".to_string(),
+            serde_json::Value::String(v.clone()),
+        );
+    }
+    if let Some(ref v) = b.recovery_time {
+        m.insert(
+            "recoveryTime".to_string(),
+            serde_json::Value::String(v.clone()),
+        );
+    }
     if b.management_features != 0 {
         m.insert(
             "suppFeat".to_string(),
@@ -1690,10 +1767,16 @@ async fn handle_pcf_mbs_binding_create(request: &SbiRequest) -> SbiResponse {
         }
     };
 
-    // Mandatory: mbsSessionId.
-    let Some(mbs_session_id) = data.get("mbsSessionId").and_then(|v| v.as_str()) else {
+    // Mandatory: mbsSessionId, which TS 29.571 defines as an OBJECT
+    // (anyOf tmgi / ssm, plus optional nid) -- not a scalar string. This used to
+    // read it with .as_str(), so a conformant object body yielded None and every
+    // spec-compliant MBS registration was rejected 400.
+    let Some(mbs_session_id) = data.get("mbsSessionId") else {
         return missing_mandatory("mbsSessionId");
     };
+    if let Err(detail) = validate_mbs_session_id(mbs_session_id) {
+        return send_bad_request(&detail, Some("MANDATORY_IE_INCORRECT"));
+    }
 
     // Mandatory: PCF address.
     let pcf_fqdn = data.get("pcfFqdn").and_then(|v| v.as_str());
@@ -1739,7 +1822,7 @@ async fn handle_pcf_mbs_binding_create(request: &SbiRequest) -> SbiResponse {
     let binding_id = uuid::Uuid::new_v4().to_string();
     let binding = context::PcfMbsBinding {
         binding_id: binding_id.clone(),
-        mbs_session_id: mbs_session_id.to_string(),
+        mbs_session_id: mbs_session_id.clone(),
         pcf_fqdn: pcf_fqdn.map(|s| s.to_string()),
         pcf_ip: data
             .get("pcfIpEndPoints")
@@ -1751,6 +1834,16 @@ async fn handle_pcf_mbs_binding_create(request: &SbiRequest) -> SbiResponse {
             .map(|s| s.to_string()),
         pcf_set_id: data
             .get("pcfSetId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        // TS 29.521 PcfMbsBinding defines bindLevel and recoveryTime; the MBS
+        // path never parsed them even though the PDU and UE paths both do.
+        bind_level: data
+            .get("bindLevel")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        recovery_time: data
+            .get("recoveryTime")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string()),
         management_features: consumer_feat & BSF_SUPPORTED_FEATURES,
@@ -1795,7 +1888,7 @@ async fn handle_pcf_mbs_binding_get(binding_id: &str) -> SbiResponse {
 async fn handle_pcf_mbs_binding_discovery(request: &SbiRequest) -> SbiResponse {
     // TS 29.521 §4.2.4.4: the query parameter is `mbs-session-id`; accept the
     // legacy `mbsSessionId` spelling only as a lenient fallback.
-    let Some(mbs_session_id) = request
+    let Some(raw) = request
         .http
         .params
         .get("mbs-session-id")
@@ -1807,10 +1900,28 @@ async fn handle_pcf_mbs_binding_discovery(request: &SbiRequest) -> SbiResponse {
         );
     };
 
+    // The parameter is declared `content: application/json` with schema
+    // MbsSessionId, so a conformant consumer sends URL-encoded JSON -- an
+    // object, not a bare string. This used to compare the raw query text
+    // against the stored value, which no conformant request could match.
+    let decoded = pct_decode(raw);
+    let query_id: serde_json::Value = match serde_json::from_str(&decoded) {
+        Ok(v) => v,
+        Err(e) => {
+            return send_bad_request(
+                &format!("mbs-session-id must be JSON-encoded MbsSessionId: {e}"),
+                Some("INVALID_QUERY_PARAM"),
+            )
+        }
+    };
+    if let Err(detail) = validate_mbs_session_id(&query_id) {
+        return send_bad_request(&detail, Some("INVALID_QUERY_PARAM"));
+    }
+
     let ctx = bsf_self();
     let results = ctx
         .read()
-        .map(|g| g.mbs_binding_find_by_mbs_session_id(mbs_session_id))
+        .map(|g| g.mbs_binding_find_by_mbs_session_id(&query_id))
         .unwrap_or_default();
 
     match results.as_slice() {
@@ -2371,6 +2482,23 @@ mod tests {
         assert_eq!(resp.status, 401, "wrong-audience token must be 401");
 
         server.stop().await.expect("stop");
+    }
+
+    /// Percent-encode a JSON query-parameter value the way a conformant
+    /// consumer must: TS 29.521 declares `mbs-session-id` as
+    /// `content: application/json`, and raw `{`/`}`/`"` are not legal URI
+    /// characters, so the JSON has to be escaped before it goes on the wire.
+    fn pct_encode_query(s: &str) -> String {
+        let mut out = String::with_capacity(s.len() * 3);
+        for b in s.bytes() {
+            match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    out.push(b as char)
+                }
+                _ => out.push_str(&format!("%{b:02X}")),
+            }
+        }
+        out
     }
 
     fn problem(resp: &SbiResponse) -> serde_json::Value {
@@ -3332,10 +3460,158 @@ mod tests {
         assert_eq!(body["pcfFqdn"], "pcf.example.com");
     }
 
+    /// #97 defect 3: MbsSessionId is an OBJECT (TS 29.571), not a string.
+    ///
+    /// A conformant PCF sends `{tmgi: {mbsServiceId, plmnId}}` or
+    /// `{ssm: {sourceIpAddr, destIpAddr}}`; bsfd read the field with `.as_str()`
+    /// so every such registration was rejected 400 missing_mandatory.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mbs_session_id_object_form() {
+        let (_srv, client) = start_bsf().await;
+
+        let tmgi = json!({
+            "tmgi": {"mbsServiceId": "aabbcc", "plmnId": {"mcc": "001", "mnc": "01"}}
+        });
+
+        // The conformant tmgi object form is ACCEPTED (was 400).
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-mbs-bindings",
+                &json!({
+                    "mbsSessionId": tmgi.clone(),
+                    "pcfFqdn": "pcf.mbs97.example.com",
+                    "bindLevel": "NF_SET",
+                    "recoveryTime": "2026-08-10T00:00:00Z"
+                }),
+            )
+            .await
+            .expect("POST tmgi object");
+        assert_eq!(
+            resp.status, 201,
+            "a conformant object MbsSessionId must be accepted"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body["mbsSessionId"], tmgi, "echoed as an object, verbatim");
+        // bindLevel / recoveryTime are PcfMbsBinding members and must round-trip;
+        // the MBS path never parsed them before.
+        assert_eq!(body["bindLevel"], "NF_SET");
+        assert_eq!(body["recoveryTime"], "2026-08-10T00:00:00Z");
+
+        // The ssm form also satisfies the schema's anyOf.
+        let ssm = json!({
+            "ssm": {"sourceIpAddr": {"ipv4Addr": "10.0.0.9"},
+                    "destIpAddr": {"ipv4Addr": "232.0.0.9"}}
+        });
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-mbs-bindings",
+                &json!({"mbsSessionId": ssm.clone(), "pcfFqdn": "pcf.ssm.example.com"}),
+            )
+            .await
+            .expect("POST ssm object");
+        assert_eq!(resp.status, 201, "the ssm form satisfies anyOf");
+
+        // A bare string is rejected LOUDLY rather than coerced.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-mbs-bindings",
+                &json!({"mbsSessionId": "TMGI-001", "pcfFqdn": "pcf.example.com"}),
+            )
+            .await
+            .expect("POST string form");
+        assert_eq!(
+            resp.status, 400,
+            "the pre-fix string spelling must not be accepted"
+        );
+        let detail = problem(&resp)["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            detail.contains("object"),
+            "the error should name the expected shape, got: {detail}"
+        );
+
+        // Neither tmgi nor ssm -> 400 per the anyOf.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-mbs-bindings",
+                &json!({"mbsSessionId": {"nid": "000007ABCDE"}, "pcfFqdn": "pcf.example.com"}),
+            )
+            .await
+            .expect("POST neither");
+        assert_eq!(resp.status, 400);
+
+        // tmgi missing plmnId -> 400 (Tmgi requires mbsServiceId AND plmnId).
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-mbs-bindings",
+                &json!({
+                    "mbsSessionId": {"tmgi": {"mbsServiceId": "aabbcc"}},
+                    "pcfFqdn": "pcf.example.com"
+                }),
+            )
+            .await
+            .expect("POST tmgi no plmn");
+        assert_eq!(resp.status, 400);
+
+        // Discovery with the JSON-encoded query parameter finds the binding, and
+        // matching is case-insensitive on mbsServiceId and order-independent --
+        // a textual comparison would miss both.
+        let upper = json!({
+            "tmgi": {"plmnId": {"mnc": "01", "mcc": "001"}, "mbsServiceId": "AABBCC"}
+        });
+        let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
+        req.http
+            .set_param("mbs-session-id", &pct_encode_query(&upper.to_string()));
+        let resp = client
+            .send_request(req)
+            .await
+            .expect("discover upper/reordered");
+        assert_eq!(
+            resp.status, 200,
+            "hex case and key order must not affect discovery"
+        );
+
+        // A duplicate differing only in hex case is still caught as a duplicate.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-mbs-bindings",
+                &json!({"mbsSessionId": upper.clone(), "pcfFqdn": "pcf.dup.example.com"}),
+            )
+            .await
+            .expect("POST duplicate different case");
+        assert_eq!(
+            resp.status, 403,
+            "canonical matching must catch the duplicate"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body["cause"], "EXISTING_BINDING_INFO_FOUND");
+
+        // A non-JSON query parameter is a client error, not a 500.
+        let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
+        req.http.set_param("mbs-session-id", "TMGI-001");
+        let resp = client.send_request(req).await.expect("discover non-json");
+        assert_eq!(resp.status, 400);
+    }
+
     // bsfd-12: pcf-mbs-bindings lifecycle + duplicate 403 + multi-match 400
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_http_pcf_mbs_bindings_lifecycle() {
         let (server, client) = start_bsf().await;
+
+        // TS 29.571 MbsSessionId is an OBJECT (anyOf tmgi / ssm), not a string.
+        // This test previously used the bare string "TMGI-001", which is not a
+        // valid MbsSessionId in any form -- it only passed because bsfd read the
+        // field with .as_str(), which is the #97 defect being fixed here.
+        let mbs_id_obj = json!({
+            "tmgi": {"mbsServiceId": "0a1b2c", "plmnId": {"mcc": "001", "mnc": "01"}}
+        });
+        let mbs_id_other = json!({
+            "tmgi": {"mbsServiceId": "ffeedd", "plmnId": {"mcc": "001", "mnc": "01"}}
+        });
 
         // POST without mbsSessionId → 400.
         let resp = client
@@ -3352,7 +3628,7 @@ mod tests {
         let resp = client
             .post_json(
                 "/nbsf-management/v1/pcf-mbs-bindings",
-                &json!({"mbsSessionId": "TMGI-001"}),
+                &json!({"mbsSessionId": mbs_id_obj.clone()}),
             )
             .await
             .expect("POST mbs no pcf");
@@ -3364,7 +3640,7 @@ mod tests {
             .post_json(
                 "/nbsf-management/v1/pcf-mbs-bindings",
                 &json!({
-                    "mbsSessionId": "TMGI-001",
+                    "mbsSessionId": mbs_id_obj.clone(),
                     "pcfFqdn": "pcf.mbs.example.com"
                 }),
             )
@@ -3375,14 +3651,15 @@ mod tests {
         let mbs_id = loc.rsplit('/').next().unwrap().to_string();
         let body: serde_json::Value =
             serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
-        assert_eq!(body["mbsSessionId"], "TMGI-001");
+        // Echoed back as an OBJECT, not a string.
+        assert_eq!(body["mbsSessionId"], mbs_id_obj);
 
         // Duplicate mbsSessionId → 403 EXISTING_BINDING_INFO_FOUND.
         let resp = client
             .post_json(
                 "/nbsf-management/v1/pcf-mbs-bindings",
                 &json!({
-                    "mbsSessionId": "TMGI-001",
+                    "mbsSessionId": mbs_id_obj.clone(),
                     "pcfFqdn": "pcf.mbs2.example.com"
                 }),
             )
@@ -3395,7 +3672,8 @@ mod tests {
 
         // Discovery by mbsSessionId → 200 single result.
         let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
-        req.http.set_param("mbsSessionId", "TMGI-001");
+        req.http
+            .set_param("mbs-session-id", &pct_encode_query(&mbs_id_obj.to_string()));
         let resp = client.send_request(req).await.expect("discover mbs");
         assert_eq!(resp.status, 200);
 
@@ -3410,7 +3688,10 @@ mod tests {
 
         // Unknown mbsSessionId → 204.
         let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
-        req.http.set_param("mbsSessionId", "TMGI-999");
+        req.http.set_param(
+            "mbs-session-id",
+            &pct_encode_query(&mbs_id_other.to_string()),
+        );
         let resp = client.send_request(req).await.expect("discover mbs miss");
         assert_eq!(resp.status, 204);
 

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -1315,18 +1315,23 @@ async fn handle_pcf_binding_update(binding_id: &str, request: &SbiRequest) -> Sb
 /// Build the PcfForUeBinding JSON representation of a UE binding.
 fn ue_binding_json(b: &context::PcfUeBinding) -> serde_json::Value {
     let mut m = serde_json::Map::new();
-    m.insert(
-        "pcfUeBindingId".to_string(),
-        serde_json::Value::String(b.binding_id.clone()),
-    );
+    // No pcfUeBindingId member: that identifier appears nowhere in TS 29.521.
+    // The binding id is the store key and the Location URI path segment
+    // (/nbsf-management/v1/pcf-ue-bindings/{id}), so the resource stays
+    // addressable without polluting the body.
     if let Some(ref v) = b.supi {
         m.insert("supi".to_string(), serde_json::Value::String(v.clone()));
     }
     if let Some(ref v) = b.gpsi {
         m.insert("gpsi".to_string(), serde_json::Value::String(v.clone()));
     }
+    // pcfForUe*-prefixed on this resource (TS 29.521 PcfForUeBinding). The
+    // unprefixed spellings belong to PcfBinding, the PDU-session binding.
     if let Some(ref v) = b.pcf_fqdn {
-        m.insert("pcfFqdn".to_string(), serde_json::Value::String(v.clone()));
+        m.insert(
+            "pcfForUeFqdn".to_string(),
+            serde_json::Value::String(v.clone()),
+        );
     }
     if !b.pcf_ip.is_empty() {
         let eps: Vec<serde_json::Value> = b
@@ -1355,7 +1360,10 @@ fn ue_binding_json(b: &context::PcfUeBinding) -> serde_json::Value {
                 serde_json::Value::Object(e)
             })
             .collect();
-        m.insert("pcfIpEndPoints".to_string(), serde_json::Value::Array(eps));
+        m.insert(
+            "pcfForUeIpEndPoints".to_string(),
+            serde_json::Value::Array(eps),
+        );
     }
     if let Some(ref v) = b.pcf_id {
         m.insert("pcfId".to_string(), serde_json::Value::String(v.clone()));
@@ -1372,18 +1380,6 @@ fn ue_binding_json(b: &context::PcfUeBinding) -> serde_json::Value {
     if let Some(ref v) = b.recovery_time {
         m.insert(
             "recoveryTime".to_string(),
-            serde_json::Value::String(v.clone()),
-        );
-    }
-    if let Some(ref v) = b.pcf_diam_host {
-        m.insert(
-            "pcfDiamHost".to_string(),
-            serde_json::Value::String(v.clone()),
-        );
-    }
-    if let Some(ref v) = b.pcf_diam_realm {
-        m.insert(
-            "pcfDiamRealm".to_string(),
             serde_json::Value::String(v.clone()),
         );
     }
@@ -1409,23 +1405,32 @@ async fn handle_pcf_ue_binding_create(request: &SbiRequest) -> SbiResponse {
         }
     };
 
-    // Mandatory: supi or gpsi (UE identifier for UE-policy bindings).
+    // Mandatory: supi. TS 29.521 PcfForUeBinding declares `required: - supi`
+    // with gpsi merely optional, so a gpsi-only registration is NOT valid --
+    // this previously accepted one whenever either identifier was present.
     let supi = data.get("supi").and_then(|v| v.as_str());
     let gpsi = data.get("gpsi").and_then(|v| v.as_str());
-    if supi.is_none() && gpsi.is_none() {
-        return missing_mandatory("supi|gpsi");
+    if supi.is_none() {
+        return missing_mandatory("supi");
     }
 
-    // Mandatory: PCF address (same requirement as PDU-session binding, bsfd-05).
-    let pcf_fqdn = data.get("pcfFqdn").and_then(|v| v.as_str());
+    // Mandatory: PCF address, per the schema's
+    // `anyOf: [required: [pcfForUeFqdn], required: [pcfForUeIpEndPoints]]`.
+    //
+    // These are pcfForUe*-prefixed on THIS resource. The unprefixed pcfFqdn /
+    // pcfIpEndPoints spellings this used to read belong to PcfBinding (the
+    // PDU-session binding), so a conformant PCF's UE-policy registration was
+    // rejected 400 while the resource this BSF emitted could not be parsed
+    // back by a conformant reader. pcfDiamHost/pcfDiamRealm are likewise not
+    // PcfForUeBinding members and no longer satisfy the address requirement
+    // here (they remain valid, and are still handled, on the PDU path).
+    let pcf_fqdn = data.get("pcfForUeFqdn").and_then(|v| v.as_str());
     let has_eps = data
-        .get("pcfIpEndPoints")
+        .get("pcfForUeIpEndPoints")
         .and_then(|v| v.as_array())
         .is_some_and(|a| !a.is_empty());
-    let diam_host = data.get("pcfDiamHost").and_then(|v| v.as_str());
-    let diam_realm = data.get("pcfDiamRealm").and_then(|v| v.as_str());
-    if pcf_fqdn.is_none() && !has_eps && !(diam_host.is_some() && diam_realm.is_some()) {
-        return missing_mandatory("pcfFqdn|pcfIpEndPoints");
+    if pcf_fqdn.is_none() && !has_eps {
+        return missing_mandatory("pcfForUeFqdn|pcfForUeIpEndPoints");
     }
 
     let consumer_feat = data
@@ -1442,7 +1447,7 @@ async fn handle_pcf_ue_binding_create(request: &SbiRequest) -> SbiResponse {
         gpsi: gpsi.map(|s| s.to_string()),
         pcf_fqdn: pcf_fqdn.map(|s| s.to_string()),
         pcf_ip: data
-            .get("pcfIpEndPoints")
+            .get("pcfForUeIpEndPoints")
             .map(parse_pcf_ip_endpoints)
             .unwrap_or_default(),
         pcf_id: data
@@ -1461,8 +1466,6 @@ async fn handle_pcf_ue_binding_create(request: &SbiRequest) -> SbiResponse {
             .get("recoveryTime")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string()),
-        pcf_diam_host: diam_host.map(|s| s.to_string()),
-        pcf_diam_realm: diam_realm.map(|s| s.to_string()),
         management_features: negotiated,
     };
 
@@ -1590,14 +1593,14 @@ async fn handle_pcf_ue_binding_update(binding_id: &str, request: &SbiRequest) ->
             }
         };
     }
-    patch_opt!(b.pcf_fqdn, "pcfFqdn");
+    // pcfForUe*-prefixed here too: PcfForUeBindingPatch (TS 29.521) defines
+    // pcfForUeFqdn / pcfForUeIpEndPoints / pcfId / cleanUpCallbackUri.
+    patch_opt!(b.pcf_fqdn, "pcfForUeFqdn");
     patch_opt!(b.pcf_id, "pcfId");
     patch_opt!(b.pcf_set_id, "pcfSetId");
     patch_opt!(b.bind_level, "bindLevel");
     patch_opt!(b.recovery_time, "recoveryTime");
-    patch_opt!(b.pcf_diam_host, "pcfDiamHost");
-    patch_opt!(b.pcf_diam_realm, "pcfDiamRealm");
-    match data.get("pcfIpEndPoints") {
+    match data.get("pcfForUeIpEndPoints") {
         Some(serde_json::Value::Null) => b.pcf_ip.clear(),
         Some(v) if v.is_array() => b.pcf_ip = parse_pcf_ip_endpoints(v),
         _ => {}
@@ -3088,12 +3091,17 @@ mod tests {
         assert_eq!(problem(&resp)["cause"], "MANDATORY_IE_MISSING");
 
         // Valid POST → 201 + Location.
+        //
+        // pcfForUeFqdn, not pcfFqdn: this test previously sent and asserted the
+        // unprefixed spelling, which PINNED the #97 non-conformance -- TS 29.521
+        // PcfForUeBinding names the member pcfForUeFqdn, and the unprefixed form
+        // belongs to PcfBinding (the PDU-session binding).
         let resp = client
             .post_json(
                 "/nbsf-management/v1/pcf-ue-bindings",
                 &json!({
                     "supi": "imsi-001019900111001",
-                    "pcfFqdn": "pcf.ue.example.com",
+                    "pcfForUeFqdn": "pcf.ue.example.com",
                     "suppFeat": "2"
                 }),
             )
@@ -3105,8 +3113,19 @@ mod tests {
         let body: serde_json::Value =
             serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
         assert_eq!(body["supi"], "imsi-001019900111001");
-        assert_eq!(body["pcfFqdn"], "pcf.ue.example.com");
+        assert_eq!(body["pcfForUeFqdn"], "pcf.ue.example.com");
         assert_eq!(body["suppFeat"], "2");
+        // The non-schema members are gone from the representation.
+        assert!(
+            body.get("pcfFqdn").is_none(),
+            "pcfFqdn is not a PcfForUeBinding member"
+        );
+        assert!(
+            body.get("pcfUeBindingId").is_none(),
+            "pcfUeBindingId appears nowhere in TS 29.521"
+        );
+        assert!(body.get("pcfDiamHost").is_none());
+        assert!(body.get("pcfDiamRealm").is_none());
 
         // GET by id → 200.
         let resp = client
@@ -3133,17 +3152,17 @@ mod tests {
         assert_eq!(resp.status, 400);
         assert_eq!(problem(&resp)["cause"], "MANDATORY_QUERY_PARAM_MISSING");
 
-        // PATCH pcfFqdn → 200.
+        // PATCH pcfForUeFqdn → 200 (PcfForUeBindingPatch member name).
         let mut req = SbiRequest::patch(format!("/nbsf-management/v1/pcf-ue-bindings/{ue_id}"));
         req.http
-            .set_content(json!({"pcfFqdn": "pcf.ue2.example.com"}).to_string());
+            .set_content(json!({"pcfForUeFqdn": "pcf.ue2.example.com"}).to_string());
         req.http
             .set_header("Content-Type", "application/merge-patch+json");
         let resp = client.send_request(req).await.expect("PATCH ue");
         assert_eq!(resp.status, 200);
         let patched: serde_json::Value =
             serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
-        assert_eq!(patched["pcfFqdn"], "pcf.ue2.example.com");
+        assert_eq!(patched["pcfForUeFqdn"], "pcf.ue2.example.com");
 
         // DELETE → 204; GET → 404 afterwards.
         let resp = client
@@ -3167,6 +3186,150 @@ mod tests {
         assert_eq!(resp.status, 204);
 
         server.stop().await.expect("server stops");
+    }
+
+    /// #97 defects 1-2: PcfForUeBinding wire conformance.
+    ///
+    /// TS 29.521 PcfForUeBinding names the PCF address members pcfForUeFqdn /
+    /// pcfForUeIpEndPoints (the unprefixed spellings belong to PcfBinding, the
+    /// PDU-session binding), declares `required: - supi` with gpsi optional, and
+    /// defines no pcfUeBindingId / pcfDiamHost / pcfDiamRealm.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pcf_for_ue_binding_conformant_attribute_names() {
+        let (_srv, client) = start_bsf().await;
+
+        // The conformant fqdn form is ACCEPTED. This returned 400 before the
+        // fix, so a spec-compliant PCF could not register at all.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-ue-bindings",
+                &json!({
+                    "supi": "imsi-001019900197001",
+                    "pcfForUeFqdn": "pcf-ue.example.com"
+                }),
+            )
+            .await
+            .expect("POST pcfForUeFqdn");
+        assert_eq!(
+            resp.status, 201,
+            "a conformant PcfForUeBinding must be accepted"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body["pcfForUeFqdn"], "pcf-ue.example.com");
+        assert!(body.get("pcfFqdn").is_none());
+        assert!(body.get("pcfUeBindingId").is_none());
+        assert!(body.get("pcfDiamHost").is_none());
+        assert!(body.get("pcfDiamRealm").is_none());
+
+        // The endpoints-only form also satisfies the schema's
+        // `anyOf: [pcfForUeFqdn, pcfForUeIpEndPoints]`.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-ue-bindings",
+                &json!({
+                    "supi": "imsi-001019900197002",
+                    "pcfForUeIpEndPoints": [{"ipv4Address": "10.45.0.77", "port": 7777}]
+                }),
+            )
+            .await
+            .expect("POST pcfForUeIpEndPoints");
+        assert_eq!(
+            resp.status, 201,
+            "pcfForUeIpEndPoints alone satisfies anyOf"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body["pcfForUeIpEndPoints"][0]["ipv4Address"], "10.45.0.77");
+        assert!(body.get("pcfIpEndPoints").is_none());
+
+        // supi is MANDATORY: a gpsi-only registration used to be accepted.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-ue-bindings",
+                &json!({
+                    "gpsi": "msisdn-14155550197",
+                    "pcfForUeFqdn": "pcf-ue.example.com"
+                }),
+            )
+            .await
+            .expect("POST gpsi only");
+        assert_eq!(
+            resp.status, 400,
+            "TS 29.521 declares `required: - supi`; gpsi alone is not enough"
+        );
+        assert_eq!(problem(&resp)["cause"], "MANDATORY_IE_MISSING");
+
+        // Neither address form -> 400, naming the spec attributes.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-ue-bindings",
+                &json!({"supi": "imsi-001019900197003"}),
+            )
+            .await
+            .expect("POST no address");
+        assert_eq!(resp.status, 400);
+        let detail = problem(&resp)["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            detail.contains("pcfForUeFqdn"),
+            "the error should name the conformant attribute, got: {detail}"
+        );
+
+        // The unprefixed spelling is no longer an accepted address: it is not a
+        // member of this resource, so it cannot satisfy the anyOf.
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-ue-bindings",
+                &json!({
+                    "supi": "imsi-001019900197004",
+                    "pcfFqdn": "pcf-ue.example.com"
+                }),
+            )
+            .await
+            .expect("POST legacy spelling");
+        assert_eq!(
+            resp.status, 400,
+            "pcfFqdn belongs to PcfBinding, not PcfForUeBinding"
+        );
+    }
+
+    /// Guard for the scoping of the above: pcfDiamHost / pcfDiamRealm ARE valid
+    /// members of PcfBinding (TS29521_Nbsf_Management.yaml:1097-1099) and of
+    /// PcfBindingPatch (:1176-1178). Removing them from PcfForUeBinding must not
+    /// leak into the PDU-session path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pdu_binding_still_accepts_diameter_members() {
+        let (_srv, client) = start_bsf().await;
+
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcfBindings",
+                &json!({
+                    "supi": "imsi-001019900197010",
+                    "ipv4Addr": "10.45.0.197",
+                    "dnn": "internet",
+                    "snssai": {"sst": 1},
+                    "pcfDiamHost": "pcf.diam.example.com",
+                    "pcfDiamRealm": "example.com",
+                    "pcfFqdn": "pcf.example.com"
+                }),
+            )
+            .await
+            .expect("POST pdu binding with diam members");
+        assert_eq!(
+            resp.status, 201,
+            "the PDU-session binding legitimately carries pcfDiamHost/Realm"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body["pcfDiamHost"], "pcf.diam.example.com");
+        assert_eq!(body["pcfDiamRealm"], "example.com");
+        // And the PDU resource keeps the UNPREFIXED pcfFqdn, correct for
+        // PcfBinding.
+        assert_eq!(body["pcfFqdn"], "pcf.example.com");
     }
 
     // bsfd-12: pcf-mbs-bindings lifecycle + duplicate 403 + multi-match 400

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_bsfd.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_bsfd.rs
@@ -104,11 +104,30 @@ async fn pcfd_production_binding_accepted_at_session_site() {
 }
 
 /// WSB-1 acceptance site 2 (UE-policy bindings, bsfd pcf-ue-bindings):
-/// the same production body (it carries supi + pcfIpEndPoints) -> 201.
+/// the production body's PCF address, RE-KEYED to this resource's schema.
+///
+/// PcfForUeBinding (TS 29.521) names the address members `pcfForUeFqdn` /
+/// `pcfForUeIpEndPoints`; the unprefixed `pcfFqdn` / `pcfIpEndPoints` this test
+/// used to send belong to `PcfBinding`, the PDU-session binding. Reusing one
+/// body across all three sites only passed because bsfd read the unprefixed
+/// names on every resource -- which is exactly the #97 defect. The PCF-address
+/// requirement under test is unchanged; only the member names are now the ones
+/// this resource actually defines.
+///
+/// pcfd has no production UE-binding registration path (it POSTs only to
+/// /pcfBindings), so there is no builder to re-key -- the mapping lives here.
 #[tokio::test]
 async fn pcfd_production_binding_accepted_at_ue_site() {
     init_peers();
-    let body = production_body("imsi-001010000000702", "10.45.0.72");
+    let src = production_body("imsi-001010000000702", "10.45.0.72");
+    let mut body = serde_json::json!({ "supi": src["supi"].clone() });
+    body["pcfForUeIpEndPoints"] = src["pcfIpEndPoints"].clone();
+    if let Some(fqdn) = src.get("pcfFqdn") {
+        body["pcfForUeFqdn"] = fqdn.clone();
+    }
+    if let Some(id) = src.get("pcfId") {
+        body["pcfId"] = id.clone();
+    }
 
     let resp = post("/nbsf-management/v1/pcf-ue-bindings", &body).await;
     assert_eq!(

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_bsfd.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_bsfd.rs
@@ -46,6 +46,18 @@ fn legacy_body(supi: &str, ipv4: &str) -> serde_json::Value {
     build_pcf_binding_body_with(None, supi, "internet", 1, Some(0x010203), Some(ipv4))
 }
 
+/// A conformant TS 29.571 `MbsSessionId` OBJECT (anyOf tmgi / ssm).
+///
+/// These tests previously set `mbsSessionId` to a bare string
+/// ("mbs-session-703"), which is not a valid MbsSessionId in any form -- it only
+/// passed because bsfd read the field with `.as_str()`, the #97 defect 3 being
+/// fixed. `mbsServiceId` is `^[A-Fa-f0-9]{6}$`.
+fn mbs_session_id(svc_hex: &str) -> serde_json::Value {
+    serde_json::json!({
+        "tmgi": {"mbsServiceId": svc_hex, "plmnId": {"mcc": "001", "mnc": "01"}}
+    })
+}
+
 fn problem(resp: &SbiResponse) -> serde_json::Value {
     serde_json::from_str(resp.http.content.as_deref().expect("problem body")).expect("json body")
 }
@@ -149,7 +161,7 @@ async fn pcfd_production_binding_accepted_at_ue_site() {
 async fn pcfd_production_binding_accepted_at_mbs_site() {
     init_peers();
     let mut body = production_body("imsi-001010000000703", "10.45.0.73");
-    body["mbsSessionId"] = serde_json::json!("mbs-session-703");
+    body["mbsSessionId"] = mbs_session_id("000703");
 
     let resp = post("/nbsf-management/v1/pcf-mbs-bindings", &body).await;
     assert_eq!(
@@ -190,9 +202,11 @@ async fn legacy_binding_still_rejected_400_at_all_three_sites() {
     assert_eq!(resp.status, 400);
     assert_eq!(problem(&resp)["cause"], "MANDATORY_IE_MISSING");
 
-    // Site 3: MBS bindings (mbsSessionId present, PCF address absent).
+    // Site 3: MBS bindings (mbsSessionId present and VALID, PCF address absent).
+    // The id must be a conformant object, or the mbsSessionId validation fires
+    // first and this stops testing the PCF-address requirement it exists for.
     let mut mbs = body.clone();
-    mbs["mbsSessionId"] = serde_json::json!("mbs-session-704");
+    mbs["mbsSessionId"] = mbs_session_id("000704");
     let resp = post("/nbsf-management/v1/pcf-mbs-bindings", &mbs).await;
     assert_eq!(resp.status, 400);
     assert_eq!(problem(&resp)["cause"], "MANDATORY_IE_MISSING");


### PR DESCRIPTION
Fixes **all six** wire defects in #97. Three commits, one per concern, each independently revert-verifiable.

Closes #97.

---

## 1. `PcfForUeBinding` attribute names (defects 1–2) — `3bfe838`

TS 29.521 names the UE-binding PCF address members **`pcfForUeFqdn`** / **`pcfForUeIpEndPoints`**. bsfd read and emitted the *unprefixed* `pcfFqdn` / `pcfIpEndPoints`, which belong to `PcfBinding` — the PDU-session binding. `pcfForUeFqdn` appeared **nowhere** in the codebase, so a conformant PCF got `400` and the emitted resource couldn't be parsed back.

Also: `supi` is now mandatory (schema says `required: - supi`; `gpsi`-only used to be accepted), and `pcfUeBindingId` / `pcfDiamHost` / `pcfDiamRealm` are dropped from the representation.

**⚠️ Scoping correction:** the issue lists `pcfDiamHost`/`pcfDiamRealm` as non-schema. They are **not, in general** — they're valid on `PcfBinding` (`:1097-1099`) and `PcfBindingPatch` (`:1176-1178`), and the PDU path stores them. Removing them globally would have broken conformant behaviour. A test guards that the PDU path still accepts and echoes them.

## 2. `MbsSessionId` object model (defect 3) — `e3c063f`

TS 29.571 `MbsSessionId` is an **object** (`anyOf` `tmgi`/`ssm`). bsfd read it with `.as_str()`, so **every** spec-compliant MBS registration was rejected `400`. Discovery had the same problem: the query parameter is declared `content: application/json`, so a conformant consumer sends URL-encoded JSON. Also picked up `bindLevel`/`recoveryTime`, never parsed on the MBS path.

**Matching is semantic, not textual.** The object is stored as received (TS 29.521 requires the create response to echo the stored binding), and compared via `context::mbs_session_key`. JSON key order isn't significant and `mbsServiceId` is `^[A-Fa-f0-9]{6}$`, so `0A1B2C` and `0a1b2c` are one session — a serialized `==` would make discovery **miss a binding just created** and let a duplicate slip past `EXISTING_BINDING_INFO_FOUND`. Both covered by tests.

## 3. `403` media type + address, discovery shapes, framed routes (defects 4–6) — `3e5fe2c`

**4a — media type.** Both duplicate `403`s used `with_json_body`, which hardcodes `application/json` (`message.rs:553`). The spec declares them `application/problem+json`. `with_problem` is unusable: it takes a typed `ProblemDetails`, but `ExtProblemDetails` is `allOf [ProblemDetails, BindingResp]` and carries members that type has no room for.

**4b — the `403` advertised the wrong endpoint.** The substantive half. `BindingResp` defines `pcfSmFqdn`/`pcfSmIpEndPoints` — the **Npcf_SMPolicyControl** endpoint. The field *names* were right; the *values* were `dup.pcf_fqdn`/`dup.pcf_ip`, i.e. the PolicyAuthorization address. `PcfBinding` carries a **distinct** SM-PCF address (`:1101-1108`) that create never parsed and the session never stored. **SamePcf recovery was routed to the wrong service** — worse than a missing field, because it looks like an answer.

Added `pcf_sm_fqdn`/`pcf_sm_ip` to the session (persisted and restored), parsed on create, emitted in the `403`. The PolicyAuthorization fallback remains for bindings registered without an SM address, but is now **logged** rather than silent.

The MBS `403` had the mirror-image bug — it emitted `pcfSmFqdn`, but `MbsBindingResp` mandates `pcfFqdn`/`pcfIpEndPoints`, since an MBS binding has no SM-PCF notion.

**5 — discovery shapes.** `GET /pcf-ue-bindings` returned `204` on no match; `GET /pcf-mbs-bindings` returned `204` on empty **and a bare object** for a single match. The spec defines for both only a `200` of `type: array, minItems: 0` — no `204` on either.

The SM `GET /pcfBindings` **does** legitimately define `204` and is left alone. **That asymmetry now has an explicit test guard**, because the tempting "make all three consistent" reading would break a conformant operation.

**6 — framed routes.** PDU create never parsed `ipv4FrameRouteList`/`ipv6FrameRouteList` (only PATCH did), yet discovery matching depends on them (`context.rs:566-590`). A UE reachable only via a framed route was **undiscoverable** after a conformant registration — the matching logic existed with nothing to match against.

---

## Tests that pinned the old behaviour

**Seven across two crates**, each converted with its reason stated in the commit rather than quietly edited:

| Test | Was | Why it passed |
|---|---|---|
| bsfd `..._ue_bindings_lifecycle` | `pcfFqdn` on the UE resource | that *is* the non-conformance |
| bsfd `..._mbs_bindings_lifecycle` | `"TMGI-001"` | not a valid `MbsSessionId` in any form |
| context `test_mbs_binding_crud` | `"TMGI-ABC"` | viable only because the store compared raw strings |
| pcfd `..._at_ue_site` | one `PcfBinding` body across three resources | only worked because bsfd read unprefixed names everywhere |
| pcfd `..._at_mbs_site` + legacy guard | `"mbs-session-703"`/`"-704"` | same `.as_str()` defect |
| bsfd UE + MBS discovery `204` asserts | `204` on empty | the defect-5 non-conformance |

Every `MbsSessionId` fixture used an **invented identifier** — a tell that the code never validated the field.

Two subtleties: the legacy-rejection guard needed a **valid** session id, or the new validation fires first and it stops covering the PCF-address requirement it exists for. And my own first SamePcf test sent `suppFeat "8"` while `SAME_PCF_BIT` is `0x4`, so the feature negotiated to zero and detection never fired — fixed in the test, no production change.

**For reviewers:** the defect 1–2 and 3 breakages surfaced **only** under `cargo test --workspace`. `-p nextgcore-bsfd` passed 79/79 and 81/81, because the coupling lives in the *consumer's* test directory (`nextgcore-pcfd/tests/strict_peer_bsfd.rs`).

## Verification

Revert-verified per defect:

- UE attribute names → *"a conformant PcfForUeBinding must be accepted: left 400, right 201"*
- `.as_str()` MBS read → *"a conformant object MbsSessionId must be accepted: left 400, right 201"*
- media type → *`got "application/json"`*
- `403` address → *left `"pcf-authz.example.com"`, right `"pcf-smpolicy.example.com"`*
- framed routes → *left 204, right 200* on discovery by an in-route address

**Gates:** 5328 passed / 0 failed, `clippy --workspace` clean, `fmt --check` clean, tree clean.

Specs: `specs/fix-bsf-pcf-for-ue-binding-wire-conformance.md`, `specs/fix-bsf-mbs-session-id-object.md`, `specs/fix-bsf-403-media-type-shapes-and-framed-routes.md`