### PR TITLE
feat(diameter): Diameter over kernel SCTP behind a default-off feature

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "log",
  "nextgcore-core",
  "nextgcore-crypt",
+ "nextgcore-sctp",
  "proptest",
  "thiserror 1.0.69",
  "tokio",

--- a/src/libs/nextgcore-diameter/Cargo.toml
+++ b/src/libs/nextgcore-diameter/Cargo.toml
@@ -6,8 +6,24 @@ authors.workspace = true
 license.workspace = true
 description = "NextGCore Diameter Protocol Library"
 
+[features]
+default = []
+# Diameter over kernel SCTP (RFC 6733 2.1). Default OFF because it links against
+# libsctp (-lsctp): a host without libsctp-dev type-checks and builds fine but
+# FAILS TO LINK, so enabling it by default would break every build that does not
+# have the library. Requires `libsctp-dev` at build time, `libsctp1` plus
+# `modprobe sctp` at runtime.
+kernel-sctp = ["nextgcore-sctp"]
+
 [dependencies]
 nextgcore-core = { workspace = true }
+# Only pulled in by the kernel-sctp feature; see above.
+# Declared by PATH rather than `workspace = true` so `default-features = false`
+# is honoured: the workspace entry does not set it, which makes the override
+# silently ignored (cargo warns, and says it may become a hard error). Without
+# it the default `sctp-proto` backend -- SCTP-over-UDP, NOT standards SCTP --
+# would be compiled in alongside the kernel one.
+nextgcore-sctp = { path = "../nextgcore-sctp", optional = true, default-features = false, features = ["kernel"] }
 nextgcore-crypt = { workspace = true }
 thiserror.workspace = true
 bytes.workspace = true

--- a/src/libs/nextgcore-diameter/src/config.rs
+++ b/src/libs/nextgcore-diameter/src/config.rs
@@ -83,7 +83,17 @@ pub struct DiameterConfigFlags {
     /// The peer does not relay messages (0xffffff app id)
     pub no_fwd: bool,
 
-    /// Disable the use of SCTP
+    /// Refuse SCTP even when the `kernel-sctp` feature is compiled in.
+    ///
+    /// Honoured by [`crate::transport::SctpDiameterTransport::connect_checked`]
+    /// and [`crate::transport::SctpDiameterListener::bind_checked`], which is
+    /// what a caller selecting a transport from config should use. It has no
+    /// effect on the TCP path, and none on a build without `kernel-sctp` (where
+    /// there is no SCTP to disable).
+    ///
+    /// Note the unchecked `connect`/`bind` do not consult it: they take an
+    /// address, not a config, and silently ignoring a flag they never received
+    /// would be worse than not offering it.
     pub no_sctp: bool,
 }
 

--- a/src/libs/nextgcore-diameter/src/peer.rs
+++ b/src/libs/nextgcore-diameter/src/peer.rs
@@ -69,8 +69,8 @@ pub enum PeerEvent {
 }
 
 /// Diameter peer representing a single connection to a remote node
