### PR TITLE
fix(eks): tag images by git SHA and assert the pods run them

### DIFF
--- a/deploy/eks/README.md
+++ b/deploy/eks/README.md
@@ -15,10 +15,38 @@ deploy/eks/
 │   └── eks-cluster.yaml      VPC, EKS, node group, ECR, EBS CSI IRSA
 ├── kustomization.yaml        overlay entrypoint (patches k8s/ + nextgsim/k8s/)
 ├── patches/                  per-concern strategic-merge patches
+├── lib/image-tag.sh          git-SHA image tag, shared by both scripts
 ├── build-and-push.sh         build 12 images, push to ECR
 ├── deploy-eks.sh             apply the overlay in dependency order
 └── README.md
 ```
+
+## Images are tagged by git SHA, not `:latest`
+
+Both scripts derive the tag from `git rev-parse --short=12 HEAD` of the
+repository each image is built from — nextgcore for the 10 core NFs,
+nextgsim for `gnb`/`ue`, since those are separate repos at separate
+commits. A dirty tree appends `-dirty`. Neither script passes the tag to
+the other: both read the same two repos, so they agree by construction
+(`lib/image-tag.sh`).
+
+**Why this matters.** With a mutable `:latest`, the Deployment spec text
+is identical before and after a rebuild, so `kubectl apply` writes no new
+ReplicaSet and the running pods keep the **old** image — while the script
+exits 0, prints `Deployed.`, and its `kubectl rollout status` loop passes
+trivially against those stale pods. Observed on devtest1: the running AMF
+was `sha256:1338b825` while the freshly pushed tag was `sha256:2665d4ca`,
+so an E2E run was reporting on code that had never been deployed.
+`imagePullPolicy: Always` does not save this — with no spec change no
+container is restarted, so nothing is re-pulled.
+
+After the rollout waits, `deploy-eks.sh` additionally asserts that every
+running container's image is the one the manifests asked for, and fails
+with the bottom-up `rollout restart` command if any pod is stale. A
+rollout wait alone cannot detect this.
+
+To pin a release or redeploy an older build, set `IMAGE_TAG` on **both**
+scripts; `IMAGE_TAG=latest` still works but warns.
 
 ## Why the addressing needed real work
 
@@ -125,10 +153,10 @@ aws cloudformation deploy \
 # 2. Credentials
 aws eks update-kubeconfig --region us-west-2 --name nextg
 
-# 3. Images -> ECR
+# 3. Images -> ECR (tagged by git SHA; see below)
 ./build-and-push.sh
 
-# 4. Workload
+# 4. Workload (derives the same SHA tags, so needs no tag argument)
 ./deploy-eks.sh
 ```
 

--- a/deploy/eks/build-and-push.sh
+++ b/deploy/eks/build-and-push.sh
@@ -9,6 +9,11 @@
 #   nextgcore/binaries/nextgcore-*d       (17 NF binaries, 10 used here)
 #   nextgsim/docker/binaries/nr-gnb,nr-ue
 #
+# Images are tagged by the git SHA of the repository they are built from, not
+# :latest. See lib/image-tag.sh for why a mutable tag makes the deploy a silent
+# no-op. IMAGE_TAG still overrides, for a release tag or to reproduce an old
+# deploy.
+#
 # Usage:
 #   ./build-and-push.sh                        # infer registry from STS
 #   REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com ./build-and-push.sh
@@ -19,9 +24,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CORE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 SIM_DIR="$(cd "${CORE_DIR}/../nextgsim" && pwd)"
 
+# shellcheck source=lib/image-tag.sh
+source "${SCRIPT_DIR}/lib/image-tag.sh"
+
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}"
 REPO_PREFIX="${REPO_PREFIX:-nextg}"
-IMAGE_TAG="${IMAGE_TAG:-latest}"
 
 # NF -> binary name. The image name is the short NF name; the binary is the
 # daemon name. Dockerfile.nf symlinks it to /usr/local/bin/nf-binary.
