### PR TITLE
fix(mmed): EMM abnormal-case handling — full-length RES, AUTHENTICATION FAILURE, NAS timers (closes #45)

### DIFF
--- a/src/bins/nextgcore-mmed/src/context.rs
+++ b/src/bins/nextgcore-mmed/src/context.rs
@@ -40,6 +40,9 @@ pub const NEXTGCORE_KEY_LEN: usize = 16;
 pub const NEXTGCORE_RAND_LEN: usize = 16;
 /// AUTN length
 pub const NEXTGCORE_AUTN_LEN: usize = 16;
+
+/// AUTS length in bytes (TS 33.102 §6.3.3: CONC(SQN_MS) ‖ MAC-S)
+pub const NEXTGCORE_AUTS_LEN: usize = 14;
 /// MAX RES length
 pub const NEXTGCORE_MAX_RES_LEN: usize = 16;
 /// SHA256 digest size
@@ -908,13 +911,55 @@ pub struct PagingInfo {
 // Timer Info
 // ============================================================================
 
-/// Timer with retry info
+/// A NAS procedure timer: its deadline, the message to retransmit, and how many
+/// retransmissions have already gone out.
+///
+/// The deadline lives beside the retransmission buffer so a procedure has one
+/// owner: arming, retransmitting and discarding are all operations on the same
+/// value, and [`TimerWithRetry::stop`] on the completing message cannot forget
+/// half of it.
 #[derive(Debug, Clone, Default)]
 pub struct TimerWithRetry {
-    /// Retry count
+    /// Number of retransmissions already sent (0 = the original transmission)
     pub retry_count: u32,
     /// Packet buffer (stored message)
     pub pkbuf: Option<Vec<u8>>,
+    /// When the timer expires; `None` means it is not running
+    pub expires_at: Option<std::time::Instant>,
+}
+
+impl TimerWithRetry {
+    /// Arm (or re-arm) the timer for `duration` from now.
+    pub fn start(&mut self, duration: std::time::Duration) {
+        self.expires_at = std::time::Instant::now().checked_add(duration);
+    }
+
+    /// Stop the timer and discard what it was holding.
+    ///
+    /// Called when the procedure completes: TS 24.301 has the network stop the
+    /// timer on the matching response, and the stored retransmission must go
+    /// with it or a later expiry would resend a message the UE already answered.
+    pub fn stop(&mut self) {
+        self.expires_at = None;
+        self.pkbuf = None;
+        self.retry_count = 0;
+    }
+
+    /// Whether the timer is running and its deadline has passed.
+    pub fn is_expired(&self, now: std::time::Instant) -> bool {
+        self.expires_at.is_some_and(|deadline| now >= deadline)
+    }
+
+    /// Whether the timer is running.
+    pub fn is_running(&self) -> bool {
+        self.expires_at.is_some()
+    }
+
+    /// Count a retransmission and re-arm.
+    pub fn record_retransmission(&mut self, duration: std::time::Duration) {
+        self.retry_count += 1;
+        self.start(duration);
+    }
 }
 
 // ============================================================================
@@ -1012,6 +1057,12 @@ pub struct MmeUe {
     pub security_context_available: bool,
     /// MAC failed flag
     pub mac_failed: bool,
+    /// AUTS from an AUTHENTICATION FAILURE with cause #21 (synch failure).
+    ///
+    /// TS 33.401 §6.1.1: the MME forwards it to the HSS as
+    /// Re-synchronization-Info in the next Authentication-Information-Request,
+    /// which `fd_path::mme_s6a_send_air` already accepts.
+    pub resync_auts: Option<[u8; NEXTGCORE_AUTS_LEN]>,
     /// Can restore context flag
     pub can_restore_context: bool,
     /// Memento for context backup

--- a/src/bins/nextgcore-mmed/src/emm_handler.rs
+++ b/src/bins/nextgcore-mmed/src/emm_handler.rs
@@ -2,7 +2,7 @@
 //!
 //! Port of src/mme/emm-handler.c - EMM message handling functions
 
-use crate::context::{EnbUe, EpsTai, MmeUe, PlmnId};
+use crate::context::{EnbUe, EpsTai, MmeUe, PlmnId, NEXTGCORE_AUTS_LEN};
 use crate::emm_build::EmmCause;
 
 // ============================================================================
@@ -330,15 +330,21 @@ pub fn handle_authentication_response(
 
     let res = &data[1..1 + res_len];
 
-    // Compare with expected response (XRES)
-    if res_len == 0 || res_len > mme_ue.xres_len as usize {
-        log::warn!("Authentication response length mismatch");
+    // TS 24.301 §5.4.2.4 / TS 33.401 §6.1.1: the UE returns the *whole* RES and
+    // the network compares it against the whole XRES. Accepting a shorter RES
+    // and comparing only that many octets — which this did — authenticates a UE
+    // that guessed a prefix, so a one-octet RES had a 1-in-256 chance per try.
+    if res_len == 0 || res_len != mme_ue.xres_len as usize {
+        log::warn!(
+            "Authentication response length {res_len} does not match the expected {} octets",
+            mme_ue.xres_len
+        );
         return Ok(false);
     }
 
     let xres = &mme_ue.xres[..res_len];
 
-    if res != xres {
+    if !constant_time_eq(res, xres) {
         log::warn!("Authentication response mismatch");
         log::debug!("  RES: {res:02x?}");
         log::debug!("  XRES: {xres:02x?}");
@@ -348,6 +354,105 @@ pub fn handle_authentication_response(
     log::info!("Authentication successful for IMSI[{}]", mme_ue.imsi_bcd);
 
     Ok(true)
+}
+
+/// Compare two byte strings without an early exit on the first differing octet.
+///
+/// The length check does short-circuit, which is fine: the RES length travels in
+/// the clear in the message. What must not leak is *where* the first difference
+/// is, since that would let a peer recover XRES octet by octet.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len()
+        && a.iter()
+            .zip(b.iter())
+            .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+            == 0
+}
+
+// ============================================================================
+// Authentication Failure Handling
+// ============================================================================
+
+/// What the UE reported in an AUTHENTICATION FAILURE (TS 24.301 §5.4.2.7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthenticationFailure {
+    /// EMM cause #20: the UE could not verify the AUTN MAC.
+    MacFailure,
+    /// EMM cause #21: the USIM's SQN is out of range; re-synchronise with AUTS.
+    SynchFailure(Box<[u8; NEXTGCORE_AUTS_LEN]>),
+    /// EMM cause #26 or anything else the UE reported.
+    Other(u8),
+}
+
+/// Handle authentication failure (TS 24.301 §5.4.2.7, §8.2.5).
+///
+/// The message carries a mandatory EMM cause and, for a synch failure, an
+/// Authentication Failure Parameter IE (0x30) holding the 14-octet AUTS.
+pub fn handle_authentication_failure(
+    _enb_ue: &EnbUe,
+    mme_ue: &mut MmeUe,
+    data: &[u8],
+) -> EmmResult<AuthenticationFailure> {
+    if data.is_empty() {
+        return Err(EmmError::InvalidMessage(
+            "Authentication failure empty".into(),
+        ));
+    }
+
+    let emm_cause = data[0];
+    match emm_cause {
+        emm_cause::MAC_FAILURE => {
+            log::warn!("[{}] Authentication Failure: MAC failure", mme_ue.imsi_bcd);
+            Ok(AuthenticationFailure::MacFailure)
+        }
+        emm_cause::SYNCH_FAILURE => {
+            // Authentication Failure Parameter: IEI 0x30, length, AUTS.
+            let mut offset = 1;
+            while offset + 1 < data.len() {
+                let iei = data[offset];
+                let len = data[offset + 1] as usize;
+                let value_start = offset + 2;
+                if iei == AUTHENTICATION_FAILURE_PARAMETER_IEI {
+                    if len != NEXTGCORE_AUTS_LEN || value_start + len > data.len() {
+                        return Err(EmmError::InvalidMessage(format!(
+                            "Authentication Failure Parameter is {len} octets, expected \
+                             {NEXTGCORE_AUTS_LEN}"
+                        )));
+                    }
+                    let mut auts = [0u8; NEXTGCORE_AUTS_LEN];
+                    auts.copy_from_slice(&data[value_start..value_start + len]);
+                    log::warn!(
+                        "[{}] Authentication Failure: synch failure, AUTS received",
+                        mme_ue.imsi_bcd
+                    );
+                    return Ok(AuthenticationFailure::SynchFailure(Box::new(auts)));
+                }
+                offset = value_start + len;
+            }
+            // TS 24.301 §5.4.2.7 d): the AUTS is mandatory for cause #21.
+            Err(EmmError::InvalidMessage(
+                "Synch failure without an Authentication Failure Parameter".into(),
+            ))
+        }
+        other => {
+            log::warn!(
+                "[{}] Authentication Failure: EMM cause #{other}",
+                mme_ue.imsi_bcd
+            );
+            Ok(AuthenticationFailure::Other(other))
+        }
+    }
+}
+
+/// IEI of the Authentication Failure Parameter (TS 24.301 §9.9.3.1).
+const AUTHENTICATION_FAILURE_PARAMETER_IEI: u8 = 0x30;
+
+/// EMM cause values used by the authentication abnormal cases.
+mod emm_cause {
+    /// #20 MAC failure
+    pub const MAC_FAILURE: u8 = 20;
+    /// #21 Synch failure
+    pub const SYNCH_FAILURE: u8 = 21;
 }
 
 // ============================================================================
@@ -918,5 +1023,119 @@ mod tests {
 
         let err = EmmError::ProtocolError(EmmCause::PlmnNotAllowed);
         assert!(err.to_string().contains("Protocol error"));
+    }
+
+    // ========================================================================
+    // Authentication abnormal cases (issue #45)
+    // ========================================================================
+
+    /// A UE context holding an 8-octet XRES, as `mme_s6a_handle_aia` leaves it.
+    fn ue_with_xres() -> MmeUe {
+        let mut mme_ue = MmeUe {
+            id: 1,
+            ..Default::default()
+        };
+        mme_ue.xres[..8].copy_from_slice(&[0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8]);
+        mme_ue.xres_len = 8;
+        mme_ue
+    }
+
+    /// AUTHENTICATION RESPONSE body: RES length followed by the RES.
+    fn authentication_response_body(res: &[u8]) -> Vec<u8> {
+        let mut body = vec![res.len() as u8];
+        body.extend_from_slice(res);
+        body
+    }
+
+    #[test]
+    fn test_full_length_res_is_accepted() {
+        let mut mme_ue = ue_with_xres();
+        let body = authentication_response_body(&[0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8]);
+
+        let accepted =
+            handle_authentication_response(&EnbUe::default(), &mut mme_ue, &body).unwrap();
+
+        assert!(accepted);
+    }
+
+    #[test]
+    fn test_truncated_res_matching_the_xres_prefix_is_rejected() {
+        let mut mme_ue = ue_with_xres();
+
+        // TS 24.301 §5.4.2.4: the UE returns the whole RES. Comparing only the
+        // octets it chose to send let a one-octet guess authenticate with
+        // probability 1/256 per attempt.
+        for prefix_len in 1..8usize {
+            let prefix = mme_ue.xres[..prefix_len].to_vec();
+            let body = authentication_response_body(&prefix);
+            let accepted =
+                handle_authentication_response(&EnbUe::default(), &mut mme_ue, &body).unwrap();
+            assert!(
+                !accepted,
+                "a {prefix_len}-octet RES matching the XRES prefix must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_over_long_and_wrong_res_are_rejected() {
+        let mut mme_ue = ue_with_xres();
+
+        let too_long = authentication_response_body(&[0xa1; 9]);
+        assert!(
+            !handle_authentication_response(&EnbUe::default(), &mut mme_ue, &too_long).unwrap()
+        );
+
+        let mut wrong = mme_ue.xres[..8].to_vec();
+        wrong[7] ^= 0xff;
+        let wrong = authentication_response_body(&wrong);
+        assert!(!handle_authentication_response(&EnbUe::default(), &mut mme_ue, &wrong).unwrap());
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq(&[1, 2, 3], &[1, 2, 3]));
+        assert!(!constant_time_eq(&[1, 2, 3], &[1, 2, 4]));
+        assert!(!constant_time_eq(&[1, 2, 3], &[1, 2]));
+        assert!(constant_time_eq(&[], &[]));
+    }
+
+    #[test]
+    fn test_authentication_failure_synch_failure_carries_the_auts() {
+        let mut mme_ue = MmeUe::default();
+        let auts = [0x5a; NEXTGCORE_AUTS_LEN];
+        let mut body = vec![21, AUTHENTICATION_FAILURE_PARAMETER_IEI, auts.len() as u8];
+        body.extend_from_slice(&auts);
+
+        let outcome = handle_authentication_failure(&EnbUe::default(), &mut mme_ue, &body).unwrap();
+
+        assert_eq!(outcome, AuthenticationFailure::SynchFailure(Box::new(auts)));
+    }
+
+    #[test]
+    fn test_authentication_failure_synch_failure_needs_the_auts() {
+        let mut mme_ue = MmeUe::default();
+
+        // Cause #21 with no Authentication Failure Parameter at all.
+        assert!(handle_authentication_failure(&EnbUe::default(), &mut mme_ue, &[21]).is_err());
+
+        // ...and with one of the wrong length.
+        let body = vec![21, AUTHENTICATION_FAILURE_PARAMETER_IEI, 4, 1, 2, 3, 4];
+        assert!(handle_authentication_failure(&EnbUe::default(), &mut mme_ue, &body).is_err());
+    }
+
+    #[test]
+    fn test_authentication_failure_causes() {
+        let mut mme_ue = MmeUe::default();
+
+        assert_eq!(
+            handle_authentication_failure(&EnbUe::default(), &mut mme_ue, &[20]).unwrap(),
+            AuthenticationFailure::MacFailure
+        );
+        assert_eq!(
+            handle_authentication_failure(&EnbUe::default(), &mut mme_ue, &[26]).unwrap(),
+            AuthenticationFailure::Other(26)
+        );
+        assert!(handle_authentication_failure(&EnbUe::default(), &mut mme_ue, &[]).is_err());
     }
 }

--- a/src/bins/nextgcore-mmed/src/main.rs
+++ b/src/bins/nextgcore-mmed/src/main.rs
@@ -17,6 +17,7 @@ pub mod gtp_path;
 pub mod nas_dispatch;
 pub mod nas_path;
 pub mod nas_security;
+pub mod nas_timer;
 pub mod s11_build;
 pub mod s11_handler;
 pub mod s1ap_build;
@@ -129,16 +130,18 @@ impl MmeApp {
     ///
     /// Drives the S1AP data path — inbound eNB signalling into
     /// [`s1ap_handler::handle_s1ap_message`] and queued downlink PDUs out to the
-    /// addressed eNB — alongside the shutdown check. Previously this was a bare
-    /// `thread::sleep` loop, which is why the whole S1AP layer was unreachable
-    /// at runtime (issue #42).
+    /// addressed eNB — plus the NAS procedure timers, alongside the shutdown
+    /// check. Previously this was a bare `thread::sleep` loop, which is why the
+    /// whole S1AP layer was unreachable at runtime (issue #42).
     pub async fn run(&mut self) -> Result<()> {
         log::info!("MME running...");
 
         // Interval at which the loop re-checks the shutdown flag when no S1AP
-        // event is pending. Keeps Ctrl-C responsive without polling hard.
+        // event is pending. Keeps Ctrl-C responsive without polling hard, and is
+        // the tick the NAS timers are swept on (issue #45).
         const SHUTDOWN_CHECK: std::time::Duration = std::time::Duration::from_millis(100);
 
+        let ctx = context::mme_self();
         while self.running.load(Ordering::SeqCst) {
             match self.s1ap.as_mut() {
                 Some(s1ap) => {
@@ -152,6 +155,11 @@ impl MmeApp {
                 }
                 None => tokio::time::sleep(SHUTDOWN_CHECK).await,
             }
+
+            // Retransmit or abort NAS procedures whose timer has run out
+            // (TS 24.301 §5.4.2.7, §5.4.4.6, §5.5.1.2.7). Cheap when idle: the
+            // sweep walks the UE pool and does nothing unless a deadline passed.
+            nas_timer::expire_nas_timers(ctx, std::time::Instant::now());
         }
 
         log::info!("MME main loop exited");

--- a/src/bins/nextgcore-mmed/src/nas_dispatch.rs
+++ b/src/bins/nextgcore-mmed/src/nas_dispatch.rs
@@ -319,22 +319,21 @@ fn dispatch_emm(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, pdu: &[u8]) {
         }
         emm_type::DETACH_REQUEST => emm_detach_request(ctx, enb_ue, mme_ue_id, body),
         emm_type::AUTHENTICATION_FAILURE => {
-            // AUTS resynchronisation and MAC-failure handling are #45.
-            log::warn!(
-                "Authentication Failure from enb_ue_s1ap_id={} (EMM cause #{}); AUTS \
-                 resynchronisation is not implemented (#45)",
-                enb_ue.enb_ue_s1ap_id,
-                body.first().copied().unwrap_or(0)
-            );
+            emm_authentication_failure(ctx, enb_ue, mme_ue_id, body);
         }
         emm_type::SECURITY_MODE_REJECT => {
-            // TS 24.301 §5.4.3.5: the network aborts the procedure.
+            // TS 24.301 §5.4.3.5: the network aborts the procedure and releases
+            // the NAS signalling connection.
             log::error!(
                 "Security Mode Reject from enb_ue_s1ap_id={} (EMM cause #{}); aborting the \
                  security mode control procedure",
                 enb_ue.enb_ue_s1ap_id,
                 body.first().copied().unwrap_or(0)
             );
+            if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+                mme_ue.t3460.stop();
+            }
+            release_ue_context(ctx, enb_ue);
         }
         emm_type::DETACH_ACCEPT => {
             log::info!(
@@ -348,6 +347,10 @@ fn dispatch_emm(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, pdu: &[u8]) {
                 "EMM 0x{message_type:02x} acknowledged by enb_ue_s1ap_id={}",
                 enb_ue.enb_ue_s1ap_id
             );
+            // TS 24.301 §5.5.3.2.4: the TAU procedure completed (issue #45).
+            if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+                mme_ue.t3450.stop();
+            }
         }
         emm_type::EMM_STATUS => {
             log::warn!(
@@ -508,7 +511,12 @@ fn emm_attach_complete(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, body: &
             return;
         };
         match emm_handler::handle_attach_complete(enb_ue, mme_ue, body) {
-            Ok(esm_message) => esm_message,
+            Ok(esm_message) => {
+                // TS 24.301 §5.5.1.2.4: the attach procedure completed, so T3450
+                // stops and the stored ATTACH ACCEPT is discarded (issue #45).
+                mme_ue.t3450.stop();
+                esm_message
+            }
             Err(e) => {
                 log::warn!("[{}] Attach Complete rejected: {e}", mme_ue.imsi_bcd);
                 return;
@@ -534,6 +542,8 @@ fn emm_identity_response(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, body:
             );
             return;
         }
+        // TS 24.301 §5.4.4.3: the identification procedure completed (issue #45).
+        mme_ue.t3470.stop();
         // `handle_identity_response` writes `imsi_bcd` only for an IMSI
         // identity; an IMEI/IMEISV answer leaves it untouched.
         mme_ue.imsi_bcd.clone()
@@ -587,7 +597,9 @@ fn emm_authentication_response(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64,
             };
             nas_security::derive_nas_keys(mme_ue, selected);
 
-            mme_ue.t3460.pkbuf = None;
+            // TS 24.301 §5.4.2.3 / §5.4.3.3: the procedure completed, so T3460
+            // stops and its retransmission buffer goes with it (issue #45).
+            mme_ue.t3460.stop();
             if let Err(e) = nas_path::nas_eps_send_security_mode_command(mme_ue, enb_ue) {
                 log::error!(
                     "[{}] Security Mode Command send failed: {e}",
@@ -616,6 +628,81 @@ fn emm_authentication_response(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64,
     }
 }
 
+/// Handle AUTHENTICATION FAILURE (TS 24.301 §5.4.2.7).
+fn emm_authentication_failure(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, body: &[u8]) {
+    let outcome = {
+        let mut pool = ctx.mme_ue_pool.write().unwrap();
+        let Some(mme_ue) = pool.get_mut(&mme_ue_id) else {
+            return;
+        };
+        // The authentication procedure is over either way, so T3460 stops and
+        // the challenge is not retransmitted.
+        mme_ue.t3460.stop();
+
+        match emm_handler::handle_authentication_failure(enb_ue, mme_ue, body) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                log::warn!(
+                    "[{}] Authentication Failure malformed: {e}; rejecting",
+                    mme_ue.imsi_bcd
+                );
+                if let Err(e) = nas_path::nas_eps_send_authentication_reject(mme_ue, enb_ue) {
+                    log::error!("Authentication Reject send failed: {e}");
+                }
+                return;
+            }
+        }
+    };
+
+    match outcome {
+        emm_handler::AuthenticationFailure::SynchFailure(auts) => {
+            // TS 33.401 §6.1.1: the AUTS goes to the HSS as
+            // Re-synchronization-Info in a fresh AIR, and the vector it returns
+            // restarts authentication. `fd_path::mme_s6a_send_air` already takes
+            // the AUTS and `s6a::add_resync_info` already encodes it — what is
+            // missing is the connected S6a peer, so the AUTS is stored for that
+            // request rather than dropped or pretended to be sent.
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let Some(mme_ue) = pool.get_mut(&mme_ue_id) else {
+                return;
+            };
+            mme_ue.resync_auts = Some(*auts);
+            mme_ue.xres_len = 0;
+            log::warn!(
+                "[{}] Synch failure: AUTS stored for a re-synchronisation AIR, which needs \
+                 mmed's S6a peer to be connected",
+                mme_ue.imsi_bcd
+            );
+        }
+        emm_handler::AuthenticationFailure::MacFailure => {
+            // TS 24.301 §5.4.2.7 e): on MAC failure the network may re-initiate
+            // the identification procedure and authenticate the UE it names,
+            // which is the only branch that can make progress without the HSS.
+            log::warn!("MAC failure reported for UE {mme_ue_id}; re-identifying");
+            {
+                // The vector the UE rejected must not be reused. `imsi_bcd` is
+                // deliberately left in place: clearing it would strand the
+                // context's entry in the IMSI index, which is keyed by that
+                // string, and the Identity Response re-indexes it anyway.
+                let mut pool = ctx.mme_ue_pool.write().unwrap();
+                if let Some(mme_ue) = pool.get_mut(&mme_ue_id) {
+                    mme_ue.xres_len = 0;
+                }
+            }
+            request_identity(ctx, enb_ue, mme_ue_id);
+        }
+        emm_handler::AuthenticationFailure::Other(cause) => {
+            // Anything else (e.g. #26 non-EPS authentication unacceptable)
+            // aborts the procedure and releases the connection.
+            log::warn!(
+                "Authentication Failure cause #{cause} for UE {mme_ue_id}; aborting and \
+                 releasing the S1 connection"
+            );
+            release_ue_context(ctx, enb_ue);
+        }
+    }
+}
+
 fn emm_security_mode_complete(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, body: &[u8]) {
     let held_esm = {
         let mut pool = ctx.mme_ue_pool.write().unwrap();
@@ -626,7 +713,9 @@ fn emm_security_mode_complete(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, 
             log::warn!("[{}] Security Mode Complete rejected: {e}", mme_ue.imsi_bcd);
             return;
         }
-        mme_ue.t3460.pkbuf = None;
+        // TS 24.301 §5.4.3.3: the security mode control procedure completed, so
+        // T3460 stops and the stored command is discarded (issue #45).
+        mme_ue.t3460.stop();
         // Replay the container held since Attach Request, now that
         // `security_context_available` is set (TS 24.301 §5.5.1.2.2).
         std::mem::take(&mut mme_ue.pdn_connectivity_request)
@@ -919,10 +1008,13 @@ fn index_imsi(ctx: &MmeContext, mme_ue_id: u64, imsi_bcd: &str) {
 
 /// Ask the eNB to release a UE-associated logical S1 connection.
 ///
+/// Crate-visible because `nas_timer` releases the connection when a NAS
+/// procedure exhausts its retransmissions (TS 24.301 §5.4.2.7).
+///
 /// The eNB answers `UE CONTEXT RELEASE COMPLETE`, which
 /// `s1ap_handler::handle_ue_context_release_complete` turns into the local
 /// teardown — so the contexts are not dropped here.
-fn release_ue_context(ctx: &MmeContext, enb_ue: &EnbUe) {
+pub(crate) fn release_ue_context(ctx: &MmeContext, enb_ue: &EnbUe) {
     if let Some(stored) = ctx.enb_ue_pool.write().unwrap().get_mut(&enb_ue.id) {
         stored.ue_ctx_rel_action = UeCtxRelAction::UeContextRemove;
         stored.relcause.group = S1apCauseGroup::Nas;
@@ -1975,6 +2067,203 @@ mod tests {
             ctx.enb_ue_find_by_id(enb_ue_id).unwrap().ue_ctx_rel_action,
             UeCtxRelAction::UeContextRemove,
             "the S1 connection must be marked for release"
+        );
+    }
+
+    #[test]
+    fn test_truncated_res_does_not_establish_a_security_context() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+
+        // A one-octet RES matching the first octet of the seeded XRES (0xaa).
+        let mut pdu = vec![
+            NAS_PROTOCOL_DISCRIMINATOR_EMM,
+            NasEpsMessageType::AuthenticationResponse as u8,
+            0x01,
+        ];
+        pdu.push(0xaa);
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdu));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(
+            !mme_ue.security_context_available,
+            "a truncated RES must not authenticate the UE"
+        );
+        assert_eq!(mme_ue.selected_int_algorithm, 0);
+        assert_eq!(mme_ue.knas_int, [0u8; 16]);
+        assert!(
+            mme_ue.t3460.pkbuf.is_none(),
+            "no Security Mode Command is due"
+        );
+    }
+
+    #[test]
+    fn test_synch_failure_stores_the_auts_and_stops_t3460() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        // An outstanding AUTHENTICATION REQUEST.
+        {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+            mme_ue.t3460.pkbuf = Some(vec![0x07, 0x52]);
+            mme_ue.t3460.start(crate::nas_timer::T3460_DURATION);
+        }
+
+        let auts = [0x5a; 14];
+        let mut pdu = vec![
+            NAS_PROTOCOL_DISCRIMINATOR_EMM,
+            NasEpsMessageType::AuthenticationFailure as u8,
+            21,   // EMM cause #21, synch failure
+            0x30, // Authentication Failure Parameter
+            14,
+        ];
+        pdu.extend_from_slice(&auts);
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdu));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(
+            mme_ue.resync_auts,
+            Some(auts),
+            "the AUTS must be kept for the re-synchronisation AIR"
+        );
+        assert_eq!(mme_ue.xres_len, 0, "the rejected vector must be discarded");
+        assert!(!mme_ue.t3460.is_running(), "T3460 must be stopped");
+        assert!(mme_ue.t3460.pkbuf.is_none());
+    }
+
+    #[test]
+    fn test_mac_failure_re_identifies_the_ue() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+
+        let pdu = vec![
+            NAS_PROTOCOL_DISCRIMINATOR_EMM,
+            NasEpsMessageType::AuthenticationFailure as u8,
+            20, // EMM cause #20, MAC failure
+        ];
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdu));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(mme_ue.xres_len, 0, "the rejected vector must be discarded");
+        assert_eq!(
+            emm_message_type(&mme_ue.t3470.pkbuf),
+            Some(NasEpsMessageType::IdentityRequest as u8),
+            "TS 24.301 5.4.2.7 e): the network may re-identify the UE"
+        );
+        assert!(mme_ue.t3470.is_running(), "T3470 must be armed");
+        // The IMSI index still resolves: clearing imsi_bcd would strand it.
+        assert_eq!(ctx.mme_ue_find_by_imsi(TEST_IMSI), Some(mme_ue_id));
+    }
+
+    #[test]
+    fn test_completing_messages_stop_their_timers() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+
+        // Identity Response stops T3470.
+        {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+            mme_ue.t3470.pkbuf = Some(vec![0x07, 0x55, 0x01]);
+            mme_ue.t3470.start(crate::nas_timer::T3470_DURATION);
+        }
+        let identity = imsi_identity();
+        let mut pdu = vec![
+            NAS_PROTOCOL_DISCRIMINATOR_EMM,
+            NasEpsMessageType::IdentityResponse as u8,
+            identity.len() as u8,
+        ];
+        pdu.extend_from_slice(&identity);
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdu));
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.t3470.is_running());
+        assert!(mme_ue.t3470.pkbuf.is_none());
+
+        // Authentication Response stops T3460 (and arms it again for the
+        // Security Mode Command it sends, which is a different procedure step).
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(
+            protected_message_type(&mme_ue.t3460.pkbuf),
+            Some(NasEpsMessageType::SecurityModeCommand as u8)
+        );
+        assert_eq!(mme_ue.t3460.retry_count, 0, "a fresh procedure starts at 0");
+
+        // Security Mode Complete stops T3460 for good.
+        let complete = protect_uplink(
+            &mme_ue,
+            1,
+            &[
+                NAS_PROTOCOL_DISCRIMINATOR_EMM,
+                NasEpsMessageType::SecurityModeComplete as u8,
+            ],
+        );
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &complete));
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.t3460.is_running());
+        assert!(mme_ue.t3460.pkbuf.is_none());
+    }
+
+    #[test]
+    fn test_attach_complete_stops_t3450() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+        {
+            // An outstanding ATTACH ACCEPT.
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+            mme_ue.t3450.pkbuf = Some(vec![0x07, 0x42]);
+            mme_ue.t3450.start(crate::nas_timer::T3450_DURATION);
+        }
+
+        // ATTACH COMPLETE carrying a two-octet ESM container length of 0.
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        let complete = protect_uplink(
+            &mme_ue,
+            1,
+            &[
+                NAS_PROTOCOL_DISCRIMINATOR_EMM,
+                NasEpsMessageType::AttachComplete as u8,
+                0x00,
+                0x00,
+            ],
+        );
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &complete));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.t3450.is_running(), "T3450 must be stopped");
+        assert!(
+            mme_ue.t3450.pkbuf.is_none(),
+            "the stored accept is discarded"
+        );
+    }
+
+    #[test]
+    fn test_security_mode_reject_aborts_and_releases() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+
+        let pdu = vec![
+            NAS_PROTOCOL_DISCRIMINATOR_EMM,
+            NasEpsMessageType::SecurityModeReject as u8,
+            24, // EMM cause #24, security mode rejected unspecified
+        ];
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdu));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.t3460.is_running());
+        assert_eq!(
+            ctx.enb_ue_find_by_id(enb_ue_id).unwrap().ue_ctx_rel_action,
+            UeCtxRelAction::UeContextRemove,
+            "TS 24.301 5.4.3.5 releases the NAS signalling connection"
         );
     }
 

