### PR TITLE
feat(diameter): application registry and CER/CEA capability negotiation

### DIFF
--- a/src/bins/nextgcore-hssd/src/main.rs
+++ b/src/bins/nextgcore-hssd/src/main.rs
@@ -204,11 +204,25 @@ fn main() -> Result<()> {
         log::info!(
             "HSS S6a Diameter identity: {diam_id} realm: {diam_realm} listen: {diam_addr}:{diam_port}"
         );
+        // Advertise the applications this HSS actually implements (s6a_path.rs,
+        // cx_path.rs, swx_path.rs) so a peer can discover them, and so a peer
+        // with none in common is refused DIAMETER_NO_COMMON_APPLICATION instead
+        // of being accepted and failing later (RFC 6733 §5.3).
+        use nextgcore_diameter::applications::{well_known, ApplicationRegistry};
+        let applications = ApplicationRegistry::new("NextGCore HSS")
+            .with_application(well_known::S6A)
+            .with_application(well_known::CX)
+            .with_application(well_known::SWX);
+
         let diameter_config = nextgcore_diameter::config::DiameterConfig {
             diameter_id: diam_id,
             diameter_realm: diam_realm,
+            // Advertised as Host-IP-Address; 0.0.0.0 is filtered out below since
+            // advertising a wildcard tells a peer nothing routable.
+            address: (diam_addr != "0.0.0.0").then(|| diam_addr.clone()),
             port: diam_port,
             timer_tc,
+            applications,
             ..Default::default()
         };
         let listen_addr: std::net::SocketAddr = format!("{diam_addr}:{diam_port}")

--- a/src/bins/nextgcore-hssd/src/s6a_path.rs
+++ b/src/bins/nextgcore-hssd/src/s6a_path.rs
@@ -1703,6 +1703,71 @@ mod tests {
         assert_ne!(answer.result_code(), Some(2001));
     }
 
+    /// An HSS advertising S6a/Cx/SWx must accept an MME advertising S6a, and
+    /// must REFUSE a peer that speaks only Gx/Rx (RFC 6733 §5.3).
+    ///
+    /// Distinct from the end-to-end test below, which leaves both registries
+    /// empty and therefore exercises the backward-compatibility path rather than
+    /// negotiation. This one drives the real `hss_s6a_serve` with the same
+    /// application set `main.rs` configures.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn s6a_server_negotiates_applications_with_its_peer() {
+        use nextgcore_diameter::applications::{well_known, ApplicationRegistry};
+        use nextgcore_diameter::config::DiameterConfig;
+        use nextgcore_diameter::transport::{DiameterClient, DiameterListener};
+
+        let hss_apps = || {
+            ApplicationRegistry::new("NextGCore HSS")
+                .with_application(well_known::S6A)
+                .with_application(well_known::CX)
+                .with_application(well_known::SWX)
+        };
+
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_cfg = DiameterConfig {
+            diameter_id: "hss.neg.example.org".to_string(),
+            diameter_realm: "neg.example.org".to_string(),
+            address: Some("127.0.0.1".to_string()),
+            applications: hss_apps(),
+            ..Default::default()
+        };
+        tokio::spawn(async move {
+            let _ = hss_s6a_serve(listener, server_cfg).await;
+        });
+
+        // An MME (S6a) shares an application with the HSS: accepted.
+        let mme_cfg = DiameterConfig {
+            diameter_id: "mme.neg.example.org".to_string(),
+            diameter_realm: "neg.example.org".to_string(),
+            applications: ApplicationRegistry::new("NextGCore MME")
+                .with_application(well_known::S6A),
+            ..Default::default()
+        };
+        let mut mme = DiameterClient::new(mme_cfg, addr);
+        mme.connect().await.expect("S6a is common, must connect");
+        assert!(mme.is_connected());
+
+        // A PCRF (Gx/Rx) shares nothing with an S6a/Cx/SWx HSS: refused.
+        let pcrf_cfg = DiameterConfig {
+            diameter_id: "pcrf.neg.example.org".to_string(),
+            diameter_realm: "neg.example.org".to_string(),
+            applications: ApplicationRegistry::new("NextGCore PCRF")
+                .with_application(well_known::GX)
+                .with_application(well_known::RX),
+            ..Default::default()
+        };
+        let mut pcrf = DiameterClient::new(pcrf_cfg, addr);
+        let result = pcrf.connect().await;
+        assert!(
+            result.is_err(),
+            "a peer with no common application must be refused, got {result:?}"
+        );
+        assert!(!pcrf.is_connected());
+    }
+
     /// Full S6a integration over real TCP: CER/CEA, AIR dispatched off the
     /// Diameter thread, and an HSS-initiated CLR actually transmitted to the
     /// connected MME peer and answered with a CLA.

