### PR TITLE
feat(mmed): request authentication vectors over S6a

### DIFF
--- a/src/bins/nextgcore-mmed/src/fd_path.rs
+++ b/src/bins/nextgcore-mmed/src/fd_path.rs
@@ -980,6 +980,171 @@ pub fn encode_visited_plmn_id(mcc: &str, mnc: &str) -> Vec<u8> {
 }
 
 // ============================================================================
+// Pending Request Queue
+// ============================================================================
+
+/// An S6a exchange the synchronous NAS layer asked for.
+///
+/// The **UE id** is queued rather than a built message: the drain re-reads the
+/// context when it runs, so a UE that detached — or a second Attach Request that
+/// replaced the context — becomes a lookup miss instead of a request sent on
+/// behalf of a UE that is gone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingS6aRequest {
+    /// Fetch authentication vectors (AIR/AIA, TS 29.272 §5.2.3.1).
+    AuthenticationInformation {
+        /// MME UE pool id the vectors are for
+        mme_ue_id: u64,
+    },
+}
+
+/// Process-global sender for the pending-request queue.
+///
+/// A `OnceLock` for the same reason `s1ap_path::SEND_TX` is one: installed once
+/// at startup and only cloned afterwards, so the synchronous side needs no lock.
+static REQUEST_TX: OnceLock<tokio::sync::mpsc::UnboundedSender<PendingS6aRequest>> =
+    OnceLock::new();
+
+/// Install the queue, returning the receiving half for the main loop to drain.
+///
+/// Returns `None` when a queue is already installed, so a second call cannot
+/// orphan the first.
+pub fn install_request_queue() -> Option<tokio::sync::mpsc::UnboundedReceiver<PendingS6aRequest>> {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    match REQUEST_TX.set(tx) {
+        Ok(()) => Some(rx),
+        Err(_) => None,
+    }
+}
+
+/// Ask for authentication vectors for `mme_ue_id`.
+///
+/// Callable from synchronous code: it never blocks and never fails the caller's
+/// procedure. `false` means the request was dropped because no queue is
+/// installed (a unit test, or a daemon whose init did not run) — which is logged,
+/// and leaves the UE without a vector exactly as before.
+pub fn queue_authentication_information(mme_ue_id: u64) -> bool {
+    let Some(tx) = REQUEST_TX.get() else {
+        log::warn!("S6a request dropped: no queue installed (mme_ue_id={mme_ue_id})");
+        return false;
+    };
+    match tx.send(PendingS6aRequest::AuthenticationInformation { mme_ue_id }) {
+        Ok(()) => {
+            log::debug!("S6a AIR queued for UE {mme_ue_id}");
+            true
+        }
+        Err(_) => {
+            log::warn!("S6a request dropped: queue closed (mme_ue_id={mme_ue_id})");
+            false
+        }
+    }
+}
+
+/// Run every queued S6a request that is ready, without waiting for more.
+///
+/// Called from the main loop beside the NAS timer sweep. Each request is a full
+/// exchange with the HSS, so this awaits them one at a time: the S6a
+/// multiplexer (#149) makes concurrent requests possible, but serialising here
+/// keeps the ordering a UE observes intact and is not a bottleneck at the rate
+/// attaches arrive.
+pub async fn poll_pending(
+    ctx: &'static crate::context::MmeContext,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<PendingS6aRequest>,
+) {
+    while let Ok(request) = rx.try_recv() {
+        match request {
+            PendingS6aRequest::AuthenticationInformation { mme_ue_id } => {
+                run_authentication_information(ctx, mme_ue_id).await;
+            }
+        }
+    }
+}
+
+/// AIR/AIA for one UE, then the AUTHENTICATION REQUEST it enables.
+async fn run_authentication_information(ctx: &'static crate::context::MmeContext, mme_ue_id: u64) {
+    let Some(mme_ue) = ctx.mme_ue_find_by_id(mme_ue_id) else {
+        log::debug!("S6a AIR skipped: UE {mme_ue_id} is gone");
+        return;
+    };
+    if mme_ue.xres_len != 0 {
+        // A retransmitted Attach Request queues a second AIR for a context that
+        // already has a vector; a lookup is cheaper than a duplicate exchange.
+        log::debug!("S6a AIR skipped: UE {mme_ue_id} already holds a vector");
+        return;
+    }
+    if mme_ue.imsi_bcd.is_empty() {
+        log::warn!("S6a AIR skipped: UE {mme_ue_id} has no IMSI to ask about");
+        return;
+    }
+
+    // A synch failure (#45) stores the AUTS the HSS needs to resynchronise; it is
+    // consumed by exactly one request (TS 33.401 §6.1.1).
+    let resync_auts = mme_ue.resync_auts;
+    let answer = mme_s6a_send_air(&mme_ue, resync_auts.as_ref()).await;
+
+    let Some(enb_ue) = ctx
+        .enb_ue_find_by_id(mme_ue.enb_ue_id)
+        .filter(|enb_ue| enb_ue.id != 0)
+    else {
+        log::warn!(
+            "[{}] S6a answer arrived with no S1 connection to answer on",
+            mme_ue.imsi_bcd
+        );
+        return;
+    };
+
+    let mut pool = ctx.mme_ue_pool.write().unwrap();
+    let Some(mme_ue) = pool.get_mut(&mme_ue_id) else {
+        return;
+    };
+    mme_ue.resync_auts = None;
+
+    let aia = match answer {
+        Ok(aia) => aia,
+        Err(e) => {
+            log::error!("[{}] S6a AIR failed: {e}", mme_ue.imsi_bcd);
+            // TS 24.301 §5.5.1.2.5: the network could not authenticate the UE,
+            // so the attach is rejected rather than left outstanding.
+            if let Err(e) = crate::nas_path::nas_eps_send_attach_reject(
+                &enb_ue,
+                mme_ue,
+                EmmCause::NetworkFailure,
+                None,
+            ) {
+                log::error!("Attach Reject send failed: {e}");
+            }
+            return;
+        }
+    };
+
+    match crate::s6a_handler::mme_s6a_handle_aia(mme_ue, &aia) {
+        Ok(EmmCause::RequestAccepted) => {
+            log::info!("[{}] Authentication vector received", mme_ue.imsi_bcd);
+            if let Err(e) = crate::nas_path::nas_eps_send_authentication_request(mme_ue, &enb_ue) {
+                log::error!(
+                    "[{}] Authentication Request send failed: {e}",
+                    mme_ue.imsi_bcd
+                );
+            }
+        }
+        Ok(cause) => {
+            // The HSS refused: an unknown subscriber, a barred UE, a roaming
+            // restriction. The EMM cause it mapped to is what the UE is told.
+            log::warn!(
+                "[{}] HSS refused authentication: {cause:?}",
+                mme_ue.imsi_bcd
+            );
+            if let Err(e) =
+                crate::nas_path::nas_eps_send_attach_reject(&enb_ue, mme_ue, cause, None)
+            {
+                log::error!("Attach Reject send failed: {e}");
+            }
+        }
+        Err(e) => log::error!("[{}] AIA rejected: {e:?}", mme_ue.imsi_bcd),
+    }
+}
+
+// ============================================================================
 // Unit Tests
 // ============================================================================
 

