### PR TITLE
fix(hssd,pcrfd): parse the YAML Diameter config instead of ignoring it

### DIFF
--- a/deploy/eks/README.md
+++ b/deploy/eks/README.md
@@ -15,10 +15,38 @@ deploy/eks/
 │   └── eks-cluster.yaml      VPC, EKS, node group, ECR, EBS CSI IRSA
 ├── kustomization.yaml        overlay entrypoint (patches k8s/ + nextgsim/k8s/)
 ├── patches/                  per-concern strategic-merge patches
+├── lib/image-tag.sh          git-SHA image tag, shared by both scripts
 ├── build-and-push.sh         build 12 images, push to ECR
 ├── deploy-eks.sh             apply the overlay in dependency order
 └── README.md
 ```
+
+## Images are tagged by git SHA, not `:latest`
+
+Both scripts derive the tag from `git rev-parse --short=12 HEAD` of the
+repository each image is built from — nextgcore for the 10 core NFs,
+nextgsim for `gnb`/`ue`, since those are separate repos at separate
+commits. A dirty tree appends `-dirty`. Neither script passes the tag to
+the other: both read the same two repos, so they agree by construction
+(`lib/image-tag.sh`).
+
+**Why this matters.** With a mutable `:latest`, the Deployment spec text
+is identical before and after a rebuild, so `kubectl apply` writes no new
+ReplicaSet and the running pods keep the **old** image — while the script
+exits 0, prints `Deployed.`, and its `kubectl rollout status` loop passes
+trivially against those stale pods. Observed on devtest1: the running AMF
+was `sha256:1338b825` while the freshly pushed tag was `sha256:2665d4ca`,
+so an E2E run was reporting on code that had never been deployed.
+`imagePullPolicy: Always` does not save this — with no spec change no
+container is restarted, so nothing is re-pulled.
+
+After the rollout waits, `deploy-eks.sh` additionally asserts that every
+running container's image is the one the manifests asked for, and fails
+with the bottom-up `rollout restart` command if any pod is stale. A
+rollout wait alone cannot detect this.
+
+To pin a release or redeploy an older build, set `IMAGE_TAG` on **both**
+scripts; `IMAGE_TAG=latest` still works but warns.
 
 ## Why the addressing needed real work
 
@@ -125,10 +153,10 @@ aws cloudformation deploy \
 # 2. Credentials
 aws eks update-kubeconfig --region us-west-2 --name nextg
 
-# 3. Images -> ECR
+# 3. Images -> ECR (tagged by git SHA; see below)
 ./build-and-push.sh
 
-# 4. Workload
+# 4. Workload (derives the same SHA tags, so needs no tag argument)
 ./deploy-eks.sh
 ```
 

--- a/deploy/eks/build-and-push.sh
+++ b/deploy/eks/build-and-push.sh
@@ -9,6 +9,11 @@
 #   nextgcore/binaries/nextgcore-*d       (17 NF binaries, 10 used here)
 #   nextgsim/docker/binaries/nr-gnb,nr-ue
 #
+# Images are tagged by the git SHA of the repository they are built from, not
+# :latest. See lib/image-tag.sh for why a mutable tag makes the deploy a silent
+# no-op. IMAGE_TAG still overrides, for a release tag or to reproduce an old
+# deploy.
+#
 # Usage:
 #   ./build-and-push.sh                        # infer registry from STS
 #   REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com ./build-and-push.sh
@@ -19,9 +24,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CORE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 SIM_DIR="$(cd "${CORE_DIR}/../nextgsim" && pwd)"
 
+# shellcheck source=lib/image-tag.sh
+source "${SCRIPT_DIR}/lib/image-tag.sh"
+
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}"
 REPO_PREFIX="${REPO_PREFIX:-nextg}"
-IMAGE_TAG="${IMAGE_TAG:-latest}"
 
 # NF -> binary name. The image name is the short NF name; the binary is the
 # daemon name. Dockerfile.nf symlinks it to /usr/local/bin/nf-binary.
@@ -41,6 +48,31 @@ CORE_NFS=(
 log()  { printf '\033[0;32m[build]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[warn ]\033[0m %s\n' "$*"; }
 die()  { printf '\033[0;31m[fail ]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- image tags ------------------------------------------------------------
+
+# Two repositories, two tags: the core NFs are built from nextgcore and the
+# gnb/ue from the sibling nextgsim, which sits at its own commit. Tagging both
+# groups with one SHA would label an image with a commit that does not describe
+# it. An explicit IMAGE_TAG overrides both.
+if [[ -n "${IMAGE_TAG:-}" ]]; then
+  CORE_TAG="${IMAGE_TAG}"
+  SIM_TAG="${IMAGE_TAG}"
+  if [[ "${IMAGE_TAG}" == "latest" ]]; then
+    warn "IMAGE_TAG=latest is MUTABLE: deploy-eks.sh's kubectl apply becomes a"
+    warn "no-op because the Deployment spec text never changes, so pods keep"
+    warn "running the old image while the deploy reports success."
+  fi
+else
+  CORE_TAG="$(nextg_image_tag "${CORE_DIR}")" || die "cannot derive nextgcore image tag"
+  SIM_TAG="$(nextg_image_tag "${SIM_DIR}")"   || die "cannot derive nextgsim image tag"
+fi
+
+for repo_tag in "nextgcore:${CORE_TAG}" "nextgsim:${SIM_TAG}"; do
+  if [[ "${repo_tag#*:}" == *-dirty ]]; then
+    warn "${repo_tag%%:*} tree is dirty; tagging ${repo_tag#*:} (not reproducible from the SHA)"
+  fi
+done
 
 # --- preflight -------------------------------------------------------------
 
@@ -111,7 +143,7 @@ docker build \
 for entry in "${CORE_NFS[@]}"; do
   nf="${entry%%:*}"
   bin="${entry#*:}"
-  remote="${REGISTRY}/${REPO_PREFIX}/${nf}:${IMAGE_TAG}"
+  remote="${REGISTRY}/${REPO_PREFIX}/${nf}:${CORE_TAG}"
 
   ensure_repo "${nf}"
   log "building ${nf} (${bin})"
@@ -133,7 +165,7 @@ done
 for pair in "gnb:Dockerfile.gnb-local" "ue:Dockerfile.ue-local"; do
   node="${pair%%:*}"
   dockerfile="${pair#*:}"
-  remote="${REGISTRY}/${REPO_PREFIX}/${node}:${IMAGE_TAG}"
+  remote="${REGISTRY}/${REPO_PREFIX}/${node}:${SIM_TAG}"
 
   ensure_repo "${node}"
   log "building ${node}"
@@ -156,11 +188,14 @@ cat <<EOF
 
 All 12 images pushed.
 
-  registry: ${REGISTRY}
-  prefix:   ${REPO_PREFIX}
-  tag:      ${IMAGE_TAG}
+  registry:      ${REGISTRY}
+  prefix:        ${REPO_PREFIX}
+  core NF tag:   ${CORE_TAG}
+  gnb/ue tag:    ${SIM_TAG}
 
-Next:
-  REGISTRY=${REGISTRY} REPO_PREFIX=${REPO_PREFIX} IMAGE_TAG=${IMAGE_TAG} \\
-    ./deploy-eks.sh
+Next (deploy-eks.sh derives the SAME tags from the same two repos, so it needs
+no tag argument -- commit either repo in between and it will fail fast on a
+missing ECR tag rather than deploying a stale image):
+
+  REGISTRY=${REGISTRY} REPO_PREFIX=${REPO_PREFIX} ./deploy-eks.sh
 EOF

--- a/deploy/eks/deploy-eks.sh
+++ b/deploy/eks/deploy-eks.sh
@@ -14,11 +14,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CORE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SIM_DIR="$(cd "${CORE_DIR}/../nextgsim" && pwd)"
 NAMESPACE="nextg-system"
+
+# shellcheck source=lib/image-tag.sh
+source "${SCRIPT_DIR}/lib/image-tag.sh"
 
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}"
 REPO_PREFIX="${REPO_PREFIX:-nextg}"
-IMAGE_TAG="${IMAGE_TAG:-latest}"
 ENABLE_DATAPLANE="${ENABLE_DATAPLANE:-false}"
 DRY_RUN="${DRY_RUN:-false}"
 # Swap MongoDB's gp3 PVC for an emptyDir. Needed on clusters without the EBS
@@ -31,6 +34,24 @@ EPHEMERAL_STORAGE="${EPHEMERAL_STORAGE:-false}"
 log()  { printf '\033[0;32m[deploy]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[warn  ]\033[0m %s\n' "$*"; }
 die()  { printf '\033[0;31m[fail  ]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- image tags ------------------------------------------------------------
+
+# Derived from the same two repositories build-and-push.sh reads, so the tags
+# match without either script passing anything to the other. IMAGE_TAG still
+# overrides (both groups), for a release tag or to redeploy an older build.
+if [[ -n "${IMAGE_TAG:-}" ]]; then
+  CORE_TAG="${IMAGE_TAG}"
+  SIM_TAG="${IMAGE_TAG}"
+  if [[ "${IMAGE_TAG}" == "latest" ]]; then
+    warn "IMAGE_TAG=latest is MUTABLE: the kubectl apply below cannot detect a"
+    warn "new image, so pods keep the old one and the rollout waits pass"
+    warn "trivially against stale pods. Prefer the default SHA tags."
+  fi
+else
+  CORE_TAG="$(nextg_image_tag "${CORE_DIR}")" || die "cannot derive nextgcore image tag"
+  SIM_TAG="$(nextg_image_tag "${SIM_DIR}")"   || die "cannot derive nextgsim image tag"
+fi
 
 # --- preflight -------------------------------------------------------------
 
@@ -52,7 +73,8 @@ if [[ "${DRY_RUN}" != "true" ]]; then
   target cluster : ${CTX}
   namespace      : ${NAMESPACE}
   registry       : ${REGISTRY}/${REPO_PREFIX}
-  tag            : ${IMAGE_TAG}
+  core NF tag    : ${CORE_TAG}
+  gnb/ue tag     : ${SIM_TAG}
   data plane     : ${ENABLE_DATAPLANE}
   mongo storage  : $([[ "${EPHEMERAL_STORAGE}" == "true" ]] && echo "emptyDir (EPHEMERAL - data lost on restart)" || echo "gp3 PVC")
 
@@ -292,20 +314,33 @@ fi
 # nextgcore-rust/<nf>:latest and nextgsim-<node>:latest, which do not exist on
 # EKS - without this every pod ends in ErrImagePull.
 log "rewriting image references to ${REGISTRY}/${REPO_PREFIX}..."
-python3 - "${RENDERED}" "${REGISTRY}" "${REPO_PREFIX}" "${IMAGE_TAG}" <<'PY'
+python3 - "${RENDERED}" "${REGISTRY}" "${REPO_PREFIX}" "${CORE_TAG}" "${SIM_TAG}" <<'PY'
 import re, sys
-path, registry, prefix, tag = sys.argv[1:5]
+path, registry, prefix, core_tag, sim_tag = sys.argv[1:6]
 src = open(path).read()
+# Two tags, because the core NFs and the simulator come from different
+# repositories at different commits (see lib/image-tag.sh).
 src, n1 = re.subn(r'nextgcore-rust/([a-z0-9]+):latest',
-                  rf'{registry}/{prefix}/\1:{tag}', src)
+                  rf'{registry}/{prefix}/\1:{core_tag}', src)
 src, n2 = re.subn(r'\bnextgsim-(gnb|ue):latest',
-                  rf'{registry}/{prefix}/\1:{tag}', src)
-# imagePullPolicy IfNotPresent is right for Kind (images side-loaded); on EKS
-# it means a :latest tag is never refreshed after the first pull.
+                  rf'{registry}/{prefix}/\1:{sim_tag}', src)
+# imagePullPolicy IfNotPresent is right for Kind (images side-loaded). On EKS an
+# immutable SHA tag makes the choice moot for correctness -- a changed tag is a
+# changed spec, so the pod is recreated and pulled regardless -- but Always is
+# kept as defence in depth for an explicit IMAGE_TAG that is mutable.
 src, n3 = re.subn(r'imagePullPolicy: IfNotPresent',
                   'imagePullPolicy: Always', src)
 open(path, 'w').write(src)