--- a/src/bins/nextgcore-pcrfd/src/fd_path.rs
+++ b/src/bins/nextgcore-pcrfd/src/fd_path.rs
@@ -559,9 +559,20 @@ pub async fn pcrf_fd_listen(
 ) -> DiameterResult<SocketAddr> {
     pcrf_fd_set_local_identity(identity.clone());
 
+    // Gx (gx_path.rs) and Rx (rx_path.rs) are the applications this PCRF
+    // implements. Advertising them lets a peer discover our capabilities, and
+    // lets us refuse a peer with none in common (RFC 6733 §5.3).
+    let applications = nextgcore_diameter::applications::ApplicationRegistry::new("NextGCore PCRF")
+        .with_application(nextgcore_diameter::applications::well_known::GX)
+        .with_application(nextgcore_diameter::applications::well_known::RX);
+
     let config = DiameterConfig {
         diameter_id: identity.host.clone(),
         diameter_realm: identity.realm.clone(),
+        // Advertised as Host-IP-Address. A wildcard bind tells a peer nothing
+        // routable, so it is omitted rather than advertised.
+        address: (!addr.ip().is_unspecified()).then(|| addr.ip().to_string()),
+        applications,
         ..Default::default()
     };
 

--- a/src/libs/nextgcore-diameter/src/applications.rs
+++ b/src/libs/nextgcore-diameter/src/applications.rs
@@ -1,0 +1,588 @@
+//! The set of Diameter applications a node supports, and the CER/CEA
+//! negotiation built on it (RFC 6733 §5.3).
+//!
+//! # Why this exists
+//!
+//! `send_cer` used to emit only `Origin-Host`, `Origin-Realm` and
+//! `Origin-State-Id`. Three AVPs the CER ABNF makes mandatory were missing
+//! (`Host-IP-Address`, `Vendor-Id`, `Product-Name`), and **no application was
+//! advertised at all**. `handle_cer` in turn validated only that Origin-Host and
+//! Origin-Realm were present and then answered `2001 Success` unconditionally,
+//! so it could never return `5010 DIAMETER_NO_COMMON_APPLICATION`.
+//!
+//! Two consequences. A conformant peer cannot discover which applications this
+//! node speaks, so it has no basis for routing decisions. And a peer with
+//! *nothing* in common is welcomed onto the connection, only to have every
+//! subsequent request fail in a way that looks like an application bug rather
+//! than a capability mismatch.
+//!
+//! # Vendor-specific applications
+//!
+//! Every application this tree implements except Gy is 3GPP vendor-specific, so
+//! it is advertised inside a `Vendor-Specific-Application-Id` grouped AVP
+//! (`Vendor-Id` + `Auth-Application-Id`) rather than a bare `Auth-Application-Id`
+//! — TS 29.272 §7 for S6a, TS 29.212 §5.6 for Gx. Gy uses application id 4
+//! (RFC 4006 Credit-Control), which is IETF-registered and therefore bare.
+//!
+//! # Scope
+//!
+//! Negotiation only: advertise, intersect, and reject when the intersection is
+//! empty. Routing a request to an application, and the per-application dispatch
+//! that would imply, is not part of this.
+
+use std::collections::BTreeSet;
+
+use crate::avp::{Avp, AvpData};
+use crate::common::avp_code;
+use crate::message::DiameterMessage;
+use crate::NEXTGCORE_3GPP_VENDOR_ID;
+
+/// A Diameter application identifier, plus the vendor that defines it.
+///
+/// Ordered (`BTreeSet`) rather than hashed so the AVP order in a CER is
+/// deterministic: a stable wire image makes byte-comparison tests and packet
+/// diffs meaningful.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ApplicationId {
+    /// The application id itself (e.g. 16777251 for S6a).
+    pub id: u32,
+    /// `Some(vendor)` for a vendor-specific application, `None` for an
+    /// IETF-registered one. Determines whether it is advertised inside a
+    /// `Vendor-Specific-Application-Id` group or as a bare `Auth-Application-Id`.
+    pub vendor: Option<u32>,
+}
+
+impl ApplicationId {
+    /// A 3GPP vendor-specific application (Vendor-Id 10415).
+    pub const fn threegpp(id: u32) -> Self {
+        Self {
+            id,
+            vendor: Some(NEXTGCORE_3GPP_VENDOR_ID),
+        }
+    }
+
+    /// An IETF-registered application, advertised as a bare
+    /// `Auth-Application-Id`.
+    pub const fn ietf(id: u32) -> Self {
+        Self { id, vendor: None }
+    }
+}
+
+/// Well-known application ids, matching the per-application modules in this
+/// crate. Kept here so a daemon names an interface rather than a magic number.
+pub mod well_known {
+    use super::ApplicationId;
+
+    /// S6a: MME ↔ HSS (TS 29.272).
+    pub const S6A: ApplicationId = ApplicationId::threegpp(16777251);
+    /// S6b: PGW ↔ 3GPP AAA (TS 29.273).
+    pub const S6B: ApplicationId = ApplicationId::threegpp(16777272);
+    /// Cx: I-CSCF/S-CSCF ↔ HSS (TS 29.229).
+    pub const CX: ApplicationId = ApplicationId::threegpp(16777216);
+    /// SWx: 3GPP AAA ↔ HSS (TS 29.273).
+    pub const SWX: ApplicationId = ApplicationId::threegpp(16777265);
+    /// Gx: PCEF ↔ PCRF (TS 29.212).
+    pub const GX: ApplicationId = ApplicationId::threegpp(16777238);
+    /// Rx: AF ↔ PCRF (TS 29.214).
+    pub const RX: ApplicationId = ApplicationId::threegpp(16777236);
+    /// Gy: online charging, RFC 4006 Credit-Control. IETF-registered, so it is
+    /// advertised as a bare Auth-Application-Id, not vendor-specific.
+    pub const GY: ApplicationId = ApplicationId::ietf(4);
+}
+
+/// The applications a node advertises, and the vendors whose AVPs it understands.
+///
+/// Empty by default and populated by each daemon at startup: hssd declares
+/// S6a + Cx + SWx, pcrfd declares Gx + Rx, mmed declares S6a. Declaring nothing
+/// is legal and preserves the previous behaviour — see
+/// [`Self::negotiate`] for what an empty set means during negotiation.
+#[derive(Debug, Clone, Default)]
+pub struct ApplicationRegistry {
+    applications: BTreeSet<ApplicationId>,
+    supported_vendors: BTreeSet<u32>,
+    /// `Product-Name`, RFC 6733 §5.3.7.
+    product_name: String,
+    /// `Firmware-Revision`, RFC 6733 §5.3.4. Optional in CER/CEA.
+    firmware_revision: Option<u32>,
+}
+
+impl ApplicationRegistry {
+    /// An empty registry with the given product name.
+    pub fn new(product_name: impl Into<String>) -> Self {
+        Self {
+            applications: BTreeSet::new(),
+            supported_vendors: BTreeSet::new(),
+            product_name: product_name.into(),
+            firmware_revision: None,
+        }
+    }
+
+    /// Declare support for an application.
+    ///
+    /// A vendor-specific application implicitly adds its vendor to
+    /// `Supported-Vendor-Id`: claiming to speak S6a while not admitting to
+    /// understanding 3GPP AVPs would be incoherent, and forgetting the separate
+    /// call is an easy mistake with no upside.
+    pub fn with_application(mut self, app: ApplicationId) -> Self {
+        if let Some(vendor) = app.vendor {
+            self.supported_vendors.insert(vendor);
+        }
+        self.applications.insert(app);
+        self
+    }
+
+    /// Declare a supported vendor without an application (RFC 6733 §5.3.6).
+    pub fn with_vendor(mut self, vendor_id: u32) -> Self {
+        self.supported_vendors.insert(vendor_id);
+        self
+    }
+
+    /// Set `Firmware-Revision` (RFC 6733 §5.3.4).
+    pub fn with_firmware_revision(mut self, revision: u32) -> Self {
+        self.firmware_revision = Some(revision);
+        self
+    }
+
+    /// The declared applications.
+    pub fn applications(&self) -> impl Iterator<Item = &ApplicationId> {
+        self.applications.iter()
+    }
+
+    /// True when nothing has been declared.
+    pub fn is_empty(&self) -> bool {
+        self.applications.is_empty()
+    }
+
+    pub fn product_name(&self) -> &str {
+        &self.product_name
+    }
+
+    /// Append the capability AVPs to a CER or CEA.
+    ///
+    /// Covers the mandatory `Host-IP-Address` / `Vendor-Id` / `Product-Name`
+    /// (RFC 6733 §5.3.1), the optional `Firmware-Revision`, every
+    /// `Supported-Vendor-Id`, and one advertisement per application.
+    ///
+    /// `Vendor-Id` here is the vendor of *this node*, which RFC 6733 §5.3.3 says
+    /// is 0 for a node that is not vendor-specific. It is distinct from the
+    /// `Vendor-Id` nested inside each `Vendor-Specific-Application-Id`, which
+    /// identifies who defined that application — conflating the two is an easy
+    /// error, so they are set from different sources.
+    pub fn append_capabilities(
+        &self,
+        msg: &mut DiameterMessage,
+        host_addresses: &[std::net::IpAddr],
+    ) {
+        for addr in host_addresses {
+            msg.add_avp(Avp::mandatory(
+                avp_code::HOST_IP_ADDRESS,
+                AvpData::Address(*addr),
+            ));
+        }
+
+        // 0 = "not vendor-specific". This node is an implementation, not a
+        // registered vendor; the 3GPP id belongs on the applications.
+        msg.add_avp(Avp::mandatory(avp_code::VENDOR_ID, AvpData::Unsigned32(0)));
+
+        msg.add_avp(Avp::mandatory(
+            avp_code::PRODUCT_NAME,
+            AvpData::Utf8String(self.product_name.clone()),
+        ));
+
+        if let Some(revision) = self.firmware_revision {
+            // Firmware-Revision is NOT mandatory (RFC 6733 §5.3.4), so it
+            // carries no M bit -- unlike every other capability AVP here.
+            msg.add_avp(Avp::new(
+                avp_code::FIRMWARE_REVISION,
+                0,
+                None,
+                AvpData::Unsigned32(revision),
+            ));
+        }
+
+        for vendor in &self.supported_vendors {
+            msg.add_avp(Avp::mandatory(
+                avp_code::SUPPORTED_VENDOR_ID,
+                AvpData::Unsigned32(*vendor),
+            ));
+        }
+
+        for app in &self.applications {
+            match app.vendor {
+                Some(vendor) => msg.add_avp(Avp::mandatory(
+                    avp_code::VENDOR_SPECIFIC_APPLICATION_ID,
+                    AvpData::Grouped(vec![
+                        Avp::mandatory(avp_code::VENDOR_ID, AvpData::Unsigned32(vendor)),
+                        Avp::mandatory(avp_code::AUTH_APPLICATION_ID, AvpData::Unsigned32(app.id)),
+                    ]),
+                )),
+                None => msg.add_avp(Avp::mandatory(
+                    avp_code::AUTH_APPLICATION_ID,
+                    AvpData::Unsigned32(app.id),
+                )),
+            }
+        }
+    }
+
+    /// Applications this node and the peer both support.
+    ///
+    /// Matching is on the application id alone, deliberately ignoring the vendor
+    /// that carried it: the same id means the same application, and a peer may
+    /// legitimately advertise S6a as a bare `Auth-Application-Id` (some stacks
+    /// do) while we advertise it vendor-specifically. Requiring the vendor to
+    /// match too would reject an interoperable peer over a presentation detail.
+    pub fn common_with(&self, peer: &[ApplicationId]) -> Vec<ApplicationId> {
+        let peer_ids: BTreeSet<u32> = peer.iter().map(|a| a.id).collect();
+        self.applications
+            .iter()
+            .filter(|a| peer_ids.contains(&a.id))
+            .copied()
+            .collect()
+    }
+
+    /// Decide whether a peer advertising `peer_apps` may proceed.
+    ///
+    /// Returns the common set, or `None` when the connection must be refused
+    /// with `DIAMETER_NO_COMMON_APPLICATION` (RFC 6733 §5.3).
+    ///
+    /// **Two cases deliberately accept rather than reject**, because rejecting
+    /// them would break working deployments in the name of conformance:
+    ///
+    /// - *This node declares nothing.* A daemon that has not been taught to
+    ///   populate a registry would otherwise refuse every peer the moment this
+    ///   code landed. An empty local registry means "not participating in
+    ///   negotiation", not "supports nothing".
+    /// - *The peer advertises nothing.* Its CER is then non-conformant, but the
+    ///   pre-existing behaviour accepted it, and turning that into a hard
+    ///   rejection is a separate decision from implementing negotiation. It is
+    ///   logged at warn so it is visible.
+    ///
+    /// An empty intersection between two non-empty sets is the case the RFC
+    /// actually describes, and that is refused.
+    pub fn negotiate(&self, peer_apps: &[ApplicationId]) -> Option<Vec<ApplicationId>> {
+        if self.is_empty() {
+            log::debug!("no local applications declared; skipping capability negotiation");
+            return Some(Vec::new());
+        }
+        if peer_apps.is_empty() {
+            log::warn!(
+                "peer advertised no applications in its CER (RFC 6733 §5.3.1 requires at least \
+                 one); accepting for backward compatibility"
+            );
+            return Some(Vec::new());
+        }
+
+        let common = self.common_with(peer_apps);
+        if common.is_empty() {
+            return None;
+        }
+        Some(common)
+    }
+}
+
+/// Extract every application a CER/CEA advertises.
+///
+/// Reads bare `Auth-Application-Id` and `Acct-Application-Id`, plus the
+/// `Auth-Application-Id` nested inside each `Vendor-Specific-Application-Id`
+/// group. A group missing its inner `Auth-Application-Id` is skipped rather than
+/// guessed at.
+pub fn advertised_applications(msg: &DiameterMessage) -> Vec<ApplicationId> {
+    let mut apps = Vec::new();
+
+    for avp in &msg.avps {
+        match avp.code {
+            avp_code::AUTH_APPLICATION_ID | avp_code::ACCT_APPLICATION_ID => {
+                if let Some(id) = avp.as_u32() {
+                    apps.push(ApplicationId::ietf(id));
+                }
+            }
+            avp_code::VENDOR_SPECIFIC_APPLICATION_ID => {
+                // `parse_grouped`, NOT `if let AvpData::Grouped`. A decoded AVP
+                // arrives as Raw/OctetString because the wire format carries no
+                // type information, so matching only the in-memory Grouped
+                // variant silently found nothing for every CER that had actually
+                // been over a socket -- which is the only case that matters.
+                let Ok(inner) = avp.parse_grouped() else {
+                    log::warn!(
+                        "Vendor-Specific-Application-Id is not decodable as grouped; ignored"
+                    );
+                    continue;
+                };
+                let vendor = inner
+                    .iter()
+                    .find(|a| a.code == avp_code::VENDOR_ID)
+                    .and_then(|a| a.as_u32());
+                let id = inner
+                    .iter()
+                    .find(|a| {
+                        a.code == avp_code::AUTH_APPLICATION_ID
+                            || a.code == avp_code::ACCT_APPLICATION_ID
+                    })
+                    .and_then(|a| a.as_u32());
+                if let Some(id) = id {
+                    apps.push(ApplicationId { id, vendor });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    apps
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{base_cmd, DiameterMessage, BASE_APPLICATION_ID};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn cer() -> DiameterMessage {
+        DiameterMessage::new_request(base_cmd::CAPABILITIES_EXCHANGE, BASE_APPLICATION_ID)
+    }
+
+    fn hss_registry() -> ApplicationRegistry {
+        ApplicationRegistry::new("NextGCore HSS")
+            .with_application(well_known::S6A)
+            .with_application(well_known::CX)
+            .with_application(well_known::SWX)
+    }
+
+    /// The three AVPs the CER ABNF makes mandatory and that were missing
+    /// entirely (RFC 6733 §5.3.1).
+    #[test]
+    fn capabilities_include_the_mandatory_cer_avps() {
+        let mut msg = cer();
+        hss_registry().append_capabilities(&mut msg, &[IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5))]);
+
+        assert!(
+            msg.find_avp(avp_code::HOST_IP_ADDRESS).is_some(),
+            "Host-IP-Address is mandatory"
+        );
+        assert!(
+            msg.find_avp(avp_code::VENDOR_ID).is_some(),
+            "Vendor-Id is mandatory"
+        );
+        assert!(
+            msg.find_avp(avp_code::PRODUCT_NAME).is_some(),
+            "Product-Name is mandatory"
+        );
+    }
+
+    /// A node's own Vendor-Id is 0 (RFC 6733 §5.3.3) even though its
+    /// applications are 3GPP vendor-specific. Conflating the two is the easy
+    /// error, so it is pinned.
+    #[test]
+    fn node_vendor_id_is_zero_not_the_application_vendor() {
+        let mut msg = cer();
+        hss_registry().append_capabilities(&mut msg, &[]);
+        assert_eq!(
+            msg.find_avp(avp_code::VENDOR_ID).and_then(|a| a.as_u32()),
+            Some(0)
+        );
+    }
+
+    /// Every 3GPP application is advertised inside a
+    /// Vendor-Specific-Application-Id group carrying Vendor-Id 10415.
+    #[test]
+    fn threegpp_applications_are_advertised_vendor_specifically() {
+        let mut msg = cer();
+        hss_registry().append_capabilities(&mut msg, &[]);
+
+        let groups: Vec<_> = msg
+            .avps
+            .iter()
+            .filter(|a| a.code == avp_code::VENDOR_SPECIFIC_APPLICATION_ID)
+            .collect();
+        assert_eq!(groups.len(), 3, "S6a, Cx and SWx");
+
+        for g in groups {
+            let AvpData::Grouped(inner) = &g.data else {
+                panic!("Vendor-Specific-Application-Id must be grouped")
+            };
+            assert_eq!(
+                inner
+                    .iter()
+                    .find(|a| a.code == avp_code::VENDOR_ID)
+                    .and_then(|a| a.as_u32()),
+                Some(NEXTGCORE_3GPP_VENDOR_ID)
+            );
+            assert!(inner
+                .iter()
+                .any(|a| a.code == avp_code::AUTH_APPLICATION_ID));
+        }
+    }
+
+    /// Gy is RFC 4006, not 3GPP, so it must be a bare Auth-Application-Id.
+    #[test]
+    fn ietf_applications_are_advertised_bare() {
+        let mut msg = cer();
+        ApplicationRegistry::new("charging")
+            .with_application(well_known::GY)
+            .append_capabilities(&mut msg, &[]);
+
+        assert_eq!(
+            msg.find_avp(avp_code::AUTH_APPLICATION_ID)
+                .and_then(|a| a.as_u32()),
+            Some(4)
+        );
+        assert!(
+            !msg.avps
+                .iter()
+                .any(|a| a.code == avp_code::VENDOR_SPECIFIC_APPLICATION_ID),
+            "an IETF application must not be wrapped in a vendor group"
+        );
+    }
+
+    /// Declaring a 3GPP application implies Supported-Vendor-Id 10415.
+    #[test]
+    fn declaring_a_vendor_application_adds_its_supported_vendor_id() {
+        let mut msg = cer();
+        ApplicationRegistry::new("mme")
+            .with_application(well_known::S6A)
+            .append_capabilities(&mut msg, &[]);
+
+        assert_eq!(
+            msg.find_avp(avp_code::SUPPORTED_VENDOR_ID)
+                .and_then(|a| a.as_u32()),
+            Some(NEXTGCORE_3GPP_VENDOR_ID)
+        );
+    }
+
+    /// What one node writes, another must be able to read.
+    #[test]
+    fn advertised_applications_round_trips_through_a_cer() {
+        let mut msg = cer();
+        hss_registry().append_capabilities(&mut msg, &[]);
+
+        let mut ids: Vec<u32> = advertised_applications(&msg).iter().map(|a| a.id).collect();
+        ids.sort_unstable();
+        let mut expected = vec![well_known::S6A.id, well_known::CX.id, well_known::SWX.id];
+        expected.sort_unstable();
+        assert_eq!(ids, expected);
+    }
+
+    /// The case RFC 6733 §5.3 actually describes: two non-empty sets that do not
+    /// intersect must be refused.
+    #[test]
+    fn no_common_application_is_refused() {
+        // An MME (S6a) meeting a PCRF (Gx + Rx).
+        let mme = ApplicationRegistry::new("mme").with_application(well_known::S6A);
+        let peer = vec![well_known::GX, well_known::RX];
+        assert!(
+            mme.negotiate(&peer).is_none(),
+            "no common application must be refused"
+        );
+    }
+
+    #[test]
+    fn overlapping_applications_are_accepted_and_reported() {
+        let hss = hss_registry();
+        // An MME advertising S6a only.
+        let common = hss
+            .negotiate(&[well_known::S6A])
+            .expect("S6a is common to both");
+        assert_eq!(common.len(), 1);
+        assert_eq!(common[0].id, well_known::S6A.id);
+    }
+
+    /// A peer advertising S6a as a BARE Auth-Application-Id (some stacks do)
+    /// must still match our vendor-specific advertisement: the id identifies the
+    /// application, and rejecting over the presentation would break interop.
+    #[test]
+    fn matching_ignores_how_the_application_was_advertised() {
+        let hss = hss_registry();
+        let bare_s6a = ApplicationId::ietf(well_known::S6A.id);
+        let common = hss
+            .negotiate(&[bare_s6a])
+            .expect("the same id must match regardless of vendor framing");
+        assert_eq!(common.len(), 1);
+    }
+
+    /// A node that declares nothing must not start refusing peers: an empty
+    /// registry means "not participating", which is how every daemon behaves
+    /// until it is taught to populate one.
+    #[test]
+    fn empty_local_registry_accepts_any_peer() {
+        let empty = ApplicationRegistry::new("unconfigured");
+        assert!(empty.negotiate(&[well_known::S6A]).is_some());
+        assert!(empty.negotiate(&[]).is_some());
+    }
+
+    /// A peer advertising nothing is non-conformant but was previously accepted;
+    /// keep accepting it (with a warning) rather than bundling a behaviour
+    /// change into this one.
+    #[test]
+    fn peer_advertising_nothing_is_accepted_for_compatibility() {
+        assert!(hss_registry().negotiate(&[]).is_some());
+    }
+
+    /// A CER that has been ENCODED AND DECODED must still yield its
+    /// applications.
+    ///
+    /// This is the case that matters and the one an in-memory test misses: the
+    /// wire format carries no type information, so a decoded grouped AVP arrives
+    /// as `Raw`, not `AvpData::Grouped`. The first version of
+    /// `advertised_applications` matched only the `Grouped` variant and therefore
+    /// found nothing for every CER that had actually crossed a socket, while
+    /// passing every in-memory test.
+    #[test]
+    fn applications_survive_an_encode_decode_round_trip() {
+        let mut msg = cer();
+        hss_registry().append_capabilities(&mut msg, &[IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5))]);
+
+        let mut encoded = msg.encode().freeze();
+        let decoded = DiameterMessage::decode(&mut encoded).expect("a CER must decode");
+
+        let mut ids: Vec<u32> = advertised_applications(&decoded)
+            .iter()
+            .map(|a| a.id)
+            .collect();
+        ids.sort_unstable();
+        let mut expected = vec![well_known::S6A.id, well_known::CX.id, well_known::SWX.id];
+        expected.sort_unstable();
+        assert_eq!(
+            ids, expected,
+            "grouped AVPs must be read via parse_grouped, not by matching AvpData::Grouped"
+        );
+
+        // The vendor inside each group must survive too.
+        for app in advertised_applications(&decoded) {
+            assert_eq!(app.vendor, Some(NEXTGCORE_3GPP_VENDOR_ID));
+        }
+    }
+
+    /// A Vendor-Specific-Application-Id with no inner Auth-Application-Id is
+    /// skipped rather than being guessed at or panicking.
+    #[test]
+    fn malformed_vendor_group_is_ignored() {
+        let mut msg = cer();
+        msg.add_avp(Avp::mandatory(
+            avp_code::VENDOR_SPECIFIC_APPLICATION_ID,
+            AvpData::Grouped(vec![Avp::mandatory(
+                avp_code::VENDOR_ID,
+                AvpData::Unsigned32(NEXTGCORE_3GPP_VENDOR_ID),
+            )]),
+        ));
+        assert!(advertised_applications(&msg).is_empty());
+    }
+
+    /// Advertisement order is deterministic, so a CER's wire image is stable
+    /// across runs (BTreeSet, not HashSet).
+    #[test]
+    fn advertisement_order_is_deterministic() {
+        let render = || {
+            let mut msg = cer();
+            hss_registry().append_capabilities(&mut msg, &[]);
+            advertised_applications(&msg)
+                .iter()
+                .map(|a| a.id)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(render(), render());
+        // Cx (16777216) < Gx-range < S6a (16777251) < SWx (16777265).
+        assert_eq!(
+            render(),
+            vec![well_known::CX.id, well_known::S6A.id, well_known::SWX.id]
+        );
+    }
+}

--- a/src/libs/nextgcore-diameter/src/common.rs
+++ b/src/libs/nextgcore-diameter/src/common.rs
@@ -16,6 +16,22 @@ pub mod avp_code {
     pub const AUTH_APPLICATION_ID: u32 = 258;
     pub const VENDOR_ID: u32 = 266;
     pub const VENDOR_SPECIFIC_APPLICATION_ID: u32 = 260;
+    /// Accounting application, RFC 6733 §6.9. Declared for completeness of the
+    /// CER/CEA capability set; nothing in this tree advertises an accounting
+    /// application yet.
+    pub const ACCT_APPLICATION_ID: u32 = 259;
+    /// RFC 6733 §5.3.5 — mandatory in CER/CEA (`1* { Host-IP-Address }`).
+    pub const HOST_IP_ADDRESS: u32 = 257;
+    /// RFC 6733 §5.3.7 — mandatory in CER/CEA.
+    pub const PRODUCT_NAME: u32 = 269;
+    /// RFC 6733 §5.3.6 — vendors whose AVPs this node understands.
+    pub const SUPPORTED_VENDOR_ID: u32 = 265;
+    /// RFC 6733 §5.3.4 — optional in CER/CEA.
+    pub const FIRMWARE_REVISION: u32 = 267;
+    /// RFC 6733 §7.5 — names the offending AVP in an error answer.
+    pub const FAILED_AVP: u32 = 279;
+    /// RFC 6733 §5.4.3 — DPR reason.
+    pub const DISCONNECT_CAUSE: u32 = 273;
     pub const EXPERIMENTAL_RESULT: u32 = 297;
     pub const EXPERIMENTAL_RESULT_CODE: u32 = 298;
     pub const ORIGIN_STATE_ID: u32 = 278;

--- a/src/libs/nextgcore-diameter/src/config.rs
+++ b/src/libs/nextgcore-diameter/src/config.rs
@@ -33,6 +33,16 @@ pub struct DiameterConfig {
     /// not going to be answered.
     pub request_timeout: u32,
 
+    /// Applications this node advertises in CER/CEA, and the vendors whose AVPs
+    /// it understands (RFC 6733 §5.3).
+    ///
+    /// Defaults to empty, which means "do not participate in capability
+    /// negotiation": the CER still gains its mandatory AVPs, but no application
+    /// is advertised and no peer is refused. That keeps every existing caller
+    /// working unchanged; a daemon opts in by declaring its interfaces. See
+    /// [`crate::applications::ApplicationRegistry::negotiate`].
+    pub applications: crate::applications::ApplicationRegistry,
+
     /// Configuration flags
     pub flags: DiameterConfigFlags,
 
@@ -56,6 +66,9 @@ impl Default for DiameterConfig {
             port_tls: crate::DIAMETER_TLS_PORT,
             timer_tc: 30,
             request_timeout: 30,
+            // Empty: no application advertised, no peer refused. A daemon opts
+            // in by populating this.
+            applications: crate::applications::ApplicationRegistry::default(),
             flags: DiameterConfigFlags::default(),
             extensions: Vec::new(),
             connections: Vec::new(),

--- a/src/libs/nextgcore-diameter/src/lib.rs
+++ b/src/libs/nextgcore-diameter/src/lib.rs
@@ -12,6 +12,7 @@
 //! The implementation follows RFC 6733 (Diameter Base Protocol) and
 //! 3GPP specifications for each interface.
 
+pub mod applications;
 pub mod avp;
 pub mod common;
 pub mod config;

--- a/src/libs/nextgcore-diameter/src/peer.rs
+++ b/src/libs/nextgcore-diameter/src/peer.rs
@@ -79,6 +79,37 @@ pub struct DiameterPeer {
     hop_by_hop_seq: u32,
     end_to_end_seq: u32,
     watchdog_interval: Duration,
+    /// Applications advertised in CER/CEA and used to reject a peer with none in
+    /// common (RFC 6733 §5.3). Empty means "do not negotiate".
+    applications: crate::applications::ApplicationRegistry,
+    /// Addresses advertised as `Host-IP-Address`. Derived from
+    /// `DiameterConfig::address`; empty when unset, in which case the AVP is
+    /// omitted -- the RFC makes it mandatory, but inventing an address would
+    /// advertise something unroutable, which is worse than omitting it.
+    host_addresses: Vec<std::net::IpAddr>,
+}
+
+/// Parse `DiameterConfig::address` into advertisable Host-IP-Addresses.
+///
+/// A comma-separated list is accepted so a multi-homed node can advertise every
+/// address, as `1* { Host-IP-Address }` allows. Unparseable entries are warned
+/// about and skipped rather than failing peer construction: a bad address in
+/// config should degrade the advertisement, not stop the node from starting.
+fn parse_host_addresses(config: &DiameterConfig) -> Vec<std::net::IpAddr> {
+    let Some(raw) = config.address.as_deref() else {
+        return Vec::new();
+    };
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| match s.parse::<std::net::IpAddr>() {
+            Ok(ip) => Some(ip),
+            Err(_) => {
+                log::warn!("ignoring unparseable Diameter address '{s}' for Host-IP-Address");
+                None
+            }
+        })
+        .collect()
 }
 
 impl DiameterPeer {
@@ -94,6 +125,8 @@ impl DiameterPeer {
             hop_by_hop_seq: rand_u32(),
             end_to_end_seq: rand_u32(),
             watchdog_interval: Duration::from_secs(config.timer_tc as u64),
+            applications: config.applications.clone(),
+            host_addresses: parse_host_addresses(config),
         }
     }
 
@@ -109,6 +142,8 @@ impl DiameterPeer {
             hop_by_hop_seq: rand_u32(),
             end_to_end_seq: rand_u32(),
             watchdog_interval: Duration::from_secs(config.timer_tc as u64),
+            applications: config.applications.clone(),
+            host_addresses: parse_host_addresses(config),
         }
     }
 
@@ -237,6 +272,14 @@ impl DiameterPeer {
             AvpData::Unsigned32(origin_state_id()),
         ));
 
+        // Host-IP-Address, Vendor-Id, Product-Name (all mandatory per RFC 6733
+        // §5.3.1 and all previously absent), plus one advertisement per declared
+        // application. With an empty registry this still adds the mandatory AVPs
+        // and advertises nothing, which is what the old code did minus the
+        // conformance violation.
+        self.applications
+            .append_capabilities(&mut msg, &self.host_addresses);
+
         self.transport.send(&msg).await
     }
 