-pub struct DiameterPeer {
-    transport: DiameterTransport,
+pub struct DiameterPeer<T = DiameterTransport> {
+    transport: T,
     state: PeerState,
     local_host: String,
     local_realm: String,
@@ -112,9 +112,9 @@ fn parse_host_addresses(config: &DiameterConfig) -> Vec<std::net::IpAddr> {
         .collect()
 }
 
-impl DiameterPeer {
+impl<T: crate::transport::DiameterTransportIo> DiameterPeer<T> {
     /// Create a new peer from an established transport (responder side)
-    pub fn new_responder(transport: DiameterTransport, config: &DiameterConfig) -> Self {
+    pub fn new_responder(transport: T, config: &DiameterConfig) -> Self {
         Self {
             transport,
             state: PeerState::WaitCER,
@@ -131,7 +131,7 @@ impl DiameterPeer {
     }
 
     /// Create a new peer and initiate connection (initiator side)
-    pub fn new_initiator(transport: DiameterTransport, config: &DiameterConfig) -> Self {
+    pub fn new_initiator(transport: T, config: &DiameterConfig) -> Self {
         Self {
             transport,
             state: PeerState::Closed,
@@ -145,6 +145,21 @@ impl DiameterPeer {
             applications: config.applications.clone(),
             host_addresses: parse_host_addresses(config),
         }
+    }
+
+    /// Alias for [`Self::new_responder`], named to make a non-TCP transport
+    /// explicit at the call site.
+    ///
+    /// The plain constructors are generic now, so these add no capability; they
+    /// exist so a reader of a test or a daemon can see that the peer is not on
+    /// the default TCP transport without inspecting the argument's type.
+    pub fn new_responder_generic(transport: T, config: &DiameterConfig) -> Self {
+        Self::new_responder(transport, config)
+    }
+
+    /// Alias for [`Self::new_initiator`]. See [`Self::new_responder_generic`].
+    pub fn new_initiator_generic(transport: T, config: &DiameterConfig) -> Self {
+        Self::new_initiator(transport, config)
     }
 
     /// Get the current peer state
@@ -198,7 +213,7 @@ impl DiameterPeer {
     /// This handles all base protocol messages (CER/CEA, DWR/DWA, DPR/DPA)
     /// internally and returns application-level events to the caller.
     pub async fn next_event(&mut self) -> DiameterResult<PeerEvent> {
-        let msg = self.transport.recv().await?;
+        let msg = self.transport.recv_message().await?;
         self.process_message(msg).await
     }
 
@@ -225,7 +240,7 @@ impl DiameterPeer {
             // Closing: received DPA (disconnect answer)
             (PeerState::Closing, base_cmd::DISCONNECT_PEER, false) => {
                 self.state = PeerState::Closed;
-                self.transport.shutdown().await?;
+                self.transport.close().await?;
                 Ok(PeerEvent::Disconnected)
             }
             // Open: application message
@@ -246,7 +261,7 @@ impl DiameterPeer {
                 self.state
             )));
         }
-        self.transport.send(msg).await
+        self.transport.send_message(msg).await
     }
 
     /// Build and send Capabilities-Exchange-Request
@@ -280,7 +295,7 @@ impl DiameterPeer {
         self.applications
             .append_capabilities(&mut msg, &self.host_addresses);
 
-        self.transport.send(&msg).await
+        self.transport.send_message(&msg).await
     }
 
     /// Handle incoming CER: validate and respond with CEA
@@ -356,7 +371,7 @@ impl DiameterPeer {
         self.applications
             .append_capabilities(&mut cea, &self.host_addresses);
 
-        self.transport.send(&cea).await?;
+        self.transport.send_message(&cea).await?;
 
         // Only reach Open on success. On 5010 the RFC closes the connection, so
         // the peer is reported as Disconnected rather than Established and stays
@@ -364,7 +379,7 @@ impl DiameterPeer {
         // carry application traffic over it.
         if negotiated.is_none() {
             self.state = PeerState::Closed;
-            self.transport.shutdown().await?;
+            self.transport.close().await?;
             return Ok(PeerEvent::Disconnected);
         }
 
@@ -431,7 +446,7 @@ impl DiameterPeer {
             AvpData::Unsigned32(origin_state_id()),
         ));
 
-        self.transport.send(&dwa).await?;
+        self.transport.send_message(&dwa).await?;
         Ok(PeerEvent::WatchdogAck)
     }
 
@@ -460,7 +475,7 @@ impl DiameterPeer {
             AvpData::Unsigned32(origin_state_id()),
         ));
 
-        self.transport.send(&dwr).await
+        self.transport.send_message(&dwr).await
     }
 
     /// Handle incoming DPR: respond with DPA and close
@@ -479,9 +494,9 @@ impl DiameterPeer {
             AvpData::DiameterIdentity(self.local_realm.clone()),
         ));
 
-        self.transport.send(&dpa).await?;
+        self.transport.send_message(&dpa).await?;
         self.state = PeerState::Closed;
-        self.transport.shutdown().await?;
+        self.transport.close().await?;
         Ok(PeerEvent::Disconnected)
     }
 
@@ -508,7 +523,7 @@ impl DiameterPeer {
         // Disconnect-Cause AVP (code 273)
         dpr.add_avp(Avp::mandatory(273, AvpData::Enumerated(cause as i32)));
 
-        self.transport.send(&dpr).await?;
+        self.transport.send_message(&dpr).await?;
         self.state = PeerState::Closing;
         Ok(())
     }

--- a/src/libs/nextgcore-diameter/src/transport.rs
+++ b/src/libs/nextgcore-diameter/src/transport.rs
@@ -1,8 +1,29 @@
 //! Diameter transport layer (TCP and SCTP)
 //!
-//! Provides TCP and SCTP-based transport for Diameter messages per RFC 6733 Section 2.1.
+//! Provides TCP and SCTP-based transport for Diameter messages per RFC 6733 §2.1.
 //! Diameter uses a 4-byte length prefix in the message header for framing.
 //! The first byte is the version, and the next 3 bytes are the message length.
+//!
+//! # Transports
+//!
+//! **TCP** is always available and is what every daemon in this tree currently
+//! uses.
+//!
+//! **SCTP** requires the default-off `kernel-sctp` feature, which delegates to
+//! [`nextgcore_sctp`]'s kernel backend (native `IPPROTO_SCTP` sockets, PPID 46).
+//! RFC 6733 §2.1 says a Diameter *server* must support both TCP and SCTP, so
+//! TCP-only is a conformance gap; the feature closes it where `libsctp` exists.
+//!
+//! The feature is off by default because it links `-lsctp`. A host without
+//! `libsctp-dev` passes `cargo check` and `cargo build -p` and then fails at
+//! LINK time (`ld: cannot find -lsctp`) — so making it default would break
+//! builds that work today. `nextgcore_sctp`'s other backend (`sctp-proto`,
+//! SCTP-over-UDP) is deliberately **not** used here: it is wire-compatible with
+//! nextgsim but not with a standards SCTP peer, so it could not talk to a real
+//! HSS or DRA and would close the gap on paper only.
+//!
+//! Runtime requirements: `libsctp-dev` at build time, `libsctp1` plus
+//! `modprobe sctp` at run time.
 
 use bytes::BytesMut;
 use std::net::SocketAddr;
@@ -840,7 +861,7 @@ pub enum DiameterTransportKind {
 /// Note: This is a stub implementation. Full SCTP support would require
 /// integrating with an SCTP library like `sctp-rs` or similar.
 /// For now, this provides the API structure.
-#[cfg(feature = "sctp")]
+#[cfg(feature = "kernel-sctp")]
 pub struct SctpDiameterTransport {
     /// Underlying SCTP stream
     stream: SctpStream,
@@ -854,10 +875,15 @@ pub struct SctpDiameterTransport {
     last_stream_id: u16,
 }
 
-#[cfg(feature = "sctp")]
+#[cfg(feature = "kernel-sctp")]
 impl SctpDiameterTransport {
-    /// Create a new SCTP Diameter transport
-    pub fn new(stream: SctpStream) -> DiameterResult<Self> {
+    /// Wrap an established SCTP stream.
+    ///
+    /// Crate-private because `SctpStream` is: a caller outside this module could
+    /// never construct the argument, so a `pub` signature advertised an API that
+    /// could not be used. Construction goes through [`Self::connect`] or
+    /// [`SctpDiameterListener::accept`].
+    fn new(stream: SctpStream) -> DiameterResult<Self> {
         let peer_addr = stream.peer_addr()?;
         Ok(Self {
             stream,
@@ -872,6 +898,25 @@ impl SctpDiameterTransport {
     pub async fn connect(addr: SocketAddr) -> DiameterResult<Self> {
         let stream = SctpStream::connect(addr).await?;
         Self::new(stream)
+    }
+
+    /// Connect via SCTP unless the config disables it.
+    ///
+    /// This is the entry point a caller choosing a transport from configuration
+    /// should use: it honours `DiameterConfigFlags::no_sctp`, which was declared
+    /// but read nowhere before SCTP existed. Refusing here rather than silently
+    /// falling back to TCP is deliberate -- a caller that asked for SCTP and got
+    /// TCP without being told would misreport its own transport.
+    pub async fn connect_checked(
+        addr: SocketAddr,
+        config: &DiameterConfig,
+    ) -> DiameterResult<Self> {
+        if config.flags.no_sctp {
+            return Err(DiameterError::Protocol(
+                "SCTP is disabled by configuration (flags.no_sctp)".into(),
+            ));
+        }
+        Self::connect(addr).await
     }
 
     /// Get the remote peer address
@@ -962,71 +1007,203 @@ impl SctpDiameterTransport {
     }
 }
 
-// Stub SCTP stream type
-// In a real implementation, this would be provided by an SCTP library
-#[cfg(feature = "sctp")]
+/// Diameter Payload Protocol Identifier for SCTP (RFC 6733 §2.1.1).
+///
+/// 46 = "DIAMETER in a SCTP DATA chunk"; 47 is the DTLS/SCTP variant, which this
+/// transport does not implement.
+#[cfg(feature = "kernel-sctp")]
+pub const DIAMETER_SCTP_PPID: u32 = 46;
+
+/// SCTP stream backed by a real kernel SCTP socket.
+///
+/// # Why this shape
+///
+/// [`nextgcore_sctp::KernelSctpSocket`] is **synchronous** (a raw fd plus
+/// `set_nonblocking`), while this transport is async. The bridge is tokio's
+/// [`AsyncFd`](tokio::io::unix::AsyncFd) driving readiness on a *borrowed*
+/// descriptor — the same pattern `nextgcore_sctp::kernel_server` already uses,
+/// reused deliberately rather than reinvented. `FdRef` exists because the
+/// `OwnedFd` lives in the socket: dropping the `AsyncFd` must only deregister
+/// from the reactor, never close the fd.
+///
+/// # Runtime status
+///
+/// Type-checks anywhere; **links and runs only on Linux with `libsctp`**
+/// (`-lsctp`). On a host without it, `cargo check` and `cargo build -p` succeed
+/// while linking a test binary fails with `cannot find -lsctp` — which is
+/// precisely how the previous stub shipped unexercised. This code has therefore
+/// been compile-verified but **not** run against a peer; see the PR and the
+/// follow-up task.
+#[cfg(feature = "kernel-sctp")]
 struct SctpStream {
-    // Internal implementation details would go here
+    socket: std::sync::Arc<nextgcore_sctp::KernelSctpSocket>,
+    async_fd: tokio::io::unix::AsyncFd<SctpFdRef>,
+    peer_addr: SocketAddr,
 }
 
-#[cfg(feature = "sctp")]
+/// Borrowed-fd shim so an `AsyncFd` can track readiness without owning the
+/// descriptor. Mirrors `nextgcore_sctp::kernel_server::FdRef`, which is private
+/// to that module.
+#[cfg(feature = "kernel-sctp")]
+struct SctpFdRef(std::os::fd::RawFd);
+
+#[cfg(feature = "kernel-sctp")]
+impl std::os::fd::AsRawFd for SctpFdRef {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.0
+    }
+}
+
+#[cfg(feature = "kernel-sctp")]
 impl SctpStream {
-    async fn connect(_addr: SocketAddr) -> std::io::Result<Self> {
-        // Stub: would actually connect to SCTP endpoint
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "SCTP support not yet implemented",
-        ))
+    /// Wrap an established SCTP socket, registering it with the tokio reactor.
+    fn from_socket(socket: nextgcore_sctp::KernelSctpSocket) -> std::io::Result<Self> {
+        // AsyncFd requires a non-blocking descriptor: a blocking socket would
+        // stall the whole runtime thread inside try_io instead of yielding.
+        socket
+            .set_nonblocking(true)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+        let peer_addr = socket.remote_addr().unwrap_or_else(|| socket.local_addr());
+        let raw = std::os::fd::AsRawFd::as_raw_fd(&socket);
+        let async_fd = tokio::io::unix::AsyncFd::new(SctpFdRef(raw))?;
+
+        Ok(Self {
+            socket: std::sync::Arc::new(socket),
+            async_fd,
+            peer_addr,
+        })
+    }
+
+    async fn connect(addr: SocketAddr) -> std::io::Result<Self> {
+        let socket = nextgcore_sctp::KernelSctpSocket::client(addr, None)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        Self::from_socket(socket)
     }
 
     fn peer_addr(&self) -> std::io::Result<SocketAddr> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "SCTP support not yet implemented",
-        ))
+        Ok(self.peer_addr)
     }
 
-    async fn send(&mut self, _data: &[u8], _stream_id: u16) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "SCTP support not yet implemented",
-        ))
+    /// Send one Diameter message as a single SCTP message on `stream_id`.
+    async fn send(&mut self, data: &[u8], stream_id: u16) -> std::io::Result<()> {
+        loop {
+            let mut ready = self.async_fd.writable().await?;
+            let attempt = ready.try_io(|_| {
+                self.socket
+                    .send(data, DIAMETER_SCTP_PPID, stream_id)
+                    .map_err(|e| std::io::Error::other(e.to_string()))
+            });
+            match attempt {
+                Ok(Ok(_)) => return Ok(()),
+                Ok(Err(e)) => return Err(e),
+                // try_io cleared readiness: wait for the next writable edge.
+                Err(_would_block) => continue,
+            }
+        }
     }
 
-    async fn recv(&mut self, _buf: &mut BytesMut) -> std::io::Result<(usize, u16)> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "SCTP support not yet implemented",
-        ))
+    /// Receive one SCTP message, appending it to `buf` and reporting its stream.
+    ///
+    /// SCTP notifications (association up/down) are skipped rather than surfaced
+    /// as data: feeding a notification into the Diameter framer would be parsed
+    /// as a malformed header and kill the connection.
+    async fn recv(&mut self, buf: &mut BytesMut) -> std::io::Result<(usize, u16)> {
+        let mut scratch = vec![0u8; nextgcore_sctp::NEXTGCORE_MAX_SDU_LEN];
+        loop {
+            let mut ready = self.async_fd.readable().await?;
+            let attempt = ready.try_io(|_| {
+                self.socket
+                    .recv_msg(&mut scratch)
+                    .map_err(|e| std::io::Error::other(e.to_string()))
+            });
+            match attempt {
+                Ok(Ok((0, _info, _flags))) => return Ok((0, 0)),
+                Ok(Ok((n, info, flags))) => {
+                    if flags & nextgcore_sctp::MSG_NOTIFICATION != 0 {
+                        // Not application data; keep waiting for a real message.
+                        continue;
+                    }
+                    buf.extend_from_slice(&scratch[..n]);
+                    return Ok((n, info.stream_no));
+                }
+                Ok(Err(e)) => return Err(e),
+                Err(_would_block) => continue,
+            }
+        }
     }
 
     async fn shutdown(&mut self) -> std::io::Result<()> {
+        // Dropping the Arc closes the OwnedFd inside KernelSctpSocket. There is
+        // no half-close here: SCTP's graceful shutdown is an association-level
+        // operation the socket wrapper does not expose.
         Ok(())
     }
 }
 
-/// SCTP Diameter listener
-#[cfg(feature = "sctp")]
+/// SCTP Diameter listener, backed by a real kernel SCTP socket.
+///
+/// One-to-one (`SOCK_STREAM`) sockets with `accept`, matching
+/// `nextgcore_sctp::kernel_server`: each peer association becomes its own
+/// accepted socket, so an accepted transport behaves like the TCP one and needs
+/// no association demultiplexing.
+///
+/// Same runtime caveat as [`SctpDiameterTransport`]: links only where `libsctp`
+/// is present.
+#[cfg(feature = "kernel-sctp")]
 pub struct SctpDiameterListener {
-    // Internal listener implementation
+    socket: nextgcore_sctp::KernelSctpSocket,
+    async_fd: tokio::io::unix::AsyncFd<SctpFdRef>,
 }
 
-#[cfg(feature = "sctp")]
+#[cfg(feature = "kernel-sctp")]
 impl SctpDiameterListener {
-    /// Bind to the given address for SCTP
-    pub async fn bind(_addr: SocketAddr) -> DiameterResult<Self> {
-        Err(DiameterError::Io(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "SCTP support not yet implemented",
-        )))
+    /// Bind and listen for SCTP associations on `addr`.
+    pub async fn bind(addr: SocketAddr) -> DiameterResult<Self> {
+        let socket = nextgcore_sctp::KernelSctpSocket::server(addr)
+            .map_err(|e| DiameterError::Io(std::io::Error::other(e.to_string())))?;
+        socket
+            .set_nonblocking(true)
+            .map_err(|e| DiameterError::Io(std::io::Error::other(e.to_string())))?;
+        let raw = std::os::fd::AsRawFd::as_raw_fd(&socket);
+        let async_fd = tokio::io::unix::AsyncFd::new(SctpFdRef(raw)).map_err(DiameterError::Io)?;
+        Ok(Self { socket, async_fd })
     }
 
-    /// Accept a new incoming SCTP connection
+    /// Bind for SCTP unless the config disables it. See
+    /// [`SctpDiameterTransport::connect_checked`].
+    pub async fn bind_checked(addr: SocketAddr, config: &DiameterConfig) -> DiameterResult<Self> {
+        if config.flags.no_sctp {
+            return Err(DiameterError::Protocol(
+                "SCTP is disabled by configuration (flags.no_sctp)".into(),
+            ));
+        }
+        Self::bind(addr).await
+    }
+
+    /// The bound local address.
+    pub fn local_addr(&self) -> DiameterResult<SocketAddr> {
+        Ok(self.socket.local_addr())
+    }
+
+    /// Accept the next SCTP association as a Diameter transport.
     pub async fn accept(&self) -> DiameterResult<SctpDiameterTransport> {
-        Err(DiameterError::Io(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "SCTP support not yet implemented",
-        )))
+        loop {
+            let mut ready = self.async_fd.readable().await.map_err(DiameterError::Io)?;
+            let attempt = ready.try_io(|_| {
+                self.socket
+                    .accept()
+                    .map_err(|e| std::io::Error::other(e.to_string()))
+            });
+            match attempt {
+                Ok(Ok((sock, _peer))) => {
+                    let stream = SctpStream::from_socket(sock).map_err(DiameterError::Io)?;
+                    return SctpDiameterTransport::new(stream);
+                }
+                Ok(Err(e)) => return Err(DiameterError::Io(e)),
+                Err(_would_block) => continue,
+            }
+        }
     }
 }
 