@@ -41,6 +48,31 @@ CORE_NFS=(
 log()  { printf '\033[0;32m[build]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[warn ]\033[0m %s\n' "$*"; }
 die()  { printf '\033[0;31m[fail ]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- image tags ------------------------------------------------------------
+
+# Two repositories, two tags: the core NFs are built from nextgcore and the
+# gnb/ue from the sibling nextgsim, which sits at its own commit. Tagging both
+# groups with one SHA would label an image with a commit that does not describe
+# it. An explicit IMAGE_TAG overrides both.
+if [[ -n "${IMAGE_TAG:-}" ]]; then
+  CORE_TAG="${IMAGE_TAG}"
+  SIM_TAG="${IMAGE_TAG}"
+  if [[ "${IMAGE_TAG}" == "latest" ]]; then
+    warn "IMAGE_TAG=latest is MUTABLE: deploy-eks.sh's kubectl apply becomes a"
+    warn "no-op because the Deployment spec text never changes, so pods keep"
+    warn "running the old image while the deploy reports success."
+  fi
+else
+  CORE_TAG="$(nextg_image_tag "${CORE_DIR}")" || die "cannot derive nextgcore image tag"
+  SIM_TAG="$(nextg_image_tag "${SIM_DIR}")"   || die "cannot derive nextgsim image tag"
+fi
+
+for repo_tag in "nextgcore:${CORE_TAG}" "nextgsim:${SIM_TAG}"; do
+  if [[ "${repo_tag#*:}" == *-dirty ]]; then
+    warn "${repo_tag%%:*} tree is dirty; tagging ${repo_tag#*:} (not reproducible from the SHA)"
+  fi
+done
 
 # --- preflight -------------------------------------------------------------
 
@@ -111,7 +143,7 @@ docker build \
 for entry in "${CORE_NFS[@]}"; do
   nf="${entry%%:*}"
   bin="${entry#*:}"
-  remote="${REGISTRY}/${REPO_PREFIX}/${nf}:${IMAGE_TAG}"
+  remote="${REGISTRY}/${REPO_PREFIX}/${nf}:${CORE_TAG}"
 
   ensure_repo "${nf}"
   log "building ${nf} (${bin})"
@@ -133,7 +165,7 @@ done
 for pair in "gnb:Dockerfile.gnb-local" "ue:Dockerfile.ue-local"; do
   node="${pair%%:*}"
   dockerfile="${pair#*:}"
-  remote="${REGISTRY}/${REPO_PREFIX}/${node}:${IMAGE_TAG}"
+  remote="${REGISTRY}/${REPO_PREFIX}/${node}:${SIM_TAG}"
 
   ensure_repo "${node}"
   log "building ${node}"
@@ -156,11 +188,14 @@ cat <<EOF
 
 All 12 images pushed.
 
-  registry: ${REGISTRY}
-  prefix:   ${REPO_PREFIX}
-  tag:      ${IMAGE_TAG}
+  registry:      ${REGISTRY}
+  prefix:        ${REPO_PREFIX}
+  core NF tag:   ${CORE_TAG}
+  gnb/ue tag:    ${SIM_TAG}
 
-Next:
-  REGISTRY=${REGISTRY} REPO_PREFIX=${REPO_PREFIX} IMAGE_TAG=${IMAGE_TAG} \\
-    ./deploy-eks.sh
+Next (deploy-eks.sh derives the SAME tags from the same two repos, so it needs
+no tag argument -- commit either repo in between and it will fail fast on a
+missing ECR tag rather than deploying a stale image):
+
+  REGISTRY=${REGISTRY} REPO_PREFIX=${REPO_PREFIX} ./deploy-eks.sh
 EOF

--- a/deploy/eks/deploy-eks.sh
+++ b/deploy/eks/deploy-eks.sh
@@ -14,11 +14,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CORE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SIM_DIR="$(cd "${CORE_DIR}/../nextgsim" && pwd)"
 NAMESPACE="nextg-system"
+
+# shellcheck source=lib/image-tag.sh
+source "${SCRIPT_DIR}/lib/image-tag.sh"
 
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}"
 REPO_PREFIX="${REPO_PREFIX:-nextg}"
-IMAGE_TAG="${IMAGE_TAG:-latest}"
 ENABLE_DATAPLANE="${ENABLE_DATAPLANE:-false}"
 DRY_RUN="${DRY_RUN:-false}"
 # Swap MongoDB's gp3 PVC for an emptyDir. Needed on clusters without the EBS
@@ -31,6 +34,24 @@ EPHEMERAL_STORAGE="${EPHEMERAL_STORAGE:-false}"
 log()  { printf '\033[0;32m[deploy]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[warn  ]\033[0m %s\n' "$*"; }
 die()  { printf '\033[0;31m[fail  ]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- image tags ------------------------------------------------------------
+
+# Derived from the same two repositories build-and-push.sh reads, so the tags
+# match without either script passing anything to the other. IMAGE_TAG still
+# overrides (both groups), for a release tag or to redeploy an older build.
+if [[ -n "${IMAGE_TAG:-}" ]]; then
+  CORE_TAG="${IMAGE_TAG}"
+  SIM_TAG="${IMAGE_TAG}"
+  if [[ "${IMAGE_TAG}" == "latest" ]]; then
+    warn "IMAGE_TAG=latest is MUTABLE: the kubectl apply below cannot detect a"
+    warn "new image, so pods keep the old one and the rollout waits pass"
+    warn "trivially against stale pods. Prefer the default SHA tags."
+  fi
+else
+  CORE_TAG="$(nextg_image_tag "${CORE_DIR}")" || die "cannot derive nextgcore image tag"
+  SIM_TAG="$(nextg_image_tag "${SIM_DIR}")"   || die "cannot derive nextgsim image tag"
+fi
 
 # --- preflight -------------------------------------------------------------
 
@@ -52,7 +73,8 @@ if [[ "${DRY_RUN}" != "true" ]]; then
   target cluster : ${CTX}
   namespace      : ${NAMESPACE}
   registry       : ${REGISTRY}/${REPO_PREFIX}
-  tag            : ${IMAGE_TAG}
+  core NF tag    : ${CORE_TAG}
+  gnb/ue tag     : ${SIM_TAG}
   data plane     : ${ENABLE_DATAPLANE}
   mongo storage  : $([[ "${EPHEMERAL_STORAGE}" == "true" ]] && echo "emptyDir (EPHEMERAL - data lost on restart)" || echo "gp3 PVC")
 
@@ -292,20 +314,33 @@ fi
 # nextgcore-rust/<nf>:latest and nextgsim-<node>:latest, which do not exist on
 # EKS - without this every pod ends in ErrImagePull.
 log "rewriting image references to ${REGISTRY}/${REPO_PREFIX}..."
-python3 - "${RENDERED}" "${REGISTRY}" "${REPO_PREFIX}" "${IMAGE_TAG}" <<'PY'
+python3 - "${RENDERED}" "${REGISTRY}" "${REPO_PREFIX}" "${CORE_TAG}" "${SIM_TAG}" <<'PY'
 import re, sys
-path, registry, prefix, tag = sys.argv[1:5]
+path, registry, prefix, core_tag, sim_tag = sys.argv[1:6]
 src = open(path).read()
+# Two tags, because the core NFs and the simulator come from different
+# repositories at different commits (see lib/image-tag.sh).
 src, n1 = re.subn(r'nextgcore-rust/([a-z0-9]+):latest',
-                  rf'{registry}/{prefix}/\1:{tag}', src)
+                  rf'{registry}/{prefix}/\1:{core_tag}', src)
 src, n2 = re.subn(r'\bnextgsim-(gnb|ue):latest',
-                  rf'{registry}/{prefix}/\1:{tag}', src)
-# imagePullPolicy IfNotPresent is right for Kind (images side-loaded); on EKS
-# it means a :latest tag is never refreshed after the first pull.
+                  rf'{registry}/{prefix}/\1:{sim_tag}', src)
+# imagePullPolicy IfNotPresent is right for Kind (images side-loaded). On EKS an
+# immutable SHA tag makes the choice moot for correctness -- a changed tag is a
+# changed spec, so the pod is recreated and pulled regardless -- but Always is
+# kept as defence in depth for an explicit IMAGE_TAG that is mutable.
 src, n3 = re.subn(r'imagePullPolicy: IfNotPresent',
                   'imagePullPolicy: Always', src)
 open(path, 'w').write(src)