--- a/src/bins/nextgcore-mmed/src/nas_path.rs
+++ b/src/bins/nextgcore-mmed/src/nas_path.rs
@@ -9,6 +9,7 @@ use crate::emm_build::{self, EmmCause, SecurityHeaderType};
 use crate::esm_build::{self, EsmCause};
 use crate::nas_dispatch;
 use crate::nas_security;
+use crate::nas_timer;
 use crate::s1ap_build;
 use crate::s1ap_path;
 
@@ -269,8 +270,10 @@ pub fn nas_eps_send_attach_accept(
     )
     .ok_or(NasError::BuildFailed)?;
 
-    // Store for retransmission (T3450)
+    // Store for retransmission and arm T3450 (issue #45): storing the buffer
+    // without starting the timer is what left procedures outstanding forever.
     mme_ue.t3450.pkbuf = Some(secured_message.clone());
+    mme_ue.t3450.start(nas_timer::T3450_DURATION);
 
     // Clear UE radio capability as per TS24.301
     mme_ue.ue_radio_capability.clear();
@@ -360,8 +363,9 @@ pub fn nas_eps_send_identity_request(mme_ue: &mut MmeUe, enb_ue: &EnbUe) -> NasR
         emm_build::build_identity_request(emm_build::IdentityType2::Imsi)
     };
 