@@ -1192,12 +1369,59 @@ mod sctp_tests {
         assert_ne!(DiameterTransportKind::Tcp, DiameterTransportKind::Sctp);
     }
 
-    #[cfg(feature = "sctp")]
+    // The previous `test_sctp_not_implemented` asserted that `connect` returns an
+    // error, which was only true of the stub. It is deleted rather than inverted:
+    // the replacement assertion ("connect succeeds") needs a listening SCTP peer,
+    // and this host cannot even LINK the feature (`ld: cannot find -lsctp`), so a
+    // test here would be unrunnable rather than merely skipped.
+    //
+    // What remains verifiable without libsctp is the transport-kind plumbing
+    // above. Runtime coverage requires a libsctp-equipped Linux host with
+    // `modprobe sctp`; see the follow-up task and the PR's own scope note.
+    /// Both transport kinds must be representable and distinct, so a caller can
+    /// select SCTP even in a build where the feature is off.
+    #[test]
+    fn both_transport_kinds_are_selectable() {
+        let kinds = [DiameterTransportKind::Tcp, DiameterTransportKind::Sctp];
+        assert_eq!(kinds.len(), 2);
+        assert_ne!(kinds[0], kinds[1]);
+    }
+
+    /// RFC 6733 §2.1.1 assigns PPID 46 to Diameter in an SCTP DATA chunk (47 is
+    /// the DTLS variant, which this transport does not implement). Pinned because
+    /// a wrong PPID is accepted by the socket layer and only rejected by the far
+    /// end, which is an expensive place to discover a typo.
+    #[cfg(feature = "kernel-sctp")]
+    #[test]
+    fn diameter_sctp_ppid_is_46() {
+        assert_eq!(DIAMETER_SCTP_PPID, 46);
+    }
+
+    /// `flags.no_sctp` must be honoured, and must be honoured BEFORE any socket
+    /// call -- which is what makes this assertion runnable on a host with no
+    /// libsctp at all. The flag was declared but read nowhere until SCTP existed.
+    #[cfg(feature = "kernel-sctp")]
     #[tokio::test]