-print(f'  {n1} core NF images, {n2} simulator images, {n3} pull policies')
+print(f'  {n1} core NF images @ {core_tag}, {n2} simulator images @ {sim_tag}, '
+      f'{n3} pull policies')
+# A Kind-local image name left anywhere means a rewrite pattern missed, which on
+# EKS is an ErrImagePull. Match on the SOURCE names rather than on a ':latest'
+# suffix: IMAGE_TAG=latest is a supported (if discouraged) override, so a
+# ':latest' that carries the registry prefix has been rewritten correctly and
+# must not fail here.
+missed = sorted(set(re.findall(r'image:\s*(nextgcore-rust/\S+|nextgsim-\S+)', src)))
+if missed:
+    sys.exit('image rewrite missed: ' + ', '.join(missed))
 PY
 
 if [[ "${DRY_RUN}" == "true" ]]; then
@@ -445,6 +480,88 @@ kubectl rollout status deployment/gnb -n "${NAMESPACE}" --timeout=300s \
 log "waiting for the UE..."
 kubectl rollout status deployment/ue -n "${NAMESPACE}" --timeout=300s \
   || warn "UE not ready - check the resolve-dns initContainer logs"
+
+# --- verify the running pods carry the images we just deployed --------------
+#
+# `kubectl rollout status` alone cannot establish this. With a mutable tag the
+# apply is a no-op, no new ReplicaSet is written, and the rollout wait then
+# passes TRIVIALLY against the pods that were already Running -- reporting
+# success for a deploy that changed nothing. SHA tags make that far less likely
+# (a changed tag is a changed spec), but "less likely" is not a check, and an
+# explicit IMAGE_TAG can still be mutable.
+#
+# So assert it directly: every running container's image must be the image the
+# rendered manifests asked for. Compared by spec image reference rather than by
+# resolved digest, because a digest comparison needs an ECR round trip per image
+# and answers a different question -- what we care about here is that no pod is
+# still running a spec we replaced.
+log "verifying running pods match the deployed image tags..."
+PODS_JSON="${RENDERED}.pods.json"
+trap 'rm -f "${RENDERED}" "${RENDERED}.tmp" "${PODS_JSON}"' EXIT
+if kubectl get pods -n "${NAMESPACE}" -o json > "${PODS_JSON}" 2>/dev/null; then
+  # Both inputs are passed as FILES: a heredoc on stdin would override a pipe
+  # (shellcheck SC2259), silently handing the script no pod data at all.
+  python3 - "${RENDERED}" "${PODS_JSON}" <<'PY' || die "image verification failed"
+import json, re, sys, yaml
+
+rendered, pods_json = sys.argv[1], sys.argv[2]
+
+# Wanted image per (kind-owner) container name, taken from the manifests just
+# applied. Keyed by container name because that is what a pod status reports.
+wanted = {}
+for d in yaml.safe_load_all(open(rendered)):
+    if not d or d.get('kind') not in ('Deployment', 'StatefulSet', 'Job'):
+        continue
+    for c in d['spec']['template']['spec'].get('containers', []):
+        wanted.setdefault(c['name'], set()).add(c['image'])
+
+pods = json.load(open(pods_json))
+mismatched, checked = [], 0
+for p in pods.get('items', []):
+    phase = p.get('status', {}).get('phase')
+    if phase not in ('Running', 'Succeeded'):
+        continue
+    pod_name = p['metadata']['name']
+    for cs in p.get('status', {}).get('containerStatuses', []):
+        want = wanted.get(cs['name'])
+        if not want:
+            continue          # not one of ours (sidecar, or renamed)
+        checked += 1
+        # `image` in a pod status is the spec reference as resolved by kubelet;
+        # it can gain a docker.io/ prefix or lose an implicit :latest, so compare
+        # on a normalised suffix rather than requiring string equality.
+        got = cs['image']
+        def norm(ref):
+            ref = re.sub(r'^docker\.io/(library/)?', '', ref)
+            return ref if ':' in ref.rsplit('/', 1)[-1] else ref + ':latest'
+        if norm(got) not in {norm(w) for w in want}:
+            mismatched.append(f'{pod_name}/{cs["name"]}: running {got}, '
+                              f'expected {" or ".join(sorted(want))}')
+
+if mismatched:
+    print('pods are NOT running the images just deployed:', file=sys.stderr)
+    for m in mismatched:
+        print(f'  {m}', file=sys.stderr)
+    print('\nThis is the stale-image failure mode: the apply did not replace '
+          'these pods.\nForce it bottom-up, then re-run this script:\n'
+          '  kubectl rollout restart -n <ns> deploy/udr deploy/udm deploy/ausf '
+          'deploy/pcf deploy/nssf deploy/bsf\n'
+          '  kubectl rollout restart -n <ns> deploy/upf deploy/smf deploy/amf '
+          'deploy/gnb deploy/ue', file=sys.stderr)
+    sys.exit(1)
+
+if not checked:
+    # Not a hard failure: an earlier rollout warn already covered the
+    # not-ready case. But "0 checked" must not read like a clean bill of
+    # health, which a bare success line would.
+    print('  WARNING: no running containers matched a deployed container name, '
+          'so nothing was verified', file=sys.stderr)
+else:
+    print(f'  {checked} running containers all match the deployed image tags')
+PY
+else
+  warn "could not list pods; skipped image verification"
+fi
 
 # --- summary ---------------------------------------------------------------
 