-    // Store for retransmission (T3470)
+    // Store for retransmission and arm T3470 (issue #45).
     mme_ue.t3470.pkbuf = Some(emm_message.clone());
+    mme_ue.t3470.start(nas_timer::T3470_DURATION);
 
     nas_eps_send_to_downlink_nas_transport(enb_ue, emm_message)
 }
@@ -396,8 +400,9 @@ pub fn nas_eps_send_authentication_request(mme_ue: &mut MmeUe, enb_ue: &EnbUe) -
         emm_build::build_authentication_request(ksi, &mme_ue.rand, &mme_ue.autn)
     };
 
-    // Store for retransmission (T3460)
+    // Store for retransmission and arm T3460 (issue #45).
     mme_ue.t3460.pkbuf = Some(emm_message.clone());
+    mme_ue.t3460.start(nas_timer::T3460_DURATION);
 
     nas_eps_send_to_downlink_nas_transport(enb_ue, emm_message)
 }
@@ -472,8 +477,9 @@ pub fn nas_eps_send_security_mode_command(mme_ue: &mut MmeUe, enb_ue: &EnbUe) ->
         .ok_or(NasError::BuildFailed)?
     };
 
-    // Store for retransmission (T3460)
+    // Store for retransmission and arm T3460 (issue #45).
     mme_ue.t3460.pkbuf = Some(emm_message.clone());