-    async fn test_sctp_not_implemented() {
-        // This test verifies that the stub returns appropriate errors
-        let addr: SocketAddr = ([127, 0, 0, 1], 3868).into();
-        let result = SctpDiameterTransport::connect(addr).await;
-        assert!(result.is_err());
+    async fn no_sctp_flag_refuses_before_touching_a_socket() {
+        let mut config = DiameterConfig::default();
+        config.flags.no_sctp = true;
+        // Port 1 on loopback: nothing listens, so a connect attempt would fail
+        // for the WRONG reason. The refusal must come from the flag instead.
+        let addr: SocketAddr = ([127, 0, 0, 1], 1).into();
+
+        // Matched rather than `expect_err`: the Ok variants hold raw descriptors
+        // and deliberately do not implement Debug.
+        match SctpDiameterTransport::connect_checked(addr, &config).await {
+            Err(e) => assert!(
+                e.to_string().contains("no_sctp"),
+                "the error must name the flag, got: {e}"
+            ),
+            Ok(_) => panic!("no_sctp must refuse to connect"),
+        }
+
+        match SctpDiameterListener::bind_checked(addr, &config).await {
+            Err(e) => assert!(e.to_string().contains("no_sctp"), "got: {e}"),
+            Ok(_) => panic!("no_sctp must refuse to bind"),
+        }
     }
 }

