### PR TITLE
test: one shared ephemeral-port helper instead of 21 hand-rolled copies

### DIFF
--- a/src/bins/nextgcore-amfd/src/lib.rs
+++ b/src/bins/nextgcore-amfd/src/lib.rs
@@ -922,12 +922,13 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn build_es256_token(

--- a/src/bins/nextgcore-amfd/src/namf_server.rs
+++ b/src/bins/nextgcore-amfd/src/namf_server.rs
@@ -2247,11 +2247,13 @@ mod tests {
             .to_string()
     }
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-        let port = probe.local_addr().expect("local_addr").port();
-        drop(probe);
-        port
+        nextgcore_sbi::test_support::free_port()
     }
 
     /// Start a capture server on an ephemeral port; returns (server, port, rx)

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -7182,9 +7182,7 @@ mod tests {
     ) {
         use nextgcore_sbi::message::{SbiRequest, SbiResponse};
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-        let port = probe.local_addr().expect("local_addr").port();
-        drop(probe);
+        let port = nextgcore_sbi::test_support::free_port();
         let (tx, rx) = mpsc::channel(8);
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
         let server = SbiServer::new(SbiServerConfig::new(addr));

--- a/src/bins/nextgcore-amfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-amfd/src/sbi_path.rs
@@ -1912,11 +1912,9 @@ mod tests {
     // UeACRequestData and maps 204 / 200-acuFailureList / 403, degrade-open.
     // ------------------------------------------------------------------
 
+    /// Reserve a loopback port for the NSACF stub server.
     fn nsacf_free_port() -> u16 {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-        let port = probe.local_addr().expect("addr").port();
-        drop(probe);
-        port
+        nextgcore_sbi::test_support::free_port()
     }
 
     /// Stub NSACF: validates the nested UeACRequestData shape (TS 29.536), then

--- a/src/bins/nextgcore-ausfd/src/app.rs
+++ b/src/bins/nextgcore-ausfd/src/app.rs
@@ -2115,11 +2115,13 @@ mod tests {
         }
     }
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-        let port = probe.local_addr().expect("addr").port();
-        drop(probe);
-        port
+        nextgcore_sbi::test_support::free_port()
     }
 
     /// Full HTTP-level flow: 5G-AKA success + failure, EAP-AKA' success +