-print(f'  {n1} core NF images, {n2} simulator images, {n3} pull policies')
+print(f'  {n1} core NF images @ {core_tag}, {n2} simulator images @ {sim_tag}, '
+      f'{n3} pull policies')
+# A Kind-local image name left anywhere means a rewrite pattern missed, which on
+# EKS is an ErrImagePull. Match on the SOURCE names rather than on a ':latest'
+# suffix: IMAGE_TAG=latest is a supported (if discouraged) override, so a
+# ':latest' that carries the registry prefix has been rewritten correctly and
+# must not fail here.
+missed = sorted(set(re.findall(r'image:\s*(nextgcore-rust/\S+|nextgsim-\S+)', src)))
+if missed:
+    sys.exit('image rewrite missed: ' + ', '.join(missed))
 PY
 
 if [[ "${DRY_RUN}" == "true" ]]; then
@@ -445,6 +480,88 @@ kubectl rollout status deployment/gnb -n "${NAMESPACE}" --timeout=300s \
 log "waiting for the UE..."
 kubectl rollout status deployment/ue -n "${NAMESPACE}" --timeout=300s \
   || warn "UE not ready - check the resolve-dns initContainer logs"
+
+# --- verify the running pods carry the images we just deployed --------------
+#
+# `kubectl rollout status` alone cannot establish this. With a mutable tag the
+# apply is a no-op, no new ReplicaSet is written, and the rollout wait then
+# passes TRIVIALLY against the pods that were already Running -- reporting
+# success for a deploy that changed nothing. SHA tags make that far less likely
+# (a changed tag is a changed spec), but "less likely" is not a check, and an
+# explicit IMAGE_TAG can still be mutable.
+#
+# So assert it directly: every running container's image must be the image the
+# rendered manifests asked for. Compared by spec image reference rather than by
+# resolved digest, because a digest comparison needs an ECR round trip per image
+# and answers a different question -- what we care about here is that no pod is
+# still running a spec we replaced.
+log "verifying running pods match the deployed image tags..."
+PODS_JSON="${RENDERED}.pods.json"
+trap 'rm -f "${RENDERED}" "${RENDERED}.tmp" "${PODS_JSON}"' EXIT
+if kubectl get pods -n "${NAMESPACE}" -o json > "${PODS_JSON}" 2>/dev/null; then
+  # Both inputs are passed as FILES: a heredoc on stdin would override a pipe
+  # (shellcheck SC2259), silently handing the script no pod data at all.
+  python3 - "${RENDERED}" "${PODS_JSON}" <<'PY' || die "image verification failed"
+import json, re, sys, yaml
+
+rendered, pods_json = sys.argv[1], sys.argv[2]
+
+# Wanted image per (kind-owner) container name, taken from the manifests just
+# applied. Keyed by container name because that is what a pod status reports.
+wanted = {}
+for d in yaml.safe_load_all(open(rendered)):
+    if not d or d.get('kind') not in ('Deployment', 'StatefulSet', 'Job'):
+        continue
+    for c in d['spec']['template']['spec'].get('containers', []):
+        wanted.setdefault(c['name'], set()).add(c['image'])
+
+pods = json.load(open(pods_json))
+mismatched, checked = [], 0
+for p in pods.get('items', []):
+    phase = p.get('status', {}).get('phase')
+    if phase not in ('Running', 'Succeeded'):
+        continue
+    pod_name = p['metadata']['name']
+    for cs in p.get('status', {}).get('containerStatuses', []):
+        want = wanted.get(cs['name'])
+        if not want:
+            continue          # not one of ours (sidecar, or renamed)
+        checked += 1
+        # `image` in a pod status is the spec reference as resolved by kubelet;
+        # it can gain a docker.io/ prefix or lose an implicit :latest, so compare
+        # on a normalised suffix rather than requiring string equality.
+        got = cs['image']
+        def norm(ref):
+            ref = re.sub(r'^docker\.io/(library/)?', '', ref)
+            return ref if ':' in ref.rsplit('/', 1)[-1] else ref + ':latest'
+        if norm(got) not in {norm(w) for w in want}:
+            mismatched.append(f'{pod_name}/{cs["name"]}: running {got}, '
+                              f'expected {" or ".join(sorted(want))}')
+
+if mismatched:
+    print('pods are NOT running the images just deployed:', file=sys.stderr)
+    for m in mismatched:
+        print(f'  {m}', file=sys.stderr)
+    print('\nThis is the stale-image failure mode: the apply did not replace '
+          'these pods.\nForce it bottom-up, then re-run this script:\n'
+          '  kubectl rollout restart -n <ns> deploy/udr deploy/udm deploy/ausf '
+          'deploy/pcf deploy/nssf deploy/bsf\n'
+          '  kubectl rollout restart -n <ns> deploy/upf deploy/smf deploy/amf '
+          'deploy/gnb deploy/ue', file=sys.stderr)
+    sys.exit(1)
+
+if not checked:
+    # Not a hard failure: an earlier rollout warn already covered the
+    # not-ready case. But "0 checked" must not read like a clean bill of
+    # health, which a bare success line would.
+    print('  WARNING: no running containers matched a deployed container name, '
+          'so nothing was verified', file=sys.stderr)
+else:
+    print(f'  {checked} running containers all match the deployed image tags')
+PY
+else
+  warn "could not list pods; skipped image verification"
+fi
 
 # --- summary ---------------------------------------------------------------
 