+    mme_ue.t3460.start(nas_timer::T3460_DURATION);
 
     nas_eps_send_to_downlink_nas_transport(enb_ue, emm_message)
 }
@@ -602,8 +608,9 @@ pub fn nas_eps_send_tau_accept(
     )
     .ok_or(NasError::BuildFailed)?;
 
-    // Store for retransmission (T3450)
+    // Store for retransmission and arm T3450 (issue #45).
     mme_ue.t3450.pkbuf = Some(emm_message.clone());
+    mme_ue.t3450.start(nas_timer::T3450_DURATION);
 
     if use_initial_context_setup {
         // The TAU Accept travels inside the Initial Context Setup Request, so

--- a/src/bins/nextgcore-mmed/src/nas_timer.rs
+++ b/src/bins/nextgcore-mmed/src/nas_timer.rs
@@ -1,0 +1,358 @@
+//! NAS procedure timers (issue #45, TS 24.301 §5.4/§5.5).
+//!
+//! ## Why this module exists
+//!
+//! `TimerWithRetry` held a retransmission buffer and a retry counter that
+//! nothing read or wrote, and there was no deadline field anywhere: the
+//! T3450/T3460/T3470 branches in `sm.rs` only logged. So a lost downlink NAS
+//! message left the procedure outstanding forever — no retransmission, no abort,
+//! no context release, and the stored `pkbuf` never discarded.
+//!
+//! ## Model
+//!
+//! Deadlines live on the UE context beside the buffer they would resend (see
+//! [`crate::context::TimerWithRetry`]), and [`expire_nas_timers`] sweeps the UE
+//! pool. `MmeApp::run` already wakes every 100 ms to check the shutdown flag, so
+//! the sweep rides that tick: no extra task, no channel, and — unlike amfd's
+//! `TimerManager`, which can start and stop timers but has no expiry function at
+//! all — it cannot silently stop firing. Tick granularity is irrelevant against
+//! six-second NAS timers.
+//!
+//! ## Retransmission
+//!
+//! TS 24.301 §5.4.2.7 b) (T3460), §5.4.4.6 (T3470) and §5.5.1.2.7 (T3450) all use
+//! the same wording: the message is retransmitted on each expiry, "repeated four
+//! times, i.e. on the fifth expiry … the network shall abort the procedure" and
+//! release the NAS signalling connection. So four retransmissions, five expiries.
+
+use std::time::{Duration, Instant};
+
+use crate::context::{EnbUe, MmeContext, MmeUe, NEXTGCORE_INVALID_POOL_ID};
+use crate::nas_path;
+
+/// T3450 — ATTACH ACCEPT / TAU ACCEPT (TS 24.301 Table 10.2.1).
+pub const T3450_DURATION: Duration = Duration::from_secs(6);
+
+/// T3460 — AUTHENTICATION REQUEST and SECURITY MODE COMMAND.
+pub const T3460_DURATION: Duration = Duration::from_secs(6);
+
+/// T3470 — IDENTITY REQUEST.
+pub const T3470_DURATION: Duration = Duration::from_secs(6);
+
+/// Retransmissions before the procedure is aborted on the next expiry.
+pub const MAX_RETRANSMISSIONS: u32 = 4;
+
+/// Which NAS timer expired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NasTimer {
+    /// Attach / TAU accept
+    T3450,
+    /// Authentication request or security mode command
+    T3460,
+    /// Identity request
+    T3470,
+}
+
+impl NasTimer {
+    /// The timer's configured duration.
+    pub fn duration(self) -> Duration {
+        match self {
+            NasTimer::T3450 => T3450_DURATION,
+            NasTimer::T3460 => T3460_DURATION,
+            NasTimer::T3470 => T3470_DURATION,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            NasTimer::T3450 => "T3450",
+            NasTimer::T3460 => "T3460",
+            NasTimer::T3470 => "T3470",
+        }
+    }
+
+    fn on(self, mme_ue: &mut MmeUe) -> &mut crate::context::TimerWithRetry {
+        match self {
+            NasTimer::T3450 => &mut mme_ue.t3450,
+            NasTimer::T3460 => &mut mme_ue.t3460,
+            NasTimer::T3470 => &mut mme_ue.t3470,
+        }
+    }
+}
+
+const ALL_TIMERS: [NasTimer; 3] = [NasTimer::T3450, NasTimer::T3460, NasTimer::T3470];
+
+/// Retransmit or abort every NAS procedure whose timer has expired by `now`.
+///
+/// Expiries are collected under a read lock and acted on afterwards, so the
+/// retransmission path can take the write lock and reach `nas_path` without the
+/// non-reentrant `RwLock` deadlocking against itself.
+pub fn expire_nas_timers(ctx: &MmeContext, now: Instant) {
+    let expired: Vec<(u64, NasTimer)> = {
+        let pool = ctx.mme_ue_pool.read().unwrap();
+        pool.iter()
+            .flat_map(|(id, mme_ue)| {
+                ALL_TIMERS.into_iter().filter_map(move |timer| {
+                    let state = match timer {
+                        NasTimer::T3450 => &mme_ue.t3450,
+                        NasTimer::T3460 => &mme_ue.t3460,
+                        NasTimer::T3470 => &mme_ue.t3470,
+                    };
+                    state.is_expired(now).then_some((*id, timer))
+                })
+            })
+            .collect()
+    };
+
+    for (mme_ue_id, timer) in expired {
+        handle_expiry(ctx, mme_ue_id, timer);
+    }
+}
+
+fn handle_expiry(ctx: &MmeContext, mme_ue_id: u64, timer: NasTimer) {
+    let enb_ue = ctx
+        .mme_ue_find_by_id(mme_ue_id)
+        .map(|mme_ue| mme_ue.enb_ue_id)
+        .filter(|id| *id != NEXTGCORE_INVALID_POOL_ID)
+        .and_then(|id| ctx.enb_ue_find_by_id(id));
+
+    // Retransmission needs a live S1 connection. Without one there is nothing to
+    // resend over, so the procedure is aborted immediately rather than counting
+    // down against a UE that is already unreachable.
+    let Some(enb_ue) = enb_ue else {
+        let imsi = {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let Some(mme_ue) = pool.get_mut(&mme_ue_id) else {
+                return;
+            };
+            timer.on(mme_ue).stop();
+            mme_ue.imsi_bcd.clone()
+        };
+        log::warn!(
+            "[{imsi}] {} expired with no S1 connection; procedure aborted",
+            timer.name()
+        );
+        return;
+    };
+
+    let abort = {
+        let mut pool = ctx.mme_ue_pool.write().unwrap();
+        let Some(mme_ue) = pool.get_mut(&mme_ue_id) else {
+            return;
+        };
+
+        let state = timer.on(mme_ue);
+        // Re-check under the write lock against a fresh instant: an uplink
+        // message may have stopped or re-armed this timer between the sweep's
+        // read and this point.
+        if !state.is_expired(Instant::now()) {
+            return;
+        }
+
+        if state.retry_count >= MAX_RETRANSMISSIONS {
+            state.stop();
+            true
+        } else {
+            let pkbuf = state.pkbuf.clone();
+            state.record_retransmission(timer.duration());
+            let attempt = state.retry_count;
+            match pkbuf {
+                Some(pkbuf) => {
+                    log::info!(
+                        "[{}] {} expired; retransmission {attempt}/{MAX_RETRANSMISSIONS}",
+                        mme_ue.imsi_bcd,
+                        timer.name()
+                    );
+                    retransmit(mme_ue, &enb_ue, timer, pkbuf);
+                    false
+                }
+                None => {
+                    // Armed with nothing to resend: treat it as an abort rather
+                    // than spinning for four more rounds.
+                    log::warn!(
+                        "[{}] {} expired with no stored message; procedure aborted",
+                        mme_ue.imsi_bcd,
+                        timer.name()
+                    );
+                    timer.on(mme_ue).stop();
+                    true
+                }
+            }
+        }
+    };
+
+    if abort {
+        // TS 24.301 §5.4.2.7 / §5.4.4.6 / §5.5.1.2.7: after the last
+        // retransmission the network aborts the procedure and releases the NAS
+        // signalling connection.
+        log::warn!(
+            "{} exhausted its {MAX_RETRANSMISSIONS} retransmissions for UE {mme_ue_id}; \
+             releasing the S1 connection",
+            timer.name()
+        );
+        crate::nas_dispatch::release_ue_context(ctx, &enb_ue);
+    }
+}
+
+fn retransmit(mme_ue: &MmeUe, enb_ue: &EnbUe, timer: NasTimer, pkbuf: Vec<u8>) {
+    // The stored buffer is the complete NAS message the procedure sent, already
+    // security-encoded where the procedure applied protection, so it is resent
+    // verbatim inside a fresh DOWNLINK NAS TRANSPORT.
+    if let Err(e) = nas_path::nas_eps_send_to_downlink_nas_transport(enb_ue, pkbuf) {
+        log::error!(
+            "[{}] {} retransmission failed: {e}",
+            mme_ue.imsi_bcd,
+            timer.name()
+        );
+    }
+}
+
+// ============================================================================
+// Unit Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::emm_build::NasEpsMessageType;
+
+    /// A UE with a live S1 connection and an outstanding IDENTITY REQUEST.
+    fn ue_with_outstanding_identity_request(ctx: &MmeContext) -> (u64, u64) {
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, 100);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        ctx.enb_ue_associate_mme_ue(enb_ue_id, mme_ue_id);
+        {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+            mme_ue.t3470.pkbuf = Some(vec![0x07, NasEpsMessageType::IdentityRequest as u8, 0x01]);
+            mme_ue.t3470.start(T3470_DURATION);
+        }
+        (enb_ue_id, mme_ue_id)
+    }
+
+    /// Move a timer's deadline into the past instead of sleeping.
+    fn force_expiry(ctx: &MmeContext, mme_ue_id: u64, timer: NasTimer) {
+        let mut pool = ctx.mme_ue_pool.write().unwrap();
+        let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+        timer.on(mme_ue).expires_at = Instant::now().checked_sub(Duration::from_secs(1));
+    }
+
+    fn test_ctx() -> MmeContext {
+        let ctx = MmeContext::new();
+        ctx.init();
+        ctx
+    }
+
+    #[test]
+    fn test_a_running_timer_is_left_alone() {
+        let ctx = test_ctx();
+        let (_, mme_ue_id) = ue_with_outstanding_identity_request(&ctx);
+
+        expire_nas_timers(&ctx, Instant::now());
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(mme_ue.t3470.retry_count, 0);
+        assert!(mme_ue.t3470.is_running());
+    }
+
+    #[test]
+    fn test_expiry_retransmits_and_counts() {
+        let ctx = test_ctx();
+        let (_, mme_ue_id) = ue_with_outstanding_identity_request(&ctx);
+
+        for expected in 1..=MAX_RETRANSMISSIONS {
+            force_expiry(&ctx, mme_ue_id, NasTimer::T3470);
+            expire_nas_timers(&ctx, Instant::now());
+
+            let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+            assert_eq!(
+                mme_ue.t3470.retry_count, expected,
+                "each expiry must retransmit once and re-arm"
+            );
+            assert!(mme_ue.t3470.is_running());
+            assert!(
+                mme_ue.t3470.pkbuf.is_some(),
+                "the message must be kept for the next retransmission"
+            );
+        }
+    }
+
+    #[test]
+    fn test_the_fifth_expiry_aborts_and_releases_the_connection() {
+        let ctx = test_ctx();
+        let (enb_ue_id, mme_ue_id) = ue_with_outstanding_identity_request(&ctx);
+
+        for _ in 0..MAX_RETRANSMISSIONS {
+            force_expiry(&ctx, mme_ue_id, NasTimer::T3470);
+            expire_nas_timers(&ctx, Instant::now());
+        }
+        // The fifth expiry: TS 24.301 §5.4.4.6 aborts instead of retransmitting.
+        force_expiry(&ctx, mme_ue_id, NasTimer::T3470);
+        expire_nas_timers(&ctx, Instant::now());
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.t3470.is_running(), "the timer must be stopped");
+        assert!(mme_ue.t3470.pkbuf.is_none());
+        assert_eq!(mme_ue.t3470.retry_count, 0);
+        assert_eq!(
+            ctx.enb_ue_find_by_id(enb_ue_id).unwrap().ue_ctx_rel_action,
+            crate::context::UeCtxRelAction::UeContextRemove,
+            "the S1 connection must be released"
+        );
+    }
+
+    #[test]
+    fn test_a_stopped_timer_never_expires() {
+        let ctx = test_ctx();
+        let (_, mme_ue_id) = ue_with_outstanding_identity_request(&ctx);
+        {
+            // What the completing message does.
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            pool.get_mut(&mme_ue_id).unwrap().t3470.stop();
+        }
+
+        expire_nas_timers(&ctx, Instant::now() + Duration::from_secs(3600));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(mme_ue.t3470.retry_count, 0);
+        assert!(!mme_ue.t3470.is_running());
+        assert!(mme_ue.t3470.pkbuf.is_none());
+    }
+
+    #[test]
+    fn test_expiry_without_an_s1_connection_aborts_immediately() {
+        let ctx = test_ctx();
+        let (enb_ue_id, mme_ue_id) = ue_with_outstanding_identity_request(&ctx);
+        ctx.enb_ue_deassociate_mme_ue(enb_ue_id, mme_ue_id);
+
+        force_expiry(&ctx, mme_ue_id, NasTimer::T3470);
+        expire_nas_timers(&ctx, Instant::now());
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.t3470.is_running());
+        assert_eq!(mme_ue.t3470.retry_count, 0);
+    }
+
+    #[test]
+    fn test_each_timer_is_swept_independently() {
+        let ctx = test_ctx();
+        let (_, mme_ue_id) = ue_with_outstanding_identity_request(&ctx);
+        {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+            mme_ue.t3460.pkbuf = Some(vec![0x07, NasEpsMessageType::AuthenticationRequest as u8]);
+            mme_ue.t3460.start(T3460_DURATION);
+        }
+
+        force_expiry(&ctx, mme_ue_id, NasTimer::T3460);
+        expire_nas_timers(&ctx, Instant::now());
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(mme_ue.t3460.retry_count, 1);
+        assert_eq!(
+            mme_ue.t3470.retry_count, 0,
+            "an unexpired timer on the same UE must not be touched"
+        );
+    }
+}


