### PR TITLE
fix(mmed,diameter): multiplex S6a instead of serialising it behind a lock

### DIFF
--- a/src/bins/nextgcore-mmed/src/fd_path.rs
+++ b/src/bins/nextgcore-mmed/src/fd_path.rs
@@ -12,6 +12,7 @@ use tokio::sync::Mutex;
 
 use nextgcore_diameter::config::DiameterConfig;
 use nextgcore_diameter::s6a;
+use nextgcore_diameter::session::DiameterSession;
 use nextgcore_diameter::transport::DiameterClient;
 
 use crate::context::MmeUe;
@@ -312,13 +313,31 @@ pub struct SessionState {
 // ============================================================================
 
 /// Diameter client state for the S6a interface (MME -> HSS)
+///
+/// # Why this no longer holds a `DiameterClient`
+///
+/// It used to, and every S6a operation took the global mutex below and then
+/// called `client.send_request(..)` **while holding the guard**. Because
+/// `send_request` awaits the HSS answer, one slow or unanswered exchange blocked
+/// every other subscriber's AIR/ULR/PUR — the whole S6a plane, not just the UE
+/// that stalled. A request timeout (added separately) bounded that to 30s of
+/// total outage per stalled request, which is better than forever but still an
+/// availability defect, and the lock was the cause.
+///
+/// The connection now lives in a [`DiameterSession`], which multiplexes requests
+/// over it by Hop-by-Hop Identifier (RFC 6733 §3) and is `Clone` + `&self`. So
+/// this struct keeps only what genuinely needs serialising: the session-id
+/// counter. The lock is taken to build a request and released before the await.
 struct S6aClientState {
-    /// Diameter client connection to HSS
-    client: DiameterClient,
+    /// Multiplexing handle for the HSS connection. Cloned out under the lock and
+    /// used without it, which is what allows concurrent exchanges.
+    session: DiameterSession,
     /// Diameter configuration
     config: DiameterConfig,
     /// Session ID counter
     session_counter: u64,
+    /// Reader task driving the session; aborted on shutdown.
+    reader: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl S6aClientState {
@@ -338,6 +357,37 @@ fn s6a_client() -> &'static Mutex<Option<S6aClientState>> {
     S6A_CLIENT.get_or_init(|| Mutex::new(None))
 }
 
+/// Configuration recorded by [`mme_fd_init_async`], consumed by
+/// [`mme_fd_connect`].
+///
+/// Kept separate from `S6A_CLIENT` because the connection is now established in
+/// one step (connect + session start), so `mme_fd_connect` needs the config
+/// before any session exists — and it must not hold the state lock while dialling.
+static S6A_CONFIG: OnceLock<Mutex<Option<(DiameterConfig, SocketAddr)>>> = OnceLock::new();
+
+fn s6a_config() -> &'static Mutex<Option<(DiameterConfig, SocketAddr)>> {
+    S6A_CONFIG.get_or_init(|| Mutex::new(None))
+}
+
+/// Take the session handle and a fresh session id, releasing the lock before the
+/// caller awaits anything.
+///
+/// Every S6a request path goes through this rather than holding the guard across
+/// its exchange. Returning owned values (a cloned handle, a `String`, the two
+/// identity strings) is what makes that possible: nothing borrowed from the
+/// guard outlives it.
+async fn s6a_begin_request() -> DiameterResult<(DiameterSession, String, String, String)> {
+    let mut guard = s6a_client().lock().await;
+    let state = guard.as_mut().ok_or(DiameterError::NotInitialized)?;
+    let session_id = state.next_session_id();
+    Ok((
+        state.session.clone(),
+        session_id,
+        state.config.diameter_id.clone(),
+        state.config.diameter_realm.clone(),
+    ))
+}
+
 // ============================================================================
 // Diameter Path Functions
 // ============================================================================
@@ -354,34 +404,62 @@ pub fn mme_fd_init() -> DiameterResult<()> {
     Ok(())
 }
 
-/// Initialize Diameter S6a interface with configuration (async version)
+/// Record the S6a configuration. The connection itself is established by
+/// [`mme_fd_connect`].
+///
+/// The peer address is stashed rather than dialled here, preserving the previous
+/// deferred-connect behaviour: `mme_fd_init` runs before the async runtime is
+/// necessarily useful, and startup must not block on an HSS that is not up yet.
 ///
 /// # Arguments
 /// * `config` - Diameter configuration (origin host, realm, etc.)
 /// * `hss_addr` - HSS peer address
 pub async fn mme_fd_init_async(config: DiameterConfig, hss_addr: SocketAddr) -> DiameterResult<()> {
     log::info!("Initializing Diameter S6a interface, HSS={hss_addr}");
-
-    let client = DiameterClient::new(config.clone(), hss_addr);
-    let state = S6aClientState {
-        client,
-        config,
-        session_counter: 0,
-    };
-
-    let mut guard = s6a_client().lock().await;
-    *guard = Some(state);
+    let mut guard = s6a_config().lock().await;
+    *guard = Some((config, hss_addr));
     Ok(())
 }
 
-/// Connect the S6a client to the HSS
+/// Connect to the HSS and start multiplexing S6a requests over the connection.
+///
+/// `DiameterSession::start` consumes the connected client, so the CER/CEA
+/// exchange has to complete first -- hence connect and session-start being one
+/// step rather than the previous init-then-connect pair. Calling this again after
+/// a connection loss replaces the session and aborts the old reader task.
 pub async fn mme_fd_connect() -> DiameterResult<()> {
-    let mut guard = s6a_client().lock().await;
-    let state = guard.as_mut().ok_or(DiameterError::NotInitialized)?;
-    state.client.connect_with_retry(3).await.map_err(|e| {
+    let (config, hss_addr) = {
+        let guard = s6a_config().lock().await;
+        guard.clone().ok_or(DiameterError::NotInitialized)?
+    };
+
+    // Dialled OUTSIDE the state lock: connect_with_retry sleeps between
+    // attempts, and holding the lock across that would reintroduce exactly the
+    // stall this change removes.
+    let mut client = DiameterClient::new(config.clone(), hss_addr);
+    client.connect_with_retry(3).await.map_err(|e| {
         log::error!("Failed to connect to HSS: {e}");
         DiameterError::ConnectionFailed
-    })
+    })?;
+
+    let (session, reader) = DiameterSession::start(client)?;
+
+    let mut guard = s6a_client().lock().await;
+    // Replacing an existing session: stop its reader so two tasks never own
+    // connections to the same peer.
+    if let Some(old) = guard.take() {
+        if let Some(handle) = old.reader {
+            handle.abort();
+        }
+    }
+    *guard = Some(S6aClientState {
+        session,
+        config,
+        session_counter: 0,
+        reader: Some(reader),
+    });
+    log::info!("S6a session established with HSS={hss_addr}");
+    Ok(())
 }
 
 /// Finalize Diameter S6a interface (sync version for shutdown)
@@ -394,10 +472,15 @@ pub fn mme_fd_final() {
 pub async fn mme_fd_final_async() {
     log::info!("Finalizing Diameter S6a interface");
     let mut guard = s6a_client().lock().await;
-    if let Some(ref mut state) = *guard {
-        let _ = state.client.disconnect().await;
+    if let Some(state) = guard.take() {
+        // Aborting the reader drops the peer, which closes the socket. There is
+        // no graceful DPR here: the session owns the peer, and adding a
+        // disconnect path through the multiplexer is only worth it once
+        // reconnection exists (tracked with the failover work).
+        if let Some(handle) = state.reader {
+            handle.abort();
+        }
     }
-    *guard = None;
 }
 
 /// True when the ULR did not set Skip-Subscriber-Data, i.e. the ULA is
@@ -434,10 +517,10 @@ pub async fn mme_s6a_send_air(
         return Err(DiameterError::BuildFailed);
     }
 
-    let mut guard = s6a_client().lock().await;
-    let state = guard.as_mut().ok_or(DiameterError::NotInitialized)?;
+    // The lock is released here, BEFORE the exchange below, so a slow answer
+    // cannot block another subscriber's request.
+    let (session, session_id, origin_host, origin_realm) = s6a_begin_request().await?;
 
-    let session_id = state.next_session_id();
     let visited_plmn = encode_plmn_id(&mme_ue.tai.plmn_id);
 
     log::debug!(
@@ -448,9 +531,9 @@ pub async fn mme_s6a_send_air(
 
     let mut air = s6a::create_air(
         &session_id,
-        &state.config.diameter_id,
-        &state.config.diameter_realm,
-        &state.config.diameter_realm, // destination realm (same or from hssmap)
+        &origin_host,
+        &origin_realm,
+        &origin_realm, // destination realm (same or from hssmap)
         &mme_ue.imsi_bcd,
         &visited_plmn,
         1, // request 1 vector
@@ -470,7 +553,7 @@ pub async fn mme_s6a_send_air(
         }
     }
 
-    let answer = state.client.send_request(&air).await?;
+    let answer = session.send_request(&air).await?;
 
     // Parse the AIA response
     let result_code = answer.result_code().unwrap_or(0);
@@ -516,10 +599,9 @@ pub async fn mme_s6a_send_ulr(mme_ue: &MmeUe, initial_attach: bool) -> DiameterR
         return Err(DiameterError::BuildFailed);
     }
 
-    let mut guard = s6a_client().lock().await;
-    let state = guard.as_mut().ok_or(DiameterError::NotInitialized)?;
+    // Lock released before the exchange; see `s6a_begin_request`.
+    let (session, session_id, origin_host, origin_realm) = s6a_begin_request().await?;
 
-    let session_id = state.next_session_id();
     let visited_plmn = encode_plmn_id(&mme_ue.tai.plmn_id);
 
     // Build ULR flags
@@ -537,16 +619,16 @@ pub async fn mme_s6a_send_ulr(mme_ue: &MmeUe, initial_attach: bool) -> DiameterR
 
     let ulr = s6a::create_ulr(
         &session_id,
-        &state.config.diameter_id,
-        &state.config.diameter_realm,
-        &state.config.diameter_realm,
+        &origin_host,
+        &origin_realm,
+        &origin_realm,
         &mme_ue.imsi_bcd,
         &visited_plmn,
         flags,
         1004, // E-UTRAN RAT type
     );
 
-    let answer = state.client.send_request(&ulr).await?;
+    let answer = session.send_request(&ulr).await?;
 
     // Parse ULA
     let result_code = answer.result_code().unwrap_or(0);
@@ -603,10 +685,8 @@ pub async fn mme_s6a_send_pur(mme_ue: &MmeUe) -> DiameterResult<(u32, u32)> {
         return Err(DiameterError::BuildFailed);
     }
 
-    let mut guard = s6a_client().lock().await;
-    let state = guard.as_mut().ok_or(DiameterError::NotInitialized)?;
-
-    let session_id = state.next_session_id();
+    // Lock released before the exchange; see `s6a_begin_request`.
+    let (session, session_id, origin_host, origin_realm) = s6a_begin_request().await?;
 
     log::debug!("[{}] Sending Purge-UE-Request", mme_ue.imsi_bcd);
 
@@ -623,17 +703,17 @@ pub async fn mme_s6a_send_pur(mme_ue: &MmeUe) -> DiameterResult<(u32, u32)> {
     // Origin-Host
     pur.add_avp(nextgcore_diameter::avp::Avp::mandatory(
         nextgcore_diameter::common::avp_code::ORIGIN_HOST,
-        nextgcore_diameter::avp::AvpData::DiameterIdentity(state.config.diameter_id.clone()),
+        nextgcore_diameter::avp::AvpData::DiameterIdentity(origin_host.clone()),
     ));
     // Origin-Realm
     pur.add_avp(nextgcore_diameter::avp::Avp::mandatory(
         nextgcore_diameter::common::avp_code::ORIGIN_REALM,
-        nextgcore_diameter::avp::AvpData::DiameterIdentity(state.config.diameter_realm.clone()),
+        nextgcore_diameter::avp::AvpData::DiameterIdentity(origin_realm.clone()),
     ));
     // Destination-Realm
     pur.add_avp(nextgcore_diameter::avp::Avp::mandatory(
         nextgcore_diameter::common::avp_code::DESTINATION_REALM,
-        nextgcore_diameter::avp::AvpData::DiameterIdentity(state.config.diameter_realm.clone()),
+        nextgcore_diameter::avp::AvpData::DiameterIdentity(origin_realm.clone()),
     ));
     // User-Name (IMSI)
     pur.add_avp(nextgcore_diameter::avp::Avp::mandatory(
@@ -652,7 +732,7 @@ pub async fn mme_s6a_send_pur(mme_ue: &MmeUe) -> DiameterResult<(u32, u32)> {
         nextgcore_diameter::avp::AvpData::Unsigned32(s6a::pur_flags::UE_PURGED_IN_MME),
     ));
 
-    let answer = state.client.send_request(&pur).await?;
+    let answer = session.send_request(&pur).await?;
 
     let result_code = answer.result_code().unwrap_or(0);
     let pua_flags = answer
@@ -695,17 +775,23 @@ pub struct InboundS6aRequest {
 pub async fn mme_fd_recv_inbound(
     timeout: std::time::Duration,
 ) -> DiameterResult<Option<InboundS6aRequest>> {
-    let mut guard = s6a_client().lock().await;
-    let state = guard.as_mut().ok_or(DiameterError::NotInitialized)?;
-
-    let Some(request) = state.client.recv_inbound_request(timeout).await? else {
-        return Ok(None);
+    // Clone the handle and identities, then RELEASE the lock: this function
+    // waits up to `timeout` for a peer-initiated request, and holding the state
+    // lock for that whole window would block every outbound AIR/ULR/PUR -- the
+    // same defect as the request paths, just with a longer hold.
+    let (session, origin_host, origin_realm) = {
+        let guard = s6a_client().lock().await;
+        let state = guard.as_ref().ok_or(DiameterError::NotInitialized)?;
+        (
+            state.session.clone(),
+            state.config.diameter_id.clone(),
+            state.config.diameter_realm.clone(),
+        )
     };
 
-    let (origin_host, origin_realm) = (
-        state.config.diameter_id.clone(),
-        state.config.diameter_realm.clone(),
-    );
+    let Some(request) = session.recv_inbound_request(timeout).await? else {
+        return Ok(None);
+    };
 
     let build_answer =
         |req: &nextgcore_diameter::message::DiameterMessage, result: u32, protocol_error: bool| {
@@ -742,7 +828,7 @@ pub async fn mme_fd_recv_inbound(
     let Some(imsi_bcd) = request.user_name().map(str::to_string) else {
         log::error!("Inbound S6a request missing User-Name");
         let answer = build_answer(&request, result_code::DIAMETER_MISSING_AVP, false);
-        state.client.send_answer(&answer).await?;
+        session.send_answer(&answer).await?;
         return Ok(None);
     };
 
@@ -758,7 +844,7 @@ pub async fn mme_fd_recv_inbound(
             let Some(cancellation_type) = cancellation_type else {
                 log::error!("[{imsi_bcd}] CLR missing Cancellation-Type");
                 let answer = build_answer(&request, result_code::DIAMETER_MISSING_AVP, false);
-                state.client.send_answer(&answer).await?;
+                session.send_answer(&answer).await?;
                 return Ok(None);
             };
             let clr_flags = request
@@ -773,7 +859,7 @@ pub async fn mme_fd_recv_inbound(
                 "[{imsi_bcd}] Received CLR (type={cancellation_type}, flags={clr_flags:#x})"
             );
             let answer = build_answer(&request, result_code::DIAMETER_SUCCESS, false);
-            state.client.send_answer(&answer).await?;
+            session.send_answer(&answer).await?;
 
             Ok(Some(InboundS6aRequest {
                 imsi_bcd,
@@ -788,7 +874,7 @@ pub async fn mme_fd_recv_inbound(
             let Some(sub_avp) = request.find_avp(avp_code::SUBSCRIPTION_DATA) else {
                 log::error!("[{imsi_bcd}] IDR missing Subscription-Data");
                 let answer = build_answer(&request, result_code::DIAMETER_MISSING_AVP, false);
-                state.client.send_answer(&answer).await?;
+                session.send_answer(&answer).await?;
                 return Ok(None);
             };
             let subscription_data = s6a::parse_subscription_data_avp(sub_avp);
@@ -802,7 +888,7 @@ pub async fn mme_fd_recv_inbound(
 
             log::info!("[{imsi_bcd}] Received IDR (flags={idr_flags:#x})");
             let answer = build_answer(&request, result_code::DIAMETER_SUCCESS, false);
-            state.client.send_answer(&answer).await?;
+            session.send_answer(&answer).await?;
 
             Ok(Some(InboundS6aRequest {
                 imsi_bcd,
@@ -819,7 +905,7 @@ pub async fn mme_fd_recv_inbound(
                 result_code::DIAMETER_COMMAND_UNSUPPORTED,
                 true, // protocol error: E-bit (RFC 6733 7.2)
             );
-            state.client.send_answer(&answer).await?;
+            session.send_answer(&answer).await?;
             Ok(None)
         }
     }

--- a/src/libs/nextgcore-diameter/src/lib.rs
+++ b/src/libs/nextgcore-diameter/src/lib.rs
@@ -24,6 +24,7 @@ pub mod peer;
 pub mod rx;
 pub mod s6a;
 pub mod s6b;
+pub mod session;
 pub mod swx;
 pub mod transport;
 

--- a/src/libs/nextgcore-diameter/src/peer.rs
+++ b/src/libs/nextgcore-diameter/src/peer.rs
@@ -162,8 +162,41 @@ impl DiameterPeer {
     ///
     /// This handles all base protocol messages (CER/CEA, DWR/DWA, DPR/DPA)
     /// internally and returns application-level events to the caller.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is **not** cancel-safe and must not be used as a `select!`
+    /// branch: [`Self::handle_message`] can await a write (a DWA answering a
+    /// watchdog, a DPA answering a disconnect), so dropping the future mid-write
+    /// would leave a partial message on the wire and desynchronise framing for
+    /// every subsequent message. Use [`Self::recv_raw`] plus
+    /// [`Self::handle_message`] when the read has to race another branch — see
+    /// [`crate::session`], which does exactly that.
     pub async fn next_event(&mut self) -> DiameterResult<PeerEvent> {
-        let msg = self.transport.recv().await?;
+        let msg = self.recv_raw().await?;
+        self.handle_message(msg).await
+    }
+
+    /// Read the next message off the wire without interpreting it.
+    ///
+    /// # Cancel safety
+    ///
+    /// This **is** cancel-safe, which is the reason it is split out. The only
+    /// await is `read_buf` into a buffer owned by the transport: if the future is
+    /// dropped, no bytes are consumed from the socket and any partial message
+    /// already buffered stays buffered, so a later call resumes exactly where
+    /// this one left off. That makes it sound as a `select!` branch, unlike
+    /// [`Self::next_event`].
+    pub async fn recv_raw(&mut self) -> DiameterResult<DiameterMessage> {
+        self.transport.recv().await
+    }
+
+    /// Advance the state machine for a message obtained from [`Self::recv_raw`].
+    ///
+    /// Handles the base protocol (CER/CEA, DWR/DWA, DPR/DPA) internally,
+    /// answering where the RFC requires it, and returns application-level events
+    /// to the caller. Not cancel-safe: see [`Self::next_event`].
+    pub async fn handle_message(&mut self, msg: DiameterMessage) -> DiameterResult<PeerEvent> {
         self.process_message(msg).await
     }
 

--- a/src/libs/nextgcore-diameter/src/session.rs
+++ b/src/libs/nextgcore-diameter/src/session.rs
@@ -1,0 +1,627 @@
+//! Concurrent request/answer multiplexing over a single Diameter connection.
+//!
+//! # The problem this solves
+//!
+//! [`crate::transport::DiameterClient::send_request`] takes `&mut self`, so a
+//! caller that wants to issue requests from several tasks has to serialise them
+//! behind a lock. `nextgcore-mmed` did exactly that: a process-global
+//! `Mutex<Option<S6aClientState>>` taken **before** `send_request` and held
+//! **across** the await. One slow HSS answer therefore blocked every other
+//! subscriber's S6a exchange — not just the one that stalled. Adding a request
+//! timeout (see `DiameterError::RequestTimeout`) bounded the outage, but the
+//! lock is the cause, so the outage was merely finite rather than absent.
+//!
+//! # The shape of the fix
+//!
+//! RFC 6733 §3 gives every request a Hop-by-Hop Identifier and requires the
+//! answer to echo it. That is precisely a correlation token, so the conventional
+//! design is a *multiplexer*: one task owns the connection and reads
+//! continuously; senders register a one-shot channel under their Hop-by-Hop ID
+//! and await it. Nothing is serialised except the brief moment of writing to the
+//! socket and touching the pending-request map.
+//!
+//! This also composes with the failover work RFC 6733 §5.5.4 needs: the pending
+//! map is exactly the set of requests that would have to be re-sent to an
+//! alternate peer with the `T` flag set. That is not implemented here.
+//!
+//! # What is deliberately NOT here
+//!
+//! - Reconnection. [`DiameterSession::start`] takes an already-connected
+//!   [`DiameterClient`]. When the reader sees the peer go away it fails every
+//!   waiter and stops; deciding whether to redial is the application's business
+//!   and mixing it in would make this module a supervisor as well as a
+//!   multiplexer.
+//! - Failover to an alternate peer, and the `T` retransmit flag.
+//! - Any change to `DiameterClient::send_request`, which keeps working for the
+//!   single-threaded callers (hssd's tests, the crate's own tests).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+use crate::error::{DiameterError, DiameterResult};
+use crate::message::DiameterMessage;
+use crate::peer::{DiameterPeer, PeerEvent};
+use crate::transport::DiameterClient;
+
+/// A request awaiting its answer, keyed by Hop-by-Hop Identifier.
+type PendingMap = Arc<Mutex<HashMap<u32, oneshot::Sender<DiameterMessage>>>>;
+
+/// A handle for issuing Diameter requests concurrently over one connection.
+///
+/// Cheap to clone: every clone shares the same connection, the same pending-map
+/// and the same reader task. Requests from different tasks interleave; a slow
+/// answer delays only the task waiting for it.
+#[derive(Clone)]
+pub struct DiameterSession {
+    /// Outbound messages, serialised by the writer half of the reader task.
+    tx: mpsc::Sender<DiameterMessage>,
+    pending: PendingMap,
+    /// Peer-initiated requests (e.g. S6a CLR/IDR) for the application to drain.
+    inbound_rx: Arc<Mutex<mpsc::Receiver<DiameterMessage>>>,
+    hop_by_hop: Arc<AtomicU32>,
+    end_to_end: Arc<AtomicU32>,
+    request_timeout: Duration,
+}
+
+impl DiameterSession {
+    /// Take ownership of a connected client and start multiplexing.
+    ///
+    /// The returned [`JoinHandle`](tokio::task::JoinHandle) is the reader task;
+    /// dropping it detaches, and aborting it tears the session down. The client
+    /// must already be connected — `start` does not perform CER/CEA.
+    pub fn start(client: DiameterClient) -> DiameterResult<(Self, tokio::task::JoinHandle<()>)> {
+        let request_timeout = Duration::from_secs(client.config().request_timeout as u64);
+        let (hop_seed, end_seed) = client.identifier_seeds();
+        let peer = client
+            .into_peer()
+            .ok_or(DiameterError::Protocol("client is not connected".into()))?;
+
+        let (tx, rx) = mpsc::channel::<DiameterMessage>(256);
+        // Bounded so a peer flooding CLR/IDR at an application that never drains
+        // cannot grow this without limit; the reader logs and drops on overflow.
+        let (inbound_tx, inbound_rx) = mpsc::channel::<DiameterMessage>(64);
+        let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
+
+        let handle = tokio::spawn(run_session(peer, rx, inbound_tx, Arc::clone(&pending)));
+
+        Ok((
+            Self {
+                tx,
+                pending,
+                inbound_rx: Arc::new(Mutex::new(inbound_rx)),
+                hop_by_hop: Arc::new(AtomicU32::new(hop_seed)),
+                end_to_end: Arc::new(AtomicU32::new(end_seed)),
+                request_timeout,
+            },
+            handle,
+        ))
+    }
+
+    /// Send a request and await its answer, concurrently with other callers.
+    ///
+    /// Assigns Hop-by-Hop and End-to-End identifiers when the message carries
+    /// zero, per RFC 6733 §3. Returns [`DiameterError::RequestTimeout`] if no
+    /// answer arrives within the configured window, and the pending entry is
+    /// removed so a very late answer is dropped rather than leaking.
+    pub async fn send_request(&self, msg: &DiameterMessage) -> DiameterResult<DiameterMessage> {
+        let mut request = msg.clone();
+        if request.header.hop_by_hop_id == 0 {
+            request.header.hop_by_hop_id = self.next_hop_by_hop();
+        }
+        if request.header.end_to_end_id == 0 {
+            request.header.end_to_end_id = self.next_end_to_end();
+        }
+        let hop_by_hop_id = request.header.hop_by_hop_id;
+        let command = request.header.command_code;
+
+        let (answer_tx, answer_rx) = oneshot::channel();
+        // Registered BEFORE the send: if the answer arrived first, the reader
+        // would find no waiter and drop it, and this caller would then wait out
+        // the full timeout for an answer that had already been and gone.
+        self.pending.lock().await.insert(hop_by_hop_id, answer_tx);
+
+        if self.tx.send(request).await.is_err() {
+            self.pending.lock().await.remove(&hop_by_hop_id);
+            return Err(DiameterError::Protocol("session is closed".into()));
+        }
+
+        match tokio::time::timeout(self.request_timeout, answer_rx).await {
+            Ok(Ok(answer)) => Ok(answer),
+            // The reader dropped the sender: the connection went away.
+            Ok(Err(_)) => {
+                self.pending.lock().await.remove(&hop_by_hop_id);
+                Err(DiameterError::Protocol("peer disconnected".into()))
+            }
+            Err(_) => {
+                self.pending.lock().await.remove(&hop_by_hop_id);
+                log::warn!(
+                    "Diameter request (command {command}, hop-by-hop {hop_by_hop_id}) \
+                     timed out after {}s with no answer",
+                    self.request_timeout.as_secs()
+                );
+                Err(DiameterError::RequestTimeout {
+                    command,
+                    seconds: self.request_timeout.as_secs(),
+                })
+            }
+        }
+    }
+
+    /// Send an answer to a peer-initiated request.
+    pub async fn send_answer(&self, msg: &DiameterMessage) -> DiameterResult<()> {
+        self.tx
+            .send(msg.clone())
+            .await
+            .map_err(|_| DiameterError::Protocol("session is closed".into()))
+    }
+
+    /// Receive a peer-initiated request (e.g. S6a CLR/IDR), waiting up to
+    /// `timeout`. `Ok(None)` on timeout.
+    pub async fn recv_inbound_request(
+        &self,
+        timeout: Duration,
+    ) -> DiameterResult<Option<DiameterMessage>> {
+        let mut rx = self.inbound_rx.lock().await;
+        match tokio::time::timeout(timeout, rx.recv()).await {
+            Ok(Some(msg)) => Ok(Some(msg)),
+            // Channel closed: the reader stopped, i.e. the peer is gone.
+            Ok(None) => Err(DiameterError::Protocol("peer disconnected".into())),
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// Number of requests currently awaiting an answer. Test/diagnostic use;
+    /// a non-zero value that never drains indicates leaked waiters.
+    pub async fn pending_count(&self) -> usize {
+        self.pending.lock().await.len()
+    }
+
+    fn next_hop_by_hop(&self) -> u32 {
+        // Relaxed is sufficient: uniqueness is all that matters, not ordering
+        // relative to other memory operations.
+        self.hop_by_hop
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1)
+    }
+
+    fn next_end_to_end(&self) -> u32 {
+        self.end_to_end
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1)
+    }
+}
+
+/// The reader task: owns the peer, writes queued messages, routes answers.
+///
+/// Reads and writes are interleaved in one task on purpose. The alternative —
+/// separate reader and writer tasks — needs the transport split into halves, and
+/// `DiameterTransport` is not written for that. A single task also removes any
+/// question of two writers interleaving bytes of different messages.
+async fn run_session(
+    mut peer: DiameterPeer,
+    mut outbound: mpsc::Receiver<DiameterMessage>,
+    inbound: mpsc::Sender<DiameterMessage>,
+    pending: PendingMap,
+) {
+    loop {
+        tokio::select! {
+            // `recv_raw` is cancel-safe (it only awaits a buffered read), which
+            // is why this branch is sound. `next_event` would NOT be: it can
+            // await a DWA/DPA write, and losing that race mid-write would leave
+            // a partial message on the wire.
+            read = peer.recv_raw() => {
+                let msg = match read {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        log::info!("Diameter session read ended: {e}");
+                        break;
+                    }
+                };
+
+                // Answers are routed here rather than through the state machine:
+                // an application answer carries no base-protocol meaning, and
+                // matching it now keeps the hot path short.
+                if msg.header.is_answer() {
+                    let waiter = pending.lock().await.remove(&msg.header.hop_by_hop_id);
+                    match waiter {
+                        Some(tx) => {
+                            // Err means the waiter timed out and went away; the
+                            // answer is simply late, so drop it quietly.
+                            let _ = tx.send(msg);
+                        }
+                        None => log::debug!(
+                            "Diameter answer with unknown hop-by-hop id {} dropped",
+                            msg.header.hop_by_hop_id
+                        ),
+                    }
+                    continue;
+                }
+
+                // Requests and base-protocol messages go through the state
+                // machine, which answers DWR/DPR itself.
+                match peer.handle_message(msg).await {
+                    Ok(PeerEvent::Message(request)) => {
+                        if let Err(e) = inbound.try_send(request) {
+                            log::warn!("inbound Diameter request dropped: {e}");
+                        }
+                    }
+                    Ok(PeerEvent::Disconnected) => {
+                        log::info!("Diameter peer disconnected");
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        log::warn!("Diameter session state error: {e}");
+                        break;
+                    }
+                }
+            }
+
+            // Writes are serialised through this one task, so no two messages
+            // can interleave on the wire.
+            Some(msg) = outbound.recv() => {
+                if let Err(e) = peer.send_message(&msg).await {
+                    log::warn!("Diameter session write failed: {e}");
+                    break;
+                }
+            }
+        }
+    }
+
+    // Fail every waiter rather than leaving it to time out: dropping the senders
+    // closes each oneshot, which surfaces as "peer disconnected" immediately.
+    // Without this, a connection loss would stall every in-flight request for
+    // the full request_timeout.
+    pending.lock().await.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::avp::{Avp, AvpData};
+    use crate::config::DiameterConfig;
+    use crate::transport::DiameterListener;
+
+    const AIR: u32 = 318;
+    const S6A_APP: u32 = 16777251;
+
+    fn config(host: &str, timeout_secs: u32) -> DiameterConfig {
+        DiameterConfig {
+            diameter_id: host.to_string(),
+            diameter_realm: "example.com".to_string(),
+            request_timeout: timeout_secs,
+            ..Default::default()
+        }
+    }
+
+    /// Answer each request after `delay`, handling requests CONCURRENTLY.
+    ///
+    /// The concurrency here is essential and was got wrong first time round: a
+    /// mock that does `recv -> sleep -> send` in one sequential loop cannot read
+    /// request 2 until it has answered request 1, so it serialises the exchange
+    /// itself and `requests_from_multiple_tasks_overlap` measured 3x the delay
+    /// even though the client was multiplexing correctly. The test was accusing
+    /// the code under test of the harness's own defect.
+    ///
+    /// So this mirrors the real design: one task owns the peer and `select!`s
+    /// between reading and writing, while a timer task per request queues the
+    /// answer after the delay.
+    async fn spawn_delayed_hss(
+        listener: DiameterListener,
+        delay: Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        let cfg = config("hss.example.com", 30);
+        tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &cfg);
+            peer.start().await.unwrap();
+            let _cer = peer.next_event().await.unwrap();
+
+            let (answer_tx, mut answer_rx) = mpsc::channel::<DiameterMessage>(16);
+            loop {
+                tokio::select! {
+                    read = peer.recv_raw() => {
+                        let Ok(msg) = read else { break };
+                        let mut answer = DiameterMessage::new_answer(&msg);
+                        answer.add_avp(Avp::mandatory(268, AvpData::Unsigned32(2001)));
+                        let tx = answer_tx.clone();
+                        tokio::spawn(async move {
+                            tokio::time::sleep(delay).await;
+                            let _ = tx.send(answer).await;
+                        });
+                    }
+                    Some(answer) = answer_rx.recv() => {
+                        if peer.send_message(&answer).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    async fn connected_session() -> (
+        DiameterSession,
+        tokio::task::JoinHandle<()>,
+        SocketAddrHolder,
+    ) {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hss = spawn_delayed_hss(listener, Duration::from_millis(300)).await;
+
+        let mut client = DiameterClient::new(config("mme.example.com", 5), addr);
+        client.connect().await.unwrap();
+        let (session, reader) = DiameterSession::start(client).unwrap();
+        (session, reader, SocketAddrHolder { _hss: hss })
+    }
+
+    /// Keeps the HSS task alive for the duration of a test.
+    struct SocketAddrHolder {
+        _hss: tokio::task::JoinHandle<()>,
+    }
+
+    /// The point of the whole change: three requests issued concurrently must
+    /// overlap, not queue. With the old lock-across-send they took 3x the
+    /// per-request latency; here they should finish in roughly 1x.
+    #[tokio::test]
+    async fn requests_from_multiple_tasks_overlap() {
+        let (session, reader, _hss) = connected_session().await;
+
+        let started = tokio::time::Instant::now();
+        let mut tasks = Vec::new();
+        for _ in 0..3 {
+            let s = session.clone();
+            tasks.push(tokio::spawn(async move {
+                let req = DiameterMessage::new_request(AIR, S6A_APP);
+                s.send_request(&req).await
+            }));
+        }
+        for t in tasks {
+            let answer = t.await.unwrap().expect("each request is answered");
+            assert_eq!(answer.result_code(), Some(2001));
+        }
+        let elapsed = started.elapsed();
+
+        // Each answer is delayed 300ms. Serialised => >=900ms; overlapped =>
+        // ~300ms. 700ms discriminates without being flaky on a loaded runner.
+        assert!(
+            elapsed < Duration::from_millis(700),
+            "requests were serialised, not multiplexed: {elapsed:?}"
+        );
+        reader.abort();
+    }
+
+    /// Answers must reach the caller that sent the matching request, even when
+    /// the peer answers out of order. This is what the Hop-by-Hop map buys, and
+    /// a naive implementation that hands each answer to the next waiter in line
+    /// would pass the timing test above while failing this one.
+    #[tokio::test]
+    async fn answers_are_routed_by_hop_by_hop_id() {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let cfg = config("hss.example.com", 30);
+        let hss = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &cfg);
+            peer.start().await.unwrap();
+            let _cer = peer.next_event().await.unwrap();
+
+            // Collect two requests, then answer them in REVERSE order.
+            let first = peer.recv_raw().await.unwrap();
+            let second = peer.recv_raw().await.unwrap();
+            for req in [second, first] {
+                let mut answer = DiameterMessage::new_answer(&req);
+                // Echo the session id so the caller can tell them apart.
+                if let Some(sid) = req.session_id() {
+                    answer.add_avp(Avp::mandatory(
+                        crate::common::avp_code::SESSION_ID,
+                        AvpData::Utf8String(sid.to_string()),
+                    ));
+                }
+                answer.add_avp(Avp::mandatory(268, AvpData::Unsigned32(2001)));
+                peer.send_message(&answer).await.unwrap();
+            }
+        });
+
+        let mut client = DiameterClient::new(config("mme.example.com", 5), addr);
+        client.connect().await.unwrap();
+        let (session, reader) = DiameterSession::start(client).unwrap();
+
+        let mut req_a = DiameterMessage::new_request(AIR, S6A_APP);
+        req_a.add_avp(Avp::mandatory(
+            crate::common::avp_code::SESSION_ID,
+            AvpData::Utf8String("session-A".into()),
+        ));
+        let mut req_b = DiameterMessage::new_request(AIR, S6A_APP);
+        req_b.add_avp(Avp::mandatory(
+            crate::common::avp_code::SESSION_ID,
+            AvpData::Utf8String("session-B".into()),
+        ));
+
+        let sa = session.clone();
+        let ta = tokio::spawn(async move { sa.send_request(&req_a).await });
+        // Ensure A is written first, so "reverse order" is well defined.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let sb = session.clone();
+        let tb = tokio::spawn(async move { sb.send_request(&req_b).await });
+
+        let ans_a = ta.await.unwrap().expect("A answered");
+        let ans_b = tb.await.unwrap().expect("B answered");
+
+        assert_eq!(
+            ans_a.session_id(),
+            Some("session-A"),
+            "caller A received another caller's answer"
+        );
+        assert_eq!(
+            ans_b.session_id(),
+            Some("session-B"),
+            "caller B received another caller's answer"
+        );
+        reader.abort();
+        hss.abort();
+    }
+
+    /// A stalled request must not block an unrelated one. This is the exact
+    /// production symptom: one wedged subscriber lookup previously took the
+    /// whole S6a plane with it.
+    #[tokio::test]
+    async fn a_stalled_request_does_not_block_others() {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let cfg = config("hss.example.com", 30);
+        let hss = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &cfg);
+            peer.start().await.unwrap();
+            let _cer = peer.next_event().await.unwrap();
+
+            // Never answer the first request; answer every later one at once.
+            let _stalled = peer.recv_raw().await.unwrap();
+            loop {
+                let msg = match peer.recv_raw().await {
+                    Ok(m) => m,
+                    Err(_) => break,
+                };
+                let mut answer = DiameterMessage::new_answer(&msg);
+                answer.add_avp(Avp::mandatory(268, AvpData::Unsigned32(2001)));
+                if peer.send_message(&answer).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let mut client = DiameterClient::new(config("mme.example.com", 5), addr);
+        client.connect().await.unwrap();
+        let (session, reader) = DiameterSession::start(client).unwrap();
+
+        // Fire the request that will never be answered.
+        let stalled_session = session.clone();
+        let stalled = tokio::spawn(async move {
+            let req = DiameterMessage::new_request(AIR, S6A_APP);
+            stalled_session.send_request(&req).await
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // A second request must complete promptly regardless.
+        let started = tokio::time::Instant::now();
+        let req = DiameterMessage::new_request(AIR, S6A_APP);
+        let answer = session
+            .send_request(&req)
+            .await
+            .expect("the healthy request must be answered");
+        let elapsed = started.elapsed();
+
+        assert_eq!(answer.result_code(), Some(2001));
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "a stalled request blocked an unrelated one: {elapsed:?}"
+        );
+
+        // And the stalled one still terminates on its own timeout.
+        let stalled_result = stalled.await.unwrap();
+        assert!(
+            matches!(stalled_result, Err(DiameterError::RequestTimeout { .. })),
+            "expected RequestTimeout, got {stalled_result:?}"
+        );
+        assert_eq!(
+            session.pending_count().await,
+            0,
+            "a timed-out request leaked its pending entry"
+        );
+        reader.abort();
+        hss.abort();
+    }
+
+    /// Losing the connection must fail in-flight requests immediately rather
+    /// than stalling each for the full timeout.
+    #[tokio::test]
+    async fn disconnect_fails_in_flight_requests_promptly() {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let cfg = config("hss.example.com", 30);
+        let hss = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &cfg);
+            peer.start().await.unwrap();
+            let _cer = peer.next_event().await.unwrap();
+            // Read one request, then drop the connection without answering.
+            let _req = peer.recv_raw().await.unwrap();
+        });
+
+        // request_timeout is 30s here: if the disconnect were not detected the
+        // test would take 30s instead of milliseconds.
+        let mut client = DiameterClient::new(config("mme.example.com", 30), addr);
+        client.connect().await.unwrap();
+        let (session, reader) = DiameterSession::start(client).unwrap();
+
+        let started = tokio::time::Instant::now();
+        let req = DiameterMessage::new_request(AIR, S6A_APP);
+        let result = session.send_request(&req).await;
+        let elapsed = started.elapsed();
+
+        assert!(result.is_err(), "expected an error after disconnect");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "disconnect was not detected promptly: {elapsed:?}"
+        );
+        reader.abort();
+        hss.abort();
+    }
+
+    /// A peer-initiated request (S6a CLR/IDR) must reach the application even
+    /// while answers are being multiplexed.
+    #[tokio::test]
+    async fn peer_initiated_requests_reach_the_application() {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        const CLR: u32 = 317;
+        let cfg = config("hss.example.com", 30);
+        let hss = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &cfg);
+            peer.start().await.unwrap();
+            let _cer = peer.next_event().await.unwrap();
+            let mut clr = DiameterMessage::new_request(CLR, S6A_APP);
+            clr.header.hop_by_hop_id = 0xABCD;
+            clr.add_avp(Avp::mandatory(
+                crate::common::avp_code::SESSION_ID,
+                AvpData::Utf8String("clr-session".into()),
+            ));
+            peer.send_message(&clr).await.unwrap();
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+
+        let mut client = DiameterClient::new(config("mme.example.com", 5), addr);
+        client.connect().await.unwrap();
+        let (session, reader) = DiameterSession::start(client).unwrap();
+
+        let inbound = session
+            .recv_inbound_request(Duration::from_secs(3))
+            .await
+            .expect("no transport error")
+            .expect("a CLR should have arrived");
+        assert_eq!(inbound.header.command_code, CLR);
+        assert_eq!(inbound.session_id(), Some("clr-session"));
+        reader.abort();
+        hss.abort();
+    }
+}

--- a/src/libs/nextgcore-diameter/src/transport.rs
+++ b/src/libs/nextgcore-diameter/src/transport.rs
@@ -392,6 +392,31 @@ impl DiameterClient {
             .unwrap_or(false)
     }
 
+    /// This client's configuration.
+    pub fn config(&self) -> &DiameterConfig {
+        &self.config
+    }
+
+    /// The current Hop-by-Hop and End-to-End counter values.
+    ///
+    /// Handing these to [`crate::session::DiameterSession`] keeps identifier
+    /// allocation continuous across the handover: RFC 6733 §3 wants Hop-by-Hop
+    /// unique per connection, and restarting from zero could collide with an
+    /// identifier already in flight from the CER/CEA exchange.
+    pub fn identifier_seeds(&self) -> (u32, u32) {
+        (self.hop_by_hop, self.end_to_end)
+    }
+
+    /// Consume the client and yield its connected peer, or `None` if it never
+    /// connected.
+    ///
+    /// Exists so [`crate::session::DiameterSession`] can take ownership of an
+    /// already-established connection (including its completed CER/CEA) rather
+    /// than dialling a second one.
+    pub fn into_peer(self) -> Option<DiameterPeer> {
+        self.peer
+    }
+
     /// Send an application-level Diameter request and wait for an answer.
     ///
     /// Hop-by-Hop and End-to-End identifiers are assigned per RFC 6733 if the


### PR DESCRIPTION
Refs #55 — **item 3 of the agreed sequence**, and the largest of the three.

## Problem

mmed held a process-global `Mutex<Option<S6aClientState>>` and every S6a operation took it, then called `send_request` **while holding the guard**:

| Procedure | locks at | sends at |
|---|---|---|
| AIR | `fd_path.rs:437` | `:473` |
| ULR | `:519` | `:549` |
| PUR | `:606` | `:655` |

Because `send_request` awaits the HSS answer, one slow or unanswered exchange blocked **every other subscriber's** authentication, location update and purge — the whole S6a plane, not just the UE that stalled.

`mme_fd_recv_inbound` was worse in one respect: it held the same lock for its entire `timeout` window waiting for a peer-initiated CLR/IDR, so a quiet HSS blocked all outbound requests for the full duration.

#148's request timeout bounded this to 30s per stalled request rather than forever. Better, but 30s of total S6a outage is still an availability defect — and the lock was the cause.

## Why a multiplexer

The mutex exists only because `DiameterClient::send_request` takes `&mut self`. RFC 6733 §3 already gives every request a Hop-by-Hop Identifier the answer must echo — that's a correlation token, so the conventional design is one task owning the connection while senders register a one-shot under their Hop-by-Hop ID. Nothing is serialised except writing to the socket and touching the pending map.

It also composes with the failover RFC 6733 §5.5.4 wants: the pending map is exactly the set of requests that would be re-sent to an alternate peer with the `T` flag set.

## The constraint that shaped the implementation

`DiameterPeer::next_event()` is **not cancel-safe** — it reads a message then calls `process_message`, which can *await a write* (a DWA answering a watchdog, a DPA answering a disconnect). As a `select!` branch, a lost race could drop the future mid-write, leaving a partial message on the wire and desynchronising framing for everything after it.

So `next_event` is split, with existing callers and behaviour untouched:

- **`recv_raw()`** — cancel-safe. Its only await is `read_buf` into a transport-owned buffer, so a dropped future consumes no bytes and a partial message stays buffered. Sound in `select!`.
- **`handle_message(msg)`** — the state machine, still not cancel-safe, never inside `select!`.

Reads and writes interleave in **one** task rather than split reader/writer: `DiameterTransport` isn't built to split into halves, and one task removes any question of two writers interleaving bytes.

**Verified property:** all four remaining `s6a_client().lock()` sites do only synchronous work — clone, counter increment, `abort()`. No `.await` inside any critical section.

## Honest scope note

`mme_fd_connect` and `mme_fd_init_async` currently have **no caller** — `main.rs` calls only the sync `mme_fd_init()`, and mmed's S6a transport is still unimplemented (#42/#43). So this does **not** fix a presently-executing hot path; it makes the S6a plane correct for when that transport lands, and removes a defect that would otherwise be discovered under production load. Concurrency is verified by library tests against real sockets, not by exercising mmed end to end.

## Not in this PR

- **Reconnection / supervision.** `DiameterSession::start` takes a connected client; when the reader sees the peer go it fails every waiter and stops. Redialling is the application's job — folding it in would make this a supervisor as well as a multiplexer.
- **Failover to an alternate peer**, and the `T` retransmit flag.
- **A graceful DPR on shutdown** — the session owns the peer, so `mme_fd_final_async` aborts the reader. Only worth adding once reconnection exists.
- `DiameterClient::send_request` is untouched and still serves single-threaded callers.

## Verification

**5 new tests**, all against real sockets:

- `requests_from_multiple_tasks_overlap` — 3 concurrent requests against a 300ms-latency HSS finish in ~300ms, not ~900ms.
- `answers_are_routed_by_hop_by_hop_id` — a peer answering **out of order** still delivers each answer to the caller that sent the matching request. A naive implementation handing each answer to the next waiter in line would pass the timing test and **fail this one**.
- `a_stalled_request_does_not_block_others` — the production symptom; also asserts `pending_count()` returns to 0, so a timed-out request leaks no waiter.
- `disconnect_fails_in_flight_requests_promptly` — with a 30s timeout configured, a disconnect fails in-flight requests in milliseconds because the reader clears the pending map.
- `peer_initiated_requests_reach_the_application` — CLR/IDR still arrive while answers are multiplexed.

**A real defect in my own first test.** The overlap test failed at 903ms ≈ 3×300ms — and the cause was the **mock HSS**, not the code under test. A sequential `recv → sleep → send` loop can't read request 2 until it has answered request 1, so the harness serialised the exchange and the test accused the client of the mock's defect. The mock now mirrors the real design (`select!` between read and write, timer task per answer).

**Separately verified the timing test can detect the bug:** holding the pending-map lock across the answer wait (simulating lock-across-send) makes it hang past 60s instead of finishing in ~300ms.

Full workspace: **5362 passed, 0 failed** (baseline 5357, +5); `cargo fmt --check` clean; `cargo clippy --workspace` (the CI gate) at **0** — it caught two `doc_lazy_continuation` warnings I introduced when a new doc block landed after an existing `# Arguments` list. The diameter suite ran clean **3/3 consecutive** times, which matters since two tests are timing-sensitive.

**Not exercised:** mmed end to end (no S6a transport yet), and a live association against a third-party HSS.

Spec: `specs/fix-mmed-s6a-concurrent-requests.md`