--- a/deploy/eks/lib/image-tag.sh
+++ b/deploy/eks/lib/image-tag.sh
@@ -1,0 +1,74 @@
+# shellcheck shell=bash
+#
+# Shared image-tag derivation for build-and-push.sh and deploy-eks.sh.
+#
+# WHY THIS IS SHARED RATHER THAN COPIED
+#
+# The two scripts must agree on the tag with no handoff file between them:
+# build-and-push.sh pushes `<nf>:<tag>` and deploy-eks.sh rewrites the manifests
+# to the same `<nf>:<tag>`. Two independent copies of this logic would work until
+# one drifted, and the failure mode of drift is an ErrImagePull *at best* -- or,
+# if the drifted tag happens to exist, a deploy of the wrong build. So it is
+# computed in one place and sourced by both.
+#
+# Both scripts read the same two git repositories, so they derive the same tag
+# without either passing anything to the other. If the tree is committed between
+# a build and a deploy the tags no longer match, and deploy-eks.sh fails fast on
+# a missing ECR tag -- which is correct, because the images no longer correspond
+# to the source being deployed.
+#
+# WHY NOT :latest
+#
+# A mutable tag makes `kubectl apply` a silent no-op. The Deployment spec text is
+# identical before and after a rebuild, so the API server sees no change, writes
+# no new ReplicaSet, and the running pods keep the OLD image. `deploy-eks.sh`
+# then exits 0, prints "Deployed.", and its `kubectl rollout status` loop passes
+# trivially against those stale pods -- so an E2E run reports on code that was
+# never deployed. Observed on devtest1: the running AMF was sha256:1338b825
+# while the freshly pushed tag was sha256:2665d4ca.
+#
+# `imagePullPolicy: Always` does NOT save this. It governs what kubelet fetches
+# when it starts a container; with no spec change no container is ever restarted,
+# so nothing is re-pulled.
+#
+# TWO REPOSITORIES, TWO TAGS
+#
+# The 10 core NF images are built from nextgcore and the gnb/ue images from the
+# sibling nextgsim, which is a separate repository at its own commit. One tag
+# across both would label an image with a SHA that does not describe it, so each
+# group is tagged from its own repository's HEAD.
+
+# Derive an immutable image tag from a git repository's HEAD.
+#
+# Emits `<short-sha>` for a clean tree, `<short-sha>-dirty` when tracked files
+# are modified. The `-dirty` suffix is deliberately not an error: local
+# iteration on a cluster is a normal workflow, and the suffix is what stops two
+# different working trees from colliding on one tag. It is a *warning* in the
+# callers, because a dirty tag is not reproducible from the SHA alone.
+#
+# Note both repos gitignore their staged binary output directories
+# (nextgcore/binaries/, nextgsim/docker/binaries/), so populating those for a
+# build does not by itself make a tree dirty.
+#
+# $1: repository path. Prints the tag; returns non-zero if $1 is not a git repo.
+nextg_image_tag() {
+  local repo="$1" sha dirty=''
+
+  git -C "${repo}" rev-parse --git-dir >/dev/null 2>&1 || {
+    printf 'not a git repository: %s\n' "${repo}" >&2
+    return 1
+  }
+
+  sha="$(git -C "${repo}" rev-parse --short=12 HEAD 2>/dev/null)" || {
+    printf 'no HEAD commit in %s (unborn branch?)\n' "${repo}" >&2
+    return 1
+  }
+
+  # --porcelain covers tracked modifications and staged changes. Untracked files
+  # are intentionally ignored: a stray file in the tree does not change what gets
+  # built, and counting it would mark nearly every real workspace dirty.
+  [[ -n "$(git -C "${repo}" status --porcelain --untracked-files=no 2>/dev/null)" ]] \
+    && dirty='-dirty'
+
+  printf '%s%s\n' "${sha}" "${dirty}"
+}

--- a/docker/rust/configs/epc/hss.yaml
+++ b/docker/rust/configs/epc/hss.yaml
@@ -15,6 +15,17 @@ global:
 
 hss:
   freeDiameter: /etc/freeDiameter/hss.conf
+  # Diameter identity for this node. Commented out so this file keeps the
+  # built-in defaults; uncomment and set your PLMN to advertise a real
+  # Origin-Host/Origin-Realm. RFC 6733 6.1 routes and authorizes on
+  # Destination-Realm, so a wrong realm breaks interop with real peers.
+  # TS 23.003 19.2 formats the EPC realm as epc.mncNNN.mccMMM.3gppnetwork.org.
+  # An explicit --diameter-id/--diameter-realm flag overrides these.
+  # diameter:
+  #   identity: hss.epc.mnc001.mcc001.3gppnetwork.org
+  #   realm: epc.mnc001.mcc001.3gppnetwork.org
+  #   addr: 172.24.0.8
+  #   port: 3868
   metrics:
     server:
       - address: 172.24.0.8

--- a/docker/rust/configs/epc/pcrf.yaml
+++ b/docker/rust/configs/epc/pcrf.yaml
@@ -15,6 +15,17 @@ global:
 
 pcrf:
   freeDiameter: /etc/freeDiameter/pcrf.conf
+  # Diameter identity for this node. Commented out so this file keeps the
+  # built-in defaults; uncomment and set your PLMN to advertise a real
+  # Origin-Host/Origin-Realm. RFC 6733 6.1 routes and authorizes on
+  # Destination-Realm, so a wrong realm breaks interop with real peers.
+  # TS 23.003 19.2 formats the EPC realm as epc.mncNNN.mccMMM.3gppnetwork.org.
+  # An explicit --diameter-id/--diameter-realm flag overrides these.
+  # diameter:
+  #   identity: pcrf.epc.mnc001.mcc001.3gppnetwork.org
+  #   realm: epc.mnc001.mcc001.3gppnetwork.org
+  #   addr: 172.24.0.9
+  #   port: 3868
   metrics:
     server:
       - address: 172.24.0.9

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2576,6 +2576,8 @@ dependencies = [
  "nextgcore-metrics",
  "proptest",
  "rand 0.9.2",
+ "serde",
+ "serde_yaml",
  "tokio",
 ]
 
@@ -2899,6 +2901,8 @@ dependencies = [
  "nextgcore-diameter",
  "nextgcore-metrics",
  "proptest",
+ "serde",
+ "serde_yaml",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/src/bins/nextgcore-hssd/Cargo.toml
+++ b/src/bins/nextgcore-hssd/Cargo.toml
@@ -25,6 +25,8 @@ tokio.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 ctrlc.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_yaml.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/src/bins/nextgcore-hssd/src/context.rs
+++ b/src/bins/nextgcore-hssd/src/context.rs
@@ -3,6 +3,7 @@
 //! Port of src/hss/hss-context.c - HSS context with IMSI/IMPI/IMPU hash tables,
 //! DB operations, and CX identity management
 
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
@@ -587,17 +588,351 @@ pub fn hss_context_final() {
     }
 }
 