### PR DESCRIPTION
Closes #45.

## The RES check was prefix-only

`handle_authentication_response` admitted `res_len < xres_len` and compared only
`xres[..res_len]`, so a **truncated RES that matched the XRES prefix
authenticated the UE** — a one-octet RES had a 1-in-256 chance per attempt. That
was latent while the routine was unreachable; #43 wired it to real signalling,
which turned it into a live authentication bypass. It now requires
`res_len == xres_len` and compares in constant time (a fold of
`acc |= a[i] ^ b[i]`, no new dependency; the length check short-circuits, which is
fine because the RES length travels in the clear on the wire).

## AUTHENTICATION FAILURE (0x5c) had no handler

#43's dispatch logged it and moved on, so neither cause #21 (synch failure) nor
#20 (MAC failure) was handled and a UE whose USIM SQN had drifted could never
attach. Now T3460 stops either way; cause #21 parses the 14-octet AUTS out of the
Authentication Failure Parameter and stores it for the re-synchronisation AIR;
cause #20 discards the vector and re-initiates identification (TS 24.301
§5.4.2.7 e); anything else aborts and releases the connection. SECURITY MODE
REJECT now also aborts and releases (§5.4.3.5) instead of only logging.

## No NAS timer ever expired

`TimerWithRetry` held a retransmission buffer and a `retry_count` that nothing
read or wrote, there was **no deadline field anywhere**, and the `sm.rs`
T3450/T3460/T3470 branches only logged. A lost downlink NAS message left the
procedure outstanding forever: no retransmission, no abort, no context release,
and the stored `pkbuf` never discarded. New `nas_timer.rs` adds the TS 24.301
Table 10.2.1 durations, the retransmission cap, and a sweep driven from the 100 ms
tick `MmeApp::run` already had. Timers are armed where their message is stored —
so "stored for retransmission" and "will be retransmitted" cannot drift apart —
and stopped by the message that completes their procedure.