--- a/src/libs/nextgcore-diameter/src/transport.rs
+++ b/src/libs/nextgcore-diameter/src/transport.rs
@@ -41,6 +41,47 @@ use crate::DIAMETER_PORT;
 /// Maximum Diameter message size (default 64KB, RFC allows up to 16MB)
 const MAX_MESSAGE_SIZE: usize = 65536;
 
+/// The three operations [`crate::peer::DiameterPeer`] needs from a transport.
+///
+/// # Why this exists
+///
+/// `DiameterPeer` held a concrete `DiameterTransport` (TCP), so the peer state
+/// machine — CER/CEA, watchdog, DPR — could not run over SCTP even once an SCTP
+/// transport existed. The transport was reachable but nothing could drive
+/// Diameter across it, which made the SCTP support real only at the byte level.
+///
+/// Deliberately narrow: `send`/`recv`/`shutdown` is the entire surface the peer
+/// uses (verified by grepping every `self.transport.*` call), so widening it
+/// would invite transports to differ in ways the state machine cannot honour.
+/// Framing stays inside each implementation, since TCP is a byte stream that
+/// must be reassembled while SCTP is message-oriented.
+#[async_trait::async_trait]
+pub trait DiameterTransportIo: Send {
+    /// Send one encoded Diameter message.
+    async fn send_message(&mut self, msg: &DiameterMessage) -> DiameterResult<()>;
+
+    /// Receive the next complete Diameter message.
+    async fn recv_message(&mut self) -> DiameterResult<DiameterMessage>;
+
+    /// Close the connection.
+    async fn close(&mut self) -> DiameterResult<()>;
+}
+
+#[async_trait::async_trait]
+impl DiameterTransportIo for DiameterTransport {
+    async fn send_message(&mut self, msg: &DiameterMessage) -> DiameterResult<()> {
+        self.send(msg).await
+    }
+
+    async fn recv_message(&mut self) -> DiameterResult<DiameterMessage> {
+        self.recv().await
+    }
+
+    async fn close(&mut self) -> DiameterResult<()> {
+        self.shutdown().await
+    }
+}
+
 /// Diameter transport connection wrapping a TCP stream
 pub struct DiameterTransport {
     stream: TcpStream,
@@ -1007,6 +1048,39 @@ impl SctpDiameterTransport {
     }
 }
 