--- a/src/bins/nextgcore-mmed/src/main.rs
+++ b/src/bins/nextgcore-mmed/src/main.rs
@@ -68,6 +68,9 @@ pub struct MmeApp {
     mme_fsm: sm::MmeFsm,
     /// S1-MME transport (issue #42). `None` until [`MmeApp::init`] binds it.
     s1ap: Option<s1ap_path::S1apServer>,
+    /// Queued S6a requests from the synchronous NAS dispatch. `None` until
+    /// [`MmeApp::init`] installs the queue.
+    s6a_requests: Option<tokio::sync::mpsc::UnboundedReceiver<fd_path::PendingS6aRequest>>,
 }
 
 impl MmeApp {
@@ -78,6 +81,7 @@ impl MmeApp {
             gtp_state: gtp_path::GtpPathState::default(),
             mme_fsm: sm::MmeFsm::new(),
             s1ap: None,
+            s6a_requests: None,
         }
     }
 
@@ -116,6 +120,14 @@ impl MmeApp {
             return Err(anyhow::anyhow!("Diameter initialization failed: {e}"));
         }
         log::debug!("Diameter S6a interface initialized");
+
+        // Install the S6a pending-request queue before anything can enqueue on
+        // it: the NAS dispatch pushes AIR requests here from synchronous code,
+        // and `run` drains them (gap (c) of the S6a bring-up).
+        self.s6a_requests = fd_path::install_request_queue();
+        if self.s6a_requests.is_none() {
+            log::warn!("S6a request queue already installed; authentication requests will drop");
+        }
 
         // Connect the S6a peer. `mme_fd_connect` has had no caller since it was
         // written — its own comment defers it until "the async runtime is
@@ -239,6 +251,13 @@ impl MmeApp {
                     }
                 }
                 None => tokio::time::sleep(SHUTDOWN_CHECK).await,
+            }
+
+            // Run the S6a exchanges the NAS dispatch asked for. Each is a full
+            // request/answer with the HSS, which is why it belongs here rather
+            // than inside the synchronous dispatch that queued it.
+            if let Some(rx) = self.s6a_requests.as_mut() {
+                fd_path::poll_pending(ctx, rx).await;
             }
 
             // Retransmit or abort NAS procedures whose timer has run out