--- a/deploy/eks/lib/image-tag.sh
+++ b/deploy/eks/lib/image-tag.sh
@@ -1,0 +1,74 @@
+# shellcheck shell=bash
+#
+# Shared image-tag derivation for build-and-push.sh and deploy-eks.sh.
+#
+# WHY THIS IS SHARED RATHER THAN COPIED
+#
+# The two scripts must agree on the tag with no handoff file between them:
+# build-and-push.sh pushes `<nf>:<tag>` and deploy-eks.sh rewrites the manifests
+# to the same `<nf>:<tag>`. Two independent copies of this logic would work until
+# one drifted, and the failure mode of drift is an ErrImagePull *at best* -- or,
+# if the drifted tag happens to exist, a deploy of the wrong build. So it is
+# computed in one place and sourced by both.
+#
+# Both scripts read the same two git repositories, so they derive the same tag
+# without either passing anything to the other. If the tree is committed between
+# a build and a deploy the tags no longer match, and deploy-eks.sh fails fast on
+# a missing ECR tag -- which is correct, because the images no longer correspond
+# to the source being deployed.
+#
+# WHY NOT :latest
+#
+# A mutable tag makes `kubectl apply` a silent no-op. The Deployment spec text is
+# identical before and after a rebuild, so the API server sees no change, writes
+# no new ReplicaSet, and the running pods keep the OLD image. `deploy-eks.sh`
+# then exits 0, prints "Deployed.", and its `kubectl rollout status` loop passes
+# trivially against those stale pods -- so an E2E run reports on code that was
+# never deployed. Observed on devtest1: the running AMF was sha256:1338b825
+# while the freshly pushed tag was sha256:2665d4ca.
+#
+# `imagePullPolicy: Always` does NOT save this. It governs what kubelet fetches
+# when it starts a container; with no spec change no container is ever restarted,
+# so nothing is re-pulled.
+#
+# TWO REPOSITORIES, TWO TAGS
+#
+# The 10 core NF images are built from nextgcore and the gnb/ue images from the
+# sibling nextgsim, which is a separate repository at its own commit. One tag
+# across both would label an image with a SHA that does not describe it, so each
+# group is tagged from its own repository's HEAD.
+
+# Derive an immutable image tag from a git repository's HEAD.
+#
+# Emits `<short-sha>` for a clean tree, `<short-sha>-dirty` when tracked files
+# are modified. The `-dirty` suffix is deliberately not an error: local
+# iteration on a cluster is a normal workflow, and the suffix is what stops two
+# different working trees from colliding on one tag. It is a *warning* in the
+# callers, because a dirty tag is not reproducible from the SHA alone.
+#
+# Note both repos gitignore their staged binary output directories
+# (nextgcore/binaries/, nextgsim/docker/binaries/), so populating those for a
+# build does not by itself make a tree dirty.
+#
+# $1: repository path. Prints the tag; returns non-zero if $1 is not a git repo.
+nextg_image_tag() {
+  local repo="$1" sha dirty=''
+
+  git -C "${repo}" rev-parse --git-dir >/dev/null 2>&1 || {
+    printf 'not a git repository: %s\n' "${repo}" >&2
+    return 1
+  }
+
+  sha="$(git -C "${repo}" rev-parse --short=12 HEAD 2>/dev/null)" || {
+    printf 'no HEAD commit in %s (unborn branch?)\n' "${repo}" >&2
+    return 1
+  }
+
+  # --porcelain covers tracked modifications and staged changes. Untracked files
+  # are intentionally ignored: a stray file in the tree does not change what gets
+  # built, and counting it would mark nearly every real workspace dirty.
+  [[ -n "$(git -C "${repo}" status --porcelain --untracked-files=no 2>/dev/null)" ]] \
+    && dirty='-dirty'
+
+  printf '%s%s\n' "${sha}" "${dirty}"
+}


