### PR TITLE
feat(mmed): bring up the S1-MME SCTP transport so S1AP reaches the wire

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2712,6 +2712,7 @@ dependencies = [
  "nextgcore-metrics",
  "nextgcore-nas",
  "nextgcore-s1ap",
+ "nextgcore-sctp",
  "proptest",
  "tokio",
 ]

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -454,6 +454,9 @@ impl NgapServer {
             max_outbound_streams: 2,
             max_message_size: MAX_NGAP_MSG_SIZE as u32,
             receive_buffer_size: 262144,
+            // NGAP PPID 60 (TS 38.412) — the default, named explicitly here so
+            // the contrast with the S1AP server's PPID 18 is visible.
+            ppid: nextgcore_sctp::NGAP_PPID,
         };
 
         let mut transport = NgapTransport::bind(backend, bind_addr, config).await?;

--- a/src/bins/nextgcore-mmed/Cargo.toml
+++ b/src/bins/nextgcore-mmed/Cargo.toml
@@ -10,11 +10,22 @@ description = "NextGCore MME (Mobility Management Entity)"
 name = "nextgcore-mmed"
 path = "src/main.rs"
 
+[features]
+# Native Linux kernel-SCTP S1-MME transport (issue #42). S1AP runs over SCTP on
+# port 36412 with PPID 18 (TS 36.412), and only a kernel SCTP socket is on the
+# wire as real SCTP — the userspace `sctp-proto` backend is SCTP-over-UDP and
+# could not carry an association from any third-party eNB. Requires Linux +
+# libsctp at link/run time, so it is off by default and the default build keeps
+# compiling (and logs that S1AP transport needs this feature). Mirrors amfd's
+# `kernel-sctp` wiring for NGAP.
+kernel-sctp = ["nextgcore-sctp/kernel"]
+
 [dependencies]
 nextgcore-core = { workspace = true }
 nextgcore-crypt = { workspace = true }
 nextgcore-nas = { workspace = true }
 nextgcore-s1ap = { workspace = true }
+nextgcore-sctp = { workspace = true }
 nextgcore-gtp = { workspace = true }
 nextgcore-diameter = { workspace = true }
 nextgcore-app = { workspace = true }

--- a/src/bins/nextgcore-mmed/src/main.rs
+++ b/src/bins/nextgcore-mmed/src/main.rs
@@ -20,6 +20,7 @@ pub mod s11_build;
 pub mod s11_handler;
 pub mod s1ap_build;
 pub mod s1ap_handler;
+pub mod s1ap_path;
 pub mod s6a_handler;
 pub mod sbc_handler;
 pub mod sbc_message;
@@ -62,6 +63,8 @@ pub struct MmeApp {
     gtp_state: gtp_path::GtpPathState,
     /// MME state machine
     mme_fsm: sm::MmeFsm,
+    /// S1-MME transport (issue #42). `None` until [`MmeApp::init`] binds it.
+    s1ap: Option<s1ap_path::S1apServer>,
 }
 
 impl MmeApp {
@@ -71,11 +74,12 @@ impl MmeApp {
             running: Arc::new(AtomicBool::new(true)),
             gtp_state: gtp_path::GtpPathState::default(),
             mme_fsm: sm::MmeFsm::new(),
+            s1ap: None,
         }
     }
 
     /// Initialize the MME application
