### PR TITLE
fix(diameter): stable Origin-State-Id and a bounded wait for answers

### DIFF
--- a/src/libs/nextgcore-diameter/src/config.rs
+++ b/src/libs/nextgcore-diameter/src/config.rs
@@ -21,6 +21,18 @@ pub struct DiameterConfig {
     /// Default Tc timer value
     pub timer_tc: u32,
 
+    /// How long to wait for an answer to a request, in seconds, before giving
+    /// up (`DiameterError::RequestTimeout`).
+    ///
+    /// Separate from `timer_tc`, which governs reconnection: an answer can be
+    /// outstanding on a connection that is perfectly healthy at the transport
+    /// level, which is exactly the case an unbounded wait cannot escape.
+    ///
+    /// 30s follows the RFC 6733 §12 guidance for Tw and is longer than any
+    /// interactive EPC procedure; a request still outstanding at that point is
+    /// not going to be answered.
+    pub request_timeout: u32,
+
     /// Configuration flags
     pub flags: DiameterConfigFlags,
 
@@ -43,6 +55,7 @@ impl Default for DiameterConfig {
             port: crate::DIAMETER_PORT,
             port_tls: crate::DIAMETER_TLS_PORT,
             timer_tc: 30,
+            request_timeout: 30,
             flags: DiameterConfigFlags::default(),
             extensions: Vec::new(),
             connections: Vec::new(),

--- a/src/libs/nextgcore-diameter/src/error.rs
+++ b/src/libs/nextgcore-diameter/src/error.rs
@@ -29,6 +29,16 @@ pub enum DiameterError {
     #[error("Protocol error: {0}")]
     Protocol(String),
 
+    /// No answer arrived for a request within the configured window.
+    ///
+    /// Distinct from [`DiameterError::Protocol`] on purpose: a timeout says
+    /// nothing about the peer being wrong, and a caller may reasonably retry it
+    /// or fail the one subscriber procedure, whereas a protocol error means the
+    /// exchange itself is broken. Carries the command code so a log line
+    /// identifies which procedure stalled.
+    #[error("No answer for request (command {command}) within {seconds}s")]
+    RequestTimeout { command: u32, seconds: u64 },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src/libs/nextgcore-diameter/src/peer.rs
+++ b/src/libs/nextgcore-diameter/src/peer.rs
@@ -584,13 +584,39 @@ impl Default for PeerTable {
     }
 }
 
-/// Generate an Origin-State-Id (seconds since process start, simplified)
+/// This node's Origin-State-Id: constant for the lifetime of the process,
+/// advancing only across a restart (RFC 6733 §8.16).
+///
+/// # Why this is latched rather than computed per call
+///
+/// This used to return `SystemTime::now().as_secs()` on every call, so the
+/// advertised value increased once per second. Origin-State-Id is how a peer
+/// detects that a node has RESTARTED and its session state is therefore gone:
+/// a value that keeps climbing tells every peer this node is perpetually
+/// rebooting. A conformant HSS/PCRF/DRA is entitled to discard the sessions it
+/// holds for us each time it sees a higher value, so the bug is not cosmetic --
+/// it invites peers to drop live state, and it does so more often the longer the
+/// connection lives (CER, CEA, DWR and DWA all carry the value, and the watchdog
+/// re-sends it periodically).
+///
+/// Seeding from the wall clock at first use is deliberate and matches the RFC's
+/// suggestion: it must increase monotonically ACROSS restarts, so it cannot be a
+/// fixed constant or a counter that starts at zero. A restart within the same
+/// second reuses the value, which is acceptable -- the RFC only requires that it
+/// not decrease, and one second of ambiguity after a crash-restart is a far
+/// smaller problem than announcing a reboot every second.
+static ORIGIN_STATE_ID: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+
+/// This node's Origin-State-Id (RFC 6733 §8.16). Stable for the process
+/// lifetime; see [`ORIGIN_STATE_ID`].
 fn origin_state_id() -> u32 {
-    use std::time::SystemTime;
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_secs() as u32)
-        .unwrap_or(0)
+    *ORIGIN_STATE_ID.get_or_init(|| {
+        use std::time::SystemTime;
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs() as u32)
+            .unwrap_or(0)
+    })
 }
 
 /// Generate a pseudo-random u32 for sequence initialization
