### PR TITLE
fix(mmed): parse the configuration file so an eNB can associate (closes #157)

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2714,6 +2714,8 @@ dependencies = [
  "nextgcore-s1ap",
  "nextgcore-sctp",
  "proptest",
+ "serde",
+ "serde_yaml",
  "tokio",
 ]
 

--- a/src/bins/nextgcore-mmed/Cargo.toml
+++ b/src/bins/nextgcore-mmed/Cargo.toml
@@ -37,6 +37,8 @@ tokio.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 ctrlc.workspace = true
+serde = { workspace = true }
+serde_yaml = { workspace = true }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/src/bins/nextgcore-mmed/src/config.rs
+++ b/src/bins/nextgcore-mmed/src/config.rs
@@ -1,0 +1,510 @@
+//! Configuration file parsing (issue #157).
+//!
+//! ## Why this module exists
+//!
+//! `MmeApp::init` took the `--config` path as `_config_path` and discarded it,
+//! and the crate had no serde dependency at all. Every field of the shipped
+//! `mme.yaml` was inert — most damagingly `mme.gummei`, because
+//! `handle_s1_setup_request` answers **S1 Setup Failure** when
+//! `served_gummei` is empty, which in production it always was. The daemon bound
+//! S1-MME and then refused every eNB association, so nothing downstream of S1
+//! Setup could run.
+//!
+//! ## Shape
+//!
+//! The serde types mirror `docker/rust/configs/epc/mme.yaml` exactly. Every
+//! field is optional: a partial file configures what it names and leaves the rest
+//! at its default, and a missing or malformed file logs a warning and changes
+//! nothing (the behaviour amfd's loader already has).
+//!
+//! ## What is deliberately not read here
+//!
+//! `mme.freeDiameter` names a file in freeDiameter's own `.conf` format, which
+//! nothing in this tree parses — so the path is *recorded* in `diam_conf_path`
+//! for diagnosis and the Diameter identity still comes from built-in defaults.
+//! That is why mmed has no HSS address and its S6a peer stays unconnected; see
+//! the filed follow-up. `mme.gtpc` clients wait on S11 (#51).
+
+use serde::Deserialize;
+
+use crate::context::{EpsTai0List, MmeContext, NetworkName, PlmnId, ServedGummei, ServedTai};
+
+// ============================================================================
+// YAML shape
+// ============================================================================
+
+#[derive(Debug, Default, Deserialize)]
+struct PlmnIdYaml {
+    mcc: Option<serde_yaml::Value>,
+    mnc: Option<serde_yaml::Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GummeiYaml {
+    plmn_id: Option<PlmnIdYaml>,
+    mme_gid: Option<u16>,
+    mme_code: Option<u8>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct TaiYaml {
+    plmn_id: Option<PlmnIdYaml>,
+    tac: Option<u16>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SecurityYaml {
+    integrity_order: Option<Vec<String>>,
+    ciphering_order: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NetworkNameYaml {
+    full: Option<String>,
+    short: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ServerYaml {
+    address: Option<String>,
+    port: Option<u16>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct S1apYaml {
+    server: Option<Vec<ServerYaml>>,
+}
+
+/// A single `<timer>: { value: <seconds> }` entry under `mme.time`, matching the
+/// nesting the 5GC configs use for `amf.time`.
+#[derive(Debug, Default, Deserialize)]
+struct TimerValueYaml {
+    value: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct TimeYaml {
+    t3402: Option<TimerValueYaml>,
+    t3412: Option<TimerValueYaml>,
+    t3423: Option<TimerValueYaml>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct MmeSection {
+    #[serde(rename = "freeDiameter")]
+    free_diameter: Option<String>,
+    s1ap: Option<S1apYaml>,
+    gummei: Option<Vec<GummeiYaml>>,
+    tai: Option<Vec<TaiYaml>>,
+    security: Option<SecurityYaml>,
+    network_name: Option<NetworkNameYaml>,
+    mme_name: Option<String>,
+    time: Option<TimeYaml>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct MmeYaml {
+    mme: Option<MmeSection>,
+}
+
+// ============================================================================
+// Loading
+// ============================================================================
+
+/// Apply `path` to `ctx`.
+///
+/// Returns `false` when nothing was applied — a missing file, unparsable YAML, or
+/// no `mme:` section — which is a warning rather than a failure so a mis-typed
+/// config cannot take the daemon down. The warning names the file, because the
+/// previous silence is what let this go unnoticed.
+pub fn load_config(ctx: &mut MmeContext, path: &str) -> bool {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(e) => {
+            log::warn!("Could not read config file '{path}': {e}. Using defaults.");
+            return false;
+        }
+    };
+
+    let yaml: MmeYaml = match serde_yaml::from_str(&content) {
+        Ok(yaml) => yaml,
+        Err(e) => {
+            log::warn!("Failed to parse YAML config '{path}': {e}. Using defaults.");
+            return false;
+        }
+    };
+
+    let Some(mme) = yaml.mme else {
+        log::warn!("Config '{path}' has no 'mme' section. Using defaults.");
+        return false;
+    };
+
+    apply(ctx, mme);
+    log::info!("Configuration loaded from {path}");
+    true
+}
+
+fn apply(ctx: &mut MmeContext, mme: MmeSection) {
+    if let Some(name) = mme.mme_name {
+        log::info!("MME name: {name}");
+        ctx.mme_name = Some(name);
+    }
+
+    if let Some(network_name) = mme.network_name {
+        if let Some(full) = network_name.full {
+            ctx.full_name = NetworkName {
+                name: full,
+                ..Default::default()
+            };
+        }
+        if let Some(short) = network_name.short {
+            ctx.short_name = NetworkName {
+                name: short,
+                ..Default::default()
+            };
+        }
+    }
+
+    // The Diameter identity and the HSS peer live in this file's own format,
+    // which nothing parses yet: record the path so a deployment is diagnosable.
+    if let Some(free_diameter) = mme.free_diameter {
+        log::info!(
+            "Diameter configuration path recorded: {free_diameter} (its contents are not parsed \
+             yet, so the S6a identity still comes from built-in defaults)"
+        );
+        ctx.diam_conf_path = Some(free_diameter);
+    }
+
+    // S1AP bind addresses. `S1apServer::bind` takes one address, so the first
+    // entry is what gets bound; the rest are recorded and named in a warning
+    // rather than dropped silently.
+    if let Some(s1ap) = mme.s1ap {
+        for server in s1ap.server.unwrap_or_default() {
+            let Some(address) = server.address else {
+                continue;
+            };
+            let port = server.port.unwrap_or(ctx.s1ap_port);
+            match parse_socket_addr(&address, port) {
+                Some(addr) => {
+                    log::info!("S1AP server address: {addr}");
+                    ctx.s1ap_list.push(addr);
+                }
+                None => log::warn!("Ignoring unparsable S1AP server address '{address}'"),
+            }
+        }
+        if ctx.s1ap_list.len() > 1 {
+            log::warn!(
+                "{} S1AP server addresses configured; only the first is bound",
+                ctx.s1ap_list.len()
+            );
+        }
+    }
+
+    // Served GUMMEI. Without at least one of these the MME rejects every S1
+    // Setup (TS 36.413 §8.7.3.4), which is the headline defect in #157.
+    for entry in mme.gummei.unwrap_or_default() {
+        let Some(plmn_id) = entry.plmn_id.and_then(resolve_plmn_id) else {
+            log::warn!("Ignoring GUMMEI entry with no usable plmn_id");
+            continue;
+        };
+        let mme_gid = entry.mme_gid.unwrap_or(0);
+        let mme_code = entry.mme_code.unwrap_or(0);
+        log::info!(
+            "Configured GUMMEI: PLMN {}, MME group {mme_gid}, MME code {mme_code}",
+            plmn_id.to_bcd()
+        );
+        ctx.served_gummei.push(ServedGummei {
+            num_of_plmn_id: 1,
+            plmn_id: vec![plmn_id],
+            num_of_mme_gid: 1,
+            mme_gid: vec![mme_gid],
+            num_of_mme_code: 1,
+            mme_code: vec![mme_code],
+        });
+        ctx.num_of_served_gummei += 1;
+    }
+
+    // Served TAI, as a TAI0 list (one PLMN, a list of TACs) which is what
+    // `find_served_tai` matches against.
+    for entry in mme.tai.unwrap_or_default() {
+        let Some(plmn_id) = entry.plmn_id.and_then(resolve_plmn_id) else {
+            log::warn!("Ignoring TAI entry with no usable plmn_id");
+            continue;
+        };
+        let tac = entry.tac.unwrap_or(0);
+        log::info!("Configured TAI: PLMN {}, TAC {tac}", plmn_id.to_bcd());
+        ctx.served_tai.push(ServedTai {
+            list0: EpsTai0List {
+                type_: 0,
+                num: 1,
+                plmn_id,
+                tac: vec![tac],
+            },
+            ..Default::default()
+        });
+        ctx.num_of_served_tai += 1;
+    }
+
+    // Algorithm order. REPLACES the built-in defaults rather than appending to
+    // them: `MmeContext::new` seeds both vectors (issue #44), so pushing would
+    // leave the defaults ahead of the configured entries and the configuration
+    // would be silently ineffective.
+    if let Some(security) = mme.security {
+        if let Some(order) = security.integrity_order {
+            ctx.integrity_order = order.iter().map(|name| parse_eia(name)).collect();
+            log::info!("NAS integrity order: {:?}", ctx.integrity_order);
+        }
+        if let Some(order) = security.ciphering_order {
+            ctx.ciphering_order = order.iter().map(|name| parse_eea(name)).collect();
+            log::info!("NAS ciphering order: {:?}", ctx.ciphering_order);
+        }
+    }
+
+    if let Some(time) = mme.time {
+        if let Some(value) = time.t3402.and_then(|t| t.value) {
+            ctx.time.t3402 = value;
+        }
+        if let Some(value) = time.t3412.and_then(|t| t.value) {
+            ctx.time.t3412 = value;
+        }
+        if let Some(value) = time.t3423.and_then(|t| t.value) {
+            ctx.time.t3423 = value;
+        }
+    }
+}
+
+/// Build a `PlmnId` from the YAML `plmn_id` block.
+///
+/// MCC and MNC are accepted as either numbers or strings, because YAML reads an
+/// unquoted `mnc: 70` as an integer while a quoted `mnc: "070"` is a string —
+/// and the leading zero matters: MNC 070 is three digits, MNC 70 is two.
+fn resolve_plmn_id(plmn: PlmnIdYaml) -> Option<PlmnId> {
+    let mcc = scalar_digits(plmn.mcc.as_ref()?)?;
+    let mnc = scalar_digits(plmn.mnc.as_ref()?)?;
+    Some(PlmnId::new(&mcc, &mnc))
+}
+
+/// Render a YAML scalar as its digit string, preserving a quoted form verbatim.
+fn scalar_digits(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::String(s) => Some(s.clone()),
+        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// `<host>` or `<host>:<port>` to a socket address, defaulting the port.
+fn parse_socket_addr(address: &str, port: u16) -> Option<std::net::SocketAddr> {
+    if let Ok(addr) = address.parse::<std::net::SocketAddr>() {
+        return Some(addr);
+    }
+    address
+        .parse::<std::net::IpAddr>()
+        .ok()
+        .map(|ip| std::net::SocketAddr::new(ip, port))
+}
+
+/// EPS integrity algorithm name to identity (TS 33.401 Annex B).
+fn parse_eia(name: &str) -> u8 {
+    match name.to_uppercase().as_str() {
+        "EIA1" | "128-EIA1" => 1,
+        "EIA2" | "128-EIA2" => 2,
+        "EIA3" | "128-EIA3" => 3,
+        // EIA0 and anything unrecognised map to null integrity, which
+        // `nas_security::select_nas_algorithms` refuses to select.
+        _ => 0,
+    }
+}
+
+/// EPS ciphering algorithm name to identity (TS 33.401 Annex B).
+fn parse_eea(name: &str) -> u8 {
+    match name.to_uppercase().as_str() {
+        "EEA1" | "128-EEA1" => 1,
+        "EEA2" | "128-EEA2" => 2,
+        "EEA3" | "128-EEA3" => 3,
+        _ => 0,
+    }
+}
+
+// ============================================================================
+// Unit Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The configuration the Docker EPC actually ships, read from the tree so
+    /// config drift breaks this test instead of going unnoticed.
+    const SHIPPED_CONFIG: &str = "../../../docker/rust/configs/epc/mme.yaml";
+
+    fn write_temp(name: &str, content: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_shipped_config_populates_the_context() {
+        let mut ctx = MmeContext::new();
+        assert!(
+            load_config(&mut ctx, SHIPPED_CONFIG),
+            "the shipped config must parse"
+        );
+
+        assert_eq!(ctx.mme_name.as_deref(), Some("nextgcore-mme0"));
+        assert_eq!(ctx.full_name.name, "NextGCore");
+        assert_eq!(ctx.short_name.name, "Next");
+        assert_eq!(
+            ctx.diam_conf_path.as_deref(),
+            Some("/etc/freeDiameter/mme.conf")
+        );
+
+        // The headline fix: a served GUMMEI, without which S1 Setup always fails.
+        assert_eq!(ctx.num_of_served_gummei, 1);
+        let gummei = &ctx.served_gummei[0];
+        assert_eq!(gummei.plmn_id[0].to_bcd(), "99970");
+        assert_eq!(gummei.mme_gid[0], 2);
+        assert_eq!(gummei.mme_code[0], 1);
+
+        assert_eq!(ctx.num_of_served_tai, 1);
+        assert_eq!(ctx.served_tai[0].list0.plmn_id.to_bcd(), "99970");
+        assert_eq!(ctx.served_tai[0].list0.tac, vec![1]);
+
+        // The S1AP bind address comes from the file.
+        assert_eq!(
+            ctx.s1ap_list,
+            vec![std::net::SocketAddr::from(([172, 24, 0, 5], 36412))]
+        );
+
+        // [EIA2, EIA1, EIA0] / [EEA0, EEA1, EEA2] as declared.
+        assert_eq!(ctx.integrity_order, vec![2, 1, 0]);
+        assert_eq!(ctx.ciphering_order, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_configured_algorithm_order_replaces_the_defaults() {
+        let mut ctx = MmeContext::new();
+        assert_eq!(
+            ctx.integrity_order,
+            crate::context::DEFAULT_INTEGRITY_ORDER.to_vec(),
+            "the defaults are seeded by MmeContext::new"
+        );
+
+        let path = write_temp(
+            "nextgcore-mmed-order.yaml",
+            "mme:\n  security:\n    integrity_order: [EIA1, EIA2]\n    ciphering_order: [EEA2]\n",
+        );
+        assert!(load_config(&mut ctx, path.to_str().unwrap()));
+
+        // Appending instead of replacing would leave [2, 1, 0, 1, 2] here, and
+        // the default EIA2 would still win the selection.
+        assert_eq!(ctx.integrity_order, vec![1, 2]);
+        assert_eq!(ctx.ciphering_order, vec![2]);
+    }
+
+    #[test]
+    fn test_missing_and_malformed_files_leave_defaults() {
+        let mut ctx = MmeContext::new();
+        assert!(!load_config(&mut ctx, "/nonexistent/nextgcore/mme.yaml"));
+        assert!(ctx.served_gummei.is_empty());
+        assert_eq!(
+            ctx.integrity_order,
+            crate::context::DEFAULT_INTEGRITY_ORDER.to_vec()
+        );
+
+        let path = write_temp("nextgcore-mmed-bad.yaml", "mme: [this is not a mapping\n");
+        assert!(!load_config(&mut ctx, path.to_str().unwrap()));
+        assert!(ctx.served_gummei.is_empty());
+
+        // A file that parses but configures nothing is also reported.
+        let path = write_temp("nextgcore-mmed-empty.yaml", "logger:\n  level: info\n");
+        assert!(!load_config(&mut ctx, path.to_str().unwrap()));
+        assert!(ctx.served_gummei.is_empty());
+    }
+
+    #[test]
+    fn test_partial_config_leaves_the_rest_alone() {
+        let mut ctx = MmeContext::new();
+        let path = write_temp(
+            "nextgcore-mmed-partial.yaml",
+            "mme:\n  mme_name: only-a-name\n",
+        );
+        assert!(load_config(&mut ctx, path.to_str().unwrap()));
+
+        assert_eq!(ctx.mme_name.as_deref(), Some("only-a-name"));
+        assert!(ctx.served_gummei.is_empty());
+        assert_eq!(ctx.s1ap_port, 36412, "untouched defaults survive");
+        assert_eq!(
+            ctx.integrity_order,
+            crate::context::DEFAULT_INTEGRITY_ORDER.to_vec()
+        );
+    }
+
+    #[test]
+    fn test_plmn_id_accepts_numeric_and_quoted_mnc() {
+        // Unquoted YAML numbers lose a leading zero, so an operator writing a
+        // three-digit MNC has to quote it; both forms must work.
+        let mut numeric = MmeContext::new();
+        let path = write_temp(
+            "nextgcore-mmed-plmn-num.yaml",
+            "mme:\n  gummei:\n    - plmn_id:\n        mcc: 001\n        mnc: 01\n",
+        );
+        assert!(load_config(&mut numeric, path.to_str().unwrap()));
+        assert_eq!(numeric.served_gummei[0].plmn_id[0].to_bcd(), "00101");
+
+        let mut quoted = MmeContext::new();
+        let path = write_temp(
+            "nextgcore-mmed-plmn-str.yaml",
+            "mme:\n  gummei:\n    - plmn_id:\n        mcc: \"001\"\n        mnc: \"010\"\n",
+        );
+        assert!(load_config(&mut quoted, path.to_str().unwrap()));
+        assert_eq!(quoted.served_gummei[0].plmn_id[0].to_bcd(), "001010");
+    }
+
+    #[test]
+    fn test_unusable_entries_are_skipped_not_fatal() {
+        let mut ctx = MmeContext::new();
+        let path = write_temp(
+            "nextgcore-mmed-partial-entries.yaml",
+            "mme:\n  gummei:\n    - mme_gid: 7\n    - plmn_id:\n        mcc: 999\n        mnc: 70\n      \
+             mme_gid: 2\n  s1ap:\n    server:\n      - address: not-an-address\n      - address: 10.0.0.1\n",
+        );
+        assert!(load_config(&mut ctx, path.to_str().unwrap()));
+
+        // The GUMMEI with no PLMN is dropped; the usable one survives.
+        assert_eq!(ctx.num_of_served_gummei, 1);
+        assert_eq!(ctx.served_gummei[0].mme_gid[0], 2);
+        // An unparsable address is skipped, not fatal.
+        assert_eq!(
+            ctx.s1ap_list,
+            vec![std::net::SocketAddr::from(([10, 0, 0, 1], 36412))]
+        );
+    }
+
+    #[test]
+    fn test_algorithm_name_parsing() {
+        assert_eq!(parse_eia("EIA2"), 2);
+        assert_eq!(parse_eia("128-EIA1"), 1);
+        assert_eq!(parse_eia("eia3"), 3);
+        assert_eq!(parse_eia("EIA0"), 0);
+        assert_eq!(parse_eia("nonsense"), 0);
+        assert_eq!(parse_eea("EEA2"), 2);
+        assert_eq!(parse_eea("128-EEA3"), 3);
+        assert_eq!(parse_eea("EEA0"), 0);
+    }
+
+    #[test]
+    fn test_socket_addr_parsing() {
+        assert_eq!(
+            parse_socket_addr("10.0.0.1", 36412),
+            Some(std::net::SocketAddr::from(([10, 0, 0, 1], 36412)))
+        );
+        assert_eq!(
+            parse_socket_addr("10.0.0.1:1234", 36412),
+            Some(std::net::SocketAddr::from(([10, 0, 0, 1], 1234))),
+            "an explicit port in the address wins"
+        );
+        assert!(parse_socket_addr("example.invalid", 36412).is_none());
+    }
+}

--- a/src/bins/nextgcore-mmed/src/context.rs
+++ b/src/bins/nextgcore-mmed/src/context.rs
@@ -2003,6 +2003,27 @@ pub fn mme_context_init() {
     mme_self().init();
 }
 
+/// Install the process-global context with `config_path` already applied.
+///
+/// The context keeps its configuration in plain fields rather than behind a lock,
+/// so it has to be *built* configured: once `mme_self()` has run, the `OnceLock`
+/// holds an immutable `&'static MmeContext` and there is no way to write
+/// `served_gummei` into it. This must therefore be the first thing that touches
+/// the context (issue #157).
+///
+/// Returns `false` when a context was already installed, in which case the
+/// configuration was not applied.
+pub fn mme_context_init_with_config(config_path: &str) -> bool {
+    let mut ctx = MmeContext::new();
+    crate::config::load_config(&mut ctx, config_path);
+
+    if MME_CONTEXT.set(ctx).is_err() {
+        return false;
+    }
+    mme_self().init();
+    true
+}
+
 /// Finalize the global MME context
 pub fn mme_context_final() {
     mme_self().final_();

--- a/src/bins/nextgcore-mmed/src/main.rs
+++ b/src/bins/nextgcore-mmed/src/main.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+pub mod config;
 pub mod context;
 pub mod emm_build;
 pub mod emm_handler;
@@ -81,11 +82,21 @@ impl MmeApp {
     }
 
     /// Initialize the MME application
-    pub async fn init(&mut self, _config_path: &str) -> Result<()> {
+    pub async fn init(&mut self, config_path: &str) -> Result<()> {
         log::info!("Initializing MME...");
 
-        // Initialize MME context
-        context::mme_context_init();
+        // Initialize the MME context WITH the configuration file applied. This
+        // has to happen before anything else touches `mme_self()`, because the
+        // context is built configured rather than mutated afterwards (issue
+        // #157). Until this landed the path was ignored entirely, which left
+        // `served_gummei` empty and made the MME answer S1 Setup Failure to
+        // every eNB.
+        if !context::mme_context_init_with_config(config_path) {
+            log::warn!(
+                "MME context was already initialised; configuration from '{config_path}' was \
+                 not applied"
+            );
+        }
         log::debug!("MME context initialized");
 
         // Initialize MME state machine
@@ -110,7 +121,13 @@ impl MmeApp {
         // Without this nothing can reach the S1AP layer, so no eNB can
         // associate and no EPS procedure can run (issue #42).
         let ctx = context::mme_self();
-        let s1ap_bind = std::net::SocketAddr::from(([0, 0, 0, 0], ctx.s1ap_port));
+        // Bind where the configuration says, falling back to the wildcard so an
+        // unconfigured deployment behaves exactly as it did before #157.
+        let s1ap_bind = ctx
+            .s1ap_list
+            .first()
+            .copied()
+            .unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], ctx.s1ap_port)));
         let send_rx = s1ap_path::install_send_queue().ok_or_else(|| {
             anyhow::anyhow!("S1AP send queue already installed (MmeApp::init called twice)")
         })?;

--- a/src/bins/nextgcore-mmed/src/s1ap_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s1ap_handler.rs
@@ -1388,6 +1388,73 @@ mod tests {
     }
 
     #[test]
+    fn test_s1_setup_succeeds_on_the_shipped_configuration() {
+        // Configuration alone must be enough for an eNB to associate. Before
+        // #157 mmed parsed no config, so `served_gummei` was empty and this
+        // request was answered with S1 Setup Failure in every deployment.
+        let mut ctx = MmeContext::new();
+        assert!(crate::config::load_config(
+            &mut ctx,
+            "../../../docker/rust/configs/epc/mme.yaml"
+        ));
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+
+        // An eNB broadcasting the PLMN and TAC the shipped file declares.
+        let plmn = PlmnId::new("999", "70");
+        let request = S1SetupRequest {
+            global_enb_id: GlobalEnbId {
+                plmn_identity: s1ap_build::encode_plmn_id(&plmn),
+                enb_id: nextgcore_s1ap::EnbId::Macro(0x1234),
+            },
+            enb_name: Some("configured-enb".to_string()),
+            supported_tas: vec![SupportedTaItem {
+                tac: 1,
+                broadcast_plmns: vec![s1ap_build::encode_plmn_id(&plmn)],
+            }],
+            default_paging_drx: nextgcore_s1ap::PagingDrx::V64,
+        };
+
+        let out = handle_s1ap_message(
+            &ctx,
+            enb_id,
+            &builder::build_s1_setup_request(&request).unwrap(),
+        );
+
+        assert_eq!(out.len(), 1);
+        match decode_s1ap_pdu(&out[0].pdu).unwrap() {
+            S1apMessage::S1SetupResponse(rsp) => {
+                assert_eq!(rsp.relative_mme_capacity, ctx.relative_capacity);
+                assert!(
+                    !rsp.served_gummeis.is_empty(),
+                    "the response must carry the configured GUMMEI"
+                );
+            }
+            other => panic!("expected S1SetupResponse, got {other:?}"),
+        }
+        assert!(ctx.enb_find_by_id(enb_id).unwrap().state.s1_setup_success);
+
+        // An eNB in a tracking area the file does not declare is still rejected.
+        let other_enb = ctx.enb_add("127.0.0.2:36412".parse().unwrap());
+        let elsewhere = S1SetupRequest {
+            supported_tas: vec![SupportedTaItem {
+                tac: 999,
+                broadcast_plmns: vec![s1ap_build::encode_plmn_id(&PlmnId::new("310", "410"))],
+            }],
+            ..request
+        };
+        let out = handle_s1ap_message(
+            &ctx,
+            other_enb,
+            &builder::build_s1_setup_request(&elsewhere).unwrap(),
+        );
+        assert_eq!(out.len(), 1);
+        assert!(matches!(
+            decode_s1ap_pdu(&out[0].pdu).unwrap(),
+            S1apMessage::S1SetupFailure(_)
+        ));
+    }
+
+    #[test]
     fn test_s1_setup_request_accept_and_reject() {
         let ctx = ctx_with_gummei();
         let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());


### PR DESCRIPTION
Closes #157.

mmed never read its configuration. `MmeApp::init` took the path as
`_config_path` and discarded it, the crate had no serde dependency at all, and
nothing anywhere read `mme.yaml` — while the CLI advertised `--config` with a
default of `/etc/nextgcore/mme.yaml`. Every field the shipped file declares was
inert.

## The consequence was not cosmetic

`served_gummei` is written **only** by two test helpers (`s1ap_build.rs:650`,
`s1ap_path.rs:373`), so in production it was always empty — and
`handle_s1_setup_request` answers **S1 SETUP FAILURE** when it is
(`s1ap_handler.rs:311`). The shipped Docker EPC therefore refused **every** eNB
association, which means the S1-MME transport (#42), the uplink NAS dispatch
(#43), the NAS security context (#44) and the abnormal-case handling (#45) all sat
behind an S1 Setup that could never succeed. The tests passed throughout because
they inject a GUMMEI by hand via `ctx_with_gummei()`.

New `config.rs` mirrors the shipped `mme.yaml` shape and populates the context:
`mme.gummei` → `served_gummei`, `mme.tai` → `served_tai` (as a TAI0 list, which is
what `find_served_tai` matches), `mme.security.*_order` → the algorithm orders,
`mme.network_name` → `full_name`/`short_name`, `mme.mme_name` → `mme_name`,
`mme.s1ap.server[].address` → `s1ap_list`, `mme.freeDiameter` → `diam_conf_path`,
`mme.time.*` → `TimerConfig`. A missing or malformed file — or one with no `mme:`
section — logs a warning **naming the file** and starts with defaults; the
previous silence is what let this go unnoticed.

## Replace, never append, the algorithm orders

#44 seeded `integrity_order`/`ciphering_order` in `MmeContext::new` with constants
mirroring the shipped yaml. amfd's loader pushes onto vectors that start *empty*,
so copying it verbatim here would have left the defaults **ahead** of the
configured entries — `[2,1,0,1,2]` for a file asking for `[EIA1, EIA2]` — and the
default EIA2 would still have won the selection. The configuration would have
parsed, logged, and had no effect: the exact class of defect this issue is about.
A test asserts the reordered file wins.

## The context is built configured, not mutated afterwards

`mme_self()` hands out `&'static MmeContext` from a `OnceLock`, and the
configuration lives in plain fields rather than behind a lock, so there is no way
to write `served_gummei` into the context once anything has observed it. New
`mme_context_init_with_config` applies the file to a fresh `MmeContext` and then
installs it, and must be the first thing that touches the context. It returns
`false` if a context was already installed rather than silently dropping the
configuration.

## Two smaller decisions

- The S1AP transport now **binds the configured address**, falling back to the
  wildcard so an unconfigured deployment behaves exactly as before. Only the first
  `s1ap.server[]` entry is bound (`S1apServer::bind` takes one address), and a
  warning names how many were configured rather than dropping the rest silently.
- `mme.freeDiameter` is **recorded, not parsed**. The Diameter identity and the
  HSS peer live in freeDiameter's own `.conf` format, which nothing in this tree
  reads (the same gap PR #147 hit for hssd/pcrfd). That is why mmed still has no
  HSS address and its S6a peer stays unconnected — the filed follow-up that the
  S6a bring-up depends on.

MCC/MNC are accepted as numbers **or** strings, because YAML reads an unquoted
`mnc: 70` as an integer while a quoted `mnc: "070"` keeps its leading zero — and
that zero decides whether the MNC is two digits or three. Both forms are tested.

## Acceptance criteria (#157)

- [x] `init` parses `--config`; missing, malformed, and `mme`-less files warn and
  start with defaults.
- [x] The shipped `mme.yaml` yields a non-empty `served_gummei`/`served_tai`, and
  S1 Setup **succeeds** for an eNB broadcasting the configured PLMN/TAC.
- [x] `mme_name`, network names and the S1AP bind address come from the file.
- [x] Configured algorithm orders *replace* the defaults.
- [x] `mme.freeDiameter` lands in `diam_conf_path`.
- [x] Tests cover each mapped field, the default paths, and the S1 Setup.

## Verification

- `cargo test -p nextgcore-mmed`: **258 passed / 0 failed** (baseline 249, +9).
- `cargo test --workspace`: **5459 passed / 0 failed** (baseline 5450).
- `cargo clippy --workspace --all-targets` identical to the pre-change baseline;
  `cargo fmt --all --check` clean.

The parse test reads the **real** `docker/rust/configs/epc/mme.yaml` rather than a
fixture copy, so config drift breaks the test instead of going unnoticed, and an
S1AP test drives a full S1 Setup Request through `handle_s1ap_message` using only
parsed configuration — asserting the response carries the configured GUMMEI, and
that an eNB in an undeclared tracking area is still rejected.

## Not done

- Parsing `/etc/freeDiameter/mme.conf`, so there is still no HSS address and the
  S6a peer stays unconnected (filed follow-up).
- `mme.gtpc` client addresses (S11 is #51), hot reload, and the access-control /
  emergency-APN / `global.max` blocks, which have no consumers in mmed.

Spec: `specs/fix-mmed-config-parse.md`