--- a/src/bins/nextgcore-mmed/src/nas_dispatch.rs
+++ b/src/bins/nextgcore-mmed/src/nas_dispatch.rs
@@ -949,14 +949,15 @@ fn authenticate(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64) {
 
     if mme_ue.xres_len == 0 {
         // Vectors reach the context only through `s6a_handler::mme_s6a_handle_aia`,
-        // and mmed never connects its S6a peer: `mme_fd_connect` has no caller and
-        // the daemon parses no config, so it has no HSS address. Report it instead
-        // of rejecting the UE for a network-side gap or inventing a vector.
-        log::warn!(
-            "[{}] Attach: no authentication vector — an S6a AIR to the HSS is required and \
-             mmed's S6a peer is not connected",
+        // so one has to be fetched from the HSS. `mme_s6a_send_air` is async and
+        // this dispatch is not, so the request is queued for the main loop to run
+        // (the same crossing `s1ap_path`'s send queue makes for downlink PDUs).
+        // The AIR carries `resync_auts` when a synch failure stored one.
+        log::info!(
+            "[{}] Requesting authentication vectors from the HSS",
             mme_ue.imsi_bcd
         );
+        crate::fd_path::queue_authentication_information(mme_ue_id);
         return;
     }
 
@@ -2068,6 +2069,35 @@ mod tests {
             UeCtxRelAction::UeContextRemove,
             "the S1 connection must be marked for release"
         );
+    }
+
+    #[test]
+    fn test_attach_without_a_vector_queues_an_s6a_request() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let pdu = attach_request(&imsi_identity(), &pdn_connectivity_request(1, false));
+
+        // No queue is installed in a unit test, so the request is dropped and
+        // reported. What matters here is that the dispatch ASKS -- before this
+        // landed it logged a dead end -- and that a dropped request leaves the UE
+        // exactly as it was rather than half-advancing the procedure.
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &pdu));
+
+        let mme_ue_id = ctx.mme_ue_find_by_imsi(TEST_IMSI).expect("UE indexed");
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(mme_ue.xres_len, 0, "no vector may be invented");
+        assert!(
+            mme_ue.t3460.pkbuf.is_none(),
+            "no challenge goes out until a vector arrives"
+        );
+        assert!(!mme_ue.security_context_available);
+    }
+
+    #[test]
+    fn test_queue_helper_reports_a_dropped_request() {
+        // The sync side must never fail its caller's procedure, so an absent
+        // queue is a `false` return and a log line, not a panic.
+        assert!(!crate::fd_path::queue_authentication_information(4242));
     }
 
     #[test]


### PR DESCRIPTION
Closes gap **(c)** of the filed mmed S6a bring-up task — the last step between a
UE's identity being known and the network challenging it.

After #159 mmed *connects* its S6a peer, but nothing ever sent a request over it.
`nas_dispatch::authenticate` found no vector on the context and logged that an AIR
was required, because the NAS dispatch is synchronous and `mme_s6a_send_air` is
`async`. So an attach stopped dead right after the identity was established: the
connection existed, the request did not. The AUTS that #45 stores on a synch
failure had the same problem — nothing could send the re-synchronisation AIR that
consumes it.

## A queue, not an async NAS path

`nas_eps_handle_uplink` and the whole EMM/ESM handler tree are synchronous, and
#42 already established how this codebase crosses that boundary for downlink PDUs.
`fd_path` gains the same shape: `install_request_queue` at startup, a sync
`queue_authentication_information` the dispatch pushes onto, and an async
`poll_pending` the main loop drains beside the NAS timer sweep. Making the dispatch
async would have forced ~4000 lines of handler code async to reach one await.

## Queue the UE id, not the request

The pending item is `{mme_ue_id, kind}` and the drain re-reads the context when it
runs. A queued *message* could be stale by the time it goes out — the UE may have
detached, or a second Attach Request may have replaced the context — and re-reading
turns that into a lookup miss instead of a request sent on behalf of a UE that is
gone.

It also collapses duplicates: a retransmitted Attach Request queues a second AIR,
and the drain skips any UE that already holds a vector, so the retransmission
costs a lookup rather than a duplicate exchange with the HSS.

## What the drain does

Carries `resync_auts` when present and clears it afterwards (one AUTS per request,
TS 33.401 §6.1.1), applies the answer through `s6a_handler::mme_s6a_handle_aia`,
then either sends the AUTHENTICATION REQUEST or **rejects the attach with the EMM
cause the HSS mapped to** — an unknown subscriber, a barred UE, a roaming
restriction now all reach the UE as the cause the HSS gave, instead of the
procedure hanging. A transport failure rejects with EMM cause #17 (network
failure) rather than leaving the UE on T3410.

## Verification

- `cargo test -p nextgcore-mmed`: **263 passed / 0 failed** (baseline 261).
- `cargo test --workspace`: **5478 passed / 0 failed** (baseline 5476).
- `cargo clippy --workspace --all-targets` identical to the pre-change baseline;
  `cargo fmt --all --check` clean.

The unit tests cover the sync half without a live peer, which is the half that was
broken: the dispatch now **asks** instead of logging a dead end, and a dropped
request (no queue installed) returns `false` and leaves the UE untouched rather
than panicking or half-advancing the procedure. The AIR/AIA exchange itself is
exercised end to end only against a real hssd — deployment testing this change
does not add.

## Not done

- ULR and the subscription data the Attach Accept needs (#46), and the S11 bearer
  setup below it (#51).
- Draining `mme_fd_recv_inbound`, so HSS-initiated CLR/IDR is still dropped —
  the only remaining item on the S6a task.

Spec: `specs/fix-mmed-s6a-authentication-request.md`