@@ -616,6 +642,42 @@ mod tests {
             diameter_realm: realm.to_string(),
             timer_tc: 30,
             ..Default::default()
+        }
+    }
+
+    /// Origin-State-Id must be CONSTANT while the process runs (RFC 6733 §8.16):
+    /// it is how a peer detects a genuine restart. It previously returned
+    /// `SystemTime::now().as_secs()` per call, so it advanced every second and
+    /// told every peer this node was perpetually rebooting -- inviting a
+    /// conformant peer to discard our live session state repeatedly.
+    ///
+    /// Sleeping past a second boundary is what makes this a real regression
+    /// test: the old implementation returned a different value here, the latched
+    /// one cannot.
+    #[test]
+    fn origin_state_id_is_stable_across_a_second_boundary() {
+        let first = origin_state_id();
+        assert_ne!(first, 0, "a zero state id would mean the clock read failed");
+
+        // Comfortably longer than one second, since the old code changed value
+        // on each wall-clock second tick.
+        std::thread::sleep(std::time::Duration::from_millis(1_100));
+
+        assert_eq!(
+            origin_state_id(),
+            first,
+            "Origin-State-Id changed while the process kept running"
+        );
+    }
+
+    /// Every call site (CER, CEA, DWR, DWA) must see the same value; a peer that
+    /// compares the CER's id against a later DWR's would otherwise conclude the
+    /// node restarted mid-connection.
+    #[test]
+    fn origin_state_id_is_identical_across_repeated_reads() {
+        let baseline = origin_state_id();
+        for _ in 0..1000 {
+            assert_eq!(origin_state_id(), baseline);
         }
     }
 