### PR DESCRIPTION
## Problem

`build-and-push.sh` pushed `<nf>:latest` and `deploy-eks.sh` rewrote the manifests to `<nf>:latest`. A mutable tag makes the deploy a **silent no-op**:

1. The Deployment spec text is byte-identical before and after a rebuild.
2. So `kubectl apply` sees no change, writes no new ReplicaSet, and the running pods keep the **old** image.
3. `deploy-eks.sh` exits 0 and prints `Deployed.`
4. Its `kubectl rollout status` loop passes **trivially** — the existing pods are already `Available`, so there is nothing to wait for.

Net effect: **an E2E run reports on code that was never deployed.** Verified on devtest1 — the running AMF was `sha256:1338b825` while the freshly pushed tag was `sha256:2665d4ca`.

`imagePullPolicy: Always` does **not** save this. It governs what kubelet fetches when it *starts* a container; with no spec change no container is restarted, so nothing is re-pulled. The manifests already set `Always` and the bug happened anyway.

## Decision

**Two tags, not one.** The 10 core NFs are built from nextgcore and `gnb`/`ue` from the sibling nextgsim — a separate repository at its own commit. One tag across both would label an image with a SHA that does not describe it. They differ in practice: `20ba75f197a5` vs `ee9d8763c17f`.