-    pub fn init(&mut self, _config_path: &str) -> Result<()> {
+    pub async fn init(&mut self, _config_path: &str) -> Result<()> {
         log::info!("Initializing MME...");
 
         // Initialize MME context
@@ -100,26 +104,53 @@ impl MmeApp {
         }
         log::debug!("Diameter S6a interface initialized");
 
+        // Bind the S1-MME SCTP transport (TS 36.412: port 36412, PPID 18).
+        // Without this nothing can reach the S1AP layer, so no eNB can
+        // associate and no EPS procedure can run (issue #42).
+        let ctx = context::mme_self();
+        let s1ap_bind = std::net::SocketAddr::from(([0, 0, 0, 0], ctx.s1ap_port));
+        let send_rx = s1ap_path::install_send_queue().ok_or_else(|| {
+            anyhow::anyhow!("S1AP send queue already installed (MmeApp::init called twice)")
+        })?;
+        let s1ap = s1ap_path::S1apServer::bind(s1ap_bind, send_rx, ctx)
+            .await
+            .map_err(|e| anyhow::anyhow!("S1-MME transport initialization failed: {e}"))?;
+        if let Some(addr) = s1ap.local_addr() {
+            log::info!("S1-MME interface ready on {addr}");
+        }
+        self.s1ap = Some(s1ap);
+
         log::info!("MME initialized successfully");
         Ok(())
     }
 
-    /// Run the MME main loop
-    pub fn run(&self) -> Result<()> {
+    /// Run the MME main loop.
+    ///
+    /// Drives the S1AP data path — inbound eNB signalling into
+    /// [`s1ap_handler::handle_s1ap_message`] and queued downlink PDUs out to the
+    /// addressed eNB — alongside the shutdown check. Previously this was a bare
+    /// `thread::sleep` loop, which is why the whole S1AP layer was unreachable
+    /// at runtime (issue #42).
+    pub async fn run(&mut self) -> Result<()> {
         log::info!("MME running...");
 
-        while self.running.load(Ordering::SeqCst) {
-            // Process events
-            // In a real implementation, this would:
-            // 1. Poll for S1AP messages from eNBs
-            // 2. Poll for GTP-C messages from SGW/PGW
-            // 3. Poll for Diameter messages from HSS
-            // 4. Poll for SGsAP messages from VLR
-            // 5. Process timer events
-            // 6. Handle state machine transitions
+        // Interval at which the loop re-checks the shutdown flag when no S1AP
+        // event is pending. Keeps Ctrl-C responsive without polling hard.
+        const SHUTDOWN_CHECK: std::time::Duration = std::time::Duration::from_millis(100);
 
-            // For now, just sleep briefly
-            std::thread::sleep(std::time::Duration::from_millis(100));
+        while self.running.load(Ordering::SeqCst) {
+            match self.s1ap.as_mut() {
+                Some(s1ap) => {
+                    // Race the S1AP data path against the shutdown tick so a
+                    // signal is honoured even while idle. `poll_once` is
+                    // cancel-safe, so losing this race consumes no message.
+                    tokio::select! {
+                        () = s1ap.poll_once() => {}
+                        () = tokio::time::sleep(SHUTDOWN_CHECK) => {}
+                    }
+                }
+                None => tokio::time::sleep(SHUTDOWN_CHECK).await,
+            }
         }
 
         log::info!("MME main loop exited");
@@ -129,6 +160,13 @@ impl MmeApp {
     /// Shutdown the MME application
     pub fn shutdown(&mut self) {
         log::info!("Shutting down MME...");
+
+        // Stop the S1-MME transport first so no new eNB signalling arrives
+        // while the layers below it are being torn down.
+        if let Some(mut s1ap) = self.s1ap.take() {
+            s1ap.stop();
+            log::debug!("S1-MME transport closed");
+        }
 
         // Close Diameter S6a interface
         fd_path::mme_fd_final();
@@ -168,7 +206,15 @@ impl Default for MmeApp {
     }
 }
 
-fn main() -> Result<()> {
+/// The MME runs on a tokio runtime.
+///
+/// Required by the S1-MME SCTP transport (issue #42), which is `AsyncFd`-driven.
+/// It also unblocks `fd_path`'s S6a layer, which was already fully async but
+/// stranded because the daemon had no runtime — see `fd_path::mme_fd_init`,
+/// whose comment defers connecting "once the async runtime is available".
+/// Actually connecting that peer is separate work and deliberately not done here.
+#[tokio::main]
+async fn main() -> Result<()> {
     // Parse command line arguments
     let args = Args::parse();
 
@@ -209,10 +255,10 @@ fn main() -> Result<()> {
     })?;
 
     // Initialize
-    app.init(&args.config)?;
+    app.init(&args.config).await?;
 
     // Run main loop
-    app.run()?;
+    app.run().await?;
 
     // Shutdown
     app.shutdown();

--- a/src/bins/nextgcore-mmed/src/nas_path.rs
+++ b/src/bins/nextgcore-mmed/src/nas_path.rs
@@ -9,6 +9,7 @@ use crate::emm_build::{self, EmmCause, SecurityHeaderType};
 use crate::esm_build::{self, EsmCause};
 use crate::nas_security;
 use crate::s1ap_build;
+use crate::s1ap_path;
 
 // ============================================================================
 // Result Types
@@ -101,19 +102,30 @@ pub enum S1apCauseNas {
 /// # Returns
 /// * `Ok(())` - Message sent successfully
 /// * `Err(NasError)` - On error
-pub fn nas_eps_send_to_enb(_mme_ue: &MmeUe, enb_ue: &EnbUe, message: Vec<u8>) -> NasResult<()> {
+pub fn nas_eps_send_to_enb(_mme_ue: &MmeUe, enb_ue: &EnbUe, s1ap_pdu: Vec<u8>) -> NasResult<()> {
     if enb_ue.id == 0 {
         log::error!("S1 context has already been removed");
         return Err(NasError::EnbUeNotFound);
     }
 
-    // In actual implementation, this would call s1ap_send_to_enb_ue
     log::debug!(
-        "Sending NAS message to eNB UE (mme_ue_s1ap_id={}, enb_ue_s1ap_id={}), len={}",
+        "Sending S1AP PDU to eNB UE (mme_ue_s1ap_id={}, enb_ue_s1ap_id={}, enb_id={}), len={}",
         enb_ue.mme_ue_s1ap_id,
         enb_ue.enb_ue_s1ap_id,
-        message.len()
+        enb_ue.enb_id,
+        s1ap_pdu.len()
     );
+
+    // Queue for transmission on the eNB's S1 association (issue #42). This
+    // previously only logged and returned Ok, so every downlink PDU the MME
+    // built was silently discarded while the caller saw success.
+    //
+    // A failed queue push is NOT an error for the caller: it means no live S1
+    // association to that eNB, which is indistinguishable from an eNB that has
+    // gone away mid-procedure. It is logged by `s1ap_send_pdu`, and the EPS
+    // procedure continues (its own timer will govern the retry), exactly as it
+    // would for a lost message on the radio side.
+    s1ap_path::s1ap_send_pdu(enb_ue.enb_id, s1ap_pdu);
 
     Ok(())
 }
@@ -134,15 +146,21 @@ pub fn nas_eps_send_to_downlink_nas_transport(enb_ue: &EnbUe, message: Vec<u8>) 
     }
 
     // Build S1AP downlink NAS transport message (APER via nextgcore-s1ap)
-    let _s1ap_message = s1ap_build::build_downlink_nas_transport(enb_ue, &message)
+    let s1ap_message = s1ap_build::build_downlink_nas_transport(enb_ue, &message)
         .map_err(|_| NasError::BuildFailed)?;
 
     log::debug!(
-        "Sending downlink NAS transport (mme_ue_s1ap_id={}, enb_ue_s1ap_id={}), len={}",
+        "Sending downlink NAS transport (mme_ue_s1ap_id={}, enb_ue_s1ap_id={}, enb_id={}), \
+         nas_len={}, s1ap_len={}",
         enb_ue.mme_ue_s1ap_id,
         enb_ue.enb_ue_s1ap_id,
-        message.len()
+        enb_ue.enb_id,
+        message.len(),
+        s1ap_message.len()
     );
+
+    // Transmit the built PDU instead of dropping it (issue #42).
+    s1ap_path::s1ap_send_pdu(enb_ue.enb_id, s1ap_message);
 
     Ok(())
 }
@@ -240,8 +258,10 @@ pub fn nas_eps_send_attach_accept(
     // Clear UE radio capability as per TS24.301
     mme_ue.ue_radio_capability.clear();
 
-    // Build S1AP initial context setup request (APER via nextgcore-s1ap)
-    let _s1ap_message = s1ap_build::build_initial_context_setup_request(
+    // Build S1AP initial context setup request (APER via nextgcore-s1ap). The
+    // Attach Accept NAS message travels inside this PDU, so the PDU — not the
+    // bare NAS message — is what goes to the eNB (issue #42).
+    let s1ap_message = s1ap_build::build_initial_context_setup_request(
         mme_ue,
         enb_ue,
         std::slice::from_ref(default_bearer),
@@ -249,7 +269,7 @@ pub fn nas_eps_send_attach_accept(
     )
     .map_err(|_| NasError::BuildFailed)?;
 
-    nas_eps_send_to_enb(mme_ue, enb_ue, secured_message)
+    nas_eps_send_to_enb(mme_ue, enb_ue, s1ap_message)
 }
 
 /// Send attach reject message
@@ -569,14 +589,16 @@ pub fn nas_eps_send_tau_accept(
     mme_ue.t3450.pkbuf = Some(emm_message.clone());
 
     if use_initial_context_setup {
-        let _s1ap_message = s1ap_build::build_initial_context_setup_request(
+        // The TAU Accept travels inside the Initial Context Setup Request, so
+        // transmit that PDU rather than the bare NAS message (issue #42).
+        let s1ap_message = s1ap_build::build_initial_context_setup_request(
             mme_ue,
             enb_ue,
             bearers,
             Some(&emm_message),
         )
         .map_err(|_| NasError::BuildFailed)?;
-        nas_eps_send_to_enb(mme_ue, enb_ue, emm_message)
+        nas_eps_send_to_enb(mme_ue, enb_ue, s1ap_message)
     } else {
         nas_eps_send_to_downlink_nas_transport(enb_ue, emm_message)
     }
@@ -794,11 +816,12 @@ pub fn nas_eps_send_activate_default_bearer_context_request(
 
     let esm_message = esm_build::build_activate_default_bearer_context_request(sess, create_action);
 
-    // Build S1AP E-RAB setup request (APER via nextgcore-s1ap)
-    let _s1ap_message = s1ap_build::build_e_rab_setup_request(enb_ue, bearer, &esm_message)
+    // Build S1AP E-RAB setup request (APER via nextgcore-s1ap). The ESM message
+    // is carried inside it, so transmit the PDU (issue #42).
+    let s1ap_message = s1ap_build::build_e_rab_setup_request(enb_ue, bearer, &esm_message)
         .map_err(|_| NasError::BuildFailed)?;
 
-    nas_eps_send_to_enb(mme_ue, enb_ue, esm_message)
+    nas_eps_send_to_enb(mme_ue, enb_ue, s1ap_message)
 }
 
 /// Send activate dedicated bearer context request message
@@ -828,11 +851,12 @@ pub fn nas_eps_send_activate_dedicated_bearer_context_request(
 
     let esm_message = esm_build::build_activate_dedicated_bearer_context_request(bearer);
 
-    // Build S1AP E-RAB setup request (APER via nextgcore-s1ap)
-    let _s1ap_message = s1ap_build::build_e_rab_setup_request(enb_ue, bearer, &esm_message)
+    // Build S1AP E-RAB setup request (APER via nextgcore-s1ap). The ESM message
+    // is carried inside it, so transmit the PDU (issue #42).
+    let s1ap_message = s1ap_build::build_e_rab_setup_request(enb_ue, bearer, &esm_message)
         .map_err(|_| NasError::BuildFailed)?;
 
-    nas_eps_send_to_enb(mme_ue, enb_ue, esm_message)
+    nas_eps_send_to_enb(mme_ue, enb_ue, s1ap_message)
 }
 
 /// Send modify bearer context request message
@@ -868,10 +892,11 @@ pub fn nas_eps_send_modify_bearer_context_request(
         esm_build::build_modify_bearer_context_request(bearer, qos_presence, tft_presence);
 
     if qos_presence {
-        // Build S1AP E-RAB modify request (APER via nextgcore-s1ap)
-        let _s1ap_message = s1ap_build::build_e_rab_modify_request(enb_ue, bearer, &esm_message)
+        // Build S1AP E-RAB modify request (APER via nextgcore-s1ap). The ESM
+        // message is carried inside it, so transmit the PDU (issue #42).
+        let s1ap_message = s1ap_build::build_e_rab_modify_request(enb_ue, bearer, &esm_message)
             .map_err(|_| NasError::BuildFailed)?;
-        nas_eps_send_to_enb(mme_ue, enb_ue, esm_message)
+        nas_eps_send_to_enb(mme_ue, enb_ue, s1ap_message)
     } else {
         nas_eps_send_to_downlink_nas_transport(enb_ue, esm_message)
     }
@@ -905,8 +930,9 @@ pub fn nas_eps_send_deactivate_bearer_context_request(
     let esm_message =
         esm_build::build_deactivate_bearer_context_request(bearer, EsmCause::RegularDeactivation);
 
-    // Build S1AP E-RAB release command (APER via nextgcore-s1ap)
-    let _s1ap_message = s1ap_build::build_e_rab_release_command(
+    // Build S1AP E-RAB release command (APER via nextgcore-s1ap). The ESM
+    // message is carried inside it, so transmit the PDU (issue #42).
+    let s1ap_message = s1ap_build::build_e_rab_release_command(
         enb_ue,
         bearer.ebi,
         S1apCauseGroup::Nas,
@@ -915,7 +941,7 @@ pub fn nas_eps_send_deactivate_bearer_context_request(
     )
     .map_err(|_| NasError::BuildFailed)?;
 
-    nas_eps_send_to_enb(mme_ue, enb_ue, esm_message)
+    nas_eps_send_to_enb(mme_ue, enb_ue, s1ap_message)
 }
 
 /// Send bearer resource allocation reject message

--- a/src/bins/nextgcore-mmed/src/s1ap_path.rs
+++ b/src/bins/nextgcore-mmed/src/s1ap_path.rs
@@ -1,0 +1,568 @@
+//! S1-MME transport (issue #42, TS 36.412 / TS 36.413 §8.7.3.2).
+//!
+//! Before this module the MME had a complete, unit-tested S1AP message layer
+//! that never reached the wire: nothing bound port 36412,
+//! [`handle_s1ap_message`] had no non-test caller, and every downlink PDU that
+//! `nas_path` built was dropped. This module is the missing transport.
+//!
+//! ## Model
+//!
+//! S1AP is carried over SCTP on port 36412 with PPID 18 (TS 36.412), and the
+//! MME is the passive side that accepts eNB-initiated associations. The
+//! transport reuses [`nextgcore_sctp::KernelSctpServer`] — the same native
+//! one-to-one kernel-SCTP listener amfd uses for NGAP — configured with the
+//! S1AP PPID instead of NGAP's.
+//!
+//! ## Ingress
+//!
+//! [`S1apServer::poll_once`] drains the server's event channel:
+//!
+//! - `NewAssociation` → register the peer with `ctx.enb_add(addr)` and map the
+//!   association to that eNB pool id;
+//! - `DataReceived` → `handle_s1ap_message(ctx, enb_id, data)`, transmitting
+//!   every returned [`S1apSend`] (S1 Setup Response, error indications, …);
+//! - `AssociationClosed` → drop the mapping and `ctx.enb_remove(enb_id)`.
+//!
+//! ## Egress
+//!
+//! Downlink PDUs are produced by *synchronous* code deep inside the EMM/ESM
+//! handlers (`nas_path::nas_eps_send_to_enb` and the E-RAB builders). Rather
+//! than make those call trees async, they push onto a process-global unbounded
+//! **send queue** via [`s1ap_send`], which `poll_once` drains and routes to the
+//! addressed eNB's association. The push is non-blocking and never fails the
+//! caller's procedure.
+//!
+//! ## Feature gating
+//!
+//! The kernel-SCTP backend needs Linux + `libsctp`, so it sits behind the
+//! `kernel-sctp` feature (mirroring amfd). Without it the daemon still builds
+//! and runs, with the transport reported as unavailable rather than silently
+//! absent. The userspace `sctp-proto` backend is deliberately NOT offered here:
+//! it is SCTP-over-UDP, so it could not carry an association from a real eNB,
+//! and offering it would make the gap look closed.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+
+use tokio::sync::mpsc;
+
+use crate::context::MmeContext;
+use crate::s1ap_handler::{handle_s1ap_message, S1apSend};
+
+/// SCTP stream used for S1AP signalling.
+///
+/// TS 36.412 reserves stream 0 for non-UE-associated signalling. UE-associated
+/// signalling may use other streams; [`S1apSend`] does not currently carry a
+/// stream id, so everything goes out on stream 0 — valid, and the conservative
+/// choice until the handler layer tracks per-UE streams.
+const S1AP_STREAM_ID: u16 = 0;
+
+/// Process-global sender for the downlink S1AP queue.
+///
+/// A `OnceLock` (not a `Mutex<Option<..>>`) because the sender is installed once
+/// at startup and only ever cloned afterwards, so the egress path needs no lock.
+static SEND_TX: OnceLock<mpsc::UnboundedSender<S1apSend>> = OnceLock::new();
+
+/// Queue an S1AP PDU for transmission to `enb_id`.
+///
+/// Callable from synchronous code on any thread; it never blocks and never
+/// fails the caller's procedure. Returns `false` when the PDU could not be
+/// queued — the transport is not up (no [`S1apServer::bind`] yet, e.g. in a
+/// unit test) or the server has shut down — which is logged and otherwise
+/// ignored, exactly as an unreachable eNB would be.
+pub fn s1ap_send(message: S1apSend) -> bool {
+    let Some(tx) = SEND_TX.get() else {
+        log::warn!(
+            "S1AP send dropped: transport not initialised (enb_id={}, {} bytes)",
+            message.enb_id,
+            message.pdu.len()
+        );
+        return false;
+    };
+    let enb_id = message.enb_id;
+    let len = message.pdu.len();
+    match tx.send(message) {
+        Ok(()) => {
+            log::debug!("S1AP PDU queued for eNB {enb_id} ({len} bytes)");
+            true
+        }
+        Err(_) => {
+            log::warn!("S1AP send dropped: transport closed (enb_id={enb_id}, {len} bytes)");
+            false
+        }
+    }
+}
+
+/// Convenience wrapper around [`s1ap_send`] for a raw encoded PDU.
+pub fn s1ap_send_pdu(enb_id: u64, pdu: Vec<u8>) -> bool {
+    s1ap_send(S1apSend { enb_id, pdu })
+}
+
+/// Install the process-global send queue, returning the receiving half to hand
+/// to [`S1apServer::bind`].
+///
+/// Returns `None` if a queue is already installed (the sender is set once per
+/// process), so a second call cannot silently orphan the first queue. Kept
+/// separate from `bind` so a test can drive a server off its own local queue
+/// without consuming the one global slot.
+pub fn install_send_queue() -> Option<mpsc::UnboundedReceiver<S1apSend>> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    match SEND_TX.set(tx) {
+        Ok(()) => Some(rx),
+        Err(_) => None,
+    }
+}
+
+/// The S1AP transport backend.
+enum Backend {
+    /// Native Linux kernel SCTP (the only backend that is real SCTP on the
+    /// wire, so the only one a third-party eNB can associate with).
+    #[cfg(feature = "kernel-sctp")]
+    Kernel(Box<nextgcore_sctp::KernelSctpServer>),
+    /// Built without `kernel-sctp`: no S1-MME transport. The daemon runs, but
+    /// no eNB can associate and queued downlink PDUs are drained and dropped.
+    Disabled,
+}
+
+/// The S1-MME server: owns the SCTP listener, the association↔eNB mapping, and
+/// both directions of the S1AP data path.
+pub struct S1apServer {
+    backend: Backend,
+    /// Inbound events from the SCTP backend.
+    events: mpsc::UnboundedReceiver<nextgcore_sctp::ServerEvent>,
+    /// Retained clone of the event sender.
+    ///
+    /// Keeps the channel open for the lifetime of the server so `events.recv()`
+    /// parks when idle instead of resolving to `None` — which would turn
+    /// [`S1apServer::poll_once`] into a busy loop once the backend's accept task
+    /// ends (or immediately, when the transport is disabled).
+    _event_tx: mpsc::UnboundedSender<nextgcore_sctp::ServerEvent>,
+    /// Outbound PDUs pushed by the synchronous NAS/E-RAB paths.
+    send_rx: mpsc::UnboundedReceiver<S1apSend>,
+    /// SCTP association id → eNB pool id.
+    assoc_to_enb: HashMap<u64, u64>,
+    /// eNB pool id → SCTP association id.
+    enb_to_assoc: HashMap<u64, u64>,
+    /// Bound address, once known.
+    local_addr: Option<SocketAddr>,
+    /// The MME context S1AP procedures run against.
+    ///
+    /// Injected rather than read from `mme_self()` inside the event handler so a
+    /// wire test can drive the server against a context it has configured (e.g.
+    /// with a served GUMMEI, without which S1 Setup is answered with a Failure).
+    /// Mirrors amfd's NGAP path, which likewise takes its context as a parameter.
+    ctx: &'static MmeContext,
+}
+
+impl S1apServer {
+    /// Bind the S1-MME SCTP listener on `addr` (conventionally `:36412`).
+    ///
+    /// Without the `kernel-sctp` feature this succeeds with the transport
+    /// disabled rather than failing startup: the rest of the MME (S11, S6a
+    /// state, timers) is unaffected by the absence of an S1 interface, and a
+    /// hard failure would make the default build unable to boot at all.
+    pub async fn bind(
+        addr: SocketAddr,
+        send_rx: mpsc::UnboundedReceiver<S1apSend>,
+        ctx: &'static MmeContext,
+    ) -> anyhow::Result<Self> {
+        let (event_tx, events) = mpsc::unbounded_channel();
+
+        #[cfg(feature = "kernel-sctp")]
+        let (backend, local_addr) = {
+            let config = nextgcore_sctp::SctpServerConfig {
+                // S1AP PPID 18 (TS 36.412), NOT NGAP's 60. This is why
+                // SctpServerConfig carries a ppid at all.
+                ppid: nextgcore_sctp::NEXTGCORE_SCTP_S1AP_PPID,
+                ..Default::default()
+            };
+            let mut server = nextgcore_sctp::KernelSctpServer::bind(addr, config)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to bind S1-MME SCTP socket on {addr}: {e}"))?;
+            let bound = server.local_addr();
+            server.set_event_sender(event_tx.clone());
+            log::info!(
+                "S1-MME SCTP server listening on {bound} (PPID {}, kernel SCTP)",
+                nextgcore_sctp::NEXTGCORE_SCTP_S1AP_PPID
+            );
+            (Backend::Kernel(Box::new(server)), Some(bound))
+        };
+
+        #[cfg(not(feature = "kernel-sctp"))]
+        let (backend, local_addr) = {
+            log::warn!(
+                "S1-MME transport unavailable: nextgcore-mmed was built without the \
+                 `kernel-sctp` feature, so nothing is listening on {addr}. No eNB can \
+                 establish an S1 association and S1 Setup cannot complete \
+                 (TS 36.413 §8.7.3.2). Rebuild with --features kernel-sctp on Linux \
+                 with libsctp to enable it."
+            );
+            (Backend::Disabled, None)
+        };
+
+        Ok(Self {
+            backend,
+            events,
+            _event_tx: event_tx,
+            send_rx,
+            assoc_to_enb: HashMap::new(),
+            enb_to_assoc: HashMap::new(),
+            local_addr,
+            ctx,
+        })
+    }
+
+    /// The bound listen address, or `None` when the transport is disabled.
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.local_addr
+    }
+
+    /// Whether a live SCTP listener is bound.
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self.backend, Backend::Disabled)
+    }
+
+    /// Number of live eNB associations.
+    pub fn num_associations(&self) -> usize {
+        self.assoc_to_enb.len()
+    }
+
+    /// Drive one step of the S1AP data path: handle the next inbound event or
+    /// transmit the next queued downlink PDU, whichever is ready first.
+    ///
+    /// Cancel-safe: both branches are `mpsc::Receiver::recv`, so a dropped
+    /// future consumes no message.
+    pub async fn poll_once(&mut self) {
+        tokio::select! {
+            event = self.events.recv() => {
+                if let Some(event) = event {
+                    self.handle_event(event).await;
+                }
+            }
+            outbound = self.send_rx.recv() => {
+                if let Some(outbound) = outbound {
+                    self.transmit(outbound).await;
+                }
+            }
+        }
+    }
+
+    /// Dispatch one SCTP event.
+    async fn handle_event(&mut self, event: nextgcore_sctp::ServerEvent) {
+        use nextgcore_sctp::ServerEvent;
+        let ctx: &MmeContext = self.ctx;
+
+        match event {
+            ServerEvent::NewAssociation {
+                association_id,
+                remote_addr,
+            } => {
+                // TS 36.412: the eNB initiates the association; register it so
+                // S1AP procedures can address this peer by eNB pool id.
+                let enb_id = ctx.enb_add(remote_addr);
+                self.assoc_to_enb.insert(association_id, enb_id);
+                self.enb_to_assoc.insert(enb_id, association_id);
+                log::info!(
+                    "S1 association up from {remote_addr} (assoc={association_id}, enb_id={enb_id})"
+                );
+            }
+            ServerEvent::DataReceived {
+                association_id,
+                message,
+            } => {
+                let Some(&enb_id) = self.assoc_to_enb.get(&association_id) else {
+                    log::warn!(
+                        "S1AP data on unknown association {association_id} ({} bytes) — dropping",
+                        message.data.len()
+                    );
+                    return;
+                };
+                log::debug!(
+                    "S1AP PDU from eNB {enb_id} ({} bytes, ppid={})",
+                    message.data.len(),
+                    message.ppid
+                );
+                // The S1AP handler's first non-test caller: decode, run the
+                // procedure, and transmit whatever it answers with.
+                let outbound = handle_s1ap_message(ctx, enb_id, &message.data);
+                for out in outbound {
+                    self.transmit(out).await;
+                }
+            }
+            ServerEvent::AssociationClosed {
+                association_id,
+                reason,
+            } => {
+                if let Some(enb_id) = self.assoc_to_enb.remove(&association_id) {
+                    self.enb_to_assoc.remove(&enb_id);
+                    ctx.enb_remove(enb_id);
+                    log::info!(
+                        "S1 association down (assoc={association_id}, enb_id={enb_id}): {reason}"
+                    );
+                } else {
+                    log::debug!("S1 association {association_id} closed: {reason}");
+                }
+            }
+        }
+    }
+
+    /// Transmit one S1AP PDU to its addressed eNB.
+    async fn transmit(&mut self, message: S1apSend) {
+        let S1apSend { enb_id, pdu } = message;
+
+        let Some(&association_id) = self.enb_to_assoc.get(&enb_id) else {
+            log::warn!(
+                "cannot send S1AP PDU to eNB {enb_id}: no live S1 association ({} bytes dropped)",
+                pdu.len()
+            );
+            return;
+        };
+
+        match &mut self.backend {
+            #[cfg(feature = "kernel-sctp")]
+            Backend::Kernel(server) => {
+                match server.send(association_id, S1AP_STREAM_ID, &pdu).await {
+                    Ok(()) => log::debug!(
+                        "S1AP PDU sent to eNB {enb_id} ({} bytes, assoc={association_id})",
+                        pdu.len()
+                    ),
+                    Err(e) => log::error!(
+                        "failed to send S1AP PDU to eNB {enb_id} (assoc={association_id}): {e}"
+                    ),
+                }
+            }
+            Backend::Disabled => {
+                // Drain rather than accumulate: the queue is unbounded, so a
+                // disabled transport must not let it grow without limit.
+                log::debug!(
+                    "S1AP transport disabled: dropping {} bytes for eNB {enb_id} \
+                     (assoc={association_id})",
+                    pdu.len()
+                );
+            }
+        }
+    }
+
+    /// Stop the listener and drop all associations.
+    pub fn stop(&mut self) {
+        match &mut self.backend {
+            #[cfg(feature = "kernel-sctp")]
+            Backend::Kernel(server) => server.stop(),
+            Backend::Disabled => {}
+        }
+        self.assoc_to_enb.clear();
+        self.enb_to_assoc.clear();
+        log::debug!("S1-MME transport stopped");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A leaked `&'static MmeContext` with a served GUMMEI, so S1 Setup is
+    /// answered with a Response rather than a Failure. Leaked because
+    /// [`S1apServer`] holds `&'static MmeContext` (matching `mme_self()`'s
+    /// lifetime); one leak per test process is acceptable.
+    fn static_ctx_with_gummei() -> &'static MmeContext {
+        use crate::context::{PlmnId, ServedGummei};
+        let mut ctx = MmeContext::new();
+        ctx.init();
+        ctx.mme_name = Some("wire-test-mme".to_string());
+        ctx.served_gummei = vec![ServedGummei {
+            num_of_plmn_id: 1,
+            plmn_id: vec![PlmnId::new("310", "410")],
+            num_of_mme_gid: 1,
+            mme_gid: vec![2],
+            num_of_mme_code: 1,
+            mme_code: vec![1],
+        }];
+        ctx.num_of_served_gummei = 1;
+        Box::leak(Box::new(ctx))
+    }
+
+    /// `s1ap_send` must never panic or block when no transport is up — the
+    /// state the default build's startup window and every unit test is in.
+    #[test]
+    fn send_without_transport_is_a_noop() {
+        // Total function: whether or not another test in this binary has
+        // installed the global queue, this must not panic.
+        let _ = s1ap_send_pdu(1, vec![0x00, 0x01]);
+    }
+
+    #[test]
+    fn install_send_queue_is_once_per_process() {
+        // The global sender is set once; a second install must be refused so it
+        // cannot orphan the first queue.
+        let first = install_send_queue();
+        let second = install_send_queue();
+        assert!(
+            first.is_some() != second.is_some() || second.is_none(),
+            "install_send_queue must not hand out two live global queues"
+        );
+        assert!(second.is_none(), "the second install must be refused");
+    }
+
+    #[test]
+    fn s1ap_stream_is_zero_for_non_ue_signalling() {
+        // TS 36.412: stream 0 carries non-UE-associated signalling.
+        assert_eq!(S1AP_STREAM_ID, 0);
+    }
+
+    /// Queued downlink PDUs addressed to an eNB with no live association are
+    /// dropped with a warning, not retained or panicked on.
+    #[tokio::test]
+    async fn transmit_without_association_is_dropped() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let mut server = S1apServer::bind(addr, rx, static_ctx_with_gummei())
+            .await
+            .expect("bind");
+        tx.send(S1apSend {
+            enb_id: 999,
+            pdu: vec![0xde, 0xad],
+        })
+        .expect("queue");
+        server.poll_once().await;
+        assert_eq!(server.num_associations(), 0);
+        server.stop();
+    }
+
+    /// **The #42 acceptance test.** A native kernel-SCTP client acts as an eNB:
+    /// it associates with the bound S1-MME socket, sends an S1 Setup Request,
+    /// and must receive an S1 Setup Response back over the association — i.e.
+    /// the S1 interface becomes operational (TS 36.413 §8.7.3.2).
+    ///
+    /// This is the criterion that could not be met before: nothing bound 36412,
+    /// so no association could exist and `handle_s1ap_message` never ran on
+    /// live data. Gated on Linux + `kernel-sctp` because kernel SCTP needs both.
+    /// Multi-threaded runtime: the blocking libc `connect`/`send`/`recv_msg`
+    /// calls on the client side run via `spawn_blocking`/`block_in_place`, which
+    /// the current-thread flavour rejects.
+    #[cfg(all(feature = "kernel-sctp", target_os = "linux"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn s1_setup_request_over_real_sctp_is_answered() {
+        use crate::context::PlmnId;
+        use nextgcore_s1ap::{
+            builder, decode_s1ap_pdu, GlobalEnbId, PagingDrx, S1SetupRequest, S1apMessage,
+            SupportedTaItem,
+        };
+
+        let ctx = static_ctx_with_gummei();
+        let (_tx, rx) = mpsc::unbounded_channel();
+
+        // Bind on an ephemeral port: 36412 may be taken, and the port number is
+        // not what this test is about.
+        let mut server = S1apServer::bind("127.0.0.1:0".parse().unwrap(), rx, ctx)
+            .await
+            .expect("bind S1-MME SCTP socket");
+        let bound = server
+            .local_addr()
+            .expect("kernel backend reports its addr");
+
+        // --- the "eNB": a real kernel-SCTP client association ---
+        let client = tokio::task::spawn_blocking(move || {
+            nextgcore_sctp::KernelSctpSocket::client(bound, None)
+                .expect("eNB kernel-SCTP client connect")
+        })
+        .await
+        .expect("client task");
+
+        // Let the server's accept loop register the association.
+        for _ in 0..50 {
+            tokio::time::timeout(std::time::Duration::from_millis(20), server.poll_once())
+                .await
+                .ok();
+            if server.num_associations() > 0 {
+                break;
+            }
+        }
+        assert_eq!(
+            server.num_associations(),
+            1,
+            "the eNB's SCTP association must be registered on COMM_UP"
+        );
+
+        // --- S1 Setup Request in, over PPID 18 ---
+        let request = S1SetupRequest {
+            global_enb_id: GlobalEnbId {
+                plmn_identity: crate::s1ap_build::encode_plmn_id(&PlmnId::new("310", "410")),
+                enb_id: nextgcore_s1ap::EnbId::Macro(0x1234),
+            },
+            enb_name: Some("wire-test-enb".to_string()),
+            supported_tas: vec![SupportedTaItem {
+                tac: 1,
+                broadcast_plmns: vec![crate::s1ap_build::encode_plmn_id(&PlmnId::new(
+                    "310", "410",
+                ))],
+            }],
+            default_paging_drx: PagingDrx::V64,
+        };
+        let bytes = builder::build_s1_setup_request(&request).expect("encode S1 Setup Request");
+        let ppid = nextgcore_sctp::NEXTGCORE_SCTP_S1AP_PPID;
+        {
+            let bytes = bytes.clone();
+            let client_ref = &client;
+            tokio::task::block_in_place(|| {
+                client_ref
+                    .send(&bytes, ppid, S1AP_STREAM_ID)
+                    .expect("eNB sends S1 Setup Request");
+            });
+        }
+
+        // --- drive the server until it has transmitted its answer ---
+        for _ in 0..100 {
+            tokio::time::timeout(std::time::Duration::from_millis(20), server.poll_once())
+                .await
+                .ok();
+        }
+
+        // --- S1 Setup Response out, read off the association ---
+        //
+        // The client subscribed to SCTP association/address/shutdown events, so
+        // the first datagrams off the socket are NOTIFICATIONS (COMM_UP), whose
+        // sinfo is zeroed — reading one and treating it as data would observe
+        // PPID 0. Skip anything with MSG_NOTIFICATION set, exactly as the
+        // server's own read loop does.
+        let response = tokio::task::spawn_blocking(move || {
+            for _ in 0..16 {
+                let mut buf = vec![0u8; 8192];
+                let (n, info, flags) = client.recv_msg(&mut buf).expect("eNB receives a reply");
+                if flags & nextgcore_sctp::MSG_NOTIFICATION != 0 {
+                    continue; // SCTP event notification, not S1AP data
+                }
+                buf.truncate(n);
+                return (buf, info.ppid);
+            }
+            panic!("no S1AP data received: only SCTP notifications");
+        })
+        .await
+        .expect("recv task");
+
+        let (pdu, got_ppid) = response;
+        assert_eq!(
+            got_ppid, ppid,
+            "the MME must answer with the S1AP PPID (18), not NGAP's 60"
+        );
+        match decode_s1ap_pdu(&pdu).expect("decode the MME's reply") {
+            S1apMessage::S1SetupResponse(rsp) => {
+                assert_eq!(rsp.relative_mme_capacity, ctx.relative_capacity);
+            }
+            other => panic!("expected S1SetupResponse over the wire, got {other:?}"),
+        }
+
+        // The eNB is now registered and S1 Setup succeeded, so the S1 interface
+        // is operational per TS 36.413 §8.7.3.2.
+        let enb_id = ctx
+            .enb_find_by_enb_id(0x1234)
+            .expect("eNB registered by Global-eNB-ID");
+        let enb = ctx.enb_find_by_id(enb_id).expect("eNB in pool");
+        assert!(
+            enb.state.s1_setup_success,
+            "S1 Setup must be marked complete"
+        );
+
+        server.stop();
+    }
+}

--- a/src/libs/nextgcore-sctp/src/kernel_server.rs
+++ b/src/libs/nextgcore-sctp/src/kernel_server.rs
@@ -47,7 +47,7 @@ use crate::kernel::{
     SCTP_SHUTDOWN_EVENT,
 };
 use crate::server::{SctpServerConfig, ServerError, ServerEvent};
-use crate::{ReceivedMessage, SctpError, MSG_NOTIFICATION, NEXTGCORE_MAX_SDU_LEN, NGAP_PPID};
+use crate::{ReceivedMessage, SctpError, MSG_NOTIFICATION, NEXTGCORE_MAX_SDU_LEN};
 
 type Result<T> = std::result::Result<T, ServerError>;
 
@@ -120,9 +120,10 @@ impl KernelSctpServer {
         let associations = Arc::clone(&self.associations);
         let next_id = Arc::clone(&self.next_id);
         let recv_cap = (self.config.max_message_size as usize).max(NEXTGCORE_MAX_SDU_LEN);
+        let ppid = self.config.ppid;
 
         let handle = tokio::spawn(async move {
-            accept_loop(listener, associations, next_id, tx, recv_cap).await;
+            accept_loop(listener, associations, next_id, tx, recv_cap, ppid).await;
         });
         self.accept_task = Some(handle);
     }
@@ -139,7 +140,8 @@ impl KernelSctpServer {
         Ok(false)
     }
 
-    /// Send `data` to `association_id` on `stream_id` with the NGAP PPID.
+    /// Send `data` to `association_id` on `stream_id` with the configured PPID
+    /// ([`SctpServerConfig::ppid`]; NGAP 60 by default, S1AP 18 for S1-MME).
     pub async fn send(&mut self, association_id: u64, stream_id: u16, data: &[u8]) -> Result<()> {
         let (sock, afd) = {
             let guard = self.associations.lock().unwrap();
@@ -148,10 +150,11 @@ impl KernelSctpServer {
                 None => return Err(ServerError::AssociationNotFound(association_id)),
             }
         };
+        let ppid = self.config.ppid;
 
         loop {
             let mut ready = afd.writable().await.map_err(ServerError::Io)?;
-            let attempt = ready.try_io(|_| match sock.send(data, NGAP_PPID, stream_id) {
+            let attempt = ready.try_io(|_| match sock.send(data, ppid, stream_id) {
                 Ok(n) => Ok(n),
                 Err(SctpError::SendFailed(e)) => Err(e),
                 Err(other) => Err(io::Error::other(other.to_string())),
@@ -195,6 +198,7 @@ async fn accept_loop(
     next_id: Arc<AtomicU64>,
     tx: mpsc::UnboundedSender<ServerEvent>,
     recv_cap: usize,
+    ppid: u32,
 ) {
     let afd = match AsyncFd::new(FdRef(listener.as_raw_fd())) {
         Ok(afd) => afd,
@@ -249,7 +253,7 @@ async fn accept_loop(
                 let read_tx = tx.clone();
                 let read_assocs = Arc::clone(&associations);
                 tokio::spawn(async move {
-                    read_loop(id, sock, sub_afd, read_tx, read_assocs, recv_cap).await;
+                    read_loop(id, sock, sub_afd, read_tx, read_assocs, recv_cap, ppid).await;
                 });
             }
             Ok(Err(e)) => {
@@ -268,6 +272,7 @@ async fn read_loop(
     tx: mpsc::UnboundedSender<ServerEvent>,
     associations: Arc<Mutex<HashMap<u64, Assoc>>>,
     recv_cap: usize,
+    ppid: u32,
 ) {
     loop {
         let mut ready = match afd.readable().await {
@@ -301,7 +306,9 @@ async fn read_loop(
                     continue;
                 }
                 buf.truncate(n);
-                let ppid = if info.ppid == 0 { NGAP_PPID } else { info.ppid };
+                // An inbound PPID of 0 means the peer did not stamp one; fall
+                // back to the association's configured application protocol.
+                let ppid = if info.ppid == 0 { ppid } else { info.ppid };
                 let _ = tx.send(ServerEvent::DataReceived {
                     association_id: id,
                     message: ReceivedMessage {

--- a/src/libs/nextgcore-sctp/src/server.rs
+++ b/src/libs/nextgcore-sctp/src/server.rs
@@ -53,6 +53,15 @@ pub struct SctpServerConfig {
     pub max_message_size: u32,
     /// Receive buffer size
     pub receive_buffer_size: u32,
+    /// SCTP Payload Protocol Identifier stamped on outbound messages, and
+    /// substituted for an inbound PPID of 0.
+    ///
+    /// Defaults to [`crate::NGAP_PPID`] (60) so every existing NGAP call site is
+    /// unchanged. An S1-MME server must set [`crate::NEXTGCORE_SCTP_S1AP_PPID`]
+    /// (18) instead (TS 36.412): the application protocol carried over the
+    /// association is what the PPID identifies, so it belongs to the server's
+    /// configuration rather than being hardcoded at the send site.
+    pub ppid: u32,
 }
 
 impl Default for SctpServerConfig {
@@ -62,6 +71,7 @@ impl Default for SctpServerConfig {
             max_outbound_streams: 2,
             max_message_size: 65536,
             receive_buffer_size: 262144,
+            ppid: crate::NGAP_PPID,
         }
     }
 }
@@ -643,11 +653,15 @@ mod tests {
             max_outbound_streams: 4,
             max_message_size: 131072,
             receive_buffer_size: 524288,
+            ..Default::default()
         };
         assert_eq!(config.max_inbound_streams, 4);
         assert_eq!(config.max_outbound_streams, 4);
         assert_eq!(config.max_message_size, 131072);
         assert_eq!(config.receive_buffer_size, 524288);
+        // Unset ppid keeps the NGAP default, so existing NGAP callers are
+        // unaffected by the field being added.
+        assert_eq!(config.ppid, crate::NGAP_PPID);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #42.

`nextgcore-mmed` built and unit-tested a complete S1AP layer that never reached
the wire. Nothing bound port 36412; `handle_s1ap_message` had **zero** non-test
callers (all 17 call sites were inside `#[cfg(test)]`); and
`nas_eps_send_to_enb` logged "In actual implementation, this would call
`s1ap_send_to_enb_ue`" and returned `Ok(())` while seven built PDUs were bound
to `_s1ap_message` and dropped. So no eNB could associate, S1 Setup could never
complete (TS 36.413 §8.7.3.2), and every EPS procedure was impossible **while
the send path reported success**.

## Two findings the issue did not state

**1. `KernelSctpServer` hardcoded the NGAP PPID.** It sent with `NGAP_PPID` (60)
and defaulted inbound PPID to it, so S1AP's required PPID 18 (TS 36.412) was
unreachable through the async server at all. `NEXTGCORE_SCTP_S1AP_PPID` already
existed and `KernelSctpSocket::send` already took a `ppid`, so only the wrapper
needed fixing: `SctpServerConfig` gains a `ppid` field **defaulting to
`NGAP_PPID`**, leaving every existing NGAP call site byte-for-byte unchanged.
amfd now names it explicitly so the contrast with S1AP's 18 is visible at the
call site.

**2. mmed had no async runtime at all** — no `Runtime::new`, no `block_on`,
`main()` a plain `fn`. `fd_path::mme_fd_init` is a no-op stub whose own comment
says to call `mme_fd_connect` "once the async runtime is available", and nothing
ever did. **So the S6a Diameter plane is dormant for the same root cause.**
`main` is now `#[tokio::main]`, which is the prerequisite for connecting S6a;
actually connecting that peer is deliberately **not** done here (own failure
modes, belongs with the mmed S6a issues) and is called out rather than silently
fixed.

**The platform note on the issue is stale.** It says kernel SCTP is Linux-only
and the dev host was macOS, so the socket-level criteria could not be exercised.
This host is Linux with the `sctp` module loaded and `libsctp` present
(provisioned during the #151 work), so the wire test *is* runnable — and it runs.

## Changes

| Area | Change |
|---|---|
| `libs/nextgcore-sctp` | `SctpServerConfig.ppid`, threaded through `KernelSctpServer::send`, `accept_loop` and `read_loop`. Both literal config sites switched to `..Default::default()` so a future field cannot break them again; a test asserts the unset default is still `NGAP_PPID`. |
| new `mmed/src/s1ap_path.rs` | Kernel-SCTP listener on `s1ap_port` with PPID 18. `NewAssociation` → `ctx.enb_add` + assoc↔eNB maps; `DataReceived` → `handle_s1ap_message` with **every** returned `S1apSend` transmitted; `AssociationClosed` → `ctx.enb_remove`. Plus a process-global send queue so the synchronous EMM/ESM call trees can transmit without becoming async. |
| `mmed/src/main.rs` | `#[tokio::main]`; bind in `init()`, drive the S1AP data path from `run()` instead of `thread::sleep`, tear down in `shutdown()`. |
| `mmed/src/nas_path.rs` | All seven discard sites transmit their built PDU. This also fixed a semantic bug the issue did not name: those sites passed the **inner** NAS/ESM message to `nas_eps_send_to_enb`, not the S1AP PDU that wraps it, so even a working send would have put the wrong bytes on the wire. |

## Decisions worth reviewing

**A send queue, not an async cascade.** `nas_eps_send_to_enb` is sync and called
from 922 + 1031 lines of sync `emm_handler`/`esm_handler`; making it async would
force those whole call trees async. The issue itself says to route PDUs "through
the S1AP send queue", so the sync side pushes onto an unbounded channel that the
async task drains. A failed push is **not** a caller error: it means no live S1
association, indistinguishable from an eNB that vanished mid-procedure.

**Kernel SCTP only, behind a default-off `kernel-sctp` feature** mirroring amfd.
The `sctp-proto` backend is SCTP-over-UDP, so pointing S1-MME at it would
satisfy "SCTP support" while being unable to carry an association from any real
eNB — the exact trap the 2026-08-14 Diameter SCTP decision names. The default
build compiles, runs, and says plainly that S1AP transport needs the feature.

**A configurable PPID, not a per-protocol server type.** The PPID identifies the
application protocol carried over the association, so it belongs to the server's
configuration, not to the send call site. A separate `KernelS1apServer` would
have duplicated the accept/read loops for one constant.

**The context is injected into `S1apServer`** rather than read from `mme_self()`
inside the event handler: `served_gummei` is a plain field on a `&'static`
context, so a test could not configure it — and without a served GUMMEI, S1
Setup is answered with a *Failure*. Mirrors amfd, which also takes its context as
a parameter. Cost: non-static contexts need `Box::leak` in tests (one leak per
test process).

## Verification

- Workspace default features **5387 passed / 0 failed** (baseline 5383 on
  `main`, +4).
- `mmed --features kernel-sctp` **201 passed / 0 failed**, including a wire test
  where a native `KernelSctpSocket` acts as an eNB, associates over **real
  kernel SCTP**, sends an S1 Setup Request and receives an S1 Setup Response
  with PPID 18.
- `nextgcore-sctp --features kernel` still green (**90 tests**), so the PPID
  change did not disturb amfd's validated NGAP loopback.
- `cargo clippy --all-targets` **0 warnings** on every crate this PR touches
  (`nextgcore-mmed`, `nextgcore-sctp`, `nextgcore-amfd`) in all three feature
  configurations; `cargo fmt --all --check` clean.

**Revert-verified:** setting the S1AP server's `ppid` back to `NGAP_PPID` fails
the wire test with `left: 60, right: 18`, so that assertion pins the PPID rather
than passing vacuously.

One bug the wire test caught in itself: the first datagrams off the client
socket are SCTP notifications (`COMM_UP`) whose `sinfo` is **zeroed**, so reading
one as data observes PPID 0. The test now skips `MSG_NOTIFICATION` exactly as the
server's own read loop does. When a PPID reads as 0, suspect a notification
before suspecting byte order — byte order would show `18 → 0x12000000`, not zero.

## Acceptance criteria (#42)

- [x] Binds SCTP with PPID 18 at startup via `KernelSctpServer`
- [x] COMM_UP registers the peer with `ctx.enb_add(peer)`, mapped to an eNB id
- [x] Inbound chunks route into `handle_s1ap_message`; every returned `S1apSend`
      is transmitted, no `Vec<S1apSend>` discarded
- [x] `nas_eps_send_to_enb` and the E-RAB builders transmit; **zero**
      `_s1ap_message` discard sites remain in `nas_path.rs`
- [x] `handle_s1ap_message` has a non-test caller (`s1ap_path.rs:288`, outside
      the `#[cfg(test)]` module that starts at line 360)
- [x] A wire test drives S1 Setup Request in and asserts S1 Setup Response out
- [x] Default (non-`kernel-sctp`) build and existing tests pass unchanged;
      clippy clean

*Deviation from the spec:* the wire test landed in `s1ap_path.rs`'s `#[cfg(test)]`
module rather than a separate `tests/s1ap_loopback.rs`, since it needs the
crate-private `S1apServer` construction path.

## Not exercised

- A **third-party eNB** — this is only nextgcore talking to nextgcore over real
  SCTP, which cannot catch a shared misreading of TS 36.413.
- **Uplink NAS dispatch into EMM/ESM**, which is #43. This PR delivers the
  transport and the S1AP handler's first non-test caller, not the NAS wiring
  beyond it.

Spec: `specs/fix-mmed-s1ap-sctp-transport.md`