--- a/src/libs/nextgcore-diameter/src/transport.rs
+++ b/src/libs/nextgcore-diameter/src/transport.rs
@@ -398,6 +398,26 @@ impl DiameterClient {
     /// message carries zero values; answers are matched on Hop-by-Hop ID.
     /// Peer-initiated requests received while waiting (e.g. S6a CLR/IDR) are
     /// queued and can be drained with [`DiameterClient::recv_inbound_request`].
+    ///
+    /// # Timeout
+    ///
+    /// Gives up after `config.request_timeout` seconds with
+    /// [`DiameterError::RequestTimeout`]. This loop previously had no bound at
+    /// all. It did handle `Disconnected`, so a peer that drops the TCP
+    /// connection unblocks it -- but a peer that stays CONNECTED and simply never
+    /// answers does not, and neither does one that keeps answering watchdogs
+    /// while dropping application requests (`WatchdogAck` hits `continue`).
+    /// Either case parked the caller forever.
+    ///
+    /// That is what makes it more than a hung request: `nextgcore-mmed` holds a
+    /// process-global mutex across this call, so one unanswered AIR/ULR/PUR
+    /// wedges the MME's entire S6a plane -- every subscriber's authentication,
+    /// not just the one that stalled. Bounding the wait here contains that;
+    /// removing the lock is tracked separately.
+    ///
+    /// The deadline covers the whole exchange rather than being reset per event,
+    /// so a peer streaming watchdogs or unmatched answers cannot extend it
+    /// indefinitely.
     pub async fn send_request(&mut self, msg: &DiameterMessage) -> DiameterResult<DiameterMessage> {
         let mut request = msg.clone();
         if request.header.hop_by_hop_id == 0 {
@@ -407,6 +427,8 @@ impl DiameterClient {
             request.header.end_to_end_id = self.next_end_to_end();
         }
         let hop_by_hop_id = request.header.hop_by_hop_id;
+        let command = request.header.command_code;
+        let timeout = Duration::from_secs(self.config.request_timeout as u64);
 
         let peer = self
             .peer
@@ -415,9 +437,32 @@ impl DiameterClient {
 
         peer.send_message(&request).await?;
 
+        // Deadline is computed AFTER the send so a slow write does not eat into
+        // the answer window.
+        let deadline = tokio::time::Instant::now() + timeout;
+
         // Wait for the answer (handle any watchdog messages in between)
         loop {
-            match peer.next_event().await? {
+            let event = match tokio::time::timeout_at(deadline, peer.next_event()).await {
+                Ok(ev) => ev?,
+                Err(_) => {
+                    // The connection is left OPEN: a timeout is a stalled
+                    // procedure, not necessarily a broken peer, and the watchdog
+                    // (RFC 3539) owns the decision to tear a peer down. Tearing
+                    // it down here would turn one slow subscriber lookup into a
+                    // reconnect storm.
+                    log::warn!(
+                        "Diameter request (command {command}, hop-by-hop {hop_by_hop_id}) \
+                         timed out after {}s with no answer",
+                        timeout.as_secs()
+                    );
+                    return Err(DiameterError::RequestTimeout {
+                        command,
+                        seconds: timeout.as_secs(),
+                    });
+                }
+            };
+            match event {
                 PeerEvent::Message(answer) => {
                     if answer.header.is_answer() && answer.header.hop_by_hop_id == hop_by_hop_id {
                         return Ok(answer);
@@ -982,6 +1027,158 @@ impl SctpDiameterListener {
             std::io::ErrorKind::Unsupported,
             "SCTP support not yet implemented",
         )))
+    }
+}
+
+#[cfg(test)]
+mod request_timeout_tests {
+    //! `send_request` must not wait forever for an answer.
+    //!
+    //! Both tests use a peer that stays CONNECTED, because the pre-fix loop did
+    //! already handle `Disconnected` -- a peer that drops the socket was never
+    //! the hang. The hang needed a peer that completes CER/CEA and then either
+    //! goes silent or answers only watchdogs, which is what these reproduce.
+    use super::*;
+    use crate::avp::{Avp, AvpData};
+    use crate::config::DiameterConfig;
+    use crate::message::DiameterMessage;
+
+    /// Short window so the test is fast; the production default is 30s.
+    const TEST_TIMEOUT_SECS: u32 = 1;
+
+    fn client_config() -> DiameterConfig {
+        DiameterConfig {
+            diameter_id: "mme.example.com".to_string(),
+            diameter_realm: "example.com".to_string(),
+            request_timeout: TEST_TIMEOUT_SECS,
+            ..Default::default()
+        }
+    }
+
+    fn server_config() -> DiameterConfig {
+        DiameterConfig {
+            diameter_id: "hss.example.com".to_string(),
+            diameter_realm: "example.com".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// A peer that answers CER then never answers the application request must
+    /// produce RequestTimeout rather than parking the caller forever.
+    #[tokio::test]
+    async fn silent_peer_yields_request_timeout() {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+
+        let cfg = server_config();
+        let server = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = crate::peer::DiameterPeer::new_responder(transport, &cfg);
+            peer.start().await.unwrap();
+            let _cer = peer.next_event().await.unwrap();
+            // Receive the AIR and deliberately send NOTHING back, while holding
+            // the connection open so the client cannot escape via Disconnected.
+            let _air = peer.next_event().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let mut client = DiameterClient::new(client_config(), listen_addr);
+        client.connect().await.unwrap();
+
+        let air = DiameterMessage::new_request(318, 16777251);
+        let result = client.send_request(&air).await;
+
+        match result {
+            Err(DiameterError::RequestTimeout { command, seconds }) => {
+                assert_eq!(command, 318, "the stalled command is named");
+                assert_eq!(seconds, u64::from(TEST_TIMEOUT_SECS));
+            }
+            other => panic!("expected RequestTimeout, got {other:?}"),
+        }
+        server.abort();
+    }
+
+    /// A peer that keeps the watchdog alive but never answers the request must
+    /// also time out. This is the case the `PeerEvent::WatchdogAck => continue`
+    /// arm would otherwise let run indefinitely, and it is why the deadline
+    /// spans the whole exchange instead of being reset per event.
+    #[tokio::test]
+    async fn watchdog_traffic_does_not_extend_the_deadline() {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+
+        let cfg = server_config();
+        let server = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = crate::peer::DiameterPeer::new_responder(transport, &cfg);
+            peer.start().await.unwrap();
+            let _cer = peer.next_event().await.unwrap();
+            let _air = peer.next_event().await.unwrap();
+            // Never answer the AIR, but keep sending watchdogs so the client
+            // sees a steady stream of events it is designed to skip.
+            loop {
+                if peer.send_watchdog().await.is_err() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        });
+
+        let mut client = DiameterClient::new(client_config(), listen_addr);
+        client.connect().await.unwrap();
+
+        let air = DiameterMessage::new_request(318, 16777251);
+        let started = tokio::time::Instant::now();
+        let result = client.send_request(&air).await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            matches!(result, Err(DiameterError::RequestTimeout { .. })),
+            "expected RequestTimeout, got {result:?}"
+        );
+        // Generous upper bound: the point is that it is BOUNDED, not that the
+        // timer is precise under a loaded test runner.
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "watchdog traffic extended the deadline: {elapsed:?}"
+        );
+        server.abort();
+    }
+
+    /// The timeout must not break the normal path: a peer that answers promptly
+    /// still gets its answer matched on Hop-by-Hop ID.
+    #[tokio::test]
+    async fn answering_peer_still_succeeds() {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+
+        let cfg = server_config();
+        let server = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = crate::peer::DiameterPeer::new_responder(transport, &cfg);
+            peer.start().await.unwrap();
+            let _cer = peer.next_event().await.unwrap();
+            if let PeerEvent::Message(msg) = peer.next_event().await.unwrap() {
+                let mut answer = DiameterMessage::new_answer(&msg);
+                answer.add_avp(Avp::mandatory(268, AvpData::Unsigned32(2001)));
+                peer.send_message(&answer).await.unwrap();
+            }
+        });
+
+        let mut client = DiameterClient::new(client_config(), listen_addr);
+        client.connect().await.unwrap();
+
+        let air = DiameterMessage::new_request(318, 16777251);
+        let answer = client.send_request(&air).await.expect("answer expected");
+        assert!(answer.header.is_answer());
+        assert_eq!(answer.result_code(), Some(2001));
+        server.abort();
     }
 }
 


### PR DESCRIPTION
Refs #55 — **slice 1 of 3**. Covers two of that issue's four gaps: the two that are behavioural fixes with no API redesign. Application/capabilities negotiation and SCTP are deliberately **not** here (the issue itself says it may be split).

## Defect 1 — Origin-State-Id advanced every second

`peer.rs:588` returned `SystemTime::now().as_secs()`, recomputed per call, emitted in four places: CER (`:237`), CEA (`:274`), DWR (`:338`), DWA (`:367`).

RFC 6733 §8.16 defines Origin-State-Id as how a peer detects a node has **restarted** and its session state is gone. A value that keeps climbing tells every peer this node is perpetually rebooting — and a conformant HSS/PCRF/DRA is entitled to **discard the sessions it holds for us** each time it sees a higher value. Not cosmetic: it invites peers to drop live state, and since the watchdog re-sends the value periodically, the longer a connection lives the more often it happens.

**Fix:** latch in a `OnceLock`. Seeding from the wall clock is deliberate and matches the RFC's suggestion — it must increase monotonically *across* restarts, so it cannot be a constant or a counter from zero. A restart within the same second reuses the value, which is acceptable: the RFC requires only that it not decrease, and one second of post-crash ambiguity beats announcing a reboot every second.

## Defect 2 — `send_request` waited forever

Worth being precise about what was actually broken. The loop **did** handle `PeerEvent::Disconnected`, so a peer that drops the socket unblocked it. The hang needed a peer that stays **connected** and never answers — or one that keeps answering watchdogs while dropping application requests, since `WatchdogAck => continue` skipped those with no deadline check. Both are ordinary failure modes for a wedged or loaded HSS.

**Why it's worse than one hung request:** `nextgcore-mmed` takes a process-global mutex and calls `send_request` *while holding it* (AIR locks at `fd_path.rs:437`, sends at `:473`; ULR and PUR likewise). One unanswered AIR/ULR/PUR wedges the MME's **entire S6a plane** — every subscriber's authentication, not just the one that stalled. This PR bounds that; removing the lock is the next item in the sequence, tracked separately.

**Fix:** `tokio::time::timeout_at`, mirroring the pattern `recv_inbound_request` already uses two functions below. New `DiameterConfig::request_timeout` (30s) and `DiameterError::RequestTimeout { command, seconds }`.

### Design points

- **The deadline spans the whole exchange**, not reset per event — otherwise a peer streaming watchdogs extends it indefinitely, which is exactly the second failure mode.
- **Computed after the send**, so a slow write doesn't eat the answer window.
- **A timeout leaves the connection OPEN.** A stalled procedure isn't proof of a broken peer, and RFC 3539's watchdog owns teardown. Tearing down here would turn one slow subscriber lookup into a reconnect storm.
- **`request_timeout` is separate from `timer_tc`**, which governs reconnection: an answer can be outstanding on a transport that is perfectly healthy — precisely the case an unbounded wait cannot escape.
- **A distinct error variant**, not `Protocol(String)`: a timeout says nothing about the peer being wrong, and a caller may reasonably retry or fail just that subscriber. It carries the command code so a log line names the stalled procedure.

## No daemon changes needed

hssd, pcrfd and mmed all build `DiameterConfig` with `..Default::default()`, so they inherit the 30s timeout automatically. Verified by building the whole workspace.

## Not in this PR

- **Capabilities/application negotiation** (#55's first gap): CER omits the RFC-mandatory `Host-IP-Address` / `Vendor-Id` / `Product-Name` and advertises no application; `handle_cer` always answers `2001` and can never return `5010 DIAMETER_NO_COMMON_APPLICATION`. Needs an application registry the daemons populate at init — the one genuinely architectural piece, sequenced after these.
- **Failover / the `T` retransmit flag** (RFC 6733 §5.5.4) — needs an alternate-peer concept that doesn't exist yet.
- **The mmed global-lock fix** — bounded here, removed separately.
- **SCTP.** Noted while scoping: the stub is gated behind `#[cfg(feature = "sctp")]` and the crate **declares no such feature**, so it is unreachable dead code. A real conformance gap (RFC 6733 §2.1) but not a live bug, and the least urgent of #55's four items.

## Verification

**5 new tests.** Origin-State-Id: stable across a second boundary; identical over 1000 reads. Timeout: a silent peer yields `RequestTimeout` naming command 318; watchdog traffic does not extend the deadline; an answering peer still succeeds (normal path intact). The timeout tests use real sockets and a peer that completes CER/CEA first, since a peer that merely drops the socket was never the bug.

**Revert-verified, both defects:**
- Restoring the per-call clock read fails `origin_state_id_is_stable_across_a_second_boundary`. Note the 1000-read test still **passed** against the broken code — fast reads land in one second — so the sleeping test is the load-bearing one.
- Restoring the unbounded wait fails `silent_peer_yields_request_timeout` **and hangs `watchdog_traffic_does_not_extend_the_deadline` past 60s**, reproducing the wedge directly.

Full workspace: **5341 passed, 0 failed** (baseline 5336, +5); `cargo fmt --check` clean; `cargo clippy --workspace` (the CI gate) at **0**; no new `--all-targets` warnings in the crate. The crate's suite still runs in 1.10s, so the socket tests cost essentially nothing.

**Not exercised:** a live association against a third-party HSS/DRA — the only way to confirm a real peer stops seeing us as rebooting.

Spec: `specs/fix-diameter-origin-state-id-and-request-timeout.md`