**Derived, not passed.** Both scripts compute the tags from the same two repos rather than one writing a handoff file the other reads — no state to go stale, no new argument at the call site. Commit either repo in between and the deploy fails fast on a missing ECR tag, which is correct: the images no longer correspond to the source being deployed.

**Shared, not copied.** The derivation lives in `lib/image-tag.sh`, sourced by both. Two copies would work until one drifted, and drift means `ErrImagePull` at best — or, if the drifted tag happens to exist, deploying the wrong build.

**`-dirty` warns rather than fails.** Iterating on a cluster from a dirty tree is a normal workflow, and the suffix is what stops two working trees colliding on one tag. Untracked files deliberately do *not* count as dirty (`--untracked-files=no`): a stray file does not change what gets built, and counting it would mark nearly every real workspace dirty.

## Tagging alone is not enough

An immutable tag makes the stale-image case *unlikely* (a changed tag is a changed spec), but "unlikely" is not a check, and an explicit `IMAGE_TAG` can still be mutable. So after the rollout waits, `deploy-eks.sh` now **asserts** that every running container's image is the image the manifests asked for, failing with the bottom-up `rollout restart` command otherwise.

Compared by **spec image reference**, not resolved digest: a digest comparison needs an ECR round trip per image and answers a different question, when what matters is that no pod is still running a spec we replaced. The comparison normalises kubelet's `docker.io/library/` prefix and implicit `:latest`, which appear in pod status but not in manifests.

