### PR TITLE
fix(mmed): establish a real NAS security context (closes #44)

### DIFF
--- a/src/bins/nextgcore-mmed/src/context.rs
+++ b/src/bins/nextgcore-mmed/src/context.rs
@@ -1415,6 +1415,26 @@ pub struct MmeContext {
 
 use std::sync::atomic::AtomicU64;
 
+/// Default NAS integrity algorithm priority, most preferred first.
+///
+/// Mirrors `security.integrity_order: [EIA2, EIA1, EIA0]` in the shipped
+/// `docker/rust/configs/epc/mme.yaml`. It lives here as a default because mmed
+/// does not parse its configuration file yet; once it does, the parsed list
+/// overwrites this field and behaviour is unchanged for that deployment.
+///
+/// Note that EIA0 is present for completeness only: TS 33.401 §5.1.4.1 permits
+/// null integrity solely for unauthenticated emergency calls, so
+/// `nas_security::select_nas_algorithms` never selects it.
+pub const DEFAULT_INTEGRITY_ORDER: [u8; 3] = [2, 1, 0];
+
+/// Default NAS ciphering algorithm priority, most preferred first.
+///
+/// Mirrors `security.ciphering_order: [EEA0, EEA1, EEA2]` in the shipped
+/// `docker/rust/configs/epc/mme.yaml`, which asks for null ciphering first. That
+/// is a deliberate operator preference rather than a fallback, and unlike null
+/// integrity it is permitted for any UE.
+pub const DEFAULT_CIPHERING_ORDER: [u8; 3] = [0, 1, 2];
+
 impl MmeContext {
     /// Create a new MME context
     pub fn new() -> Self {
@@ -1425,6 +1445,8 @@ impl MmeContext {
             mme_ue_s1ap_id: AtomicU32::new(1),
             pool_id_counter: AtomicU64::new(NEXTGCORE_MIN_POOL_ID),
             initialized: AtomicBool::new(false),
+            integrity_order: DEFAULT_INTEGRITY_ORDER.to_vec(),
+            ciphering_order: DEFAULT_CIPHERING_ORDER.to_vec(),
             ..Default::default()
         }
     }

--- a/src/bins/nextgcore-mmed/src/emm_build.rs
+++ b/src/bins/nextgcore-mmed/src/emm_build.rs
@@ -401,15 +401,11 @@ pub fn build_attach_accept(
 ) -> Result<Vec<u8>, &'static str> {
     let mut buf = NasBuffer::new();
 
-    // Security header
-    buf.write_u8(
-        (SecurityHeaderType::IntegrityProtectedAndCiphered as u8) << 4
-            | NAS_PROTOCOL_DISCRIMINATOR_EMM,
-    );
-    buf.write_u32(0); // MAC placeholder
-    buf.write_u8(0); // Sequence number placeholder
-
-    // EMM header
+    // EMM header. The security header is deliberately NOT written here: every
+    // caller passes this message through `nas_security::nas_eps_security_encode`,
+    // which prepends the real 6-octet header with a computed MAC. Writing a
+    // placeholder as well produced a message with two headers, the inner one
+    // covered by the MAC (issue #44).
     buf.write_u8(NAS_PROTOCOL_DISCRIMINATOR_EMM);
     buf.write_u8(NasEpsMessageType::AttachAccept as u8);
 
@@ -528,15 +524,8 @@ pub fn build_security_mode_command(
 ) -> Vec<u8> {
     let mut buf = NasBuffer::new();
 
-    // Security header (integrity protected with new security context)
-    buf.write_u8(
-        (SecurityHeaderType::IntegrityProtectedNewContext as u8) << 4
-            | NAS_PROTOCOL_DISCRIMINATOR_EMM,
-    );
-    buf.write_u32(0); // MAC placeholder
-    buf.write_u8(0); // Sequence number placeholder
-
-    // EMM header
+    // EMM header only; `nas_eps_security_encode` prepends the security header
+    // with the new-context header type and the real MAC (issue #44).
     buf.write_u8(NAS_PROTOCOL_DISCRIMINATOR_EMM);
     buf.write_u8(NasEpsMessageType::SecurityModeCommand as u8);
 
@@ -573,15 +562,8 @@ pub fn build_security_mode_command(
 pub fn build_detach_request(_mme_ue: &MmeUe, detach_type: DetachTypeToUe) -> Vec<u8> {
     let mut buf = NasBuffer::new();
 
-    // Security header
-    buf.write_u8(
-        (SecurityHeaderType::IntegrityProtectedAndCiphered as u8) << 4
-            | NAS_PROTOCOL_DISCRIMINATOR_EMM,
-    );
-    buf.write_u32(0); // MAC placeholder
-    buf.write_u8(0); // Sequence number placeholder
-
-    // EMM header
+    // EMM header only; `nas_eps_security_encode` prepends the security header
+    // and the real MAC (issue #44).
     buf.write_u8(NAS_PROTOCOL_DISCRIMINATOR_EMM);
     buf.write_u8(NasEpsMessageType::DetachRequest as u8);
 
@@ -601,15 +583,8 @@ pub fn build_detach_request(_mme_ue: &MmeUe, detach_type: DetachTypeToUe) -> Vec
 pub fn build_detach_accept(_mme_ue: &MmeUe) -> Vec<u8> {
     let mut buf = NasBuffer::new();
 
-    // Security header
-    buf.write_u8(
-        (SecurityHeaderType::IntegrityProtectedAndCiphered as u8) << 4
-            | NAS_PROTOCOL_DISCRIMINATOR_EMM,
-    );
-    buf.write_u32(0); // MAC placeholder
-    buf.write_u8(0); // Sequence number placeholder
-
-    // EMM header
+    // EMM header only; `nas_eps_security_encode` prepends the security header
+    // and the real MAC (issue #44).
     buf.write_u8(NAS_PROTOCOL_DISCRIMINATOR_EMM);
     buf.write_u8(NasEpsMessageType::DetachAccept as u8);
 
@@ -625,15 +600,8 @@ pub fn build_tau_accept(
 ) -> Vec<u8> {
     let mut buf = NasBuffer::new();
 
-    // Security header
-    buf.write_u8(
-        (SecurityHeaderType::IntegrityProtectedAndCiphered as u8) << 4
-            | NAS_PROTOCOL_DISCRIMINATOR_EMM,
-    );
-    buf.write_u32(0); // MAC placeholder
-    buf.write_u8(0); // Sequence number placeholder
-
-    // EMM header
+    // EMM header only; `nas_eps_security_encode` prepends the security header
+    // and the real MAC (issue #44).
     buf.write_u8(NAS_PROTOCOL_DISCRIMINATOR_EMM);
     buf.write_u8(NasEpsMessageType::TauAccept as u8);
 
@@ -728,15 +696,8 @@ pub fn build_emm_information(
 ) -> Vec<u8> {
     let mut buf = NasBuffer::new();
 
-    // Security header
-    buf.write_u8(
-        (SecurityHeaderType::IntegrityProtectedAndCiphered as u8) << 4
-            | NAS_PROTOCOL_DISCRIMINATOR_EMM,
-    );
-    buf.write_u32(0); // MAC placeholder
-    buf.write_u8(0); // Sequence number placeholder
-
-    // EMM header
+    // EMM header only; `nas_eps_security_encode` prepends the security header
+    // and the real MAC (issue #44).
     buf.write_u8(NAS_PROTOCOL_DISCRIMINATOR_EMM);
     buf.write_u8(NasEpsMessageType::EmmInformation as u8);
 

--- a/src/bins/nextgcore-mmed/src/nas_dispatch.rs
+++ b/src/bins/nextgcore-mmed/src/nas_dispatch.rs
@@ -146,14 +146,21 @@ pub fn nas_eps_handle_uplink(ctx: &MmeContext, uplink: UplinkNas<'_>) {
     };
 
     match uplink.nas_pdu[0] & 0x0f {
+        // Every security-protected NAS message carries the EMM protocol
+        // discriminator in its outer header (TS 24.301 §9.3), whatever the inner
+        // message is, so this is also the entry point for protected ESM.
         NAS_PROTOCOL_DISCRIMINATOR_EMM => dispatch_emm(ctx, &enb_ue, mme_ue_id, uplink.nas_pdu),
         NAS_PROTOCOL_DISCRIMINATOR_ESM => {
-            // An ESM message may arrive standalone (TS 24.301 §8.3), not only
-            // piggybacked in an EMM container.
-            let Some(mme_ue) = ctx.mme_ue_find_by_id(mme_ue_id) else {
-                return;
-            };
-            handle_esm_message(ctx, &enb_ue, &mme_ue, uplink.nas_pdu);
+            // A standalone ESM message with no security header. TS 24.301
+            // §4.4.4.2 forbids forwarding unprotected messages to the ESM
+            // entity; the one legitimate unprotected ESM message is the
+            // container piggybacked on ATTACH REQUEST, which is held on the UE
+            // context and replayed once security is established.
+            log::warn!(
+                "Unprotected standalone ESM message from enb_ue_s1ap_id={} discarded (TS 24.301 \
+                 4.4.4.2)",
+                enb_ue.enb_ue_s1ap_id
+            );
         }
         other => log::warn!(
             "Uplink NAS with unknown protocol discriminator 0x{other:02x} discarded \
@@ -212,6 +219,27 @@ fn resolve_mme_ue(ctx: &MmeContext, enb_ue: &EnbUe, s_tmsi: Option<(u8, u32)>) -
 // EMM dispatch
 // ============================================================================
 
+/// Whether an EMM message may be processed without integrity protection.
+///
+/// TS 24.301 §4.4.4.2 lists the messages the MME accepts before a NAS security
+/// context exists — the ones a UE legitimately has no key for. Everything else
+/// must arrive integrity protected, so a plain copy is discarded (§4.4.4.3).
+/// SECURITY MODE COMPLETE is deliberately absent: it is always protected with
+/// the new context the Security Mode Command established.
+fn may_be_sent_unprotected(message_type: u8) -> bool {
+    matches!(
+        message_type,
+        emm_type::ATTACH_REQUEST
+            | emm_type::IDENTITY_RESPONSE
+            | emm_type::AUTHENTICATION_RESPONSE
+            | emm_type::AUTHENTICATION_FAILURE
+            | emm_type::SECURITY_MODE_REJECT
+            | emm_type::DETACH_REQUEST
+            | emm_type::DETACH_ACCEPT
+            | emm_type::TAU_REQUEST
+    )
+}
+
 fn dispatch_emm(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, pdu: &[u8]) {
     let security_header_type = pdu[0] >> 4;
 
@@ -221,6 +249,18 @@ fn dispatch_emm(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, pdu: &[u8]) {
     }
 
     let plain = if security_header_type == 0 {
+        // TS 24.301 §4.4.4.2: outside an enumerated allowlist, an EMM message
+        // that is not integrity protected must not be processed, nor forwarded
+        // to the ESM entity.
+        if !may_be_sent_unprotected(pdu[1]) {
+            log::warn!(
+                "Unprotected EMM message type 0x{:02x} from enb_ue_s1ap_id={} discarded: it is \
+                 not in the TS 24.301 4.4.4.2 allowlist",
+                pdu[1],
+                enb_ue.enb_ue_s1ap_id
+            );
+            return;
+        }
         pdu.to_vec()
     } else {
         match decode_protected(ctx, mme_ue_id, security_header_type, pdu) {
@@ -232,6 +272,32 @@ fn dispatch_emm(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, pdu: &[u8]) {
     if plain.len() < 2 {
         log::warn!("Decoded EMM message too short ({} bytes)", plain.len());
         return;
+    }
+
+    // What came out of the security container: an EMM message, an ESM message,
+    // or — when no algorithm was in use, so `nas_eps_security_decode` left the
+    // 6-octet header attached — the protected message itself. A plain EMM
+    // header is exactly 0x07 (security header type 0, PD 7), an inner ESM
+    // message has PD 2 in its low nibble, and an unstripped header keeps PD 7
+    // with a non-zero security-header-type nibble.
+    match plain[0] & 0x0f {
+        NAS_PROTOCOL_DISCRIMINATOR_ESM => {
+            let Some(mme_ue) = ctx.mme_ue_find_by_id(mme_ue_id) else {
+                return;
+            };
+            handle_esm_message(ctx, enb_ue, &mme_ue, &plain);
+            return;
+        }
+        NAS_PROTOCOL_DISCRIMINATOR_EMM if plain[0] == NAS_PROTOCOL_DISCRIMINATOR_EMM => {}
+        _ => {
+            log::warn!(
+                "NAS security decode left a protected message (first octet {:#04x}) from \
+                 enb_ue_s1ap_id={}; discarded",
+                plain[0],
+                enb_ue.enb_ue_s1ap_id
+            );
+            return;
+        }
     }
 
     let message_type = plain[1];
@@ -333,32 +399,16 @@ fn decode_protected(
         return None;
     }
 
-    if let Err(e) = nas_security::nas_eps_security_decode(mme_ue, flags, &mut message) {
-        log::warn!("[{}] NAS security decode failed: {e}", mme_ue.imsi_bcd);
-        return None;
-    }
+    let decoded = nas_security::nas_eps_security_decode(mme_ue, flags, &mut message);
 
-    // TS 24.301 §4.4.4.3: a message that fails the integrity check is
-    // discarded. `mac_failed` is cleared so it cannot leak into the next
-    // message on this context.
-    if std::mem::take(&mut mme_ue.mac_failed) {
+    // TS 24.301 §4.4.4.3: a message that fails the integrity check is discarded.
+    // The decode reports that as an error; the flag is cleared as well so it
+    // cannot leak into the next message on this context.
+    let mac_failed = std::mem::take(&mut mme_ue.mac_failed);
+    if let Err(e) = decoded {
         log::warn!(
-            "[{}] NAS integrity check failed; message discarded",
+            "[{}] NAS security decode failed: {e} (mac_failed={mac_failed})",
             mme_ue.imsi_bcd
-        );
-        return None;
-    }
-
-    // The security header is only stripped when an algorithm is actually in
-    // use, and NAS algorithm selection is not implemented (#44). Rather than
-    // read a MAC octet as a message type, insist the decode produced a plain
-    // EMM header (TS 24.301 §9.3.1: security header type 0, PD 0x07).
-    if message.first() != Some(&NAS_PROTOCOL_DISCRIMINATOR_EMM) {
-        log::warn!(
-            "[{}] NAS security decode left a protected message (first octet {:#04x}); discarded — \
-             no NAS algorithm is selected (#44)",
-            mme_ue.imsi_bcd,
-            message.first().copied().unwrap_or(0)
         );
         return None;
     }
@@ -511,7 +561,32 @@ fn emm_authentication_response(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64,
     match emm_handler::handle_authentication_response(enb_ue, mme_ue, body) {
         Ok(true) => {
             // TS 24.301 §5.4.3.2: authentication done, take the NAS security
-            // context into use.
+            // context into use. TS 33.401 §7.2.4.3: the algorithms are chosen
+            // here, from the UE's advertised capabilities and the MME's ordered
+            // preference, and the NAS keys are derived from KASME for exactly
+            // those algorithms (Annex A.7) — so both must happen before the
+            // Security Mode Command is built with them.
+            let Some(selected) = nas_security::select_nas_algorithms(
+                &ctx.integrity_order,
+                &ctx.ciphering_order,
+                &mme_ue.ue_network_capability,
+            ) else {
+                log::warn!(
+                    "[{}] No NAS integrity algorithm in common with the UE; rejecting the attach",
+                    mme_ue.imsi_bcd
+                );
+                if let Err(e) = nas_path::nas_eps_send_attach_reject(
+                    enb_ue,
+                    mme_ue,
+                    EmmCause::UeSecurityCapabilitiesMismatch,
+                    None,
+                ) {
+                    log::error!("Attach Reject send failed: {e}");
+                }
+                return;
+            };
+            nas_security::derive_nas_keys(mme_ue, selected);
+
             mme_ue.t3460.pkbuf = None;
             if let Err(e) = nas_path::nas_eps_send_security_mode_command(mme_ue, enb_ue) {
                 log::error!(
@@ -1383,6 +1458,72 @@ mod tests {
             .flatten()
     }
 
+    /// Message type of a message the MME sent under a security header
+    /// (6 octets: header type / PD, 4-octet MAC, sequence number).
+    fn protected_message_type(pkbuf: &Option<Vec<u8>>) -> Option<u8> {
+        let buf = pkbuf.as_ref()?;
+        (buf.len() > 7 && buf[0] & 0x0f == NAS_PROTOCOL_DISCRIMINATOR_EMM && buf[0] >> 4 != 0)
+            .then(|| buf[7])
+    }
+
+    /// Wrap `plain` in an integrity-protected uplink security header carrying
+    /// the MAC a UE holding the same NAS context would compute.
+    ///
+    /// The MME derives its verification count from the sequence number in the
+    /// header, so with no overflow the count *is* that sequence number.
+    fn protect_uplink(mme_ue: &MmeUe, sequence_number: u8, plain: &[u8]) -> Vec<u8> {
+        let mut protected = vec![
+            ((crate::emm_build::SecurityHeaderType::IntegrityProtected as u8) << 4)
+                | NAS_PROTOCOL_DISCRIMINATOR_EMM,
+            0,
+            0,
+            0,
+            0, // MAC, filled in below
+            sequence_number,
+        ];
+        protected.extend_from_slice(plain);
+
+        let mac = nas_security::nas_mac_calculate(
+            mme_ue.selected_int_algorithm,
+            &mme_ue.knas_int,
+            u32::from(sequence_number),
+            nas_security::NAS_SECURITY_BEARER,
+            nas_security::NAS_SECURITY_UPLINK_DIRECTION,
+            &protected[5..],
+        );
+        protected[1..5].copy_from_slice(&mac);
+        protected
+    }
+
+    /// A UE context with an HSS vector and the capabilities of a UE supporting
+    /// EEA/EIA 0-3, as an Attach Request would have left it.
+    fn ue_with_vector(ctx: &MmeContext, enb_ue_id: u64) -> u64 {
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        ctx.enb_ue_associate_mme_ue(enb_ue_id, mme_ue_id);
+        ctx.mme_ue_set_imsi(mme_ue_id, TEST_IMSI);
+        let mut pool = ctx.mme_ue_pool.write().unwrap();
+        let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+        mme_ue.xres[..8].copy_from_slice(&[0xaa; 8]);
+        mme_ue.xres_len = 8;
+        mme_ue.rand = [0x11; 16];
+        mme_ue.autn = [0x22; 16];
+        mme_ue.kasme = [0x44; 32];
+        mme_ue.ue_network_capability.eea = 0xf0;
+        mme_ue.ue_network_capability.eia = 0xf0;
+        mme_ue_id
+    }
+
+    /// AUTHENTICATION RESPONSE echoing the XRES `ue_with_vector` seeded.
+    fn authentication_response() -> Vec<u8> {
+        let mut pdu = vec![
+            NAS_PROTOCOL_DISCRIMINATOR_EMM,
+            NasEpsMessageType::AuthenticationResponse as u8,
+            0x08,
+        ];
+        pdu.extend_from_slice(&[0xaa; 8]);
+        pdu
+    }
+
     #[test]
     fn test_attach_request_with_imsi_indexes_ue_and_awaits_a_vector() {
         let ctx = test_ctx();
@@ -1626,34 +1767,190 @@ mod tests {
     }
 
     #[test]
-    fn test_authentication_response_match_sends_security_mode_command() {
+    fn test_authentication_response_selects_algorithms_and_derives_keys() {
         let ctx = test_ctx();
         let enb_ue_id = enb_with_connection(&ctx);
-        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
-        ctx.enb_ue_associate_mme_ue(enb_ue_id, mme_ue_id);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        // The shipped configuration's order is [EIA2, EIA1, EIA0] and
+        // [EEA0, EEA1, EEA2], and this UE supports 0-3.
+        assert_eq!(mme_ue.selected_int_algorithm, 2, "EIA2 must be selected");
+        assert_eq!(
+            mme_ue.selected_enc_algorithm, 0,
+            "EEA0 is what the shipped ciphering order asks for first"
+        );
+        // TS 33.401 Annex A.7 keys, derived for exactly those algorithms.
+        assert_eq!(
+            mme_ue.knas_int,
+            nextgcore_crypt::kdf::nextgcore_kdf_nas_eps(
+                nas_security::NAS_INT_ALG_DISTINGUISHER,
+                2,
+                &[0x44; 32]
+            )
+        );
+        assert_eq!(
+            mme_ue.knas_enc,
+            nextgcore_crypt::kdf::nextgcore_kdf_nas_eps(
+                nas_security::NAS_ENC_ALG_DISTINGUISHER,
+                0,
+                &[0x44; 32]
+            )
+        );
+        assert_ne!(mme_ue.knas_int, [0u8; 16], "the keys must not be null");
+        assert_eq!(
+            protected_message_type(&mme_ue.t3460.pkbuf),
+            Some(NasEpsMessageType::SecurityModeCommand as u8),
+            "a Security Mode Command must be armed on T3460"
+        );
+        // Non-null integrity means the command carries a real MAC.
+        let smc = mme_ue.t3460.pkbuf.clone().unwrap();
+        assert_ne!(&smc[1..5], &[0u8; 4], "the MAC must not be null");
+        // Selected NAS security algorithms IE: EEA in the high nibble, EIA in
+        // the low one, so EEA0/EIA2 is 0x02.
+        assert_eq!(
+            smc[8], 0x02,
+            "the command must carry the selected EEA0/EIA2"
+        );
+        assert!(mme_ue.security_context_available);
+    }
+
+    #[test]
+    fn test_no_common_integrity_algorithm_rejects_the_attach() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        {
+            // A UE advertising EIA0 only: TS 33.401 5.1.4.1 allows null
+            // integrity for unauthenticated emergency calls only.
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            pool.get_mut(&mme_ue_id).unwrap().ue_network_capability.eia = 0x80;
+        }
+
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(
+            mme_ue.selected_int_algorithm, 0,
+            "no algorithm may be taken into use"
+        );
+        assert_eq!(mme_ue.knas_int, [0u8; 16], "no keys may be derived");
+        assert!(
+            mme_ue.t3460.pkbuf.is_none(),
+            "no Security Mode Command may go out; the attach is rejected instead"
+        );
+    }
+
+    #[test]
+    fn test_protected_uplink_round_trip_completes_the_security_procedure() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
         {
             let mut pool = ctx.mme_ue_pool.write().unwrap();
             let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
-            mme_ue.xres[..8].copy_from_slice(&[0xaa; 8]);
-            mme_ue.xres_len = 8;
+            mme_ue.nas_eps.type_ = MmeEpsType::AttachRequest;
+            mme_ue.pdn_connectivity_request = pdn_connectivity_request(5, false);
         }
-        let mut pdu = vec![
-            NAS_PROTOCOL_DISCRIMINATOR_EMM,
-            NasEpsMessageType::AuthenticationResponse as u8,
-            0x08,
-        ];
-        pdu.extend_from_slice(&[0xaa; 8]);
 
-        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdu));
+        // Authentication Response -> real Security Mode Command.
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+
+        // The UE answers with an integrity-protected SECURITY MODE COMPLETE,
+        // MAC'd with the key both sides now hold.
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        let complete = protect_uplink(
+            &mme_ue,
+            1,
+            &[
+                NAS_PROTOCOL_DISCRIMINATOR_EMM,
+                NasEpsMessageType::SecurityModeComplete as u8,
+            ],
+        );
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &complete));
 
         let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(mme_ue.ul_count, 1, "the verified message advanced UL COUNT");
         assert!(
-            mme_ue.t3460.pkbuf.is_some(),
-            "a Security Mode Command must be armed on T3460"
+            mme_ue.pdn_connectivity_request.is_empty(),
+            "the held ESM container must be consumed"
         );
+        // The container reached the ESM entity through a verified message.
+        let sess_id = ctx
+            .sess_find_by_pti(mme_ue_id, 5)
+            .expect("the ESM handler must have created the session");
+        let sess = ctx.sess_find_by_id(sess_id).unwrap();
+        assert_eq!(sess.apn, TEST_APN);
+        assert_eq!(sess.ue_request_pdn_type, PdnType::Ipv4);
+    }
+
+    #[test]
+    fn test_protected_standalone_esm_reaches_the_esm_entity() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+
+        // A standalone ESM message under a security header: the outer header
+        // carries the EMM protocol discriminator, the inner message ESM's
+        // (TS 24.301 9.3), so the dispatch must route on the INNER one.
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        let request = protect_uplink(&mme_ue, 1, &pdn_connectivity_request(3, true));
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &request));
+
+        // TS 24.301 6.5.1.2: the transfer flag with no APN means the UE will
+        // send them separately, so the MME asks.
+        let sess_id = ctx.sess_find_by_pti(mme_ue_id, 3).expect("session created");
+        let bearer_id = ctx.sess_find_by_id(sess_id).unwrap().bearer_list[0];
+        let bearer = ctx.bearer_find_by_id(bearer_id).unwrap();
         assert!(
-            mme_ue.security_context_available,
-            "encoding the Security Mode Command establishes the security context"
+            bearer.t3489.pkbuf.is_some(),
+            "an ESM Information Request must be armed on T3489"
+        );
+    }
+
+    #[test]
+    fn test_unprotected_messages_outside_the_allowlist_are_discarded() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            pool.get_mut(&mme_ue_id).unwrap().pdn_connectivity_request =
+                pdn_connectivity_request(5, false);
+        }
+
+        // SECURITY MODE COMPLETE is always protected with the new context, so a
+        // plain copy must not be processed (TS 24.301 4.4.4.2).
+        nas_eps_handle_uplink(
+            &ctx,
+            uplink(
+                enb_ue_id,
+                &[
+                    NAS_PROTOCOL_DISCRIMINATOR_EMM,
+                    NasEpsMessageType::SecurityModeComplete as u8,
+                ],
+            ),
+        );
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.security_context_available);
+        assert!(!mme_ue.pdn_connectivity_request.is_empty());
+
+        // A standalone unprotected ESM message must not reach the ESM entity.
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdn_connectivity_request(9, false)));
+        assert!(ctx.sess_find_by_pti(mme_ue_id, 9).is_none());
+
+        // An allowlisted message still is: this one a UE has no key for.
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+        assert!(
+            ctx.mme_ue_find_by_id(mme_ue_id)
+                .unwrap()
+                .t3460
+                .pkbuf
+                .is_some(),
+            "an ATTACH/AUTHENTICATION-class message may arrive unprotected"
         );
     }
 
@@ -1682,81 +1979,29 @@ mod tests {
     }
 
     #[test]
-    fn test_security_mode_complete_replays_the_held_esm_container() {
+    fn test_rejected_esm_request_hands_back_its_session() {
         let ctx = test_ctx();
         let enb_ue_id = enb_with_connection(&ctx);
-        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
-        ctx.enb_ue_associate_mme_ue(enb_ue_id, mme_ue_id);
-        ctx.mme_ue_set_imsi(mme_ue_id, TEST_IMSI);
-        {
-            let mut pool = ctx.mme_ue_pool.write().unwrap();
-            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
-            mme_ue.nas_eps.type_ = MmeEpsType::AttachRequest;
-            mme_ue.pdn_connectivity_request = pdn_connectivity_request(5, false);
-        }
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
 
-        // Plain SECURITY MODE COMPLETE: no security context is established, so
-        // it arrives unprotected in this test and only the dispatch is exercised.
-        let pdu = vec![
-            NAS_PROTOCOL_DISCRIMINATOR_EMM,
-            NasEpsMessageType::SecurityModeComplete as u8,
-        ];
-        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdu));
-
+        // A PDN CONNECTIVITY REQUEST whose body is shorter than its mandatory
+        // IEs: protected and verified, but the ESM handler refuses it.
         let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
-        assert!(mme_ue.security_context_available);
-        assert!(
-            mme_ue.pdn_connectivity_request.is_empty(),
-            "the held container must be consumed"
+        let malformed = protect_uplink(
+            &mme_ue,
+            1,
+            &[
+                NAS_PROTOCOL_DISCRIMINATOR_ESM,
+                7, // procedure transaction identity
+                EsmMessageType::PdnConnectivityRequest as u8,
+                0x11, // one octet where two are mandatory
+            ],
         );
-        // The replayed container reached the ESM entity, which created the
-        // session it names.
-        let sess_id = ctx
-            .sess_find_by_pti(mme_ue_id, 5)
-            .expect("the ESM handler must have created the session");
-        let sess = ctx.sess_find_by_id(sess_id).unwrap();
-        assert_eq!(sess.ue_request_type, 1);
-        assert_eq!(sess.ue_request_pdn_type, PdnType::Ipv4);
-        assert_eq!(sess.apn, TEST_APN);
-        assert_eq!(mme_ue.sess_list, vec![sess_id]);
-    }
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &malformed));
 
-    #[test]
-    fn test_standalone_pdn_connectivity_request_asks_for_esm_information() {
-        let ctx = test_ctx();
-        let enb_ue_id = enb_with_connection(&ctx);
-        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
-        ctx.enb_ue_associate_mme_ue(enb_ue_id, mme_ue_id);
-        ctx.mme_ue_set_imsi(mme_ue_id, TEST_IMSI);
-        {
-            let mut pool = ctx.mme_ue_pool.write().unwrap();
-            pool.get_mut(&mme_ue_id).unwrap().security_context_available = true;
-        }
-
-        // TS 24.301 §6.5.1.2: the transfer flag with no APN means the UE will
-        // send them separately, so the MME asks.
-        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdn_connectivity_request(3, true)));
-
-        let sess_id = ctx.sess_find_by_pti(mme_ue_id, 3).expect("session created");
-        let bearer_id = ctx.sess_find_by_id(sess_id).unwrap().bearer_list[0];
-        let bearer = ctx.bearer_find_by_id(bearer_id).unwrap();
-        assert!(
-            bearer.t3489.pkbuf.is_some(),
-            "an ESM Information Request must be armed on T3489"
-        );
-    }
-
-    #[test]
-    fn test_esm_message_without_a_security_context_is_rejected() {
-        let ctx = test_ctx();
-        let enb_ue_id = enb_with_connection(&ctx);
-        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
-        ctx.enb_ue_associate_mme_ue(enb_ue_id, mme_ue_id);
-
-        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdn_connectivity_request(7, false)));
-
-        // The ESM handler refused it (no security context), so the contexts the
-        // request allocated are handed back rather than accumulating.
+        // The contexts the rejected request allocated are handed back rather
+        // than accumulating.
         assert!(ctx.sess_find_by_pti(mme_ue_id, 7).is_none());
         assert!(ctx.sess_pool.read().unwrap().is_empty());
         assert!(ctx.bearer_pool.read().unwrap().is_empty());

--- a/src/bins/nextgcore-mmed/src/nas_security.rs
+++ b/src/bins/nextgcore-mmed/src/nas_security.rs
@@ -4,7 +4,7 @@
 //!
 //! Implements NAS message integrity protection and ciphering for EPS.
 
-use crate::context::MmeUe;
+use crate::context::{MmeUe, UeNetworkCapability};
 use crate::emm_build::SecurityHeaderType;
 
 // ============================================================================
@@ -13,6 +13,21 @@ use crate::emm_build::SecurityHeaderType;
 
 /// NAS security bearer (always 0 for NAS)
 pub const NAS_SECURITY_BEARER: u32 = 0;
+
+/// Highest NAS algorithm identity this codec implements.
+///
+/// [`nas_mac_calculate`] and [`nas_encrypt`] cover identities 0-3 (null,
+/// SNOW 3G, AES, ZUC) and fall through to a **zero MAC / no encryption** with a
+/// warning for anything else. Selecting 4-7 would therefore reintroduce the
+/// silent downgrade this module exists to prevent, so
+/// [`select_nas_algorithms`] refuses to consider them.
+pub const MAX_IMPLEMENTED_ALGORITHM: u8 = 3;
+
+/// TS 33.401 Annex A.7 algorithm type distinguisher for NAS ciphering.
+pub const NAS_ENC_ALG_DISTINGUISHER: u8 = 0x01;
+
+/// TS 33.401 Annex A.7 algorithm type distinguisher for NAS integrity.
+pub const NAS_INT_ALG_DISTINGUISHER: u8 = 0x02;
 
 /// NAS security MAC size in bytes
 pub const NAS_SECURITY_MAC_SIZE: usize = 4;
@@ -25,6 +40,106 @@ pub const NAS_SECURITY_UPLINK_DIRECTION: u32 = 0;
 
 /// NAS headroom for security header
 pub const NEXTGCORE_NAS_HEADROOM: usize = 16;
+
+// ============================================================================
+// Algorithm Selection and Key Derivation
+// ============================================================================
+
+/// The NAS security algorithms selected for a UE.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectedNasAlgorithms {
+    /// EIA identity (never 0 — see [`select_nas_algorithms`])
+    pub integrity: u8,
+    /// EEA identity (0 = EEA0, null ciphering, is a valid choice)
+    pub ciphering: u8,
+}
+
+/// Whether the UE advertises support for `algorithm`.
+///
+/// TS 24.301 §9.9.3.34: in the UE network capability the EEA and EIA octets are
+/// bitmaps whose most significant bit is algorithm 0, so algorithm *n* is
+/// supported iff bit `0x80 >> n` is set.
+fn ue_supports(capability: u8, algorithm: u8) -> bool {
+    algorithm <= 7 && capability & (0x80 >> algorithm) != 0
+}
+
+/// Pick the NAS algorithms for a UE (TS 33.401 §7.2.4.3).
+///
+/// Each ordered list is the MME's preference, most preferred first; the first
+/// entry the UE advertises and this codec implements wins.
+///
+/// Returns `None` when no usable integrity algorithm matches. Null integrity is
+/// deliberately *not* a fallback: TS 33.401 §5.1.4.1 permits EIA0 only for
+/// unauthenticated emergency calls, so a UE that supports nothing else must be
+/// rejected (TS 24.301 EMM cause #23) rather than admitted unprotected. Null
+/// ciphering is different — EEA0 is a legitimate configured choice for any UE,
+/// and is what the shipped configuration asks for first.
+pub fn select_nas_algorithms(
+    integrity_order: &[u8],
+    ciphering_order: &[u8],
+    capability: &UeNetworkCapability,
+) -> Option<SelectedNasAlgorithms> {
+    let integrity = integrity_order
+        .iter()
+        .copied()
+        .find(|algorithm| {
+            *algorithm != 0
+                && *algorithm <= MAX_IMPLEMENTED_ALGORITHM
+                && ue_supports(capability.eia, *algorithm)
+        })
+        .or_else(|| {
+            log::warn!(
+                "No usable NAS integrity algorithm: MME order {integrity_order:?} vs UE EIA \
+                 bitmap 0x{:02x}",
+                capability.eia
+            );
+            None
+        })?;
+
+    // Falling back to EEA0 is safe and matches the spec's "null ciphering is
+    // always supported" assumption, so an empty or unmatched list is not fatal.
+    let ciphering = ciphering_order
+        .iter()
+        .copied()
+        .find(|algorithm| {
+            *algorithm <= MAX_IMPLEMENTED_ALGORITHM && ue_supports(capability.eea, *algorithm)
+        })
+        .unwrap_or(0);
+
+    Some(SelectedNasAlgorithms {
+        integrity,
+        ciphering,
+    })
+}
+
+/// Take the selected algorithms into use and derive the NAS keys from `KASME`.
+///
+/// TS 33.401 Annex A.7: `KNASenc` and `KNASint` come from the FC=0x15 KDF keyed
+/// on `KASME`, with the algorithm type distinguisher and the selected algorithm
+/// identity as inputs — so this must run *after* selection, and re-running it
+/// with different algorithms yields different keys.
+pub fn derive_nas_keys(mme_ue: &mut MmeUe, selected: SelectedNasAlgorithms) {
+    mme_ue.selected_int_algorithm = selected.integrity;
+    mme_ue.selected_enc_algorithm = selected.ciphering;
+
+    mme_ue.knas_int = nextgcore_crypt::kdf::nextgcore_kdf_nas_eps(
+        NAS_INT_ALG_DISTINGUISHER,
+        selected.integrity,
+        &mme_ue.kasme,
+    );
+    mme_ue.knas_enc = nextgcore_crypt::kdf::nextgcore_kdf_nas_eps(
+        NAS_ENC_ALG_DISTINGUISHER,
+        selected.ciphering,
+        &mme_ue.kasme,
+    );
+
+    log::debug!(
+        "[{}] NAS security context: EIA{} / EEA{}",
+        mme_ue.imsi_bcd,
+        selected.integrity,
+        selected.ciphering
+    );
+}
 
 // ============================================================================
 // Security Header Type Parsing
@@ -535,7 +650,13 @@ pub fn nas_eps_security_decode(
                     header.message_authentication_code,
                     calculated_mac_u32
                 );
+                // TS 24.301 §4.4.4.3: a message that fails the integrity check
+                // is discarded and must not be processed further. The flag is
+                // kept for the caller's diagnostics, but the error is what makes
+                // that impossible to ignore: this used to strip the header,
+                // decrypt, and answer Ok.
                 mme_ue.mac_failed = true;
+                return Err("NAS integrity check failed");
             }
         }
 
@@ -616,7 +737,10 @@ fn decode_service_request(mme_ue: &mut MmeUe, message: &mut Vec<u8>) -> Result<(
             original_mac[0],
             original_mac[1]
         );
+        // TS 24.301 §4.4.4.3, as on the full-MAC path: a SERVICE REQUEST whose
+        // short MAC does not verify is discarded, not admitted.
         mme_ue.mac_failed = true;
+        return Err("NAS integrity check failed");
     }
 
     Ok(())