## Five findings the issue did not state

**1. Three of its premises are already fixed.** It says uplink EMM dispatch is
missing, `handle_authentication_response` has no caller, and AUTHENTICATION
REJECT is never sent. #43 delivered all three. What survived is the prefix
comparison itself — the security-critical half — which is why this change leads
with it.

**2. The issue's retry count contradicts the spec.** It asks for "up to 4 times
total, then aborts". TS 24.301 §5.4.2.7 b) says the retransmission "is repeated
four times, i.e. on the fifth expiry of timer T3460 the network shall abort" —
four retransmissions, five expiries. §5.4.4.6 (T3470) and §5.5.1.2.7 (T3450) use
the same wording. This implements the spec, and the test walks all five expiries.

**3. There is no working timer subsystem to mirror.** amfd ships a 484-line
`timer::TimerManager` that can start and stop timers but has **no expiry or tick
function at all**, and nothing drives it. Copying it would have added a second
never-fired timer manager, so mmed's timers ride the existing run-loop tick where
they cannot silently stop firing.

**4. The AUTS re-synchronisation AIR cannot be sent yet, but everything below it
exists.** `fd_path::mme_s6a_send_air` already takes
`resync_auts: Option<&[u8; 14]>` and
`nextgcore_diameter::s6a::add_resync_info` already encodes RAND ‖ AUTS into
Requested-EUTRAN-Authentication-Info. The missing piece is the connected S6a peer
(filed task), so the handler stores the AUTS and says so rather than pretending
to send.