## Two defects caught in my own first draft

- **`shellcheck -x` found SC2259** — a heredoc overriding piped stdin in the verification block, which would have handed the script *no pod data at all* and passed vacuously. Both inputs are now files.
- The first rewrite guard **wrongly aborted the supported `IMAGE_TAG=latest` override** by matching on a `:latest` suffix. It now matches the *source* image names, so a correctly-rewritten `:latest` passes.

## Changes

1. **New** `deploy/eks/lib/image-tag.sh` — `nextg_image_tag <repo>` → `<short-sha>[-dirty]`; fails on a non-repo or unborn branch.
2. `build-and-push.sh` — derives `CORE_TAG`/`SIM_TAG`, tags each group from its own repo, warns on `-dirty` and on `IMAGE_TAG=latest`, reports both tags.
3. `deploy-eks.sh` — same derivation; two-tag manifest rewrite; both tags in the confirmation banner; a guard failing if any Kind-local image name survives the rewrite; the post-rollout image verification.
4. `README.md` — documents the tagging, why `:latest` broke the deploy, and the override.

`IMAGE_TAG` still overrides both groups, for a release tag or to redeploy an older build.

## Non-goals

- **Kind** (`k8s/deploy.sh`): side-loads via `kind load docker-image`, so no registry and no mutable-tag hazard. These two EKS scripts are the only `IMAGE_TAG` consumers in either repo.
- **Digest-pinning the manifests** (`image@sha256:...`): strictly stronger, but needs a registry round trip during render and makes manifests unreadable. The SHA tag plus the running-pod assertion closes the observed failure.
- **Third-party images** (mongo, prometheus, grafana, jaeger, busybox) — all already version-pinned; verified while confirming the new guard cannot false-positive on them.

## Verification

- `shellcheck -x` on all three scripts: **exit 0**.
- `DRY_RUN=true ./deploy-eks.sh`: 10 core NF images at the nextgcore SHA, 2 simulator images at the **different** nextgsim SHA, 41 manifests checked, **0 errors**. Rendered output confirms every NextG image carries an immutable tag while third-party pins are untouched.
- `DRY_RUN=true IMAGE_TAG=latest`: renders, warns, does **not** fail.
- **Revert-verified (rewrite guard)**: breaking the simulator pattern fails with `image rewrite missed: nextgsim-gnb:latest, nextgsim-ue:latest`.
- **Verification logic unit-tested** against synthetic pod JSON (it cannot run in a dry run — no cluster): matching pods pass; a stale AMF fails with the restart guidance (the devtest1 scenario); non-`Running` pods are skipped, not flagged; `docker.io/library/mongo:6.0` normalises correctly. A "0 containers checked" outcome warns instead of printing a clean bill of health.
- **Tag semantics** in a throwaway repo: clean → bare SHA; clean + untracked → still bare SHA; modified tracked → `-dirty`; staged → `-dirty`.
- Rust workspace unaffected: **5336 passed, 0 failed**; clippy 0; fmt clean.

**Not exercised:** a real `build-and-push.sh` run and a live cluster deploy, both of which need AWS credentials and an EKS cluster. The end-to-end render path is covered by the dry runs above.

Spec: `specs/fix-eks-image-tag-by-git-sha.md`