+#[cfg(feature = "kernel-sctp")]
+#[async_trait::async_trait]
+impl DiameterTransportIo for SctpDiameterTransport {
+    async fn send_message(&mut self, msg: &DiameterMessage) -> DiameterResult<()> {
+        // Uses the default stream; RFC 6733 does not require a specific one.
+        self.send(msg).await
+    }
+
+    async fn recv_message(&mut self) -> DiameterResult<DiameterMessage> {
+        self.recv().await
+    }
+
+    async fn close(&mut self) -> DiameterResult<()> {
+        self.shutdown().await
+    }
+}
+
+/// Convert an [`nextgcore_sctp::SctpError`] into an `io::Error`, PRESERVING the
+/// original `ErrorKind` where the SCTP layer wrapped one.
+///
+/// This matters for `AsyncFd::try_io`, which decides whether an operation
+/// would-block purely from `ErrorKind::WouldBlock`. `SctpError::{ReceiveFailed,
+/// SendFailed}` carry the real `io::Error` from `last_os_error()`, so they are
+/// unwrapped; anything else has no os error behind it and is stringified.
+#[cfg(feature = "kernel-sctp")]
+fn sctp_io_error(e: nextgcore_sctp::SctpError) -> std::io::Error {
+    match e {
+        nextgcore_sctp::SctpError::ReceiveFailed(inner)
+        | nextgcore_sctp::SctpError::SendFailed(inner) => inner,
+        other => std::io::Error::other(other.to_string()),
+    }
+}
+
 /// Diameter Payload Protocol Identifier for SCTP (RFC 6733 §2.1.1).
 ///
 /// 46 = "DIAMETER in a SCTP DATA chunk"; 47 is the DTLS/SCTP variant, which this
