### PR TITLE
feat(diameter): parse the freeDiameter .conf and connect mmed's S6a peer

### DIFF
--- a/src/bins/nextgcore-hssd/src/context.rs
+++ b/src/bins/nextgcore-hssd/src/context.rs
@@ -684,16 +684,38 @@ pub fn hss_context_parse_config(config_path: &str) -> Result<(), String> {
         .write()
         .map_err(|_| "HSS context lock poisoned".to_string())?;
 
+    // The freeDiameter file is the LOWER-precedence source, so it is applied
+    // before the YAML block: `hss.diameter` wins wherever both speak, and the
+    // .conf supplies what the YAML leaves out. Until this landed the path was
+    // only recorded, so the identity came from the built-in
+    // `hss.epc.mnc001.mcc001...` default even though the deployment mounts a file
+    // that says `hss.localdomain`.
     if let Some(path) = section.free_diameter {
+        match nextgcore_diameter::fd_conf::FreeDiameterConf::load(&path) {
+            Ok(conf) => {
+                if !conf.ignored.is_empty() {
+                    log::info!(
+                        "{path}: directives not interpreted: {}",
+                        conf.ignored
+                            .iter()
+                            .map(String::as_str)
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                }
+                apply_fd_conf(&mut ctx.diam_config, &conf);
+            }
+            Err(e) => log::warn!("Could not read freeDiameter config '{path}': {e}"),
+        }
         ctx.diam_conf_path = Some(path);
     }
 
-    let Some(diam) = section.diameter else {
-        log::debug!("{config_path}: no 'hss.diameter' block; keeping defaults");
-        return Ok(());
-    };
+    if let Some(diam) = section.diameter {
+        apply_diameter_yaml(&mut ctx.diam_config, diam);
+    } else {
+        log::debug!("{config_path}: no 'hss.diameter' block");
+    }
 
-    apply_diameter_yaml(&mut ctx.diam_config, diam);
     log::info!(
         "HSS Diameter identity: {} realm: {} listen: {}:{}",
         ctx.diam_config.cnf_diamid.as_deref().unwrap_or("<default>"),
@@ -705,6 +727,48 @@ pub fn hss_context_parse_config(config_path: &str) -> Result<(), String> {
         ctx.diam_config.cnf_port,
     );
     Ok(())
+}
+
+/// Copy a parsed freeDiameter `.conf` onto a [`DiamConfig`].
+///
+/// Only fields the file actually states are copied, and `connections` is only
+/// seeded when none are configured yet — a `ConnectPeer` in the .conf must not
+/// silently replace a peer list the YAML declared. `NoRelay` maps to
+/// `cnf_flags_no_fwd`: both mean "do not advertise the relay application".
+pub fn apply_fd_conf(cfg: &mut DiamConfig, conf: &nextgcore_diameter::fd_conf::FreeDiameterConf) {
+    if let Some(identity) = conf.identity.clone() {
+        cfg.cnf_diamid = Some(identity);
+    }
+    if let Some(realm) = conf.realm.clone() {
+        cfg.cnf_diamrlm = Some(realm);
+    }
+    if let Some(addr) = conf.listen_address() {
+        cfg.cnf_addr = Some(addr.to_string());
+    }
+    if let Some(port) = conf.port {
+        cfg.cnf_port = port;
+    }
+    if let Some(port) = conf.sec_port {
+        cfg.cnf_port_tls = port;
+    }
+    if conf.flags.no_relay {
+        cfg.cnf_flags_no_fwd = true;
+    }
+    if cfg.connections.is_empty() {
+        for peer in &conf.peers {
+            let Some(addr) = peer.connect_to.clone() else {
+                continue;
+            };
+            cfg.connections.push(DiamConnection {
+                identity: peer.identity.clone(),
+                addr,
+                // 0 is how `DiamConnection` spells "unset" for both of these:
+                // the node-level port and Tc apply.
+                port: peer.port.unwrap_or(0),
+                tc_timer: 0,
+            });
+        }
+    }
 }
 
 /// Copy the parsed `diameter` block onto a [`DiamConfig`].
@@ -1119,5 +1183,64 @@ hss:
         );
         assert_eq!(cfg.cnf_addr.as_deref(), Some("172.24.0.8"));
         assert_eq!(cfg.cnf_port, 3868);
+    }
+
+    /// The shipped `hss.conf`, read from the tree.
+    fn shipped_hss_conf() -> nextgcore_diameter::fd_conf::FreeDiameterConf {
+        let path = "../../../docker/rust/configs/epc/freeDiameter/hss.conf";
+        nextgcore_diameter::fd_conf::FreeDiameterConf::load(path)
+            .unwrap_or_else(|e| panic!("cannot read shipped {path}: {e}"))
+    }
+
+    #[test]
+    fn freediameter_conf_supplies_the_identity_the_deployment_mounts() {
+        let mut cfg = DiamConfig::default();
+        apply_fd_conf(&mut cfg, &shipped_hss_conf());
+
+        // Previously the mounted file was only recorded, so the identity came
+        // from the built-in `hss.epc.mnc001.mcc001...` default instead.
+        assert_eq!(cfg.cnf_diamid.as_deref(), Some("hss.localdomain"));
+        assert_eq!(cfg.cnf_diamrlm.as_deref(), Some("localdomain"));
+        assert_eq!(cfg.cnf_addr.as_deref(), Some("172.24.0.8"));
+        assert!(cfg.cnf_flags_no_fwd, "NoRelay maps to no_fwd");
+
+        // ConnectPeer becomes a dialable connection.
+        assert_eq!(cfg.connections.len(), 1);
+        assert_eq!(cfg.connections[0].identity, "mme.localdomain");
+        assert_eq!(cfg.connections[0].addr, "172.24.0.5");
+        assert_eq!(cfg.connections[0].port, 0, "0 means the node-level port");
+    }
+
+    #[test]
+    fn yaml_wins_over_the_freediameter_conf() {
+        let mut cfg = DiamConfig::default();
+        apply_fd_conf(&mut cfg, &shipped_hss_conf());
+
+        let yaml = "hss:\n  diameter:\n    identity: from.yaml\n    port: 3869\n";
+        let parsed: HssYaml = serde_yaml::from_str(yaml).expect("must parse");
+        apply_diameter_yaml(&mut cfg, parsed.hss.unwrap().diameter.unwrap());
+
+        assert_eq!(cfg.cnf_diamid.as_deref(), Some("from.yaml"));
+        assert_eq!(cfg.cnf_port, 3869);
+        // What the YAML did not state still comes from the .conf.
+        assert_eq!(cfg.cnf_diamrlm.as_deref(), Some("localdomain"));
+        assert_eq!(cfg.cnf_addr.as_deref(), Some("172.24.0.8"));
+    }
+
+    #[test]
+    fn configured_connections_are_not_replaced_by_the_conf() {
+        let mut cfg = DiamConfig {
+            connections: vec![DiamConnection {
+                identity: "configured.localdomain".to_string(),
+                addr: "10.0.0.1".to_string(),
+                port: 3868,
+                tc_timer: 0,
+            }],
+            ..Default::default()
+        };
+        apply_fd_conf(&mut cfg, &shipped_hss_conf());
+
+        assert_eq!(cfg.connections.len(), 1);
+        assert_eq!(cfg.connections[0].identity, "configured.localdomain");
     }
 }