@@ -767,5 +891,244 @@ mod tests {
 
         // security_context_available should be set
         assert!(mme_ue.security_context_available);
+    }
+
+    // ========================================================================
+    // Algorithm selection and key derivation (issue #44)
+    // ========================================================================
+
+    /// A UE advertising EEA/EIA 0-3, i.e. the top four bits of each bitmap.
+    fn capability_0_to_3() -> UeNetworkCapability {
+        UeNetworkCapability {
+            eea: 0xf0,
+            eia: 0xf0,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_select_honours_the_mme_order() {
+        // The shipped configuration's order.
+        let selected = select_nas_algorithms(&[2, 1, 0], &[0, 1, 2], &capability_0_to_3()).unwrap();
+        assert_eq!(selected.integrity, 2);
+        assert_eq!(selected.ciphering, 0);
+
+        // Reordering the MME's preference changes the outcome, so the order is
+        // genuinely consulted rather than a hardcoded pick.
+        let selected = select_nas_algorithms(&[1, 2], &[2, 1, 0], &capability_0_to_3()).unwrap();
+        assert_eq!(selected.integrity, 1);
+        assert_eq!(selected.ciphering, 2);
+    }
+
+    #[test]
+    fn test_select_intersects_with_ue_capability() {
+        // TS 24.301 9.9.3.34: bit 0x80 >> n advertises algorithm n. This UE
+        // supports EIA2 and EEA2 only.
+        let capability = UeNetworkCapability {
+            eea: 0x20,
+            eia: 0x20,
+            ..Default::default()
+        };
+        let selected = select_nas_algorithms(&[3, 2, 1], &[1, 2], &capability).unwrap();
+        assert_eq!(selected.integrity, 2, "EIA3 is not advertised, EIA2 is");
+        assert_eq!(selected.ciphering, 2);
+    }
+
+    #[test]
+    fn test_select_rejects_when_only_null_integrity_is_possible() {
+        // TS 33.401 5.1.4.1: EIA0 is for unauthenticated emergency calls only,
+        // so a UE offering nothing else must be rejected, not admitted with
+        // null integrity.
+        let capability = UeNetworkCapability {
+            eea: 0xf0,
+            eia: 0x80, // EIA0 only
+            ..Default::default()
+        };
+        assert!(select_nas_algorithms(&[2, 1, 0], &[0, 1, 2], &capability).is_none());
+        // Same when the MME offers nothing at all.
+        assert!(select_nas_algorithms(&[], &[0], &capability_0_to_3()).is_none());
+    }
+
+    #[test]
+    fn test_select_skips_algorithms_this_codec_does_not_implement() {
+        // EIA4-7 / EEA4-7 have no implementation: `nas_mac_calculate` returns a
+        // zero MAC for them, so selecting one would silently disable protection.
+        let capability = UeNetworkCapability {
+            eea: 0xff,
+            eia: 0xff,
+            ..Default::default()
+        };
+        let selected = select_nas_algorithms(&[7, 4, 3], &[6, 5, 1], &capability).unwrap();
+        assert_eq!(selected.integrity, 3);
+        assert_eq!(selected.ciphering, 1);
+
+        // Nothing implemented on the integrity side leaves no usable choice.
+        assert!(select_nas_algorithms(&[7, 6, 5, 4], &[0], &capability).is_none());
+    }
+
+    #[test]
+    fn test_select_falls_back_to_null_ciphering_but_never_null_integrity() {
+        // A UE advertising no ciphering algorithm the MME offers still gets a
+        // security context: EEA0 is always acceptable.
+        let capability = UeNetworkCapability {
+            eea: 0x00,
+            eia: 0xf0,
+            ..Default::default()
+        };
+        let selected = select_nas_algorithms(&[2], &[2, 1], &capability).unwrap();
+        assert_eq!(selected.integrity, 2);
+        assert_eq!(selected.ciphering, 0);
+    }
+
+    #[test]
+    fn test_derive_nas_keys_is_keyed_on_kasme_algorithm_and_distinguisher() {
+        let mut ue = MmeUe {
+            kasme: [0x44; 32],
+            ..Default::default()
+        };
+        derive_nas_keys(
+            &mut ue,
+            SelectedNasAlgorithms {
+                integrity: 2,
+                ciphering: 0,
+            },
+        );
+
+        assert_eq!(ue.selected_int_algorithm, 2);
+        assert_eq!(ue.selected_enc_algorithm, 0);
+        assert_ne!(ue.knas_int, [0u8; 16]);
+        assert_ne!(
+            ue.knas_int, ue.knas_enc,
+            "the algorithm type distinguisher must separate the two keys"
+        );
+
+        // TS 33.401 Annex A.7 takes the algorithm identity as an input, so a
+        // different selection must yield different keys...
+        let mut other_algorithm = MmeUe {
+            kasme: [0x44; 32],
+            ..Default::default()
+        };
+        derive_nas_keys(
+            &mut other_algorithm,
+            SelectedNasAlgorithms {
+                integrity: 1,
+                ciphering: 0,
+            },
+        );
+        assert_ne!(ue.knas_int, other_algorithm.knas_int);
+        assert_eq!(
+            ue.knas_enc, other_algorithm.knas_enc,
+            "the ciphering key must not move when only the integrity algorithm did"
+        );
+
+        // ...and so must a different KASME.
+        let mut other_kasme = MmeUe {
+            kasme: [0x45; 32],
+            ..Default::default()
+        };
+        derive_nas_keys(
+            &mut other_kasme,
+            SelectedNasAlgorithms {
+                integrity: 2,
+                ciphering: 0,
+            },
+        );
+        assert_ne!(ue.knas_int, other_kasme.knas_int);
+
+        // Regression snapshot for KASME = 0x44 repeated, EIA2. TS 33.401
+        // Annex A publishes no numeric vectors for FC=0x15, so this pins *this*
+        // implementation's inputs and ordering rather than claiming to be a
+        // 3GPP vector. It is verifiable by hand: the value is the low 16 bytes
+        // of HMAC-SHA256(KASME, S) with
+        // S = FC(0x15) || P0(0x02) || L0(0x0001) || P1(0x02) || L1(0x0001),
+        // i.e. TS 33.220 Annex B's S-string with the NAS-int-alg
+        // distinguisher and the selected algorithm identity.
+        assert_eq!(
+            ue.knas_int,
+            [
+                0x16, 0xd0, 0x84, 0x8a, 0x13, 0x38, 0xb8, 0x0e, 0xd1, 0xc3, 0xf1, 0xad, 0x9c, 0x75,
+                0xad, 0x3f
+            ]
+        );
+    }
+
+    #[test]
+    fn test_decode_rejects_a_failed_mac_instead_of_returning_ok() {
+        let mut ue = MmeUe {
+            security_context_available: true,
+            selected_int_algorithm: 2,
+            knas_int: [0x33; 16],
+            ..Default::default()
+        };
+        // Integrity-protected header with a deliberately wrong MAC.
+        let mut message = vec![0x17, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x07, 0x5e];
+        let before = message.clone();
+
+        let result = nas_eps_security_decode(
+            &mut ue,
+            SecurityHeaderTypeFlags::from_header_type(1),
+            &mut message,
+        );
+
+        assert!(result.is_err(), "a MAC failure must not answer Ok");
+        assert!(ue.mac_failed);
+        assert_eq!(
+            message, before,
+            "the message must not be stripped or decrypted"
+        );
+    }
+
+    #[test]
+    fn test_decode_accepts_a_correct_mac_and_strips_the_header() {
+        let mut ue = MmeUe {
+            security_context_available: true,
+            selected_int_algorithm: 2,
+            knas_int: [0x33; 16],
+            ..Default::default()
+        };
+        let inner = [0x07u8, 0x5e];
+        let mut message = vec![0x17, 0, 0, 0, 0, 0x01];
+        message.extend_from_slice(&inner);
+        let mac = nas_mac_calculate(
+            2,
+            &ue.knas_int,
+            1, // the count the MME derives from sequence number 1
+            NAS_SECURITY_BEARER,
+            NAS_SECURITY_UPLINK_DIRECTION,
+            &message[5..],
+        );
+        message[1..5].copy_from_slice(&mac);
+
+        nas_eps_security_decode(
+            &mut ue,
+            SecurityHeaderTypeFlags::from_header_type(1),
+            &mut message,
+        )
+        .expect("a correct MAC must verify");
+
+        assert!(!ue.mac_failed);
+        assert_eq!(message, inner, "the security header must be stripped");
+        assert_eq!(ue.ul_count, 1);
+    }
+
+    #[test]
+    fn test_service_request_short_mac_failure_is_rejected() {
+        let mut ue = MmeUe {
+            security_context_available: true,
+            selected_int_algorithm: 2,
+            knas_int: [0x33; 16],
+            ..Default::default()
+        };
+        // SERVICE REQUEST with a wrong short MAC (TS 24.301 8.2.25).
+        let mut message = vec![0xc7, 0x01, 0xba, 0xad];
+
+        let result = nas_eps_security_decode(
+            &mut ue,
+            SecurityHeaderTypeFlags::from_header_type(12),
+            &mut message,
+        );
+
+        assert!(result.is_err());
+        assert!(ue.mac_failed);
     }
 }


### PR DESCRIPTION
Closes #44.

mmed never established a working EPS NAS security context. `KNASenc`/`KNASint`
were never derived from `KASME` — the only writes to `knas_int`/`knas_enc` in the
crate were in a unit test. The EEA/EIA algorithms were never selected from the
UE's capabilities, so `selected_enc_algorithm`/`selected_int_algorithm` stayed
`0`, and **both** the encode and decode paths clear their protection flags when
the algorithm is `0` — so every Security Mode Command went out as EEA0/EIA0 with
a null MAC. And a MAC mismatch only set `mac_failed` before stripping the header,
decrypting, and returning `Ok(())`.

Now: at NAS SMC the MME intersects the UE's advertised algorithms with its own
ordered preference, derives `KNASenc`/`KNASint` for exactly those algorithms via
the TS 33.401 Annex A.7 FC=0x15 KDF, and sends a Security Mode Command carrying
them with a real MAC. A protected uplink message is verified against that
context; one that fails is discarded.

## Five findings the issue did not state

**1. The MME's prioritised algorithm list existed as dead config.**
`MmeContext.ciphering_order` / `integrity_order` had **zero readers and zero
writers** — mmed parses no config at all, so they were empty `Vec`s — while the
shipped `docker/rust/configs/epc/mme.yaml` declares
`integrity_order: [EIA2, EIA1, EIA0]` / `ciphering_order: [EEA0, EEA1, EEA2]`
that nothing reads. Those fields are now the live source of the order, defaulted
from constants mirroring that file, so config parsing (filed follow-up) later
populates the same fields with no behaviour change.

**2. Selecting an unimplemented algorithm would silently produce a null MAC.**
`nas_mac_calculate` implements EIA0-3 and falls through to `[0u8; 4]` with a
warning for anything else; `nas_encrypt` behaves the same. A list containing
EEA4-7/EIA4-7 would reintroduce the exact silent downgrade this issue is about,
so selection refuses identities above 3.

**3. EIA0 must not be selectable as the integrity algorithm.** TS 33.401 §5.1.4.1
permits null integrity only for unauthenticated emergency calls, so the trailing
`EIA0` in the configured order must not act as a fallback. The selector skips
identity 0 for integrity and reports no-match, which the caller turns into EMM
cause #23. EEA0 stays a legitimate *ciphering* choice — and is what the shipped
configuration asks for first.

**4. The `mac_failed` premise was half-stale.** The issue says the flag is never
read for enforcement; as of #43 it *is* read and the message discarded. What
remained true is that the decode still answered `Ok(())`, so enforcement depended
on every caller remembering to check. It now returns `Err` on both the full-MAC
and the short-MAC SERVICE REQUEST path.

**5. Six EMM builders emitted a second security header.**
`build_attach_accept`, `build_security_mode_command`, `build_detach_request`,
`build_detach_accept`, `build_tau_accept` and `build_emm_information` each wrote
their own security-header placeholder (header type + zero MAC + zero sequence
number), and all six are passed through `nas_eps_security_encode`, which prepends
the real header. The result carried **two** headers, the inner placeholder
counted as payload and covered by the MAC — every one would have been rejected by
any UE. It was invisible while the messages never reached the wire and the MAC was
null anyway; the first protected round-trip test found it instantly (message type
read as `0x00` instead of `0x5d`). The placeholder is removed from all six, so
builders emit plain NAS messages — as `build_identity_request` and
`build_authentication_request` already did — and the encoder owns the header.

Also fixed while making protection real: a protected message carries the EMM
protocol discriminator in its **outer** header whatever the inner message is
(TS 24.301 §9.3), so the dispatch now routes on the **inner** discriminator and a
protected standalone ESM message reaches `esm_handler` instead of being discarded
by #43's plain-header sanity check.

## TS 24.301 §4.4.4.2 enforcement, which #43 did not have

An unprotected EMM message is processed only if its type is in the clause's
allowlist (ATTACH REQUEST, IDENTITY RESPONSE, AUTHENTICATION RESPONSE,
AUTHENTICATION FAILURE, SECURITY MODE REJECT, DETACH REQUEST, DETACH ACCEPT, TAU
REQUEST), and an unprotected standalone ESM message is never forwarded to the ESM
entity. The one legitimate unprotected ESM message is the container piggybacked on
ATTACH REQUEST, which is held on the UE context and replayed once security is up.

## Decisions

**Select and derive at NAS SMC, not at S6a AIA.** The algorithm identity is an
*input* to the Annex A.7 KDF, so keys cannot be derived before the algorithms are
chosen, and the algorithms cannot be chosen before the UE's capabilities are
known. AIA only supplies `KASME`. Deriving at SMC is the only ordering that is
correct by construction.

**Defaults mirror the shipped config rather than a "more secure" order.**
`mme.yaml` lists EEA0 first, so ciphering resolves to null on this deployment:
the operator's declared preference, not a fallback. A different built-in default
would make the daemon disagree with its own shipped configuration file. The
mechanism is proven independently by a test that reorders the list and gets EEA2.

**No feature flag.** The issue offers a staged rollout, but there is nothing to
stage: the only NAS ingress is #43's dispatch, one release old, and no deployment
can complete an attach today (mmed's S6a peer is not connected), so there is no
lenient E2E setup to break. A flag would leave the unprotected path reachable,
which is the defect.

## Acceptance criteria (#44)

- [x] `knas_enc`/`knas_int` derived from `KASME` via FC=0x15 with distinguishers
  `0x01`/`0x02` and the selected identity, in production.
- [x] `selected_enc_algorithm`/`selected_int_algorithm` computed at NAS SMC from
  `ue_network_capability` ∩ the ordered MME list; the Security Mode Command
  carries them (asserted at the byte offset of the selected-algorithms IE).
- [x] No matching integrity algorithm ⇒ reject with UE-security-capabilities
  mismatch (EMM cause #23), never a fall back to EIA0.
- [x] A message failing integrity is discarded — decode returns `Err` on both the
  full-MAC and short-MAC paths and nothing reaches the EMM/ESM handlers.
- [x] Tests: corrupted MAC rejected, correct MAC accepted and header stripped,
  key-derivation assertions.
- [x] `mac_failed` is read on an enforcement path.

## Verification

- `cargo test -p nextgcore-mmed`: **230 passed / 0 failed** (baseline 219: +13
  new, 2 superseded tests replaced by protected equivalents).
- `cargo test --workspace`: **5431 passed / 0 failed** (baseline 5420).
- `cargo clippy --workspace --all-targets` identical to the pre-change baseline;
  `cargo fmt --all --check` clean.

The headline test is a **full protected round trip**: seed a vector, drive
Authentication Response → real Security Mode Command → an integrity-protected
SECURITY MODE COMPLETE whose MAC is computed the way a UE would → the MME verifies
it, advances UL COUNT, and replays the held ESM container into `esm_handler`.

**Revert-verified**: forcing the selector to return EIA0 fails 7 tests including
that round trip, so the assertions pin real protection rather than passing
vacuously.

Key derivation is pinned by properties a snapshot cannot fake (keyed on `KASME`,
separated by the algorithm type distinguisher, changed by the algorithm identity)
plus one byte snapshot. TS 33.401 Annex A publishes no numeric vectors for
FC=0x15, so that snapshot is labelled as pinning this implementation's input
ordering rather than claiming to be a 3GPP vector, and the comment states the
S-string layout so it is verifiable by hand.

## Not done

- Connecting the S6a peer, so a live attach still cannot obtain a vector (filed
  follow-up); config parsing for the two order fields (same follow-up).
- `KeNB`/NH derivation; EMM abnormal cases (#45).
- The four **ESM** builders that write a placeholder security header but are never
  security-encoded. They have no callers at all (bearer setup needs S11, #51), so
  fixing them means deciding to *add* ESM egress encoding — separate work, filed
  rather than bundled here.

Spec: `specs/fix-mmed-nas-security-context.md`