**5. A missed reset, found by the new tests.** `emm_security_mode_complete`
cleared `t3460.pkbuf` but left the deadline running, so the procedure would have
retransmitted a SECURITY MODE COMMAND the UE had already answered. Caught by the
timer-stop test — which is why that test asserts `is_running()` and not just that
the buffer is gone.

## Decisions

**Sweep the UE pool on the existing tick rather than build a timer wheel.** The
loop already wakes every 100 ms; a sweep is O(active UEs), needs no extra task or
channel, and tick granularity is irrelevant against six-second timers. The expiry
is **re-checked under the write lock against a fresh instant**, because an uplink
message may have stopped or re-armed the timer between the sweep's read and the
action.

**Deadlines live on the UE context, beside the buffer they would resend.** One
owner covers "this procedure is outstanding", and `stop()`-on-COMPLETE is a single
call that cannot drop half the state. A registry keyed by UE id would have to be
kept in step with context removal.

**Two degenerate cases abort immediately** rather than counting down: an expiry
with no live S1 connection (nothing to resend over), and a running deadline with
no stored message.

**`sm.rs` is left alone.** Its FSM is a separate never-wired subsystem; the
behaviour this issue asks for is expressible on the UE context, and
half-migrating the state machine would leave two owners of the same procedure
state.