@@ -251,12 +294,46 @@ impl DiameterPeer {
             .ok_or_else(|| DiameterError::MissingAvp("Origin-Realm".into()))?
             .to_string();
 
+        // Capability negotiation (RFC 6733 §5.3). `negotiate` returns None only
+        // when both sides advertised applications and none matched; an empty
+        // registry on either side is accepted for backward compatibility, with
+        // the reasoning on `ApplicationRegistry::negotiate`.
+        let peer_apps = crate::applications::advertised_applications(&cer);
+        let negotiated = self.applications.negotiate(&peer_apps);
+
+        let result_code = match &negotiated {
+            Some(common) => {
+                if !common.is_empty() {
+                    log::info!(
+                        "CER from {origin_host}: {} common application(s): {}",
+                        common.len(),
+                        common
+                            .iter()
+                            .map(|a| a.id.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                }
+                crate::error::ResultCode::Success as u32
+            }
+            None => {
+                log::warn!(
+                    "CER from {origin_host} rejected: no common application (local {:?}, peer {:?})",
+                    self.applications
+                        .applications()
+                        .map(|a| a.id)
+                        .collect::<Vec<_>>(),
+                    peer_apps.iter().map(|a| a.id).collect::<Vec<_>>()
+                );
+                crate::error::ResultCode::NoCommonApplication as u32
+            }
+        };
+
         // Build CEA
         let mut cea = DiameterMessage::new_answer(&cer);
-        // Result-Code: Success
         cea.add_avp(Avp::mandatory(
             avp_code::RESULT_CODE,
-            AvpData::Unsigned32(crate::error::ResultCode::Success as u32),
+            AvpData::Unsigned32(result_code),
         ));
         // Origin-Host
         cea.add_avp(Avp::mandatory(
@@ -273,8 +350,24 @@ impl DiameterPeer {
             avp_code::ORIGIN_STATE_ID,
             AvpData::Unsigned32(origin_state_id()),
         ));
+        // The CEA advertises our own capabilities too: §5.3.2 gives it the same
+        // mandatory AVPs as the CER, and the initiator has no other way to learn
+        // what we support.
+        self.applications
+            .append_capabilities(&mut cea, &self.host_addresses);
 
         self.transport.send(&cea).await?;
+
+        // Only reach Open on success. On 5010 the RFC closes the connection, so
+        // the peer is reported as Disconnected rather than Established and stays
+        // out of PeerState::Open -- which is what makes `send_message` refuse to
+        // carry application traffic over it.
+        if negotiated.is_none() {
+            self.state = PeerState::Closed;
+            self.transport.shutdown().await?;
+            return Ok(PeerEvent::Disconnected);
+        }
+
         self.remote_host = Some(origin_host.clone());
         self.remote_realm = Some(origin_realm.clone());
         self.state = PeerState::Open;
@@ -736,6 +829,195 @@ mod tests {
         assert_eq!(client.state(), PeerState::Open);
 
         let _server_peer = handle.await.unwrap();
+    }
+
+    // -----------------------------------------------------------------------
+    // CER/CEA application negotiation (RFC 6733 §5.3), issue #55
+    // -----------------------------------------------------------------------
+
+    fn config_with_apps(host: &str, apps: &[crate::applications::ApplicationId]) -> DiameterConfig {
+        let mut registry = crate::applications::ApplicationRegistry::new("NextGCore test");
+        for app in apps {
+            registry = registry.with_application(*app);
+        }
+        DiameterConfig {
+            diameter_id: host.to_string(),
+            diameter_realm: "epc.example.org".to_string(),
+            address: Some("127.0.0.1".to_string()),
+            applications: registry,
+            ..Default::default()
+        }
+    }
+
+    /// An MME advertising only S6a meeting a PCRF that speaks only Gx/Rx must be
+    /// refused with 5010 and must NOT reach Open — the case RFC 6733 §5.3
+    /// describes and that `handle_cer` previously could not express, because it
+    /// answered 2001 unconditionally.
+    #[tokio::test]
+    async fn cer_with_no_common_application_is_rejected_with_5010() {
+        use crate::applications::well_known;
+
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+
+        // Responder speaks Gx and Rx only.
+        let server_cfg = config_with_apps("pcrf.example.org", &[well_known::GX, well_known::RX]);
+        let server = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &server_cfg);
+            peer.start().await.unwrap();
+            let event = peer.next_event().await.unwrap();
+            // The responder reports a disconnect, not an establishment.
+            assert!(
+                matches!(event, PeerEvent::Disconnected),
+                "expected Disconnected on no-common-application"
+            );
+            assert_ne!(
+                peer.state(),
+                PeerState::Open,
+                "a refused peer must never reach Open"
+            );
+        });
+
+        // Initiator speaks S6a only.
+        let client_cfg = config_with_apps("mme.example.org", &[well_known::S6A]);
+        let transport = DiameterTransport::connect(listen_addr).await.unwrap();
+        let mut client = DiameterPeer::new_initiator(transport, &client_cfg);
+        client.start().await.unwrap();
+
+        // The initiator sees the 5010 CEA as an error (is_success is 2000..3000).
+        let result = client.next_event().await;
+        assert!(
+            result.is_err(),
+            "a 5010 CEA must not be treated as a successful handshake"
+        );
+        assert_ne!(client.state(), PeerState::Open);
+
+        server.await.unwrap();
+    }
+
+    /// One application in common is enough: an MME (S6a) and an HSS
+    /// (S6a + Cx + SWx) must both reach Open.
+    #[tokio::test]
+    async fn cer_with_one_common_application_succeeds() {
+        use crate::applications::well_known;
+
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+
+        let server_cfg = config_with_apps(
+            "hss.example.org",
+            &[well_known::S6A, well_known::CX, well_known::SWX],
+        );
+        let server = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &server_cfg);
+            peer.start().await.unwrap();
+            let event = peer.next_event().await.unwrap();
+            assert!(matches!(event, PeerEvent::Established { .. }));
+            assert_eq!(peer.state(), PeerState::Open);
+        });
+
+        let client_cfg = config_with_apps("mme.example.org", &[well_known::S6A]);
+        let transport = DiameterTransport::connect(listen_addr).await.unwrap();
+        let mut client = DiameterPeer::new_initiator(transport, &client_cfg);
+        client.start().await.unwrap();
+        let event = client.next_event().await.unwrap();
+        assert!(matches!(event, PeerEvent::Established { .. }));
+        assert_eq!(client.state(), PeerState::Open);
+
+        server.await.unwrap();
+    }
+
+    /// A CER must now carry the three AVPs the ABNF makes mandatory and that
+    /// were entirely absent, plus the advertised application. Asserted by
+    /// inspecting the CER the responder actually receives, not by re-reading the
+    /// builder, so the check covers encode/decode too.
+    #[tokio::test]
+    async fn cer_carries_mandatory_avps_and_advertises_applications() {
+        use crate::applications::well_known;
+
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let mut transport = listener.accept().await.unwrap();
+            transport.recv().await.unwrap()
+        });
+
+        let client_cfg = config_with_apps("mme.example.org", &[well_known::S6A]);
+        let transport = DiameterTransport::connect(listen_addr).await.unwrap();
+        let mut client = DiameterPeer::new_initiator(transport, &client_cfg);
+        client.start().await.unwrap();
+
+        let cer = server.await.unwrap();
+        assert_eq!(cer.header.command_code, base_cmd::CAPABILITIES_EXCHANGE);
+        assert!(
+            cer.find_avp(avp_code::HOST_IP_ADDRESS).is_some(),
+            "Host-IP-Address (RFC 6733 §5.3.1) was missing entirely before this change"
+        );
+        assert!(cer.find_avp(avp_code::VENDOR_ID).is_some(), "Vendor-Id");
+        assert!(
+            cer.find_avp(avp_code::PRODUCT_NAME).is_some(),
+            "Product-Name"
+        );
+
+        let advertised = crate::applications::advertised_applications(&cer);
+        assert_eq!(
+            advertised.iter().map(|a| a.id).collect::<Vec<_>>(),
+            vec![well_known::S6A.id],
+            "the CER must advertise the declared application"
+        );
+    }
+
+    /// Backward compatibility: peers whose config declares no applications (every
+    /// existing caller, including the other tests in this file) must still
+    /// complete the handshake. Negotiation is opt-in.
+    #[tokio::test]
+    async fn peers_without_declared_applications_still_handshake() {
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+
+        let server_cfg = test_config("hss.example.org", "epc.example.org");
+        let server = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &server_cfg);
+            peer.start().await.unwrap();
+            let event = peer.next_event().await.unwrap();
+            assert!(matches!(event, PeerEvent::Established { .. }));
+            assert_eq!(peer.state(), PeerState::Open);
+        });
+
+        let client_cfg = test_config("mme.example.org", "epc.example.org");
+        let transport = DiameterTransport::connect(listen_addr).await.unwrap();
+        let mut client = DiameterPeer::new_initiator(transport, &client_cfg);
+        client.start().await.unwrap();
+        assert!(matches!(
+            client.next_event().await.unwrap(),
+            PeerEvent::Established { .. }
+        ));
+        server.await.unwrap();
+    }
+
+    /// An unparseable configured address degrades the advertisement rather than
+    /// preventing the node from starting: the CER simply omits Host-IP-Address.
+    #[test]
+    fn unparseable_configured_address_is_skipped_not_fatal() {
+        let cfg = DiameterConfig {
+            address: Some("not-an-ip, 10.0.0.7".to_string()),
+            ..Default::default()
+        };
+        let addrs = parse_host_addresses(&cfg);
+        assert_eq!(addrs.len(), 1, "the good half is kept");
+        assert_eq!(addrs[0].to_string(), "10.0.0.7");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Refs #55 — **item 4 of the agreed sequence**: the architectural slice, and the last gap in that issue apart from SCTP.

## Problem

`send_cer` emitted only `Origin-Host`, `Origin-Realm` and `Origin-State-Id`:

- **Three mandatory AVPs absent.** RFC 6733 §5.3.1 makes `1* { Host-IP-Address }`, `{ Vendor-Id }` and `{ Product-Name }` mandatory in CER and CEA. None were emitted.
- **No application advertised.** So a conformant peer had no way to learn which applications this node speaks.
- **`handle_cer` could not refuse.** It checked only that Origin-Host/Origin-Realm were present, then answered `2001` unconditionally — making `DIAMETER_NO_COMMON_APPLICATION (5010)` unreachable. A peer sharing nothing was welcomed, then failed every request in a way that looks like an application bug rather than a capability mismatch.

`VENDOR_SPECIFIC_APPLICATION_ID` was already defined and already emitted by the per-application request builders — it was simply never used in the handshake. `Supported-Vendor-Id` was absent crate-wide.

## Design

**`ApplicationRegistry` on `DiameterConfig`, empty by default.** Empty means "do not participate in negotiation": the CER still gains its mandatory AVPs, but nothing is advertised and no peer is refused. That's what keeps every existing caller working unchanged.

**`ApplicationId` carries an optional vendor.** Every application here except Gy is 3GPP vendor-specific and belongs in a `Vendor-Specific-Application-Id` group (TS 29.272 §7, TS 29.212 §5.6); Gy is id 4 — RFC 4006, IETF-registered — so it must be bare. Encoding that in the type stops the two being confused.

**Matching compares application ids only, ignoring vendor framing.** Some stacks advertise S6a bare; rejecting over a presentation detail would break an interoperable peer.

**Two `Vendor-Id`s that are easy to conflate.** The node's own is 0 (§5.3.3 — this is an implementation, not a registered vendor); each application group carries 10415 for who defined *that application*. They come from different sources and a test pins the node value at 0.

**`BTreeSet`, not `HashSet`** — advertisement order is deterministic, so a CER's wire image is stable and byte-level comparison is meaningful.

### Two cases deliberately accept rather than reject

Both would otherwise break working deployments in the name of conformance:

- **Local registry empty** — a daemon not yet taught to populate one would start refusing every peer the moment this landed.
- **Peer advertises nothing** — non-conformant, but previously accepted. Turning that into a rejection is a separate decision; logged at `warn` so it's visible.

An empty intersection between two **non-empty** sets is the case the RFC describes: refused with 5010, connection closed, peer reported `Disconnected` so it never reaches `PeerState::Open` and `send_message` won't carry traffic over it. The initiator needed no change — `is_success()` is `2000..3000`, so a 5010 CEA already fails the handshake.

## Changes

1. **New** `applications.rs` — `ApplicationId`, `well_known` (S6a/S6b/Cx/SWx/Gx/Rx/Gy), `ApplicationRegistry` (`append_capabilities` / `common_with` / `negotiate`), `advertised_applications`.
2. `common.rs` — missing AVP codes: `HOST_IP_ADDRESS` 257, `ACCT_APPLICATION_ID` 259, `SUPPORTED_VENDOR_ID` 265, `FIRMWARE_REVISION` 267, `PRODUCT_NAME` 269, `DISCONNECT_CAUSE` 273, `FAILED_AVP` 279.
3. `config.rs` — `applications` field, empty default.
4. `peer.rs` — peers carry the registry + parsed host addresses; CER and CEA append capabilities; `handle_cer` negotiates and refuses with 5010.
5. `hssd/main.rs` — declares S6a + Cx + SWx. `pcrfd/fd_path.rs` — declares Gx + Rx.

A wildcard bind is **not** advertised as `Host-IP-Address`: it tells a peer nothing routable, and omitting a mandatory AVP is less harmful than advertising an unusable address. Unparseable configured addresses are skipped with a warning rather than failing peer construction.

## Not in this PR

- **mmed does not declare S6a.** Its `DiameterConfig` is built by the caller of `mme_fd_init_async`, which has no caller at all yet (#42/#43) — no live site to wire.
- **Routing a request to an application** / per-application dispatch. Negotiation only.
- **Rejecting a peer that advertises nothing**, and **`Failed-AVP` in the 5010 answer** (code now defined; populating it is separate).
- **SCTP** — #55's remaining item, still unreachable dead code behind an undeclared feature.

## Verification

**19 new tests** — 13 registry units, 5 handshake tests over real sockets, 1 strict-peer test in hssd.

The hssd one matters most: it drives the **real `hss_s6a_serve`** with the same application set `main.rs` configures, asserting an S6a MME connects while a Gx/Rx PCRF is refused. The pre-existing end-to-end S6a test leaves both registries empty, so it exercises the compatibility path — not negotiation.

**A real bug in my own first implementation, caught by a socket test.** `advertised_applications` matched `AvpData::Grouped` directly — but the wire format carries no type information, so a *decoded* grouped AVP arrives as `Raw`. The parser found **zero applications for every CER that had actually crossed a socket**, while passing every in-memory test. Fixed with `parse_grouped()`, which handles both forms. `applications_survive_an_encode_decode_round_trip` pins it, and reverting to the naive match makes that test fail with the reason in its assertion message.

Full workspace: **5377 passed, 0 failed** (baseline 5357, +20); `cargo fmt --check` clean; `cargo clippy --workspace` (the CI gate) at **0**.

**Not exercised:** a live association against a third-party HSS/PCRF/DRA — the only way to confirm a real peer accepts our capabilities and honours our 5010. And mmed's S6a, which has no transport yet.

Spec: `specs/fix-diameter-cer-application-negotiation.md`