### PR TITLE
fix(amfd): read the amf.time timer keys the shipped configs declare

### DIFF
--- a/src/bins/nextgcore-amfd/src/gmm_build.rs
+++ b/src/bins/nextgcore-amfd/src/gmm_build.rs
@@ -472,9 +472,10 @@ pub fn build_registration_accept(amf_ue: &AmfUe) -> Option<Vec<u8>> {
     // hardcoded. Previously this was a literal 9 minutes while
     // `context.rs` carried `t3512_value: 3240` — 54 minutes — with no reader,
     // and `docker/rust/configs/5gc/amf.yaml` declared `time.t3512.value: 540`
-    // (9 min) which `parse_time` silently drops into its `_ => {}` arm. Three
-    // values, two of them dead, and the live one agreeing with the YAML only by
-    // coincidence.
+    // (9 min) that nothing read. Three values, two of them dead, and the live
+    // one agreeing with the YAML only by coincidence. `lib.rs`'s `load_config`
+    // now applies `amf.time.t3512.value` to the context field, so the YAML is
+    // authoritative and this call site stays the single encoder.
     //
     // A poisoned context lock falls back to the historical 9 minutes rather
     // than dropping a mandatory-for-this-message IE.

--- a/src/bins/nextgcore-amfd/src/lib.rs
+++ b/src/bins/nextgcore-amfd/src/lib.rs
@@ -141,6 +141,34 @@ struct NasYaml {
     use_nextgcore_security: Option<bool>,
 }
 
+/// A single `<timer>: { value: <seconds> }` entry under `amf.time`.
+///
+/// The nesting under `value` mirrors the shipped configs
+/// (`docker/rust/configs/5gc/amf.yaml`, `k8s/manifests/configmap.yaml`,
+/// `deploy/helm/.../configmap.yaml`), all of which write
+/// `time: { t3512: { value: 540 } }`.
+#[derive(Debug, Default, Deserialize)]
+struct TimerValueYaml {
+    value: Option<u64>,
+}
+
+/// The `amf.time` block: 5GMM timers the AMF signals to the UE, in seconds.
+///
+/// Only the timers the AMF actually emits are read here. `t3512` lands in the
+/// Registration Accept as GPRS Timer 3; `t3502` has a context field that
+/// `build_registration_accept` still sends as `None`, so it is parsed and
+/// stored but not yet signalled — see the timer task in TASKS.md.
+///
+/// Note this is NOT read by `nextgcore_app`'s `parse_time`: that path hangs off
+/// `NextgcoreLocalConf::parse`, which only `ConfigReloadManager` reaches, and
+/// that type is never constructed nor exported. The AMF's own serde path (here)
+/// is the one that actually runs at startup.
+#[derive(Debug, Default, Deserialize)]
+struct TimeYaml {
+    t3502: Option<TimerValueYaml>,
+    t3512: Option<TimerValueYaml>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct AmfSection {
     amf_name: Option<String>,
@@ -151,6 +179,7 @@ struct AmfSection {
     security: Option<SecurityYaml>,
     sbi: Option<SbiYaml>,
     nas: Option<NasYaml>,
+    time: Option<TimeYaml>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -483,14 +512,55 @@ impl AmfApp {
             }
         }
 
+        // 5GMM timers (`amf.time`). Previously dropped: the shipped configs all
+        // declare `time.t3512.value: 540`, but nothing read it, so the emitted
+        // T3512 came solely from the context default and agreed with the YAML
+        // only by coincidence. A config change was silently inert.
+        //
+        // These are applied to BOTH contexts on purpose. `self.amf_context` (the
+        // one this function fills, and the one NGAP is handed) and the global
+        // `context::amf_self()` are separate `AmfContext` instances today — see
+        // `apply_timer_conf`. `build_registration_accept` reads the global, so
+        // writing only `ctx` here would leave the YAML inert for the one message
+        // that actually carries T3512.
+        let timers = amf_section.time.unwrap_or_default();
+        Self::apply_timer_conf(&mut ctx, &timers);
+        if let Ok(mut global) = context::amf_self().write() {
+            Self::apply_timer_conf(&mut global, &timers);
+        } else {
+            log::warn!("global AMF context lock poisoned; T3512/T3502 left at defaults");
+        }
+
         log::info!(
-            "AMF configuration loaded: {} GUAMI, {} TAI, {} PLMN support",
+            "AMF configuration loaded: {} GUAMI, {} TAI, {} PLMN support, T3512={}s",
             ctx.num_of_served_guami,
             ctx.num_of_served_tai,
-            ctx.num_of_plmn_support
+            ctx.num_of_plmn_support,
+            ctx.t3512_value
         );
 
         Ok(())
+    }
+
+    /// Apply the parsed `amf.time` timers to one `AmfContext`.
+    ///
+    /// Split out because the values must land in two distinct contexts (see the
+    /// call site), and because it makes the mapping unit-testable without
+    /// standing up an `AmfApp` or touching process-wide state.
+    ///
+    /// An absent key leaves the context default untouched. A present `0` is
+    /// applied rather than rejected: `gmm_build::encode_gprs_timer3_seconds`
+    /// maps 0 to the spec's "timer is deactivated" unit (TS 24.008
+    /// Table 10.5.163b), so it is a meaningful configuration.
+    fn apply_timer_conf(ctx: &mut context::AmfContext, timers: &TimeYaml) {
+        if let Some(seconds) = timers.t3512.as_ref().and_then(|t| t.value) {
+            log::info!("T3512 periodic registration update timer: {seconds}s");
+            ctx.t3512_value = seconds;
+        }
+        if let Some(seconds) = timers.t3502.as_ref().and_then(|t| t.value) {
+            log::info!("T3502 timer: {seconds}s (stored; not yet signalled)");
+            ctx.t3502_value = seconds;
+        }
     }
 
     /// Resolve a PLMN ID from the typed YAML struct (mcc/mnc may be int or string)
@@ -905,6 +975,66 @@ mod tests {
         let app = AmfApp::new();
         app.metrics().inc(metrics::GlobalMetric::RmRegInitReq);
         assert_eq!(app.metrics().get(metrics::GlobalMetric::RmRegInitReq), 1);
+    }
+
+    /// The `amf.time` block deserializes from the shape the shipped configs
+    /// actually use — `time: { t3512: { value: 540 } }`, nested under `value`,
+    /// as written by `docker/rust/configs/5gc/amf.yaml`,
+    /// `k8s/manifests/configmap.yaml` and the Helm configmap template.
+    #[test]
+    fn amf_time_block_parses_the_shipped_config_shape() {
+        let yaml: AmfYaml = serde_yaml::from_str(
+            "amf:\n  amf_name: nextgcore-amf0\n  time:\n    t3512:\n      value: 540\n",
+        )
+        .expect("shipped time block must deserialize");
+
+        let time = yaml.amf.expect("amf section").time.expect("time block");
+        assert_eq!(time.t3512.and_then(|t| t.value), Some(540));
+    }
+
+    /// A configured T3512 must reach the context field that
+    /// `build_registration_accept` reads. Before this wiring the YAML key was
+    /// parsed by nothing at all, so the emitted timer came only from the context
+    /// default and matched the config by coincidence.
+    #[test]
+    fn configured_t3512_overrides_the_context_default() {
+        let mut ctx = context::AmfContext::new();
+        assert_eq!(ctx.t3512_value, 540, "context default, per amf.yaml");
+
+        let timers = TimeYaml {
+            t3502: None,
+            t3512: Some(TimerValueYaml { value: Some(3240) }),
+        };
+        AmfApp::apply_timer_conf(&mut ctx, &timers);
+
+        assert_eq!(ctx.t3512_value, 3240, "YAML must win over the default");
+        assert_eq!(ctx.t3502_value, 720, "absent key leaves the default alone");
+    }
+
+    /// An absent `time` block must not zero the timers: `unwrap_or_default()` at
+    /// the call site yields an all-`None` `TimeYaml`, which has to be a no-op
+    /// rather than an assignment of 0 (which would encode as "deactivated").
+    #[test]
+    fn absent_time_block_leaves_timer_defaults_intact() {
+        let mut ctx = context::AmfContext::new();
+        let before = (ctx.t3512_value, ctx.t3502_value);
+
+        AmfApp::apply_timer_conf(&mut ctx, &TimeYaml::default());
+
+        assert_eq!((ctx.t3512_value, ctx.t3502_value), before);
+    }
+
+    /// An explicit 0 is a real setting — TS 24.008 Table 10.5.163b has a
+    /// "timer is deactivated" unit — so it is applied, not filtered out.
+    #[test]
+    fn explicit_zero_t3512_is_applied_not_ignored() {
+        let mut ctx = context::AmfContext::new();
+        let timers = TimeYaml {
+            t3502: None,
+            t3512: Some(TimerValueYaml { value: Some(0) }),
+        };
+        AmfApp::apply_timer_conf(&mut ctx, &timers);
+        assert_eq!(ctx.t3512_value, 0, "0 means deactivated, not unset");
     }
 }
 


### PR DESCRIPTION
## Problem

Every shipped AMF config declares a T3512 value:

- `docker/rust/configs/5gc/amf.yaml:71` — `time: { t3512: { value: 540 } }`
- `k8s/manifests/configmap.yaml:203`
- `deploy/helm/nextgcore/templates/configmap.yaml:91`, from `values.yaml:120` (`t3512: 540`)

**Nothing read any of them.** The emitted T3512 came solely from `AmfContext::new`'s `t3512_value: 540` default (`context.rs:669`), which agreed with the YAML only by coincidence. Editing the config — or the Helm value, which exists precisely to be overridden — changed nothing on the wire.

## The filed cause was wrong, in a way that changes the fix

The task said `nextgcore-app`'s `parse_time` (`libs/nextgcore-app/src/config.rs:691`) drops `t3512` into its `_ => {}` arm, and to teach it the missing keys.

`parse_time` *does* drop the key — but fixing it there would have changed **nothing**, because that whole path is **unreachable**:

```
NextgcoreLocalConf::parse   (config.rs:604)
  ← ::reload                (config.rs:1121)     the only caller
  ← ConfigReloadManager::start_auto_reload        the only caller
```

`ConfigReloadManager` is never constructed anywhere, and is not among `nextgcore-app`'s `pub use config::{...}` exports (`lib.rs:23` lists `NextgcoreLocalConf` and `TimeConf` but not it). No binary reaches it; `NextgcoreLocalConf::parse` has no non-test caller in the tree.

Each NF reads its config through its own serde path instead — for the AMF, `AmfYaml`/`AmfSection` applied by `load_config`. That is where this fix goes. A follow-up task is filed to decide the dead path's fate.

## A second, larger defect found while wiring it

`load_config` writes `self.amf_context` (`lib.rs:415`), an `AmfApp`-owned `Arc<RwLock<AmfContext>>` from `AmfApp::new`. But `gmm_build::build_registration_accept` reads the **process-global** context via `context::amf_self()` (`gmm_build.rs:481`), a distinct `AmfContext` behind a `OnceLock`.

They are **two different instances**. A value written by `load_config` never reaches the code that emits T3512 — so a fix touching only `ctx` would have passed its tests while the wire stayed unchanged.

This is not timer-specific: `amf_name`, `served_guami`, `served_tai`, the `num_of_*` counters and the integrity/ciphering orders are all written only to the app-owned context. NGAP happens to work because `amf_ngap_open` is handed `Arc::clone(&self.amf_context)` (`lib.rs:643`), so it reads the same instance `load_config` wrote. The NAS/GMM path reads the global and does not.

**Scope call:** this PR applies the timers to *both* contexts and documents why, rather than unifying them. Collapsing the two touches 58 `amf_self()` call sites plus every `load_config` field and needs its own review — it should not ride inside a timer-config fix. Follow-up task filed, including the audit needed to classify which of those call sites read config-derived fields (latent bugs of the same shape) versus runtime state seeded elsewhere.

## Changes

1. `TimeYaml` / `TimerValueYaml` matching the shipped `time: { t3512: { value: N } }` shape, added to `AmfSection`.
2. `AmfApp::apply_timer_conf(&mut AmfContext, &TimeYaml)` — split out so it is unit-testable without an `AmfApp` or process-wide state, and so both contexts share one mapping.
3. `load_config` calls it on `self.amf_context` and on `context::amf_self()`, warning (not failing) if the global lock is poisoned — losing a timer default is not worth aborting startup.
4. `gmm_build.rs`'s comment corrected: it blamed `parse_time`'s `_` arm, which was never the live path.

`t3502` is parsed and stored alongside, since the context field exists and the shape is identical. It is still **not signalled** — `build_registration_accept` sends `t3502_value: None` — and the log line says so rather than implying otherwise.

## Semantics

- **Absent key → default untouched.** `load_config` uses `unwrap_or_default()`, yielding an all-`None` `TimeYaml`, so an absent `time` block must be a no-op, not an assignment of 0.
- **Explicit `0` → applied.** TS 24.008 Table 10.5.163b defines a "timer is deactivated" unit, which `encode_gprs_timer3_seconds` already maps 0 onto, so 0 is a real setting and is not filtered out.
- An inexpressible value is **not** rejected here: the existing encoder logs a warning and falls back to 9 minutes. Validating at parse time would duplicate that policy in a second place.

## Non-goals

- Timers with no context field: T3346, T3396, T3521/3525/3540/3565/3575/3585/3591/3592 (absent from the tree). Adding a YAML key for a timer nothing emits would recreate the very inert-config defect this removes.
- Making T3502 actually signalled.
- Reviving or deleting the dead `parse_time` / `ConfigReloadManager` path (follow-up filed).
- Unifying the app-owned and global AMF contexts (follow-up filed).

## Verification

- 4 new tests: the shipped-config shape deserializes; a configured value overrides the default; an absent block leaves defaults intact; an explicit 0 is applied.
- **Revert-verified**: neutering the `t3512` assignment (simulating the pre-fix dropped key) fails `configured_t3512_overrides_the_context_default` ("YAML must win over the default") and `explicit_zero_t3512_is_applied_not_ignored`.
- Full workspace: **5335 passed, 0 failed** (baseline 5331, +4 new).
- `cargo fmt --check` clean; `cargo clippy --workspace` (the CI gate) clean; no new `--all-targets` warnings in any touched file.

Spec: `specs/fix-amf-time-timer-config-read.md`