--- a/src/bins/nextgcore-mmed/src/config.rs
+++ b/src/bins/nextgcore-mmed/src/config.rs
@@ -165,13 +165,11 @@ fn apply(ctx: &mut MmeContext, mme: MmeSection) {
         }
     }
 
-    // The Diameter identity and the HSS peer live in this file's own format,
-    // which nothing parses yet: record the path so a deployment is diagnosable.
+    // The Diameter identity, realm, listener and HSS peer live in this file's
+    // own format. It is mounted into the container and is what an operator
+    // edits, so it is read rather than merely recorded.
     if let Some(free_diameter) = mme.free_diameter {
-        log::info!(
-            "Diameter configuration path recorded: {free_diameter} (its contents are not parsed \
-             yet, so the S6a identity still comes from built-in defaults)"
-        );
+        apply_fd_conf(ctx, &free_diameter);
         ctx.diam_conf_path = Some(free_diameter);
     }
 
@@ -273,6 +271,64 @@ fn apply(ctx: &mut MmeContext, mme: MmeSection) {
     }
 }
 
+/// Read the freeDiameter `.conf` at `path` into the S6a fields of the context.
+///
+/// The MME is the S6a *client*, so the peer that matters is the one it dials:
+/// `ConnectPeer = "hss.localdomain" { ConnectTo = "172.24.0.8"; }` becomes
+/// `hss_peer`, which is the address `mme_fd_connect` needs and which mmed
+/// previously had no way to learn.
+fn apply_fd_conf(ctx: &mut MmeContext, path: &str) {
+    let conf = match nextgcore_diameter::fd_conf::FreeDiameterConf::load(path) {
+        Ok(conf) => conf,
+        Err(e) => {
+            log::warn!("Could not read freeDiameter config '{path}': {e}");
+            return;
+        }
+    };
+
+    if !conf.ignored.is_empty() {
+        log::info!(
+            "{path}: directives not interpreted: {}",
+            conf.ignored
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    if let Some(identity) = conf.identity.clone() {
+        log::info!("Diameter identity: {identity}");
+        ctx.diam_identity = Some(identity);
+    }
+    ctx.diam_realm = conf.realm.clone();
+    ctx.diam_addr = conf.listen_address().map(str::to_string);
+
+    // Port is optional in the shipped files; RFC 6733 §2.1 puts unsecured
+    // Diameter on 3868.
+    let default_port = conf.port.unwrap_or(DIAMETER_PORT);
+    match conf.first_connect_peer() {
+        Some((identity, address, port)) => {
+            let port = port.unwrap_or(default_port);
+            match parse_socket_addr(address, port) {
+                Some(addr) => {
+                    log::info!("S6a peer: {identity} at {addr}");
+                    ctx.hss_peer = Some((identity.to_string(), addr));
+                }
+                None => log::warn!(
+                    "{path}: peer '{identity}' has unusable ConnectTo address '{address}'"
+                ),
+            }
+        }
+        None => log::warn!(
+            "{path}: no ConnectPeer with a ConnectTo address, so no S6a peer can be dialled"
+        ),
+    }
+}
+
+/// Default unsecured Diameter port (RFC 6733 §2.1).
+const DIAMETER_PORT: u16 = 3868;
+
 /// Build a `PlmnId` from the YAML `plmn_id` block.
 ///
 /// MCC and MNC are accepted as either numbers or strings, because YAML reads an
@@ -359,6 +415,12 @@ mod tests {
             ctx.diam_conf_path.as_deref(),
             Some("/etc/freeDiameter/mme.conf")
         );
+        // The .conf lives at an absolute path that only exists inside the
+        // container, so the shipped config cannot populate the identity here;
+        // `test_freediameter_conf_supplies_the_identity_and_peer` covers that
+        // mapping against the file as shipped in the tree.
+        assert_eq!(ctx.diam_identity, None);
+        assert_eq!(ctx.hss_peer, None);
 
         // The headline fix: a served GUMMEI, without which S1 Setup always fails.
         assert_eq!(ctx.num_of_served_gummei, 1);
@@ -479,6 +541,68 @@ mod tests {
         assert_eq!(
             ctx.s1ap_list,
             vec![std::net::SocketAddr::from(([10, 0, 0, 1], 36412))]
+        );
+    }
+
+    #[test]
+    fn test_freediameter_conf_supplies_the_identity_and_peer() {
+        // Point `freeDiameter:` at the file as it ships in the tree, standing in
+        // for the container path the compose deployment mounts it to.
+        let path = write_temp(
+            "nextgcore-mmed-fd.yaml",
+            "mme:\n  freeDiameter: ../../../docker/rust/configs/epc/freeDiameter/mme.conf\n",
+        );
+        let mut ctx = MmeContext::new();
+        assert!(load_config(&mut ctx, path.to_str().unwrap()));
+
+        assert_eq!(ctx.diam_identity.as_deref(), Some("mme.localdomain"));
+        assert_eq!(ctx.diam_realm.as_deref(), Some("localdomain"));
+        assert_eq!(ctx.diam_addr.as_deref(), Some("172.24.0.5"));
+        // The HSS address mmed previously had no way to learn, defaulted to the
+        // RFC 6733 port because the shipped file leaves `Port` commented out.
+        assert_eq!(
+            ctx.hss_peer,
+            Some((
+                "hss.localdomain".to_string(),
+                std::net::SocketAddr::from(([172, 24, 0, 8], 3868))
+            ))
+        );
+    }
+
+    #[test]
+    fn test_unreadable_freediameter_conf_is_recorded_but_not_fatal() {
+        let path = write_temp(
+            "nextgcore-mmed-fd-missing.yaml",
+            "mme:\n  mme_name: still-configured\n  freeDiameter: /nonexistent/mme.conf\n",
+        );
+        let mut ctx = MmeContext::new();
+        assert!(load_config(&mut ctx, path.to_str().unwrap()));
+
+        // The rest of the file still applies, and the path is recorded so the
+        // deployment can be diagnosed.
+        assert_eq!(ctx.mme_name.as_deref(), Some("still-configured"));
+        assert_eq!(ctx.diam_conf_path.as_deref(), Some("/nonexistent/mme.conf"));
+        assert_eq!(ctx.diam_identity, None);
+        assert_eq!(ctx.hss_peer, None);
+    }
+
+    #[test]
+    fn test_peer_without_connect_to_yields_no_s6a_peer() {
+        let conf = write_temp(
+            "nextgcore-mmed-noconnect.conf",
+            "Identity = \"mme.localdomain\";\nConnectPeer = \"hss.localdomain\";\n",
+        );
+        let path = write_temp(
+            "nextgcore-mmed-noconnect.yaml",
+            &format!("mme:\n  freeDiameter: {}\n", conf.to_str().unwrap()),
+        );
+        let mut ctx = MmeContext::new();
+        assert!(load_config(&mut ctx, path.to_str().unwrap()));
+
+        assert_eq!(ctx.diam_identity.as_deref(), Some("mme.localdomain"));
+        assert_eq!(
+            ctx.hss_peer, None,
+            "a peer with no address is not something to dial"
         );
     }
 

--- a/src/bins/nextgcore-mmed/src/context.rs
+++ b/src/bins/nextgcore-mmed/src/context.rs
@@ -1343,6 +1343,15 @@ pub struct MmeContext {
     /// Diameter configuration path
     pub diam_conf_path: Option<String>,
 
+    /// Local Diameter identity (Origin-Host), from the freeDiameter `.conf`
+    pub diam_identity: Option<String>,
+    /// Local Diameter realm (Origin-Realm)
+    pub diam_realm: Option<String>,
+    /// Local Diameter listen address, if the configuration names one
+    pub diam_addr: Option<String>,
+    /// The HSS peer to dial for S6a: `(Diameter identity, socket address)`
+    pub hss_peer: Option<(String, std::net::SocketAddr)>,
+
     /// S1AP port
     pub s1ap_port: u16,
     /// SGsAP port

--- a/src/bins/nextgcore-mmed/src/main.rs
+++ b/src/bins/nextgcore-mmed/src/main.rs
@@ -117,6 +117,13 @@ impl MmeApp {
         }
         log::debug!("Diameter S6a interface initialized");
 
+        // Connect the S6a peer. `mme_fd_connect` has had no caller since it was
+        // written — its own comment defers it until "the async runtime is
+        // available" (#42 provided that) and until an HSS address existed, which
+        // the freeDiameter config now supplies. Without this the MME can never
+        // obtain an authentication vector, so no UE can complete an attach.
+        self.connect_s6a().await;
+
         // Bind the S1-MME SCTP transport (TS 36.412: port 36412, PPID 18).
         // Without this nothing can reach the S1AP layer, so no eNB can
         // associate and no EPS procedure can run (issue #42).
@@ -141,6 +148,67 @@ impl MmeApp {
 
         log::info!("MME initialized successfully");
         Ok(())
+    }
+
+    /// Establish the S6a Diameter connection to the HSS.
+    ///
+    /// A failure is logged and startup continues: an HSS that is not up yet is
+    /// the normal case in a compose deployment, and the S6a request path already
+    /// answers `NotInitialized`/`RequestTimeout` for a peer that is not there.
+    /// Taking the daemon down instead would mean an MME that cannot serve S1AP
+    /// because its HSS was slow to start.
+    async fn connect_s6a(&self) {
+        let ctx = context::mme_self();
+        let Some((peer_identity, peer_addr)) = ctx.hss_peer.clone() else {
+            log::warn!(
+                "No S6a peer configured (no ConnectPeer with a ConnectTo in {}); \
+                 authentication will not be possible",
+                ctx.diam_conf_path.as_deref().unwrap_or("<no config>")
+            );
+            return;
+        };
+
+        // Advertise only S6a: that is the single application this daemon
+        // implements, so a peer with nothing in common is refused up front
+        // (RFC 6733 §5.3) rather than accepted and failing at the first request.
+        let applications =
+            nextgcore_diameter::applications::ApplicationRegistry::new("NextGCore MME")
+                .with_application(nextgcore_diameter::applications::well_known::S6A);
+
+        let config = nextgcore_diameter::config::DiameterConfig {
+            diameter_id: ctx
+                .diam_identity
+                .clone()
+                .unwrap_or_else(|| "mme.localdomain".to_string()),
+            diameter_realm: ctx
+                .diam_realm
+                .clone()
+                .unwrap_or_else(|| "localdomain".to_string()),
+            // Advertised as Host-IP-Address. A wildcard tells a peer nothing
+            // routable, so it is omitted rather than advertised as 0.0.0.0.
+            address: ctx
+                .diam_addr
+                .clone()
+                .filter(|addr| addr != "0.0.0.0" && addr != "::"),
+            applications,
+            ..Default::default()
+        };
+
+        log::info!(
+            "Connecting S6a to {peer_identity} at {peer_addr} as {}",
+            config.diameter_id
+        );
+        if let Err(e) = fd_path::mme_fd_init_async(config, peer_addr).await {
+            log::error!("S6a client setup failed: {e}");
+            return;
+        }
+        match fd_path::mme_fd_connect().await {
+            Ok(()) => log::info!("S6a connected to {peer_identity} at {peer_addr}"),
+            Err(e) => log::warn!(
+                "S6a connection to {peer_identity} at {peer_addr} failed: {e}. Authentication \
+                 will fail until the peer is reachable."
+            ),
+        }
     }
 
     /// Run the MME main loop.

--- a/src/bins/nextgcore-pcrfd/src/context.rs
+++ b/src/bins/nextgcore-pcrfd/src/context.rs
@@ -613,17 +613,59 @@ pub fn pcrf_context_parse_config(config_path: &str) -> Result<(), String> {
         .write()
         .map_err(|_| "PCRF context lock poisoned".to_string())?;
 
+    // The freeDiameter file is the LOWER-precedence source, applied before the
+    // YAML block so `pcrf.diameter` wins wherever both speak. Until this landed
+    // the path was only recorded, so the identity came from the built-in
+    // `pcrf.localdomain` default rather than the mounted file.
     if let Some(path) = section.free_diameter {
+        match nextgcore_diameter::fd_conf::FreeDiameterConf::load(&path) {
+            Ok(conf) => {
+                if !conf.ignored.is_empty() {
+                    log::info!(
+                        "{path}: directives not interpreted: {}",
+                        conf.ignored
+                            .iter()
+                            .map(String::as_str)
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                }
+                apply_fd_conf(&mut ctx.diam_config, &conf);
+            }
+            Err(e) => log::warn!("Could not read freeDiameter config '{path}': {e}"),
+        }
         ctx.diam_conf_path = Some(path);
     }
 
-    let Some(diam) = section.diameter else {
-        log::debug!("{config_path}: no 'pcrf.diameter' block; keeping defaults");
-        return Ok(());
-    };
-
-    apply_diameter_yaml(&mut ctx.diam_config, diam);
+    if let Some(diam) = section.diameter {
+        apply_diameter_yaml(&mut ctx.diam_config, diam);
+    } else {
+        log::debug!("{config_path}: no 'pcrf.diameter' block");
+    }
     Ok(())
+}
+
+/// Copy a parsed freeDiameter `.conf` onto a [`DiamConfig`].
+///
+/// Only what the file states is copied. `pcrf.conf` declares no peers this
+/// daemon dials — the PCRF is the Gx server — so `ConnectPeer` entries are
+/// ignored here rather than invented into a client list.
+pub fn apply_fd_conf(cfg: &mut DiamConfig, conf: &nextgcore_diameter::fd_conf::FreeDiameterConf) {
+    if let Some(identity) = conf.identity.clone() {
+        cfg.cnf_diamid = Some(identity);
+    }
+    if let Some(realm) = conf.realm.clone() {
+        cfg.cnf_diamrlm = Some(realm);
+    }
+    if let Some(addr) = conf.listen_address() {
+        cfg.cnf_addr = Some(addr.to_string());
+    }
+    if let Some(port) = conf.port {
+        cfg.cnf_port = port;
+    }
+    if let Some(port) = conf.sec_port {
+        cfg.cnf_port_tls = port;
+    }
 }
 
 /// Copy the parsed `diameter` block onto a [`DiamConfig`].
@@ -825,5 +867,43 @@ mod tests {
         assert_eq!(session.sid, "rx-session-1");
         assert_eq!(session.gx_session_idx, 0);
         assert!(session.pcc_rules.is_empty());
+    }
+
+    #[test]
+    fn freediameter_conf_supplies_the_identity_the_deployment_mounts() {
+        let path = "../../../docker/rust/configs/epc/freeDiameter/pcrf.conf";
+        let conf = nextgcore_diameter::fd_conf::FreeDiameterConf::load(path)
+            .unwrap_or_else(|e| panic!("cannot read shipped {path}: {e}"));
+
+        let mut cfg = DiamConfig::default();
+        apply_fd_conf(&mut cfg, &conf);
+
+        assert_eq!(cfg.cnf_diamid.as_deref(), Some("pcrf.localdomain"));
+        assert_eq!(cfg.cnf_diamrlm.as_deref(), Some("localdomain"));
+        // The listen address the deployment mounts, which was previously ignored.
+        assert_eq!(cfg.cnf_addr.as_deref(), Some("172.24.0.9"));
+    }
+
+    #[test]
+    fn yaml_wins_over_the_freediameter_conf() {
+        let mut cfg = DiamConfig::default();
+        apply_fd_conf(
+            &mut cfg,
+            &nextgcore_diameter::fd_conf::FreeDiameterConf::parse(
+                "Identity = \"from.conf\";\nRealm = \"conf.realm\";\n",
+            ),
+        );
+
+        let parsed: PcrfYaml =
+            serde_yaml::from_str("pcrf:\n  diameter:\n    identity: from.yaml\n")
+                .expect("must parse");
+        apply_diameter_yaml(&mut cfg, parsed.pcrf.unwrap().diameter.unwrap());
+
+        assert_eq!(cfg.cnf_diamid.as_deref(), Some("from.yaml"));
+        assert_eq!(
+            cfg.cnf_diamrlm.as_deref(),
+            Some("conf.realm"),
+            "what the YAML omits still comes from the .conf"
+        );
     }
 }

--- a/src/libs/nextgcore-diameter/src/fd_conf.rs
+++ b/src/libs/nextgcore-diameter/src/fd_conf.rs
@@ -1,0 +1,428 @@
+//! freeDiameter `.conf` parsing.
+//!
+//! ## Why this module exists
+//!
+//! The shipped EPC deployment mounts `configs/epc/freeDiameter` into the mmed,
+//! hssd and pcrfd containers, and each daemon's YAML names its file
+//! (`mme.freeDiameter: /etc/freeDiameter/mme.conf`). Those files hold the real
+//! Diameter identity, realm, listen address and peer for the deployment — and
+//! **nothing read them**. Each daemon fell back to a built-in default identity
+//! (`hss.epc.mnc001.mcc001.3gppnetwork.org` and friends), and mmed had no HSS
+//! address at all, which is why its S6a peer could never be connected.
+//!
+//! There is also no freeDiameter binary anywhere in the tree — no package
+//! install, no `.fdx` extension, nothing that could consume these files instead.
+//! So the files are not a foreign library's configuration that happens to sit
+//! nearby: they are this deployment's Diameter configuration, and reading them is
+//! what makes them true.
+//!
+//! ## Scope
+//!
+//! Only the directives the shipped files actually use, plus the handful that
+//! naturally accompany them:
+//!
+//! ```text
+//! Identity = "mme.localdomain";
+//! Realm = "localdomain";
+//! Port = 3868;            SecPort = 5868;
+//! ListenOn = "172.24.0.5";
+//! No_IPv6;  No_IP;  No_TCP;  No_SCTP;  Prefer_TCP;  NoRelay;
+//! ConnectPeer = "hss.localdomain" { ConnectTo = "172.24.0.8"; No_TLS; };
+//! ```
+//!
+//! Anything else — `LoadExtension`, `TLS_Cred`, `AppServThreads`, … — is collected
+//! into [`FreeDiameterConf::ignored`] so a caller can log what it skipped rather
+//! than dropping it silently. This is deliberately not a complete freeDiameter
+//! grammar: an unknown directive is reported, never guessed at.
+
+use std::collections::BTreeSet;
+use std::io;
+use std::path::Path;
+
+/// A peer declared by `ConnectPeer`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FreeDiameterPeer {
+    /// The peer's Diameter identity (the quoted name after `ConnectPeer =`)
+    pub identity: String,
+    /// `ConnectTo` address, when given
+    pub connect_to: Option<String>,
+    /// A `Port` inside the peer's block
+    pub port: Option<u16>,
+    /// `No_TLS` inside the peer's block
+    pub no_tls: bool,
+}
+
+/// The subset of a freeDiameter configuration this crate understands.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FreeDiameterConf {
+    /// `Identity` — the local Diameter identity (an FQDN)
+    pub identity: Option<String>,
+    /// `Realm` — the local Diameter realm
+    pub realm: Option<String>,
+    /// `ListenOn` addresses, in declaration order
+    pub listen_on: Vec<String>,
+    /// `Port` — the local TCP/SCTP port
+    pub port: Option<u16>,
+    /// `SecPort` — the local TLS port
+    pub sec_port: Option<u16>,
+    /// `No_IP` / `No_IPv6` / `No_TCP` / `No_SCTP` / `Prefer_TCP` / `NoRelay`
+    pub flags: FreeDiameterFlags,
+    /// `ConnectPeer` entries, in declaration order
+    pub peers: Vec<FreeDiameterPeer>,
+    /// Directives this parser does not interpret, deduplicated by keyword
+    pub ignored: BTreeSet<String>,
+}
+
+/// The valueless directives.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FreeDiameterFlags {
+    /// `No_IP`
+    pub no_ip: bool,
+    /// `No_IPv6`
+    pub no_ipv6: bool,
+    /// `No_TCP`
+    pub no_tcp: bool,
+    /// `No_SCTP`
+    pub no_sctp: bool,
+    /// `Prefer_TCP`
+    pub prefer_tcp: bool,
+    /// `NoRelay` — the peer does not relay, i.e. do not advertise the relay
+    /// application (0xffffff)
+    pub no_relay: bool,
+}
+
+impl FreeDiameterConf {
+    /// Read and parse `path`.
+    pub fn load(path: impl AsRef<Path>) -> io::Result<Self> {
+        let text = std::fs::read_to_string(path)?;
+        Ok(Self::parse(&text))
+    }
+
+    /// Parse configuration text. Never fails: unrecognised or malformed
+    /// directives are recorded in [`Self::ignored`] rather than rejected, so a
+    /// caller keeps whatever the file did state clearly.
+    pub fn parse(text: &str) -> Self {
+        let mut conf = Self::default();
+        for statement in statements(text) {
+            conf.apply(&statement);
+        }
+        conf
+    }
+
+    /// The first `ListenOn` address, which is the one a single-socket server
+    /// binds.
+    pub fn listen_address(&self) -> Option<&str> {
+        self.listen_on.first().map(String::as_str)
+    }
+
+    /// The first peer that names a `ConnectTo` address, as
+    /// `(identity, address, port)`.
+    ///
+    /// The shipped files declare exactly one peer each, which is the HSS for
+    /// mmed and the MME for hssd.
+    pub fn first_connect_peer(&self) -> Option<(&str, &str, Option<u16>)> {
+        self.peers.iter().find_map(|peer| {
+            peer.connect_to
+                .as_deref()
+                .map(|addr| (peer.identity.as_str(), addr, peer.port))
+        })
+    }
+
+    fn apply(&mut self, statement: &str) {
+        let (keyword, value) = split_statement(statement);
+
+        match keyword.to_ascii_lowercase().as_str() {
+            "identity" => self.identity = value.and_then(unquote),
+            "realm" => self.realm = value.and_then(unquote),
+            "listenon" => {
+                if let Some(address) = value.and_then(unquote) {
+                    self.listen_on.push(address);
+                }
+            }
+            "port" => self.port = value.and_then(parse_port),
+            "secport" => self.sec_port = value.and_then(parse_port),
+            "no_ip" => self.flags.no_ip = true,
+            "no_ipv6" => self.flags.no_ipv6 = true,
+            "no_tcp" => self.flags.no_tcp = true,
+            "no_sctp" => self.flags.no_sctp = true,
+            "prefer_tcp" => self.flags.prefer_tcp = true,
+            "norelay" => self.flags.no_relay = true,
+            "connectpeer" => {
+                if let Some(peer) = value.and_then(parse_connect_peer) {
+                    self.peers.push(peer);
+                }
+            }
+            other if !other.is_empty() => {
+                self.ignored.insert(keyword.to_string());
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Split configuration text into `;`-terminated statements, keeping a
+/// `ConnectPeer` block with its directive.
+///
+/// Comments run from `#` to end of line. The shipped files put no `#` inside a
+/// quoted value, and freeDiameter itself treats `#` as a comment anywhere, so
+/// stripping before tokenising matches the reference behaviour.
+fn statements(text: &str) -> Vec<String> {
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0usize;
+
+    for line in text.lines() {
+        let line = match line.find('#') {
+            Some(idx) => &line[..idx],
+            None => line,
+        };
+
+        for ch in line.chars() {
+            match ch {
+                '{' => {
+                    depth += 1;
+                    current.push(ch);
+                }
+                '}' => {
+                    depth = depth.saturating_sub(1);
+                    current.push(ch);
+                }
+                // A `;` inside a ConnectPeer block separates that block's own
+                // directives, so only a top-level one ends a statement.
+                ';' if depth == 0 => {
+                    push_statement(&mut statements, &mut current);
+                }
+                _ => current.push(ch),
+            }
+        }
+        // Statements may span lines, so only a newline's worth of whitespace is
+        // added rather than terminating here.
+        current.push(' ');
+    }
+    push_statement(&mut statements, &mut current);
+    statements
+}
+
+fn push_statement(statements: &mut Vec<String>, current: &mut String) {
+    let statement = current.trim().to_string();
+    current.clear();
+    if !statement.is_empty() {
+        statements.push(statement);
+    }
+}
+
+/// Split `Key = value` (or a bare `Key`) into its keyword and optional value.
+fn split_statement(statement: &str) -> (&str, Option<&str>) {
+    match statement.find('=') {
+        Some(idx) => (
+            statement[..idx].trim(),
+            Some(statement[idx + 1..].trim()).filter(|value| !value.is_empty()),
+        ),
+        None => (statement.trim(), None),
+    }
+}
+
+fn unquote(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    let unquoted = trimmed
+        .strip_prefix('"')
+        .and_then(|rest| rest.strip_suffix('"'))
+        .unwrap_or(trimmed);
+    (!unquoted.is_empty()).then(|| unquoted.to_string())
+}
+
+fn parse_port(value: &str) -> Option<u16> {
+    unquote(value)?.parse().ok()
+}
+
+/// Parse `"peer.identity" { ConnectTo = "addr"; No_TLS; }`.
+fn parse_connect_peer(value: &str) -> Option<FreeDiameterPeer> {
+    let (identity_part, block) = match value.find('{') {
+        Some(idx) => (&value[..idx], value[idx + 1..].trim_end_matches(['}', ' '])),
+        None => (value, ""),
+    };
+
+    let identity = unquote(identity_part)?;
+    let mut peer = FreeDiameterPeer {
+        identity,
+        ..Default::default()
+    };
+
+    for inner in block.split(';') {
+        let (keyword, inner_value) = split_statement(inner);
+        match keyword.to_ascii_lowercase().as_str() {
+            "connectto" => peer.connect_to = inner_value.and_then(unquote),
+            "port" => peer.port = inner_value.and_then(parse_port),
+            "no_tls" => peer.no_tls = true,
+            _ => {}
+        }
+    }
+
+    Some(peer)
+}
+
+// ============================================================================
+// Unit Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The MME file the Docker EPC ships, verbatim.
+    const SHIPPED_MME_CONF: &str = r#"
+# freeDiameter configuration for MME
+Identity = "mme.localdomain";
+Realm = "localdomain";
+
+# LoadExtension = "/usr/lib/freeDiameter/dbg_msg_dumps.fdx" : "0x8888";
+No_IPv6;
+ListenOn = "172.24.0.5";
+NoRelay;
+
+ConnectPeer = "hss.localdomain" { ConnectTo = "172.24.0.8"; No_TLS; };
+"#;
+
+    #[test]
+    fn test_parses_the_shipped_mme_conf() {
+        let conf = FreeDiameterConf::parse(SHIPPED_MME_CONF);
+
+        assert_eq!(conf.identity.as_deref(), Some("mme.localdomain"));
+        assert_eq!(conf.realm.as_deref(), Some("localdomain"));
+        assert_eq!(conf.listen_address(), Some("172.24.0.5"));
+        assert!(conf.flags.no_ipv6);
+        assert!(conf.flags.no_relay);
+        assert_eq!(
+            conf.port, None,
+            "the shipped file leaves Port commented out"
+        );
+
+        assert_eq!(
+            conf.first_connect_peer(),
+            Some(("hss.localdomain", "172.24.0.8", None))
+        );
+        assert!(conf.peers[0].no_tls);
+
+        // The commented LoadExtension must not be reported as an unknown
+        // directive, because it is a comment.
+        assert!(
+            conf.ignored.is_empty(),
+            "nothing outside comments is unrecognised here: {:?}",
+            conf.ignored
+        );
+    }
+
+    #[test]
+    fn test_unknown_directives_are_reported_not_guessed() {
+        let conf = FreeDiameterConf::parse(
+            r#"
+            Identity = "mme.localdomain";
+            LoadExtension = "/usr/lib/freeDiameter/dict_dcca_3gpp.fdx";
+            TLS_Cred = "/cert.pem", "/key.pem";
+            AppServThreads = 4;
+            "#,
+        );
+
+        assert_eq!(conf.identity.as_deref(), Some("mme.localdomain"));
+        assert_eq!(
+            conf.ignored.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["AppServThreads", "LoadExtension", "TLS_Cred"],
+            "a caller can log exactly what was skipped"
+        );
+    }
+
+    #[test]
+    fn test_ports_flags_and_multiple_listen_addresses() {
+        let conf = FreeDiameterConf::parse(
+            r#"
+            Port = 3868;
+            SecPort = 5868;
+            No_IP;
+            No_SCTP;
+            Prefer_TCP;
+            ListenOn = "10.0.0.1";
+            ListenOn = "10.0.0.2";
+            "#,
+        );
+
+        assert_eq!(conf.port, Some(3868));
+        assert_eq!(conf.sec_port, Some(5868));
+        assert!(conf.flags.no_ip);
+        assert!(conf.flags.no_sctp);
+        assert!(conf.flags.prefer_tcp);
+        assert!(!conf.flags.no_tcp);
+        assert_eq!(conf.listen_on, vec!["10.0.0.1", "10.0.0.2"]);
+        assert_eq!(conf.listen_address(), Some("10.0.0.1"));
+    }
+
+    #[test]
+    fn test_connect_peer_variants() {
+        let conf = FreeDiameterConf::parse(
+            r#"
+            ConnectPeer = "no-address.localdomain";
+            ConnectPeer = "with-port.localdomain" { ConnectTo = "10.0.0.9"; Port = 3869; };
+            ConnectPeer = "hss.localdomain" { ConnectTo = "10.0.0.8"; No_TLS; };
+            "#,
+        );
+
+        assert_eq!(conf.peers.len(), 3);
+        assert_eq!(conf.peers[0].connect_to, None);
+        assert_eq!(conf.peers[1].port, Some(3869));
+        // A peer with no ConnectTo is not a connection target, so the first
+        // usable one is chosen rather than the first declared.
+        assert_eq!(
+            conf.first_connect_peer(),
+            Some(("with-port.localdomain", "10.0.0.9", Some(3869)))
+        );
+    }
+
+    #[test]
+    fn test_multi_line_connect_peer_block() {
+        // freeDiameter allows the block to span lines, and the shipped files may
+        // be reformatted at any time.
+        let conf = FreeDiameterConf::parse(
+            r#"
+            ConnectPeer = "hss.localdomain" {
+                ConnectTo = "172.24.0.8";
+                No_TLS;
+            };
+            "#,
+        );
+
+        assert_eq!(
+            conf.first_connect_peer(),
+            Some(("hss.localdomain", "172.24.0.8", None))
+        );
+        assert!(conf.peers[0].no_tls);
+    }
+
+    #[test]
+    fn test_comments_and_empty_input() {
+        let conf = FreeDiameterConf::parse(
+            "# Identity = \"commented.out\";\n\n   \n# ConnectPeer = \"nope\" { };\n",
+        );
+        assert_eq!(conf, FreeDiameterConf::default());
+
+        assert_eq!(FreeDiameterConf::parse(""), FreeDiameterConf::default());
+    }
+
+    #[test]
+    fn test_trailing_statement_without_semicolon() {
+        // A file whose last line lost its `;` still yields what it stated.
+        let conf = FreeDiameterConf::parse("Identity = \"mme.localdomain\"");
+        assert_eq!(conf.identity.as_deref(), Some("mme.localdomain"));
+    }
+
+    #[test]
+    fn test_case_insensitive_keywords_and_unquoted_values() {
+        let conf = FreeDiameterConf::parse("identity = mme.localdomain;\nNORELAY;\nport = 3869;\n");
+        assert_eq!(conf.identity.as_deref(), Some("mme.localdomain"));
+        assert!(conf.flags.no_relay);
+        assert_eq!(conf.port, Some(3869));
+    }
+
+    #[test]
+    fn test_load_reports_a_missing_file() {
+        assert!(FreeDiameterConf::load("/nonexistent/freeDiameter/mme.conf").is_err());
+    }
+}

--- a/src/libs/nextgcore-diameter/src/lib.rs
+++ b/src/libs/nextgcore-diameter/src/lib.rs
@@ -18,6 +18,7 @@ pub mod common;
 pub mod config;
 pub mod cx;
 pub mod error;
+pub mod fd_conf;
 pub mod gx;
 pub mod gy;
 pub mod message;


### PR DESCRIPTION
Resolves the filed follow-up *"implement a freeDiameter-format (.conf) parser for
hssd/pcrfd, or migrate the Docker EPC configs to the new YAML `diameter:` block"*,
and unblocks the mmed S6a bring-up that depended on it.

## The pre-check the task asked for, answered

The task gated the choice on **"whether any real freeDiameter binary reads them"**:

- `docker-compose-epc.yml` mounts `./configs/epc/freeDiameter` into **three**
  containers (lines 65, 82, 112 — hss, mme, pcrf), read-only.
- There is **no** freeDiameter binary or package anywhere in the tree: no apt
  install, no `.fdx` extension, nothing that could consume them.
- Each daemon's YAML names its file, and PR #147 recorded that path into
  `diam_conf_path` — but nothing ever read the *contents*.
- The active directive set across all three files is **six** keywords: `Identity`,
  `Realm`, `No_IPv6`, `ListenOn`, `NoRelay`, `ConnectPeer { ConnectTo; No_TLS; }`.

So they are not a foreign library's configuration sitting nearby: they are this
deployment's Diameter configuration, mounted where an operator edits them, read by
nobody. Parsing six directives is a much smaller change than editing three
deployments' configs and then explaining why the mounts remain. Option **(a)**.

## What was actually broken

- **hssd** took its identity from the built-in
  `hss.epc.mnc001.mcc001.3gppnetwork.org` default while the mounted file says
  `hss.localdomain` — so its CER carried an Origin-Host the deployment never chose.
- **pcrfd** ignored its configured listen address the same way.
- **mmed** had **no HSS address from any source**, which is the concrete reason
  `mme_fd_connect` had never had a caller: there was nothing to connect *to*.

## Changes

New `libs/nextgcore-diameter/src/fd_conf.rs` — a shared parser: statements split
on top-level `;` with brace depth tracked so a `ConnectPeer` block may span lines,
comments stripped, keywords case-insensitive, values quoted or bare. Directives it
does not interpret (`LoadExtension`, `TLS_Cred`, `AppServThreads`) go into an
`ignored` set the callers **log**, so a skipped directive is visible rather than
silently dropped. Deliberately *not* a complete freeDiameter grammar: unknown
input is reported, never guessed at.

**Precedence is YAML > .conf > built-in default**, which is what the filed task
proposed. Mechanically the `.conf` is applied *before* the YAML block, so
`hss.diameter` / `pcrf.diameter` overwrite it where both speak and the `.conf`
fills what the YAML omits. Tests pin both directions. A `.conf` `ConnectPeer` only
seeds `connections` when none are configured, so it cannot silently replace a peer
list the YAML declared.

**mmed now connects its S6a peer.** `init` builds a `DiameterConfig` from the
parsed identity/realm/listen address, advertises S6a only so a peer with nothing
in common is refused up front (RFC 6733 §5.3), and dials the `ConnectPeer`
address. A failure is **logged and startup continues**: an HSS that is not up yet
is the normal case in compose, and the request path already answers
`NotInitialized`/`RequestTimeout` for an absent peer. Failing startup would mean an
MME that cannot serve S1AP because its HSS was slow to start.

Host-IP-Address is omitted when the configured listen address is a wildcard,
matching the choice #150 made for hssd — advertising `0.0.0.0` tells a peer
nothing routable.

## Verification

- `cargo test --workspace`: **5476 passed / 0 failed** (baseline 5459, +17).
- `cargo clippy --workspace --all-targets` identical to the pre-change baseline;
  `cargo fmt --all --check` clean.

The tests read the **three shipped `.conf` files from the tree** rather than
fixture copies, so config drift breaks them instead of going unnoticed.

## Not done

- **AIR-on-attach** still needs the sync→async seam between the NAS dispatch and
  `fd_path`, so an attach reaching `nas_dispatch::authenticate` still reports "no
  authentication vector" — the *connection* is now there, the *request* is not.
- Nothing drains `mme_fd_recv_inbound`, so HSS-initiated CLR/IDR is still dropped.

Both remain on the filed S6a task, now reduced to gap (c).

Spec: `specs/fix-freediameter-conf-parse.md`
