### PR TITLE
test(crypt): pin milenage_opc argument order to the TS 35.208 vector

### DIFF
--- a/src/libs/nextgcore-crypt/src/property_tests.rs
+++ b/src/libs/nextgcore-crypt/src/property_tests.rs
@@ -19,6 +19,12 @@ mod tests {
 
         // Feature: nextgcore-rust-conversion, Property 8: Cryptographic Algorithm Bit-Identical Output
         // Test: OPc generation is deterministic - same K and OP always produce same OPc
+        //
+        // Determinism alone cannot pin the ARGUMENT ORDER: this test previously
+        // called `milenage_opc(&op, &k)` against a `(k, op)` signature and still
+        // passed, because two identical transposed calls agree with each other.
+        // `prop_opc_matches_3gpp_test_set_1` below pins the order to the spec
+        // vector, so a future transposition fails a test instead of hiding.
         proptest! {
             #![proptest_config(ProptestConfig::with_cases(100))]
 
@@ -27,8 +33,8 @@ mod tests {
                 k in prop::array::uniform16(any::<u8>()),
                 op in prop::array::uniform16(any::<u8>()),
             ) {
-                let opc1 = milenage_opc(&op, &k);
-                let opc2 = milenage_opc(&op, &k);
+                let opc1 = milenage_opc(&k, &op);
+                let opc2 = milenage_opc(&k, &op);
                 prop_assert_eq!(opc1, opc2, "OPc generation must be deterministic");
             }
 
@@ -48,6 +54,42 @@ mod tests {
                     prop_assert_eq!(r1, r2, "f2345 must be deterministic");
                 }
             }
+        }
+
+        /// Pins `milenage_opc`'s argument order to 3GPP TS 35.208 Test Set 1.
+        ///
+        /// OPc = E_K(OP) XOR OP, which is NOT symmetric in its two arguments, so
+        /// a transposed call yields a different OPc and fails here. That is the
+        /// point: the neighbouring determinism property is blind to argument
+        /// order, so this vector is what actually holds the contract.
+        #[test]
+        fn prop_opc_matches_3gpp_test_set_1() {
+            const K: [u8; 16] = [
+                0x46, 0x5b, 0x5c, 0xe8, 0xb1, 0x99, 0xb4, 0x9f, 0xaa, 0x5f, 0x0a, 0x2e, 0xe2, 0x38,
+                0xa6, 0xbc,
+            ];
+            const OP: [u8; 16] = [
+                0xcd, 0xc2, 0x02, 0xd5, 0x12, 0x3e, 0x20, 0xf6, 0x2b, 0x6d, 0x67, 0x6a, 0xc7, 0x2c,
+                0xb3, 0x18,
+            ];
+            const OPC: [u8; 16] = [
+                0xcd, 0x63, 0xcb, 0x71, 0x95, 0x4a, 0x9f, 0x4e, 0x48, 0xa5, 0x99, 0x4e, 0x37, 0xa0,
+                0x2b, 0xaf,
+            ];
+
+            assert_eq!(
+                milenage_opc(&K, &OP).expect("OPc derivation must succeed"),
+                OPC,
+                "milenage_opc(k, op) must match TS 35.208 Test Set 1"
+            );
+
+            // Guard the guard: if the function were symmetric the assertion above
+            // could not detect a transposition at all.
+            assert_ne!(
+                milenage_opc(&OP, &K).expect("transposed call still computes"),
+                OPC,
+                "OPc must depend on argument order, else this test proves nothing"
+            );
         }
     }
 


### PR DESCRIPTION
## Problem

`libs/nextgcore-crypt/src/property_tests.rs:30-31` called

```rust
let opc1 = milenage_opc(&op, &k);
let opc2 = milenage_opc(&op, &k);
```

against a signature of `milenage_opc(k: &[u8; 16], op: &[u8; 16])` (`milenage.rs:226`). The arguments are transposed.

The test passed anyway, because it only asserted `opc1 == opc2` — two identical calls agree with each other regardless of argument order. The property was **self-consistent rather than correct**, and blind to exactly the class of defect its name suggests it covers.

**No production defect.** Every real caller passes `(k, op)` correctly, and `milenage.rs`'s own `test_milenage_opc` already checks the TS 35.208 Set-1 vector. Found while verifying #86; deliberately left out of `cdcff51` so a cosmetic test fix would not ride inside a security commit.

## Why the swap alone wasn't enough

Determinism and argument order are **independent properties**, and only the first was being tested. Swapping to `(&k, &op)` restores correctness but leaves the test just as unable to *detect* a future transposition — the next person to "tidy" the argument order would again see green.

So this does both:

1. Swaps the transposed call to `milenage_opc(&k, &op)`.
2. Adds `prop_opc_matches_3gpp_test_set_1`, asserting the TS 35.208 Test Set 1 vector. `OPc = E_K(OP) XOR OP` is **not** symmetric, so a transposed call yields a different OPc and fails.

The new test also asserts the **converse** — that the transposed call does *not* equal the expected OPc. If the function were ever symmetric, the positive assertion could not detect a transposition at all, and the test would silently stop guarding anything while still passing. Asserting the asymmetry makes the guard self-checking.

## Non-goals

- Changing `milenage_opc` itself: the function and every production caller are correct.
- Deduplicating against `milenage.rs`'s `test_milenage_opc`, which checks the same vector. The duplication is deliberate — the property-test file is where the transposition happened, so the guard belongs where the mistake was made.

## Verification

- `cargo test -p nextgcore-crypt` — 154 passed, 0 failed.
- **Revert-verified**: transposing the new test's call to `milenage_opc(&OP, &K)` fails with `milenage_opc(k, op) must match TS 35.208 Test Set 1`, confirming the test detects the original defect.
- Full workspace: **5336 passed, 0 failed** (baseline 5331).
- `cargo fmt --check` clean; `cargo clippy --workspace` (the CI gate) clean; no new `--all-targets` warnings in the touched file.

Spec: `specs/fix-crypt-opc-property-arg-order.md`