@@ -3257,11 +3259,7 @@ mod oauth2_h8_tests {
     use std::time::Duration;
 
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn build_es256_token(

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -2424,11 +2424,9 @@ mod tests {
     use nextgcore_sbi::client::SbiClient;
     use serde_json::json;
 
+    /// Loopback address on a shared-helper-issued ephemeral port.
     fn ephemeral_addr() -> SocketAddr {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe binds");
-        let addr = probe.local_addr().expect("probe addr");
-        drop(probe);
-        addr
+        nextgcore_sbi::test_support::ephemeral_addr()
     }
 
     async fn start_bsf() -> (SbiServer, SbiClient) {

--- a/src/bins/nextgcore-dccfd/src/main.rs
+++ b/src/bins/nextgcore-dccfd/src/main.rs
@@ -498,12 +498,13 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn build_es256_token(

--- a/src/bins/nextgcore-eesd/src/notifier.rs
+++ b/src/bins/nextgcore-eesd/src/notifier.rs
@@ -477,12 +477,13 @@ mod tests {
     /// index, return `(status, Retry-After?)`.
     type Responder = Arc<dyn Fn(usize) -> (u16, Option<String>) + Send + Sync>;
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     /// Spin a `nextgcore-sbi` `SbiServer` on `127.0.0.1:port` acting as the

--- a/src/bins/nextgcore-lmfd/src/main.rs
+++ b/src/bins/nextgcore-lmfd/src/main.rs
@@ -3651,12 +3651,13 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn build_es256_token(
@@ -3882,11 +3883,7 @@ mod a8_event_notify_tests {
     }
 
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     async fn start_sink() -> (SbiServer, u16) {
@@ -4208,11 +4205,7 @@ mod positioning_chain_strict_peer {
     static NEXT_NGAP_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(88_000);
 
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .expect("bind probe")
-            .local_addr()
-            .expect("local_addr")
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn body_json(resp: &SbiResponse) -> serde_json::Value {

--- a/src/bins/nextgcore-mbsmfd/src/main.rs
+++ b/src/bins/nextgcore-mbsmfd/src/main.rs
@@ -2786,12 +2786,13 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn build_es256_token(

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -2941,10 +2941,7 @@ mod tests {
     async fn test_http_lifecycle_register_discover_patch_deregister() {
         use serde_json::json;
 
-        // Ephemeral port: bind a probe listener, reuse its address.
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe binds");
-        let addr = probe.local_addr().expect("probe addr");
-        drop(probe);
+        let addr = nextgcore_sbi::test_support::ephemeral_addr();
 
         let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
         server

--- a/src/bins/nextgcore-nsacfd/src/main.rs
+++ b/src/bins/nextgcore-nsacfd/src/main.rs
@@ -1835,11 +1835,13 @@ nsacf:
     // HTTP-level tests (ephemeral ports, bounded timeouts)
     // -----------------------------------------------------------------
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-        let port = probe.local_addr().expect("local addr").port();
-        drop(probe);
-        port
+        nextgcore_sbi::test_support::free_port()
     }
 
     /// Serializes every test that touches the PROCESS-GLOBAL NSACF context.

--- a/src/bins/nextgcore-nssfd/src/main.rs
+++ b/src/bins/nextgcore-nssfd/src/main.rs
@@ -2508,11 +2508,13 @@ mod tests {
         out
     }
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-        let port = probe.local_addr().expect("local addr").port();
-        drop(probe);
-        port
+        nextgcore_sbi::test_support::free_port()
     }
 
     /// Serializes tests that mutate the *global* NSSF availability/restriction

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -809,9 +809,7 @@ mod g21_strict_peer_tests {
         nwdaf_context_init("nwdaf-test".to_string(), 1024);
 
         // Real nwdafd SBI server on a free localhost port.
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe port");
-        let port = probe.local_addr().expect("addr").port();
-        drop(probe);
+        let port = nextgcore_sbi::test_support::free_port();
         let server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
             [127, 0, 0, 1],
             port,
@@ -974,12 +972,13 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn build_es256_token(

--- a/src/bins/nextgcore-pcfd/src/app.rs
+++ b/src/bins/nextgcore-pcfd/src/app.rs
@@ -2540,10 +2540,7 @@ mod tests {
         // suite indefinitely while holding the shared pcf_context).
         let mut started: Option<(SbiServer, u16)> = None;
         for attempt in 0..4u32 {
-            let port = std::net::TcpListener::bind("127.0.0.1:0")
-                .and_then(|l| l.local_addr())
-                .map(|a| a.port())
-                .expect("probe ephemeral port");
+            let port = nextgcore_sbi::test_support::free_port();
             let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
             let server = SbiServer::new(SbiServerConfig::new(addr));
             match tokio::time::timeout(
@@ -3153,12 +3150,13 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn build_es256_token(

--- a/src/bins/nextgcore-pcfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-pcfd/src/sbi_path.rs
@@ -1223,10 +1223,7 @@ mod tests {
             Resp::with_status(404)
         }
 
-        let port = std::net::TcpListener::bind("127.0.0.1:0")
-            .and_then(|l| l.local_addr())
-            .map(|a| a.port())
-            .expect("probe ephemeral port");
+        let port = nextgcore_sbi::test_support::free_port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
         let server = SbiServer::new(SbiServerConfig::new(addr));
         server.start(stub_smf).await.expect("start stub SMF");
@@ -1257,10 +1254,10 @@ mod tests {
         assert_eq!(status, 204);
 
         // Unreachable receiver → bounded error, not a hang
-        let dead_port = std::net::TcpListener::bind("127.0.0.1:0")
-            .and_then(|l| l.local_addr())
-            .map(|a| a.port())
-            .unwrap();
+        // Intentionally NOT served: the test needs a port with nothing listening.
+        // The shared helper still guarantees no other test is handed this port,
+        // which is what makes "unreachable" reliable rather than accidental.
+        let dead_port = nextgcore_sbi::test_support::free_port();
         let dead_uri = format!("http://127.0.0.1:{dead_port}/cb");
         let res = tokio::time::timeout(
             Duration::from_secs(8),
@@ -1289,10 +1286,7 @@ mod tests {
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
         use std::time::Duration;
 
-        let port = std::net::TcpListener::bind("127.0.0.1:0")
-            .and_then(|l| l.local_addr())
-            .map(|a| a.port())
-            .expect("probe ephemeral port");
+        let port = nextgcore_sbi::test_support::free_port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
         let server = SbiServer::new(SbiServerConfig::new(addr));
 

--- a/src/bins/nextgcore-scpd/src/proxy.rs
+++ b/src/bins/nextgcore-scpd/src/proxy.rs
@@ -1502,37 +1502,13 @@ mod tests {
     // (ephemeral ports, bounded timeouts, fully async — no blocking threads)
     // ------------------------------------------------------------------
 
-    /// Reserve an ephemeral localhost port, never handing the same port to two
-    /// callers in this process.
+    /// Reserve a loopback port for a test server.
     ///
-    /// Binding a probe and dropping it is inherently TOCTOU: between the drop
-    /// and the caller's real bind the port is free, so the OS is entitled to
-    /// hand it to the next probe. Under parallel test threads that happened
-    /// often enough to fail ~1 run in 10 with
-    /// `producer start: ServerError("Failed to bind: Address already in use")`
-    /// at the `start_mock_producer` / `start_scp` bind. (The flake was
-    /// originally diagnosed as hardcoded port numbers, but these helpers
-    /// always used ephemeral ports -- the defect is the reuse window, not a
-    /// fixed constant.)
-    ///
-    /// Excluding already-issued ports closes the in-process race, which is the
-    /// one parallel `cargo test` threads create. A foreign process claiming the
-    /// port in the same window remains theoretically possible and is not worth
-    /// synchronising against here.
+    /// Delegates to the shared helper. This crate previously carried its own
+    /// process-wide dedup (PR #138); that logic now lives in one place so all
+    /// 21 crates share it and there is a single site to harden further.
     fn ephemeral_port() -> u16 {
-        static ISSUED: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<u16>>> =
-            std::sync::OnceLock::new();
-        let issued = ISSUED.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()));
-
-        for _ in 0..256 {
-            let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-            let port = probe.local_addr().expect("probe addr").port();
-            drop(probe);
-            if issued.lock().expect("issued lock").insert(port) {
-                return port;
-            }
-        }
-        panic!("could not obtain an unused ephemeral port in 256 attempts");
+        nextgcore_sbi::test_support::free_port()
     }
 
     /// Start a mock producer that echoes the request (method, uri, body and

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -3733,12 +3733,13 @@ mod oauth2_h8_tests {
     use nextgcore_sbi::types::NfType;
     use std::time::Duration;
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     /// Mint an ES256 access token in the NRF's shape, signed by `sk`.

--- a/src/bins/nextgcore-smfd/src/policy.rs
+++ b/src/bins/nextgcore-smfd/src/policy.rs
@@ -1654,11 +1654,13 @@ mod tests {
         nextgcore_sbi::message::SbiResponse::with_status(404)
     }
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .and_then(|l| l.local_addr())
-            .map(|a| a.port())
-            .expect("probe ephemeral port")
+        nextgcore_sbi::test_support::free_port()
     }
 
     #[tokio::test]

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -2361,11 +2361,13 @@ mod tests {
             .unwrap_or_else(|_| SbiResponse::with_status(500))
     }
 
+    /// Reserve a loopback port for a test server.
+    ///
+    /// Delegates to the shared helper: 21 crates each had a private
+    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
+    /// `cargo test`. One implementation means one place to harden.
     fn free_port() -> u16 {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-        let port = probe.local_addr().expect("addr").port();
-        drop(probe);
-        port
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn unhex(s: &str) -> Vec<u8> {
@@ -3466,11 +3468,7 @@ mod oauth2_h8_tests {
     use std::time::Duration;
 
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        nextgcore_sbi::test_support::free_port()
     }
 
     fn build_es256_token(

--- a/src/bins/nextgcore-udrd/src/main.rs
+++ b/src/bins/nextgcore-udrd/src/main.rs
@@ -2820,12 +2820,9 @@ udr:
     use std::time::Duration;
     use tokio::sync::mpsc;
 
-    /// Bind an ephemeral port (probe-and-release) for an SBI server.
+    /// Loopback address on a shared-helper-issued ephemeral port.
     fn ephemeral_addr() -> SocketAddr {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe binds");
-        let addr = probe.local_addr().expect("probe addr");
-        drop(probe);
-        addr
+        nextgcore_sbi::test_support::ephemeral_addr()
     }
 
     /// Serializes tests that depend on the global nextgcore-dbi backend

--- a/src/libs/nextgcore-sbi/src/http3.rs
+++ b/src/libs/nextgcore-sbi/src/http3.rs
@@ -478,9 +478,7 @@ mod tests {
         let (h2_server, port) = {
             let mut started = None;
             for _ in 0..5 {
-                let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
-                let port = probe.local_addr().expect("probe addr").port();
-                drop(probe);
+                let port = crate::test_support::free_port();
                 let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
                     [127, 0, 0, 1],
                     port,

--- a/src/libs/nextgcore-sbi/src/lib.rs
+++ b/src/libs/nextgcore-sbi/src/lib.rs
@@ -55,6 +55,7 @@ pub mod overload;
 pub mod pubsub;
 pub mod scp;
 pub mod security;
+pub mod test_support; // Shared test helpers (NOT cfg(test): other crates' tests use it)
 pub mod tls;
 pub mod types; // Event-driven pub-sub (B6.1)
 

--- a/src/libs/nextgcore-sbi/src/server.rs
+++ b/src/libs/nextgcore-sbi/src/server.rs
@@ -1437,9 +1437,7 @@ mod tests {
         use crate::message::SbiPart;
 
         // Find a free localhost port for the test server.
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("value expected");
-        let port = probe.local_addr().expect("value expected").port();
-        drop(probe);
+        let port = crate::test_support::free_port();
 
         let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
             [127, 0, 0, 1],
@@ -1520,9 +1518,7 @@ mod tests {
         mut config: SbiServerConfig,
         handler: H,
     ) -> (SbiServer, u16) {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("value expected");
-        let port = probe.local_addr().expect("value expected").port();
-        drop(probe);
+        let port = crate::test_support::free_port();
         config.addr = SocketAddr::from(([127, 0, 0, 1], port));
         let server = SbiServer::new(config);
         server.start(handler).await.expect("value expected");

--- a/src/libs/nextgcore-sbi/src/test_support.rs
+++ b/src/libs/nextgcore-sbi/src/test_support.rs
@@ -1,0 +1,99 @@
+//! Test-support helpers shared across the NF crates.
+//!
+//! Deliberately NOT `#[cfg(test)]`: a `cfg(test)` item in a library is invisible
+//! to other crates' test binaries, which is exactly the sharing these helpers
+//! exist to provide. Follows the repo's existing `pub mod test_support`
+//! convention (see `nextgcore-bsfd`, `-amfd`, `-ausfd`, `-pcfd`, `-udmd`).
+
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::{Mutex, OnceLock};
+
+/// Reserve a loopback port for a test server, never handing the same port to
+/// two callers in this process.
+///
+/// # The window this closes, and the one it does not
+///
+/// The obvious implementation — bind `127.0.0.1:0`, read the assigned port,
+/// drop the probe, let the caller bind it — is inherently TOCTOU: between the
+/// drop and the caller's real bind the port is unbound, so the OS may hand it
+/// to the next probe. Twenty-one crates each had a private copy of exactly that
+/// helper, and under parallel `cargo test` it surfaced as spurious
+/// `Address already in use` failures: `nextgcore-scpd` at roughly 1 run in 10
+/// before it was mitigated, and `nextgcore-nssfd` on a clean merged main.
+///
+/// Excluding already-issued ports closes the *in-process* race, which is the
+/// one parallel test threads create and the only one actually observed here.
+///
+/// It does NOT close the probe-drop window itself: a foreign process can still
+/// claim the port in that gap. Eliminating that requires handing callers a
+/// PRE-BOUND `TcpListener` — the port is then never unbound — which in turn
+/// requires [`crate::server::SbiServer`] to accept a listener instead of only a
+/// `SocketAddr` (it binds internally today). That API change is tracked
+/// separately; when it lands, every caller of this helper inherits it, which is
+/// the point of having one implementation rather than 21.
+///
+/// # Panics
+///
+/// If 256 consecutive probes all return already-issued ports, which would mean
+/// the ephemeral range is effectively exhausted.
+pub fn free_port() -> u16 {
+    static ISSUED: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
+    let issued = ISSUED.get_or_init(|| Mutex::new(HashSet::new()));
+
+    for _ in 0..256 {
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+        let port = probe.local_addr().expect("probe addr").port();
+        drop(probe);
+        // insert() returns false when the port was already handed out.
+        if issued.lock().expect("issued lock").insert(port) {
+            return port;
+        }
+    }
+    panic!("could not obtain an unused ephemeral port in 256 attempts");
+}
+
+/// A loopback `SocketAddr` on a port from [`free_port`], for the callers that
+/// want an address rather than a bare port.
+pub fn ephemeral_addr() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], free_port()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet as Set;
+
+    /// The core guarantee: no port is ever issued twice in one process.
+    #[test]
+    fn free_port_never_repeats() {
+        let mut seen = Set::new();
+        for _ in 0..300 {
+            let p = free_port();
+            assert!(p != 0, "port 0 means the probe never bound");
+            assert!(seen.insert(p), "port {p} was issued twice");
+        }
+    }
+
+    /// Concurrent callers must also receive distinct ports -- the parallel
+    /// `cargo test` case that produced the original flakes.
+    #[test]
+    fn free_port_distinct_across_threads() {
+        let handles: Vec<_> = (0..8)
+            .map(|_| std::thread::spawn(|| (0..25).map(|_| free_port()).collect::<Vec<_>>()))
+            .collect();
+        let mut seen = Set::new();
+        for h in handles {
+            for p in h.join().expect("thread panicked") {
+                assert!(seen.insert(p), "port {p} handed to two threads");
+            }
+        }
+    }
+
+    #[test]
+    fn ephemeral_addr_is_loopback_with_a_real_port() {
+        let a = ephemeral_addr();
+        assert!(a.ip().is_loopback());
+        assert_ne!(a.port(), 0);
+    }
+}


### PR DESCRIPTION
Fixes the flake that failed a **clean merged `main`** right after #142 landed.

## The defect

Twenty-one crates each carried a private copy of the same test helper:

```rust
fn free_port() -> u16 {
    let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
    let port = probe.local_addr().expect("local addr").port();
    drop(probe);          // <-- the window opens here
    port
}
```

Between the `drop` and the caller's real bind the port is unbound, so the OS may hand it to another test's probe. Under parallel `cargo test` that surfaces as a spurious bind failure — `nextgcore-scpd` at roughly 1 run in 10 before PR #138 mitigated it, and **`nextgcore-nssfd` on clean merged main** (`main.rs:2512`), which passed 6/6 in isolation and so read as an environment artefact.

PR #138 fixed exactly **one** of those copies. This is **one defect with many sites**, so the fix is shared code: a new `nextgcore_sbi::test_support` module, with every local helper reduced to a one-line delegation. Keeping the local wrappers rather than editing every *call* keeps the diff mechanical — no call-site or import churn.

## ⚠️ Nine sites deliberately left alone

`nextgcore-sbi`'s own `client.rs` (6) and `oauth.rs` (3) bind `127.0.0.1:0` and then **serve on that listener**, never dropping it. That has **no TOCTOU window at all** — it is the pattern the follow-up wants everywhere. Converting them to the helper would have made them *worse*.

The grep count alone doesn't distinguish the two forms, so each site was read before being touched. Only probe-and-drop was changed.

Also preserved: pcfd's deliberately-unbound `dead_port` test now takes its port from the shared helper, which is what makes "nothing is listening here" *reliable* rather than accidental — no other test can be handed that port.

## Why not the complete fix

Handing callers a **pre-bound `TcpListener`** would close the window entirely. That requires `SbiServer::new` to accept a listener instead of only a `SocketAddr` (it binds internally at `server.rs:823`) — an API change on a library every NF depends on. Doing it here would mean an SBI API change *plus* 20-odd call-site edits in one commit, with no way to attribute a regression.

Dedup now, shared, leaves exactly **one** place to implement the listener change later, at which point every caller inherits it. The residual window is documented in the helper's doc comment rather than left implicit, and the follow-up task exists.

## Verification

| Check | Result |
|---|---|
| Helper never repeats a port | 300 iterations, all distinct |
| Concurrent callers | 8 threads × 25 ports, all distinct |
| Revert the dedup | fails with *"port 41969 handed to two threads"* / *"port 33737 was issued twice"* |
| Full workspace runs | **6 consecutive clean** (the scpd/nssfd flake class) |
| Remaining `bind("127.0.0.1:0")` | exactly the shared impl + the 9 keep-alive sites |

`scpd`'s bespoke dedup from #138 is replaced by the shared one, so a single implementation remains.

**Gates:** 5331 passed / 0 failed, `clippy --workspace` clean, `fmt --check` clean, tree clean.

Spec: `specs/fix-shared-ephemeral-port-helper.md`