-/// Parse HSS configuration from YAML
-pub fn hss_context_parse_config(_config_path: &str) -> Result<(), String> {
-    // Note: Implement YAML configuration parsing
-    // This would parse the hss section from the config file
-    // Configuration parsing uses the serde_yaml crate for YAML deserialization
+// ---------------------------------------------------------------------------
+// YAML configuration (`hss:` section)
+// ---------------------------------------------------------------------------
+
+/// One `hss.diameter.connections[]` peer entry.
+#[derive(Debug, Default, Deserialize)]
+pub struct DiamConnectionYaml {
+    pub identity: Option<String>,
+    pub addr: Option<String>,
+    pub port: Option<u16>,
+    /// Per-peer Tc override, seconds. Absent means "use the node-level Tc",
+    /// which `DiamConnection` represents as 0.
+    pub timer_tc: Option<i32>,
+}
+
+/// The `hss.diameter` block: this node's Diameter identity and listener.
+///
+/// Field names mirror the freeDiameter vocabulary the deployment already uses
+/// (`Identity`, `Realm`, `ListenOn`, `Port`) in snake_case, so an operator
+/// translating an existing `hss.conf` does not have to learn new names.
+#[derive(Debug, Default, Deserialize)]
+pub struct DiameterYaml {
+    /// Origin-Host (RFC 6733 §6.3) — this node's Diameter identity.
+    pub identity: Option<String>,
+    /// Origin-Realm (RFC 6733 §6.4). TS 23.003 §19.2 formats the EPC home
+    /// realm as `epc.mncNNN.mccMMM.3gppnetwork.org`.
+    pub realm: Option<String>,
+    /// Listen address for the S6a server.
+    pub addr: Option<String>,
+    pub port: Option<u16>,
+    pub port_tls: Option<u16>,
+    /// Tc timer, seconds (RFC 6733 §12).
+    pub timer_tc: Option<i32>,
+    pub no_fwd: Option<bool>,
+    pub connections: Option<Vec<DiamConnectionYaml>>,
+}
+
+/// The `hss:` section. Only the keys this daemon acts on are declared; unknown
+/// keys are ignored rather than rejected, because the shipped configs carry
+/// `freeDiameter:` and `metrics:` keys owned by other subsystems.
+#[derive(Debug, Default, Deserialize)]
+pub struct HssSectionYaml {
+    pub diameter: Option<DiameterYaml>,
+    /// Path to a freeDiameter-style config. Recorded in `diam_conf_path` so a
+    /// deployment can be diagnosed; this daemon does not parse that format.
+    #[serde(rename = "freeDiameter")]
+    pub free_diameter: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct HssYaml {
+    pub hss: Option<HssSectionYaml>,
+}
+
+/// Parse HSS configuration from YAML and apply it to the global context.
+///
+/// # Why this exists
+///
+/// This function used to `return Ok(())` without reading the file, while
+/// `main()` logged "Loading configuration from <file>". Because hssd exposes no
+/// `--diameter-id`/`--diameter-realm` CLI flag either, the daemon was
+/// hard-locked to the `unwrap_or_else` fallbacks in `main.rs`
+/// (`hss.epc.mnc001.mcc001.3gppnetwork.org` / `epc.mnc001.mcc001...`). RFC 6733
+/// §6.1 routes and authorizes requests on Destination-Realm matched against the
+/// receiver's Origin-Realm, so an HSS on any real PLMN could not be reached:
+/// there was no runtime workaround at all.
+///
+/// # Errors
+///
+/// Returns `Err` when the file cannot be read or is not valid YAML. This
+/// deliberately FAILS rather than warning and continuing, unlike the lenient
+/// `if let Ok(..)` pattern the 5GC NFs use for their optional SBI knobs: here a
+/// silently-ignored config does not degrade one feature, it silently reverts the
+/// node's identity to a different PLMN, which is far worse to diagnose than a
+/// refusal to start. `main()` is responsible for exiting non-zero.
+///
+/// A file that parses but carries no `hss.diameter` block is NOT an error: the
+/// shipped `docker/rust/configs/epc/hss.yaml` is exactly that, and it must keep
+/// working. Absent keys leave the existing defaults untouched.
+pub fn hss_context_parse_config(config_path: &str) -> Result<(), String> {
+    let content = std::fs::read_to_string(config_path)
+        .map_err(|e| format!("cannot read {config_path}: {e}"))?;
+
+    let parsed: HssYaml = serde_yaml::from_str(&content)
+        .map_err(|e| format!("invalid YAML in {config_path}: {e}"))?;
+
+    let Some(section) = parsed.hss else {
+        log::debug!("{config_path}: no 'hss' section; keeping defaults");
+        return Ok(());
+    };
+
+    let ctx = hss_self();
+    let mut ctx = ctx
+        .write()
+        .map_err(|_| "HSS context lock poisoned".to_string())?;
+
+    if let Some(path) = section.free_diameter {
+        ctx.diam_conf_path = Some(path);
+    }
+
+    let Some(diam) = section.diameter else {
+        log::debug!("{config_path}: no 'hss.diameter' block; keeping defaults");
+        return Ok(());
+    };
+
+    apply_diameter_yaml(&mut ctx.diam_config, diam);
+    log::info!(
+        "HSS Diameter identity: {} realm: {} listen: {}:{}",
+        ctx.diam_config.cnf_diamid.as_deref().unwrap_or("<default>"),
+        ctx.diam_config
+            .cnf_diamrlm
+            .as_deref()
+            .unwrap_or("<default>"),
+        ctx.diam_config.cnf_addr.as_deref().unwrap_or("<default>"),
+        ctx.diam_config.cnf_port,
+    );
     Ok(())
+}
+
+/// Copy the parsed `diameter` block onto a [`DiamConfig`].
+///
+/// Absent keys are left at their existing value rather than being zeroed, so a
+/// partial config cannot clear `cnf_port` (which `main.rs` reads as "unset" and
+/// replaces with 3868) or reduce `cnf_timer_tc` below its `.max(1)` floor.
+/// Shared with the unit tests so the mapping is verified directly.
+pub fn apply_diameter_yaml(cfg: &mut DiamConfig, diam: DiameterYaml) {
+    if let Some(v) = diam.identity {
+        cfg.cnf_diamid = Some(v);
+    }
+    if let Some(v) = diam.realm {
+        cfg.cnf_diamrlm = Some(v);
+    }
+    if let Some(v) = diam.addr {
+        cfg.cnf_addr = Some(v);
+    }
+    if let Some(v) = diam.port {
+        cfg.cnf_port = v;
+    }
+    if let Some(v) = diam.port_tls {
+        cfg.cnf_port_tls = v;
+    }
+    if let Some(v) = diam.timer_tc {
+        cfg.cnf_timer_tc = v;
+    }
+    if let Some(v) = diam.no_fwd {
+        cfg.cnf_flags_no_fwd = v;
+    }
+    if let Some(conns) = diam.connections {
+        cfg.connections = conns
+            .into_iter()
+            .filter_map(|c| {
+                // An entry with no identity cannot be routed to, so it is
+                // dropped with a warning rather than stored as an empty peer.
+                let identity = match c.identity {
+                    Some(id) => id,
+                    None => {
+                        log::warn!("hss.diameter.connections[]: entry without identity; ignored");
+                        return None;
+                    }
+                };
+                Some(DiamConnection {
+                    identity,
+                    // `addr` is a plain String here, so an omitted address
+                    // becomes empty rather than absent. Callers treat empty as
+                    // "resolve the identity by DNS", matching freeDiameter's
+                    // ConnectPeer without an explicit ConnectTo.
+                    addr: c.addr.unwrap_or_default(),
+                    port: c.port.unwrap_or(0),
+                    tc_timer: c.timer_tc.unwrap_or(0),
+                })
+            })
+            .collect();
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // YAML Diameter configuration (issue #58)
+    //
+    // Asserted against `apply_diameter_yaml` / a local `DiamConfig` rather than
+    // through `hss_context_parse_config`, because that writes the PROCESS-GLOBAL
+    // context: two of these tests running in parallel would race, and the
+    // surviving value would depend on scheduling. The parse function is a thin
+    // read-file + deserialize + apply wrapper over this mapping.
+    // -----------------------------------------------------------------------
+
+    /// A realistic operator config must reach every DiamConfig field, so an HSS
+    /// on a real PLMN advertises its own Origin-Realm instead of the hardcoded
+    /// mnc001/mcc001 fallback in main.rs (RFC 6733 §6.1, TS 23.003 §19.2).
+    #[test]
+    fn diameter_yaml_populates_every_diam_config_field() {
+        let yaml = r#"
+hss:
+  diameter:
+    identity: hss.epc.mnc070.mcc310.3gppnetwork.org
+    realm: epc.mnc070.mcc310.3gppnetwork.org
+    addr: 10.0.0.5
+    port: 3869
+    port_tls: 5869
+    timer_tc: 30
+    no_fwd: true
+    connections:
+      - identity: mme.epc.mnc070.mcc310.3gppnetwork.org
+        addr: 10.0.0.6
+        port: 3868
+        timer_tc: 15
+"#;
+        let parsed: HssYaml = serde_yaml::from_str(yaml).expect("fixture must deserialize");
+        let diam = parsed
+            .hss
+            .expect("hss section")
+            .diameter
+            .expect("diameter block");
+
+        let mut cfg = DiamConfig {
+            cnf_port: 3868,
+            cnf_port_tls: 5868,
+            ..Default::default()
+        };
+        apply_diameter_yaml(&mut cfg, diam);
+
+        assert_eq!(
+            cfg.cnf_diamid.as_deref(),
+            Some("hss.epc.mnc070.mcc310.3gppnetwork.org")
+        );
+        assert_eq!(
+            cfg.cnf_diamrlm.as_deref(),
+            Some("epc.mnc070.mcc310.3gppnetwork.org")
+        );
+        assert_eq!(cfg.cnf_addr.as_deref(), Some("10.0.0.5"));
+        assert_eq!(cfg.cnf_port, 3869);
+        assert_eq!(cfg.cnf_port_tls, 5869);
+        assert_eq!(cfg.cnf_timer_tc, 30);
+        assert!(cfg.cnf_flags_no_fwd);
+        assert_eq!(cfg.connections.len(), 1);
+        assert_eq!(
+            cfg.connections[0].identity,
+            "mme.epc.mnc070.mcc310.3gppnetwork.org"
+        );
+        assert_eq!(cfg.connections[0].addr, "10.0.0.6");
+        assert_eq!(cfg.connections[0].port, 3868);
+        assert_eq!(cfg.connections[0].tc_timer, 15);
+    }
+
+    /// A partial config must not zero the fields it omits. `main.rs` reads
+    /// `cnf_port == 0` as "unset" and substitutes 3868, so clearing the port
+    /// here would silently move the listener.
+    #[test]
+    fn absent_diameter_keys_leave_existing_values_untouched() {
+        let parsed: HssYaml =
+            serde_yaml::from_str("hss:\n  diameter:\n    realm: epc.example.org\n")
+                .expect("fixture must deserialize");
+        let mut cfg = DiamConfig {
+            cnf_diamid: Some("keep.me".to_string()),
+            cnf_port: 3868,
+            cnf_port_tls: 5868,
+            cnf_timer_tc: 7,
+            ..Default::default()
+        };
+        apply_diameter_yaml(&mut cfg, parsed.hss.unwrap().diameter.unwrap());
+
+        assert_eq!(cfg.cnf_diamrlm.as_deref(), Some("epc.example.org"));
+        assert_eq!(cfg.cnf_diamid.as_deref(), Some("keep.me"), "not cleared");
+        assert_eq!(cfg.cnf_port, 3868, "not zeroed");
+        assert_eq!(cfg.cnf_port_tls, 5868, "not zeroed");
+        assert_eq!(cfg.cnf_timer_tc, 7, "not zeroed");
+    }
+
+    /// A peer with no identity cannot be routed to, so it is dropped rather than
+    /// stored as an empty-identity connection that would fail obscurely later.
+    #[test]
+    fn connection_without_identity_is_dropped() {
+        let parsed: HssYaml = serde_yaml::from_str(
+            "hss:\n  diameter:\n    connections:\n      - addr: 10.0.0.6\n      - identity: real.peer\n",
+        )
+        .expect("fixture must deserialize");
+        let mut cfg = DiamConfig::default();
+        apply_diameter_yaml(&mut cfg, parsed.hss.unwrap().diameter.unwrap());
+
+        assert_eq!(cfg.connections.len(), 1);
+        assert_eq!(cfg.connections[0].identity, "real.peer");
+        assert_eq!(
+            cfg.connections[0].addr, "",
+            "omitted addr means DNS-resolve"
+        );
+    }
+
+    /// The SHIPPED config (docker/rust/configs/epc/hss.yaml) has an `hss:`
+    /// section with no `diameter:` block, plus keys owned by other subsystems.
+    /// It must keep parsing, or this change breaks every existing deployment.
+    #[test]
+    fn shipped_config_shape_parses_and_keeps_defaults() {
+        let yaml = r#"
+db_uri: mongodb://mongodb:27017/nextgcore
+logger:
+  file:
+    path: /var/log/nextgcore/hss.log
+  level: info
+global:
+  max:
+    ue: 1024
+hss:
+  freeDiameter: /etc/freeDiameter/hss.conf
+  metrics:
+    server:
+      - address: 172.24.0.8
+        port: 9090
+"#;
+        let parsed: HssYaml = serde_yaml::from_str(yaml).expect("shipped shape must deserialize");
+        let section = parsed.hss.expect("hss section");
+        assert_eq!(
+            section.free_diameter.as_deref(),
+            Some("/etc/freeDiameter/hss.conf")
+        );
+        assert!(
+            section.diameter.is_none(),
+            "no diameter block: defaults must survive"
+        );
+    }
+
+    /// Malformed YAML must be an Err so main() can exit non-zero, rather than
+    /// warn-and-continue on a different PLMN's identity.
+    #[test]
+    fn malformed_yaml_is_an_error() {
+        let path = std::env::temp_dir().join(format!(
+            "nextgcore-hssd-bad-{}-{:?}.yaml",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, "hss:\n  diameter:\n    port: \"not a number\"\n").unwrap();
+        let result = hss_context_parse_config(path.to_str().unwrap());
+        std::fs::remove_file(&path).ok();
+        assert!(result.is_err(), "a malformed config must not be accepted");
+    }
+
+    /// An unreadable/missing path is an Err too. main() only calls this when the
+    /// file exists, so reaching here means a genuine I/O problem.
+    #[test]
+    fn unreadable_config_is_an_error() {
+        let missing = std::env::temp_dir().join("nextgcore-hssd-does-not-exist-58.yaml");
+        assert!(hss_context_parse_config(missing.to_str().unwrap()).is_err());
+    }
 
     #[test]
     fn test_hss_context_new() {
@@ -737,5 +1072,52 @@ mod tests {
 
         impu.set_server_name("sip:scscf.example.com");
         assert_eq!(impu.server_name, Some("sip:scscf.example.com".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod shipped_config_smoke {
+    //! Parses the REAL shipped config from the repo, not a fixture copy, so a
+    //! future edit to that file cannot silently break the daemon's startup path.
+    use super::*;
+
+    #[test]
+    fn repo_shipped_hss_yaml_parses() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../docker/rust/configs/epc/hss.yaml"
+        );
+        let content = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("cannot read shipped config {path}: {e}"));
+        let parsed: HssYaml = serde_yaml::from_str(&content).expect("shipped hss.yaml must parse");
+        let section = parsed.hss.expect("hss section");
+        assert!(section.free_diameter.is_some());
+        // The diameter block ships commented out, so defaults must survive.
+        assert!(section.diameter.is_none());
+    }
+
+    /// Uncommenting the documented block must actually take effect -- otherwise
+    /// the comment in the shipped file is advice that does not work.
+    #[test]
+    fn documented_diameter_block_takes_effect_when_uncommented() {
+        let yaml = r#"
+hss:
+  freeDiameter: /etc/freeDiameter/hss.conf
+  diameter:
+    identity: hss.epc.mnc001.mcc001.3gppnetwork.org
+    realm: epc.mnc001.mcc001.3gppnetwork.org
+    addr: 172.24.0.8
+    port: 3868
+"#;
+        let parsed: HssYaml = serde_yaml::from_str(yaml).expect("must parse");
+        let diam = parsed.hss.unwrap().diameter.expect("diameter block");
+        let mut cfg = DiamConfig::default();
+        apply_diameter_yaml(&mut cfg, diam);
+        assert_eq!(
+            cfg.cnf_diamid.as_deref(),
+            Some("hss.epc.mnc001.mcc001.3gppnetwork.org")
+        );
+        assert_eq!(cfg.cnf_addr.as_deref(), Some("172.24.0.8"));
+        assert_eq!(cfg.cnf_port, 3868);
     }
 }

--- a/src/bins/nextgcore-hssd/src/main.rs
+++ b/src/bins/nextgcore-hssd/src/main.rs
@@ -47,6 +47,31 @@ struct Args {
     #[arg(long, default_value = "/etc/nextgcore/freeDiameter/hss.conf")]
     diameter_config: String,
 
+    // Parity with pcrfd, which has had these three since it was written. hssd
+    // had NEITHER a config path nor a CLI flag for its Diameter identity, so it
+    // was hard-locked to the mnc001/mcc001 defaults below with no runtime
+    // workaround at all -- that combination is what made issue #58 a blocker
+    // rather than an inconvenience. Option (no clap default) so "not passed" is
+    // distinguishable from "passed the default": precedence is
+    // CLI > YAML > built-in default.
+    /// Diameter Origin-Host identity of this HSS
+    /// [default: hss.epc.mnc001.mcc001.3gppnetwork.org]
+    #[arg(long)]
+    diameter_id: Option<String>,
+
+    /// Diameter Origin-Realm of this HSS
+    /// [default: epc.mnc001.mcc001.3gppnetwork.org]
+    #[arg(long)]
+    diameter_realm: Option<String>,
+
+    /// Diameter listen address for S6a [default: 0.0.0.0]
+    #[arg(long)]
+    diameter_addr: Option<String>,
+
+    /// Diameter listen port for S6a [default: 3868]
+    #[arg(long)]
+    diameter_port: Option<u16>,
+
     /// Maximum number of UEs
     #[arg(long, default_value = "1024")]
     max_ue: usize,
@@ -98,12 +123,22 @@ fn main() -> Result<()> {
         args.max_ue * 4
     );
 
-    // Parse configuration file
+    // Parse configuration file.
+    //
+    // A present-but-unparseable config is FATAL. Previously this warned and
+    // continued, which silently reverted the HSS to the hardcoded
+    // mnc001/mcc001 identity below -- an S6a realm mismatch (RFC 6733 §6.1)
+    // presenting as peers rejecting or misrouting traffic, with a
+    // "Loading configuration from ..." line in the log implying the file had
+    // been applied. Refusing to start is far easier to diagnose.
+    //
+    // A MISSING config file stays non-fatal: the defaults are a working
+    // single-PLMN dev configuration and existing deployments rely on them.
     if std::path::Path::new(&args.config).exists() {
-        log::info!("Loading configuration from {}", args.config);
-        if let Err(e) = hss_context_parse_config(&args.config) {
-            log::warn!("Failed to parse config: {e}");
-        }
+        hss_context_parse_config(&args.config)
+            .map_err(|e| anyhow::anyhow!("Failed to parse config {}: {e}", args.config))?;
+        // Logged AFTER the parse succeeds, so the line means what it says.
+        log::info!("Loaded configuration from {}", args.config);
     } else {
         log::debug!("Configuration file not found: {}", args.config);
     }
@@ -133,28 +168,42 @@ fn main() -> Result<()> {
     // Start the S6a Diameter server (accepts MME connections; answers
     // AIR/ULR/PUR and carries HSS-initiated CLR/IDR on the same connections)
     {
+        // Precedence: CLI flag > YAML config > built-in default. The config file
+        // is the primary source (it is the only one that can express peers and
+        // Tc), while an explicit flag stays a usable override for a deployment
+        // whose config is wrong.
         let (diam_id, diam_realm, diam_addr, diam_port, timer_tc) = {
             let ctx = nextgcore_hssd::hss_self();
             let ctx = ctx.read().expect("HSS context lock poisoned");
             let diam = &ctx.diam_config;
             (
-                diam.cnf_diamid
+                args.diameter_id
                     .clone()
+                    .or_else(|| diam.cnf_diamid.clone())
                     .unwrap_or_else(|| "hss.epc.mnc001.mcc001.3gppnetwork.org".to_string()),
-                diam.cnf_diamrlm
+                args.diameter_realm
                     .clone()
+                    .or_else(|| diam.cnf_diamrlm.clone())
                     .unwrap_or_else(|| "epc.mnc001.mcc001.3gppnetwork.org".to_string()),
-                diam.cnf_addr
+                args.diameter_addr
                     .clone()
+                    .or_else(|| diam.cnf_addr.clone())
                     .unwrap_or_else(|| "0.0.0.0".to_string()),
-                if diam.cnf_port == 0 {
-                    3868
-                } else {
-                    diam.cnf_port
-                },
+                args.diameter_port
+                    .or(if diam.cnf_port == 0 {
+                        None
+                    } else {
+                        Some(diam.cnf_port)
+                    })
+                    .unwrap_or(3868),
+                // .max(1) preserved: a Tc of 0 would mean "reconnect with no
+                // delay", which the Diameter stack treats as unset.
                 diam.cnf_timer_tc.max(1) as u32,
             )
         };
+        log::info!(
+            "HSS S6a Diameter identity: {diam_id} realm: {diam_realm} listen: {diam_addr}:{diam_port}"
+        );
         let diameter_config = nextgcore_diameter::config::DiameterConfig {
             diameter_id: diam_id,
             diameter_realm: diam_realm,
@@ -329,6 +378,40 @@ mod tests {
         assert_eq!(args.max_ue, 1024);
         assert_eq!(args.db_name, "nextgcore");
         assert!(!args.kill);
+        // Unset by default so the YAML config can win; a clap default_value
+        // would make the flag always look explicit and outrank the file.
+        assert_eq!(args.diameter_id, None);
+        assert_eq!(args.diameter_realm, None);
+        assert_eq!(args.diameter_addr, None);
+        assert_eq!(args.diameter_port, None);
+    }
+
+    /// hssd previously had no CLI path to its Diameter identity at all, which is
+    /// what made #58 a hard blocker: with the parse function also a no-op, the
+    /// daemon was pinned to PLMN mnc001/mcc001 with no runtime workaround.
+    #[test]
+    fn diameter_identity_flags_parse() {
+        let args = Args::parse_from([
+            "nextgcore-hssd",
+            "--diameter-id",
+            "hss.epc.mnc070.mcc310.3gppnetwork.org",
+            "--diameter-realm",
+            "epc.mnc070.mcc310.3gppnetwork.org",
+            "--diameter-addr",
+            "10.0.0.5",
+            "--diameter-port",
+            "3869",
+        ]);
+        assert_eq!(
+            args.diameter_id.as_deref(),
+            Some("hss.epc.mnc070.mcc310.3gppnetwork.org")
+        );
+        assert_eq!(
+            args.diameter_realm.as_deref(),
+            Some("epc.mnc070.mcc310.3gppnetwork.org")
+        );
+        assert_eq!(args.diameter_addr.as_deref(), Some("10.0.0.5"));
+        assert_eq!(args.diameter_port, Some(3869));
     }
 
     #[test]

--- a/src/bins/nextgcore-pcrfd/Cargo.toml
+++ b/src/bins/nextgcore-pcrfd/Cargo.toml
@@ -25,6 +25,8 @@ clap.workspace = true
 ctrlc.workspace = true
 tokio.workspace = true
 bytes.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_yaml.workspace = true
 
 # Internal crates
 nextgcore-core = { path = "../../libs/nextgcore-core" }

--- a/src/bins/nextgcore-pcrfd/src/context.rs
+++ b/src/bins/nextgcore-pcrfd/src/context.rs
@@ -3,6 +3,7 @@
 //! Port of src/pcrf/pcrf-context.c - PCRF context with IP hash tables for
 //! Gx session lookup, DB operations, and session management
 
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -533,11 +534,119 @@ pub fn pcrf_context_final() {
     }
 }
 
-/// Parse PCRF configuration from YAML
-pub fn pcrf_context_parse_config(_config_path: &str) -> Result<(), String> {
-    // Note: Implement YAML configuration parsing
-    // YAML configuration loading handled by serde_yaml with DiamConfig struct mapping
+// ---------------------------------------------------------------------------
+// YAML configuration (`pcrf:` section)
+// ---------------------------------------------------------------------------
+
+/// The `pcrf.diameter` block: this node's Diameter identity and listener.
+///
+/// Only the keys `PcrfContext`'s [`DiamConfig`] can hold are declared. It is a
+/// smaller struct than the HSS's -- no Tc timer, no forwarding flag, no peer
+/// connections -- so those keys are deliberately absent here rather than parsed
+/// and dropped, which would be the same silently-ignored-config defect this
+/// change removes.
+#[derive(Debug, Default, Deserialize)]
+pub struct DiameterYaml {
+    /// Origin-Host (RFC 6733 §6.3) — this node's Diameter identity.
+    pub identity: Option<String>,
+    /// Origin-Realm (RFC 6733 §6.4).
+    pub realm: Option<String>,
+    /// Listen address for the shared Gx + Rx listener.
+    pub addr: Option<String>,
+    pub port: Option<u16>,
+    pub port_tls: Option<u16>,
+}
+
+/// The `pcrf:` section. Unknown keys are ignored: the shipped configs carry
+/// `freeDiameter:` and `metrics:` keys owned by other subsystems.
+#[derive(Debug, Default, Deserialize)]
+pub struct PcrfSectionYaml {
+    pub diameter: Option<DiameterYaml>,
+    /// Path to a freeDiameter-style config, recorded for diagnosis only; this
+    /// daemon does not parse that format.
+    #[serde(rename = "freeDiameter")]
+    pub free_diameter: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct PcrfYaml {
+    pub pcrf: Option<PcrfSectionYaml>,
+}
+
+/// Parse PCRF configuration from YAML and apply it to the global context.
+///
+/// # Why this exists
+///
+/// This function used to `return Ok(())` without reading the file, while
+/// `main()` logged "Loading configuration from <file>". The only source of the
+/// Diameter identity was therefore the CLI, whose defaults are
+/// `pcrf.localdomain` / `localdomain` -- well-formed but matching no real
+/// deployment, so Gx/Rx peers fail realm-based routing (RFC 6733 §6.1) until
+/// flags are supplied, and the config file could not fix it.
+///
+/// Unlike the HSS, pcrfd does expose `--diameter-id`/`--diameter-realm`/
+/// `--diameter-addr`, so those flags remain a valid workaround. `main()` applies
+/// YAML first and lets an EXPLICITLY-passed flag win; see its
+/// `resolve_diameter_identity`.
+///
+/// # Errors
+///
+/// Returns `Err` when the file cannot be read or is not valid YAML — a fatal
+/// condition for `main()`, deliberately not a warn-and-continue, because
+/// silently falling back to `localdomain` is much harder to diagnose than a
+/// refusal to start. A file with no `pcrf.diameter` block is not an error: the
+/// shipped `docker/rust/configs/epc/pcrf.yaml` is exactly that.
+pub fn pcrf_context_parse_config(config_path: &str) -> Result<(), String> {
+    let content = std::fs::read_to_string(config_path)
+        .map_err(|e| format!("cannot read {config_path}: {e}"))?;
+
+    let parsed: PcrfYaml = serde_yaml::from_str(&content)
+        .map_err(|e| format!("invalid YAML in {config_path}: {e}"))?;
+
+    let Some(section) = parsed.pcrf else {
+        log::debug!("{config_path}: no 'pcrf' section; keeping defaults");
+        return Ok(());
+    };
+
+    let ctx = pcrf_self();
+    let mut ctx = ctx
+        .write()
+        .map_err(|_| "PCRF context lock poisoned".to_string())?;
+
+    if let Some(path) = section.free_diameter {
+        ctx.diam_conf_path = Some(path);
+    }
+
+    let Some(diam) = section.diameter else {
+        log::debug!("{config_path}: no 'pcrf.diameter' block; keeping defaults");
+        return Ok(());
+    };
+
+    apply_diameter_yaml(&mut ctx.diam_config, diam);
     Ok(())
+}
+
+/// Copy the parsed `diameter` block onto a [`DiamConfig`].
+///
+/// Absent keys leave the existing value untouched, so a partial config cannot
+/// zero `cnf_port`. Shared with the unit tests so the mapping is verified
+/// directly rather than only through `main()`.
+pub fn apply_diameter_yaml(cfg: &mut DiamConfig, diam: DiameterYaml) {
+    if let Some(v) = diam.identity {
+        cfg.cnf_diamid = Some(v);
+    }
+    if let Some(v) = diam.realm {
+        cfg.cnf_diamrlm = Some(v);
+    }
+    if let Some(v) = diam.addr {
+        cfg.cnf_addr = Some(v);
+    }
+    if let Some(v) = diam.port {
+        cfg.cnf_port = v;
+    }
+    if let Some(v) = diam.port_tls {
+        cfg.cnf_port_tls = v;
+    }
 }
 
 /// Set IPv4 to Session-Id mapping (global function)

--- a/src/bins/nextgcore-pcrfd/src/lib.rs
+++ b/src/bins/nextgcore-pcrfd/src/lib.rs
@@ -15,9 +15,10 @@ pub mod sm;
 
 // Re-export commonly used types
 pub use context::{
-    pcrf_context_final, pcrf_context_init, pcrf_context_parse_config, pcrf_self,
-    pcrf_sess_find_by_ipv4, pcrf_sess_find_by_ipv6, pcrf_sess_set_ipv4, pcrf_sess_set_ipv6,
-    PcrfContext, PcrfGxSession, PcrfRxSession,
+    apply_diameter_yaml, pcrf_context_final, pcrf_context_init, pcrf_context_parse_config,
+    pcrf_self, pcrf_sess_find_by_ipv4, pcrf_sess_find_by_ipv6, pcrf_sess_set_ipv4,
+    pcrf_sess_set_ipv6, DiamConfig, DiameterYaml, PcrfContext, PcrfGxSession, PcrfRxSession,
+    PcrfSectionYaml, PcrfYaml,
 };
 pub use event::{PcrfEvent, PcrfEventId};
 pub use fd_path::{

--- a/src/bins/nextgcore-pcrfd/src/main.rs
+++ b/src/bins/nextgcore-pcrfd/src/main.rs
@@ -9,8 +9,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use nextgcore_pcrfd::{
     pcrf_context_final, pcrf_context_init, pcrf_context_parse_config, pcrf_fd_final, pcrf_fd_init,
-    pcrf_fd_listen, pcrf_gx_final, pcrf_gx_init, pcrf_rx_final, pcrf_rx_init, LocalIdentity,
-    PcrfEvent, PcrfSmContext,
+    pcrf_fd_listen, pcrf_gx_final, pcrf_gx_init, pcrf_rx_final, pcrf_rx_init, pcrf_self,
+    LocalIdentity, PcrfEvent, PcrfSmContext,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -46,17 +46,22 @@ struct Args {
     #[arg(long, default_value = "/etc/nextgcore/freeDiameter/pcrf.conf")]
     diameter_config: String,
 
-    /// Diameter Origin-Host identity of this PCRF
-    #[arg(long, default_value = "pcrf.localdomain")]
-    diameter_id: String,
+    // These three are Option rather than carrying a clap default_value so that
+    // "not passed" is distinguishable from "passed the default". The precedence
+    // is CLI > YAML > built-in default (see `resolve_diameter_identity`); with a
+    // clap default the flag would always look explicit and would silently
+    // outrank every value from the config file.
+    /// Diameter Origin-Host identity of this PCRF [default: pcrf.localdomain]
+    #[arg(long)]
+    diameter_id: Option<String>,
 
-    /// Diameter Origin-Realm of this PCRF
-    #[arg(long, default_value = "localdomain")]
-    diameter_realm: String,
+    /// Diameter Origin-Realm of this PCRF [default: localdomain]
+    #[arg(long)]
+    diameter_realm: Option<String>,
 
-    /// Diameter listen address (Gx and Rx share one listener)
-    #[arg(long, default_value = "0.0.0.0:3868")]
-    diameter_addr: String,
+    /// Diameter listen address, Gx and Rx share one listener [default: 0.0.0.0:3868]
+    #[arg(long)]
+    diameter_addr: Option<String>,
 
     /// Maximum number of sessions
     #[arg(long, default_value = "1024")]
@@ -73,6 +78,61 @@ struct Args {
 
 /// Global shutdown flag
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+/// Built-in Diameter identity, used when neither the CLI nor the config file
+/// supplies one. Preserved from the previous clap `default_value`s so a daemon
+/// started with no config and no flags behaves exactly as before.
+const DEFAULT_DIAMETER_ID: &str = "pcrf.localdomain";
+const DEFAULT_DIAMETER_REALM: &str = "localdomain";
+const DEFAULT_DIAMETER_ADDR: &str = "0.0.0.0:3868";
+
+/// Resolve the Diameter identity, realm and listen address by precedence:
+/// **CLI flag > YAML config > built-in default**.
+///
+/// Kept a pure function of its two inputs so the precedence is unit-testable
+/// without starting a daemon, binding a socket, or touching the global context.
+///
+/// The listen address is assembled from the config's separate `addr` and `port`
+/// fields, since `DiamConfig` stores them apart while the CLI takes one
+/// `host:port` string. A config that sets only `addr` still gets the default
+/// port, and one that sets only `port` still gets the default host -- neither
+/// half forces the other to be specified.
+fn resolve_diameter_identity(
+    args: &Args,
+    cfg: &nextgcore_pcrfd::DiamConfig,
+) -> (String, String, String) {
+    let id = args
+        .diameter_id
+        .clone()
+        .or_else(|| cfg.cnf_diamid.clone())
+        .unwrap_or_else(|| DEFAULT_DIAMETER_ID.to_string());
+
+    let realm = args
+        .diameter_realm
+        .clone()
+        .or_else(|| cfg.cnf_diamrlm.clone())
+        .unwrap_or_else(|| DEFAULT_DIAMETER_REALM.to_string());
+
+    let addr = args.diameter_addr.clone().unwrap_or_else(|| {
+        match (cfg.cnf_addr.as_deref(), cfg.cnf_port) {
+            (None, 0) => DEFAULT_DIAMETER_ADDR.to_string(),
+            (host, port) => {
+                // Split the default once so each half can fall back on its own.
+                let (default_host, default_port) = DEFAULT_DIAMETER_ADDR
+                    .rsplit_once(':')
+                    .expect("DEFAULT_DIAMETER_ADDR must contain a port");
+                let host = host.unwrap_or(default_host);
+                if port == 0 {
+                    format!("{host}:{default_port}")
+                } else {
+                    format!("{host}:{port}")
+                }
+            }
+        }
+    });
+
+    (id, realm, addr)
+}
 
 fn main() -> Result<()> {
     let args = Args::parse();
@@ -104,12 +164,20 @@ fn main() -> Result<()> {
     pcrf_context_init(args.max_sess);
     log::info!("PCRF context initialized (max_sess={})", args.max_sess);
 
-    // Parse configuration file
+    // Parse configuration file.
+    //
+    // A present-but-unparseable config is FATAL. Previously this warned and
+    // continued, which silently left the PCRF advertising the CLI default
+    // `localdomain` realm -- Gx/Rx peers then fail realm-based routing
+    // (RFC 6733 §6.1) while the log claimed the config had been loaded.
+    //
+    // A MISSING config file stays non-fatal: the CLI defaults are a working dev
+    // configuration and existing deployments rely on them.
     if std::path::Path::new(&args.config).exists() {
-        log::info!("Loading configuration from {}", args.config);
-        if let Err(e) = pcrf_context_parse_config(&args.config) {
-            log::warn!("Failed to parse config: {e}");
-        }
+        pcrf_context_parse_config(&args.config)
+            .map_err(|e| anyhow::anyhow!("Failed to parse config {}: {e}", args.config))?;
+        // Logged AFTER the parse succeeds, so the line means what it says.
+        log::info!("Loaded configuration from {}", args.config);
     } else {
         log::debug!("Configuration file not found: {}", args.config);
     }
@@ -127,15 +195,26 @@ fn main() -> Result<()> {
     }
     log::info!("Diameter stack initialized");
 
-    // Start the Diameter listener (Gx + Rx) on a dedicated runtime thread
-    let identity = LocalIdentity {
-        host: args.diameter_id.clone(),
-        realm: args.diameter_realm.clone(),
+    // Start the Diameter listener (Gx + Rx) on a dedicated runtime thread.
+    //
+    // Precedence is CLI > YAML > built-in default, so an explicitly-passed flag
+    // remains a working override for a deployment whose config file is wrong,
+    // while the config file becomes the primary source.
+    let (diam_id, diam_realm, diam_addr) = {
+        let ctx = pcrf_self();
+        let cfg = ctx.read().map_err(|_| {
+            anyhow::anyhow!("PCRF context lock poisoned while reading Diameter config")
+        })?;
+        resolve_diameter_identity(&args, &cfg.diam_config)
     };
-    let listen_addr: std::net::SocketAddr = args
-        .diameter_addr
+    log::info!("PCRF Diameter identity: {diam_id} realm: {diam_realm} listen: {diam_addr}");
+    let identity = LocalIdentity {
+        host: diam_id,
+        realm: diam_realm,
+    };
+    let listen_addr: std::net::SocketAddr = diam_addr
         .parse()
-        .context("Invalid --diameter-addr")?;
+        .with_context(|| format!("Invalid Diameter listen address: {diam_addr}"))?;
     std::thread::Builder::new()
         .name("pcrf-diameter".to_string())
         .spawn(move || {
@@ -333,6 +412,170 @@ mod tests {
     fn test_args_kill() {
         let args = Args::parse_from(["nextgcore-pcrfd", "-k"]);
         assert!(args.kill);
+    }
+
+    // -----------------------------------------------------------------------
+    // Diameter identity precedence: CLI > YAML > built-in default (issue #58)
+    // -----------------------------------------------------------------------
+
+    /// With neither a flag nor a config value, the built-in defaults apply —
+    /// byte-identical to the clap `default_value`s these flags used to carry, so
+    /// a daemon started bare behaves exactly as before this change.
+    #[test]
+    fn identity_falls_back_to_builtin_defaults() {
+        let args = Args::parse_from(["nextgcore-pcrfd"]);
+        let cfg = nextgcore_pcrfd::DiamConfig::default();
+        let (id, realm, addr) = resolve_diameter_identity(&args, &cfg);
+        assert_eq!(id, "pcrf.localdomain");
+        assert_eq!(realm, "localdomain");
+        assert_eq!(addr, "0.0.0.0:3868");
+    }
+
+    /// With no flags, the YAML values win over the built-in defaults — the whole
+    /// point of the issue: the config file must actually take effect.
+    #[test]
+    fn yaml_values_win_over_builtin_defaults() {
+        let args = Args::parse_from(["nextgcore-pcrfd"]);
+        let cfg = nextgcore_pcrfd::DiamConfig {
+            cnf_diamid: Some("pcrf.epc.mnc070.mcc310.3gppnetwork.org".to_string()),
+            cnf_diamrlm: Some("epc.mnc070.mcc310.3gppnetwork.org".to_string()),
+            cnf_addr: Some("10.0.0.9".to_string()),
+            cnf_port: 3869,
+            cnf_port_tls: 5869,
+        };
+        let (id, realm, addr) = resolve_diameter_identity(&args, &cfg);
+        assert_eq!(id, "pcrf.epc.mnc070.mcc310.3gppnetwork.org");
+        assert_eq!(realm, "epc.mnc070.mcc310.3gppnetwork.org");
+        assert_eq!(addr, "10.0.0.9:3869");
+    }
+
+    /// An explicitly-passed flag outranks the config file, so the CLI remains a
+    /// usable override for a deployment whose config is wrong.
+    #[test]
+    fn explicit_cli_flags_override_yaml() {
+        let args = Args::parse_from([
+            "nextgcore-pcrfd",
+            "--diameter-id",
+            "cli.example.org",
+            "--diameter-realm",
+            "cli-realm.example.org",
+            "--diameter-addr",
+            "127.0.0.1:4000",
+        ]);
+        let cfg = nextgcore_pcrfd::DiamConfig {
+            cnf_diamid: Some("yaml.example.org".to_string()),
+            cnf_diamrlm: Some("yaml-realm.example.org".to_string()),
+            cnf_addr: Some("10.0.0.9".to_string()),
+            cnf_port: 3869,
+            cnf_port_tls: 5869,
+        };
+        let (id, realm, addr) = resolve_diameter_identity(&args, &cfg);
+        assert_eq!(id, "cli.example.org");
+        assert_eq!(realm, "cli-realm.example.org");
+        assert_eq!(addr, "127.0.0.1:4000");
+    }
+
+    /// Precedence is per-field: a flag for one value must not suppress the YAML
+    /// values for the others.
+    ///
+    /// Each of the three fields is driven independently here. An earlier version
+    /// of this test only passed `--diameter-realm`, which meant an inverted
+    /// precedence on `identity` alone went undetected — found by deliberately
+    /// inverting it and seeing this test still pass.
+    #[test]
+    fn cli_override_is_per_field_not_all_or_nothing() {
+        let yaml_cfg = || nextgcore_pcrfd::DiamConfig {
+            cnf_diamid: Some("yaml.example.org".to_string()),
+            cnf_diamrlm: Some("yaml-realm.example.org".to_string()),
+            cnf_addr: Some("10.0.0.9".to_string()),
+            cnf_port: 3869,
+            cnf_port_tls: 5869,
+        };
+
+        // Only --diameter-realm: realm from CLI, other two from YAML.
+        let args = Args::parse_from(["nextgcore-pcrfd", "--diameter-realm", "cli-realm.example"]);
+        let (id, realm, addr) = resolve_diameter_identity(&args, &yaml_cfg());
+        assert_eq!(realm, "cli-realm.example", "flag wins for realm");
+        assert_eq!(id, "yaml.example.org", "yaml still wins for identity");
+        assert_eq!(addr, "10.0.0.9:3869", "yaml still wins for address");
+
+        // Only --diameter-id: identity from CLI, other two from YAML.
+        let args = Args::parse_from(["nextgcore-pcrfd", "--diameter-id", "cli.example.org"]);
+        let (id, realm, addr) = resolve_diameter_identity(&args, &yaml_cfg());
+        assert_eq!(id, "cli.example.org", "flag wins for identity");
+        assert_eq!(realm, "yaml-realm.example.org", "yaml still wins for realm");
+        assert_eq!(addr, "10.0.0.9:3869", "yaml still wins for address");
+
+        // Only --diameter-addr: address from CLI, other two from YAML.
+        let args = Args::parse_from(["nextgcore-pcrfd", "--diameter-addr", "127.0.0.1:4001"]);
+        let (id, realm, addr) = resolve_diameter_identity(&args, &yaml_cfg());
+        assert_eq!(addr, "127.0.0.1:4001", "flag wins for address");
+        assert_eq!(id, "yaml.example.org", "yaml still wins for identity");
+        assert_eq!(realm, "yaml-realm.example.org", "yaml still wins for realm");
+    }
+
+    /// `addr` and `port` are separate config fields but one CLI string, so each
+    /// half must fall back independently: setting only one must not force the
+    /// other to be specified.
+    #[test]
+    fn config_addr_and_port_fall_back_independently() {
+        let args = Args::parse_from(["nextgcore-pcrfd"]);
+
+        let host_only = nextgcore_pcrfd::DiamConfig {
+            cnf_addr: Some("10.1.2.3".to_string()),
+            cnf_port: 0,
+            ..Default::default()
+        };
+        let (_, _, addr) = resolve_diameter_identity(&args, &host_only);
+        assert_eq!(addr, "10.1.2.3:3868", "default port kept");
+
+        let port_only = nextgcore_pcrfd::DiamConfig {
+            cnf_addr: None,
+            cnf_port: 3999,
+            ..Default::default()
+        };
+        let (_, _, addr) = resolve_diameter_identity(&args, &port_only);
+        assert_eq!(addr, "0.0.0.0:3999", "default host kept");
+    }
+
+    /// The shipped `docker/rust/configs/epc/pcrf.yaml` has a `pcrf:` section with
+    /// no `diameter:` block; it must keep parsing and keep the defaults.
+    #[test]
+    fn shipped_pcrf_config_shape_parses() {
+        let yaml = r#"
+db_uri: mongodb://mongodb:27017/nextgcore
+logger:
+  level: info
+pcrf:
+  freeDiameter: /etc/freeDiameter/pcrf.conf
+  metrics:
+    server:
+      - address: 172.24.0.9
+        port: 9090
+"#;
+        let parsed: nextgcore_pcrfd::PcrfYaml =
+            serde_yaml::from_str(yaml).expect("shipped shape must deserialize");
+        let section = parsed.pcrf.expect("pcrf section");
+        assert_eq!(
+            section.free_diameter.as_deref(),
+            Some("/etc/freeDiameter/pcrf.conf")
+        );
+        assert!(section.diameter.is_none());
+    }
+
+    /// A malformed config must be an Err so main() exits non-zero instead of
+    /// silently advertising `localdomain`.
+    #[test]
+    fn malformed_pcrf_yaml_is_an_error() {
+        let path = std::env::temp_dir().join(format!(
+            "nextgcore-pcrfd-bad-{}-{:?}.yaml",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, "pcrf:\n  diameter:\n    port: \"nope\"\n").unwrap();
+        let result = pcrf_context_parse_config(path.to_str().unwrap());
+        std::fs::remove_file(&path).ok();
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes #58.

## Problem

Both EPC daemons shipped a `*_context_parse_config` that returned `Ok(())` **without reading the file**, while `main()` logged `Loading configuration from <file>`:

- `bins/nextgcore-hssd/src/context.rs:591`
- `bins/nextgcore-pcrfd/src/context.rs:537`

So the Diameter identity, realm, listen address and Tc timer could never come from config. RFC 6733 §6.1 routes and authorizes requests on Destination-Realm matched against the receiver's Origin-Realm, and TS 23.003 §19.2 derives the EPC realm from the deployed PLMN (`epc.mncNNN.mccMMM.3gppnetwork.org`), so a wrong realm breaks S6a/Gx/Rx interop outright.

The two differed sharply in severity, and the issue was right about why:

- **pcrfd** had a partial workaround — `--diameter-id` / `--diameter-realm` / `--diameter-addr`, defaulting to the well-formed but useless `pcrf.localdomain` / `localdomain`.
- **hssd** had **none**. It exposes no identity/realm flag at all, so with the parser also a no-op it was hard-locked to the `mnc001/mcc001` fallbacks in `main.rs` — **no runtime workaround whatsoever**.

Every file and line the issue cited was verified against the tree before any code changed.

## One finding the issue did not mention

The shipped configs (`docker/rust/configs/epc/{hss,pcrf}.yaml`) carry **no inline identity at all**. They point at freeDiameter files whose `Identity =` / `Realm =` lines are the real values in the Docker deployment — and **nothing parses that format either**: `diam_conf_path` is initialised to `None` and never populated.

So the identity was unreachable from *both* config sources, not just from YAML. This change records `freeDiameter:` into `diam_conf_path` so a deployment can be diagnosed, but does **not** implement a freeDiameter parser — separate work, and until it lands the Docker EPC still takes its identity from the built-in defaults. Called out as a non-goal.

## Decisions

**Fail-hard on a malformed config, unlike the 5GC NFs.** Peer NFs (nssfd, udrd, amfd) use a lenient `if let Ok(..)` and continue. That is defensible there — an ignored optional SBI knob degrades one feature. Here a silently-ignored config reverts the node's **identity** to a different PLMN, presenting as peers rejecting traffic with no local error at all. A **missing** file stays non-fatal: the defaults are a working dev configuration existing deployments rely on. The log line now reads `Loaded configuration from` and is emitted only *after* the parse succeeds.

**pcrfd's three flags become `Option` rather than keeping `default_value`.** The issue requires CLI to override YAML. With a clap `default_value` every flag always *looks* explicitly set, so it would unconditionally outrank the config file and the YAML could never take effect — the same bug, moved. Defaults move to consts, so a daemon started bare behaves exactly as before. hssd gains matching flags for parity, wired identically.

**Absent keys leave existing values untouched** rather than overwriting with zero: `main.rs` reads `cnf_port == 0` as "unset" and substitutes 3868, so zeroing a partial config would silently move the listener.

**Only keys the target struct can hold are declared.** pcrfd's `DiamConfig` has no Tc, no forwarding flag and no peer list, so those keys are absent from its schema rather than parsed and dropped — parsing a key that cannot take effect is exactly the defect being fixed.

**A connection without an `identity` is dropped with a warning**, not stored as an empty-identity peer that fails obscurely at connect time.

## Changes

1. **hssd** `context.rs` — YAML types + real `hss_context_parse_config`; mapping split into `apply_diameter_yaml` so it is testable without the process-global context.
2. **hssd** `main.rs` — fail-hard parse; log after success; new `--diameter-id` / `--diameter-realm` / `--diameter-addr` / `--diameter-port` with CLI > YAML > default precedence.
3. **pcrfd** `context.rs` — the same, against its smaller `DiamConfig`.
4. **pcrfd** `main.rs` — flags become `Option`; new pure `resolve_diameter_identity`; fail-hard parse; log after success.
5. **pcrfd** `lib.rs` — export `DiamConfig`, the YAML types, `apply_diameter_yaml`.
6. Both `Cargo.toml` — workspace `serde` / `serde_yaml`.
7. Both shipped configs — document the `diameter:` block **commented out**, so behaviour is unchanged while the keys become discoverable.

## Verification

**16 new tests.**

- hssd: every `DiamConfig` field populated from a realistic operator config; absent keys not zeroed; identity-less connection dropped; shipped-config shape keeps defaults; malformed YAML is `Err`; unreadable path is `Err`; a smoke test parsing the **real repo file** (not a fixture copy) so a future edit to it cannot silently break startup; and one asserting the newly-documented commented-out block works when uncommented.
- pcrfd: built-in defaults; YAML over defaults; CLI over YAML; per-field precedence; independent `addr`/`port` fallback; shipped shape; malformed YAML is `Err`.

**Revert-verified:**
- Restoring hssd's `return Ok(())` no-op fails `malformed_yaml_is_an_error` and `unreadable_config_is_an_error`.
- Inverting pcrfd's `identity` precedence fails `explicit_cli_flags_override_yaml`.

**That revert also exposed a gap in my own test.** The first version of `cli_override_is_per_field_not_all_or_nothing` passed only `--diameter-realm`, so an identity-only inversion slipped past it. It now drives all three fields independently, and re-running the inversion confirms it fails.

Existing tests unaffected — the pcrfd arg tests never asserted on the three flags whose type changed.

Full workspace: **5352 passed, 0 failed** (baseline 5336, +16); `cargo fmt --check` clean; `cargo clippy --workspace` (the CI gate) at **0**. The pre-existing `unused variable: idx` warning in hssd is untouched and unrelated.

**Not exercised:** a live S6a/Gx association against a real MME or PCEF. The acceptance criterion "hssd advertises `epc.mnc070.mcc310.3gppnetwork.org` on S6a" is covered at the level of the config reaching `DiamConfig` and `main.rs` reading it into `DiameterConfig`, not by observing a CER on the wire.

Spec: `specs/fix-hssd-pcrfd-diameter-config-parse.md`