## Acceptance criteria (#45)

- [x] `handle_authentication_response` requires `res_len == xres_len` with a
  full-length comparison; a prefix-matching truncated RES is rejected.
- [x] A RES mismatch sends AUTHENTICATION REJECT and aborts (wired in #43,
  re-verified here).
- [x] AUTHENTICATION FAILURE stops T3460; cause #21 captures the AUTS; cause #20
  follows §5.4.2.7 e).
- [x] T3460/T3450/T3470 retransmit and, after four retransmissions, abort and
  release the connection — no log-only paths.
- [x] Stored `pkbuf`s are cleared when the corresponding COMPLETE arrives
  (finding 5 was exactly this leaking).
- [x] Tests for the truncated RES, the correct RES, the synch-failure AUTS, and
  the abort after the final expiry.
- [x] `handle_authentication_response` reachable from S1AP.

## Verification

- `cargo test -p nextgcore-mmed`: **249 passed / 0 failed** (baseline 230, +19).
- `cargo test --workspace`: **5450 passed / 0 failed** (baseline 5431).
- `cargo clippy --workspace --all-targets` identical to the pre-change baseline;
  `cargo fmt --all --check` clean.
- Timer tests move `expires_at` into the past instead of sleeping, so they are
  deterministic and add no wall-clock time to the suite.

**Revert-verified**: relaxing the length check back to `res_len > xres_len` fails
exactly the two truncated-RES tests (the `emm_handler` unit test across every
prefix length 1-7, and the dispatch-level test asserting no security context is
established), so those assertions pin the fix rather than passing vacuously.

## Not done

- Connecting the S6a peer, so the re-synchronisation AIR is stored rather than
  sent (filed task).
- T3413 paging retransmission (#47); Attach Accept content (#46).

Spec: `specs/fix-mmed-emm-abnormal-cases.md`