@@ -1090,9 +1164,15 @@ impl SctpStream {
         loop {
             let mut ready = self.async_fd.writable().await?;
             let attempt = ready.try_io(|_| {
+                // The inner io::Error must be surfaced UNWRAPPED: try_io only
+                // recognises a would-block by its ErrorKind, and flattening
+                // through `to_string()` erases it. That turned a routine EAGAIN
+                // on a non-blocking socket into a fatal error -- which is what
+                // the first real run of this code produced ("Send failed:
+                // Resource temporarily unavailable (os error 11)").
                 self.socket
                     .send(data, DIAMETER_SCTP_PPID, stream_id)
-                    .map_err(|e| std::io::Error::other(e.to_string()))
+                    .map_err(sctp_io_error)
             });
             match attempt {
                 Ok(Ok(_)) => return Ok(()),
@@ -1113,9 +1193,8 @@ impl SctpStream {
         loop {
             let mut ready = self.async_fd.readable().await?;
             let attempt = ready.try_io(|_| {
-                self.socket
-                    .recv_msg(&mut scratch)
-                    .map_err(|e| std::io::Error::other(e.to_string()))
+                // Unwrapped for the same reason as `send`; see the note there.
+                self.socket.recv_msg(&mut scratch).map_err(sctp_io_error)
             });
             match attempt {
                 Ok(Ok((0, _info, _flags))) => return Ok((0, 0)),
@@ -1191,9 +1270,8 @@ impl SctpDiameterListener {
         loop {
             let mut ready = self.async_fd.readable().await.map_err(DiameterError::Io)?;
             let attempt = ready.try_io(|_| {
-                self.socket
-                    .accept()
-                    .map_err(|e| std::io::Error::other(e.to_string()))
+                // Unwrapped so a would-block is retried, not reported.
+                self.socket.accept().map_err(sctp_io_error)
             });
             match attempt {
                 Ok(Ok((sock, _peer))) => {
@@ -1423,5 +1501,156 @@ mod sctp_tests {
             Err(e) => assert!(e.to_string().contains("no_sctp"), "got: {e}"),
             Ok(_) => panic!("no_sctp must refuse to bind"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Real SCTP end-to-end
+    //
+    // These are the first tests to actually OPEN an SCTP socket. Everything
+    // else under this feature is either pure logic or refuses before touching
+    // the network, which is why the transport shipped unexercised: the code
+    // type-checked, and on a host without libsctp it could not even link.
+    //
+    // Requirements: `libsctp` (to link) and the `sctp` kernel module loaded
+    // (`modprobe sctp`). No root is needed at RUN time -- an unprivileged
+    // process may open `IPPROTO_SCTP` SOCK_STREAM sockets, unlike raw sockets.
+    // If the module is absent, `bind` fails with EPROTONOSUPPORT and these
+    // tests fail loudly rather than silently passing, which is the intent: a
+    // skipped test here would recreate the false confidence being fixed.
+    // -----------------------------------------------------------------------
+
+    #[cfg(feature = "kernel-sctp")]
+    fn sctp_config(host: &str) -> DiameterConfig {
+        DiameterConfig {
+            diameter_id: host.to_string(),
+            diameter_realm: "sctp.example.org".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// A full Diameter exchange over real SCTP: bind, connect, CER/CEA, then an
+    /// AIR answered with an AIA.
+    ///
+    /// This covers the two parts of the transport that were least certain by
+    /// inspection: the PPID-46 send path, and the `recv` loop's skipping of SCTP
+    /// notifications (an unfiltered notification would enter the Diameter framer
+    /// as a malformed header and kill the association).
+    #[cfg(feature = "kernel-sctp")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sctp_carries_a_full_diameter_exchange() {
+        use crate::avp::{Avp, AvpData};
+        use crate::peer::{DiameterPeer, PeerEvent};
+
+        const AIR: u32 = 318;
+        const S6A_APP: u32 = 16777251;
+
+        // Port 0: the kernel assigns a free SCTP port, so concurrent test runs
+        // cannot collide.
+        let listener = SctpDiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .expect("SCTP bind failed -- is the sctp kernel module loaded?");
+        let addr = listener.local_addr().expect("local_addr");
+        assert_ne!(addr.port(), 0, "the kernel must assign a real port");
+
+        // Responder: accept one association, complete CER/CEA, answer the AIR.
+        let server = tokio::spawn(async move {
+            let transport = listener.accept().await.expect("accept");
+            let cfg = sctp_config("hss.sctp.example.org");
+            let mut peer = DiameterPeer::new_responder_generic(transport, &cfg);
+            peer.start().await.expect("responder start");
+
+            match peer.next_event().await.expect("CER") {
+                PeerEvent::Established { origin_host, .. } => {
+                    assert_eq!(origin_host, "mme.sctp.example.org");
+                }
+                other => panic!("expected Established, got {other:?}"),
+            }
+
+            match peer.next_event().await.expect("AIR") {
+                PeerEvent::Message(request) => {
+                    assert_eq!(request.header.command_code, AIR);
+                    let mut answer = DiameterMessage::new_answer(&request);
+                    answer.add_avp(Avp::mandatory(268, AvpData::Unsigned32(2001)));
+                    peer.send_message(&answer).await.expect("send AIA");
+                }
+                other => panic!("expected the AIR, got {other:?}"),
+            }
+        });
+
+        // Initiator.
+        let transport = SctpDiameterTransport::connect(addr)
+            .await
+            .expect("SCTP connect");
+        let cfg = sctp_config("mme.sctp.example.org");
+        let mut client = DiameterPeer::new_initiator_generic(transport, &cfg);
+        client.start().await.expect("send CER");
+
+        match client.next_event().await.expect("CEA") {
+            PeerEvent::Established { origin_host, .. } => {
+                assert_eq!(origin_host, "hss.sctp.example.org");
+            }
+            other => panic!("expected Established, got {other:?}"),
+        }
+
+        let air = DiameterMessage::new_request(AIR, S6A_APP);
+        client.send_message(&air).await.expect("send AIR");
+
+        match client.next_event().await.expect("AIA") {
+            PeerEvent::Message(answer) => {
+                assert!(answer.header.is_answer());
+                assert_eq!(answer.result_code(), Some(2001));
+            }
+            other => panic!("expected the AIA, got {other:?}"),
+        }
+
+        server.await.expect("responder task");
+    }
+
+    /// Framing must survive messages larger than one read: SCTP is
+    /// message-oriented, so this also proves a Diameter message is not being
+    /// silently truncated at an SCTP message boundary.
+    #[cfg(feature = "kernel-sctp")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sctp_preserves_framing_for_a_large_message() {
+        use crate::avp::{Avp, AvpData};
+
+        let listener = SctpDiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .expect("SCTP bind");
+        let addr = listener.local_addr().expect("local_addr");
+
+        let server = tokio::spawn(async move {
+            let mut transport = listener.accept().await.expect("accept");
+            transport.recv().await.expect("recv large message")
+        });
+
+        let mut transport = SctpDiameterTransport::connect(addr)
+            .await
+            .expect("SCTP connect");
+
+        // ~4KB of AVP payload: comfortably past the 4096-byte initial read
+        // buffer, so the framer must reassemble rather than assume one read.
+        let mut msg = DiameterMessage::new_request(316, 16777251);
+        msg.add_avp(Avp::mandatory(
+            crate::common::avp_code::USER_NAME,
+            AvpData::Utf8String("x".repeat(4096)),
+        ));
+        let expected_len = msg.encode().len();
+        transport.send(&msg).await.expect("send");
+
+        let received = server.await.expect("server task");
+        assert_eq!(received.header.command_code, 316);
+        assert_eq!(
+            received.encode().len(),
+            expected_len,
+            "the message must survive framing intact"
+        );
+        assert_eq!(
+            received
+                .find_avp(crate::common::avp_code::USER_NAME)
+                .and_then(|a| a.as_utf8_string())
+                .map(|s| s.len()),
+            Some(4096)
+        );
     }
 }

--- a/src/libs/nextgcore-sctp/src/lib.rs
+++ b/src/libs/nextgcore-sctp/src/lib.rs
@@ -26,15 +26,26 @@
 
 use std::collections::VecDeque;
 use std::io;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use bytes::Bytes;
 use nextgcore_core::pkbuf::NextgcorePkbuf;
 use nextgcore_core::sockaddr::NextgcoreSockaddr;
 
 use thiserror::Error;
+
+// Used only by the `sctp_proto_impl` module below. Gated because a
+// `--no-default-features --features kernel` build (which nextgcore-diameter's
+// `kernel-sctp` feature selects, to avoid pulling in the SCTP-over-UDP backend)
+// compiles this file without that module and would otherwise emit four
+// unused-import warnings.
+#[cfg(feature = "sctp-proto")]
+use std::net::SocketAddr;
+#[cfg(feature = "sctp-proto")]
+use std::sync::Arc;
+#[cfg(feature = "sctp-proto")]
+use std::time::Instant;
+#[cfg(feature = "sctp-proto")]
 use tokio::sync::Mutex;
 
 // Kernel SCTP module (Linux only, requires libsctp)


### PR DESCRIPTION
Refs #55 — **item 5 (final)** of the agreed sequence.

## Problem

`transport.rs` carried an `SctpDiameterTransport` whose inner `SctpStream` returned `ErrorKind::Unsupported` from every method, gated on `#[cfg(feature = "sctp")]` — **a feature the crate never declared**. Unreachable dead code that couldn't be compiled, let alone used, while implying support that didn't exist.

RFC 6733 §2.1 requires a Diameter server support both TCP and SCTP, so TCP-only is a real conformance gap.

## Two findings that reshaped the work

**A real SCTP library already exists in-tree.** `nextgcore-sctp` — 3,937 lines, two backends, already used by amfd. So this was wiring, not implementation from scratch.

**But the backend choice decides whether it's useful.** The default `sctp-proto` backend is SCTP-over-**UDP**: wire-compatible with nextgsim, **not** with a standards SCTP peer. Wiring that would have produced a Diameter-over-SCTP no real HSS or DRA could talk to — gap closed on paper, interop still broken. Only the `kernel` backend (native `IPPROTO_SCTP`) interoperates, and it links `-lsctp`.

## ⚠️ The verification limit, established empirically

| command | result |
|---|---|
| `cargo check -p nextgcore-sctp --features kernel` | **passes** |
| `cargo build -p nextgcore-sctp --features kernel` | **passes** |
| `cargo test -p nextgcore-sctp --features kernel --no-run` | **fails** — `ld: cannot find -lsctp` |

`check` and `build` of a *library* never link, so they prove nothing about linkability. `kernel.rs`'s own header already documents this. **This is exactly how the original stub shipped unexercised**, so this PR states its limits rather than implying it was run.

**This code has never been executed.** It is type-checked and lint-clean but unlinkable on this host. Please treat it as reviewed-not-run.

## Design

**Default-off feature** — on by default would break every build without `libsctp-dev`, at *link* time after a successful compile, which is a confusing failure to hand someone.

**Reused the proven async bridge.** `KernelSctpSocket` is synchronous (raw fd + `set_nonblocking`) while the transport is async. `nextgcore_sctp::kernel_server` already solves this with tokio `AsyncFd` over a *borrowed* fd, so that pattern (including the `FdRef` shim) is reused rather than reinvented — the `OwnedFd` lives in the socket, so dropping the `AsyncFd` must deregister from the reactor without closing anything.

**Dependency declared by path, not `workspace = true`.** The workspace entry doesn't set `default-features`, which makes a `default-features = false` override **silently ignored** (cargo warns it may become a hard error). Without it, the SCTP-over-UDP backend would be compiled in alongside the kernel one — the wrong transport, quietly present.

**Notifications skipped, not framed.** `recv` drops SCTP association-change notifications; feeding one into the Diameter framer would parse as a malformed header and kill the connection.

**PPID 46** (§2.1.1 — 47 is the DTLS variant, not implemented), pinned by a test because a wrong PPID is accepted locally and rejected only by the far end.

**`flags.no_sctp` now honoured** — declared but read nowhere before. Exposed via `connect_checked`/`bind_checked`, which take a config; plain `connect`/`bind` take only an address and deliberately don't consult it, since silently ignoring a flag they never received would be worse than not offering it. Refusing rather than falling back to TCP is deliberate: a caller that asked for SCTP and got TCP unannounced would misreport its own transport.

## Fixed along the way

Four **pre-existing** unused-import warnings in `nextgcore-sctp` that appear *only* under `--no-default-features --features kernel` — the exact configuration this feature selects, and one nothing had ever built. Now cfg-gated; all three combinations (default / `kernel` / kernel-only) verified warning-free.

Also made `SctpDiameterTransport::new` private: it took a private `SctpStream`, so a `pub` signature advertised an API no external caller could invoke.

## Not in this PR

- **Any daemon using SCTP** — no caller selects it; hssd/pcrfd stay TCP. Wiring one needs runtime validation first.
- **DTLS/SCTP** (PPID 47).
- **Multi-homing / multi-streaming** beyond the single default stream.
- **Runtime validation** — filed as a follow-up; needs a libsctp-equipped Linux host with `modprobe sctp`, and CI has neither.

## Verification

- **Deleted** `test_sctp_not_implemented`, which asserted the stub *fails* and would now be wrong. Not inverted, because the honest replacement ("connect succeeds") needs a listening SCTP peer this host can't even link against.
- **New**: `both_transport_kinds_are_selectable` (runs everywhere); under the feature, `diameter_sctp_ppid_is_46` and `no_sctp_flag_refuses_before_touching_a_socket` — the last runnable *without* libsctp precisely because the refusal precedes any socket call, and it asserts the error names the flag.
- `cargo check -p nextgcore-diameter --features kernel-sctp --all-targets`: **0 errors, 0 warnings**. `cargo clippy` with the feature: **0** — it caught a redundant `as i32` cast I'd written.
- Default build unaffected: workspace **5378 passed, 0 failed**; `cargo fmt --check` clean; `cargo clippy --workspace` **0**.

Spec: `specs/fix-diameter-sctp-kernel-transport.md`