### PR TITLE
feat(mmed): apply HSS-initiated S6a requests (CLR/IDR)

### DIFF
--- a/src/bins/nextgcore-mmed/src/fd_path.rs
+++ b/src/bins/nextgcore-mmed/src/fd_path.rs
@@ -1144,6 +1144,62 @@ async fn run_authentication_information(ctx: &'static crate::context::MmeContext
     }
 }
 
+/// How long each poll waits for a peer-initiated request.
+///
+/// Short on purpose: this runs on the main loop, which also has to service S1AP,
+/// so it is a poll rather than a wait. The loop's own 100 ms cadence is what
+/// bounds how long a CLR can sit unread.
+const INBOUND_POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(5);
+
+/// Most HSS-initiated requests handled per pass.
+///
+/// A bound so a chatty (or hostile) HSS cannot starve the S1AP data path on this
+/// single-threaded loop. Hitting it is logged rather than passed over quietly —
+/// the remainder is read on the next pass, not dropped.
+const MAX_INBOUND_PER_PASS: usize = 8;
+
+/// Read and apply HSS-initiated S6a requests (CLR/IDR).
+///
+/// `mme_fd_recv_inbound` already parses the request and sends its answer
+/// (CLA/IDA); `s6a_handler::mme_s6a_process_inbound` applies it to the UE
+/// context — a network-initiated detach for a CLR, or refreshed subscription
+/// data for an IDR. Neither had a caller, so an HSS that cancelled a location or
+/// pushed new subscriber data got a correct answer from the Diameter layer and no
+/// effect whatsoever on the MME's state.
+pub async fn poll_inbound() {
+    for handled in 0..MAX_INBOUND_PER_PASS {
+        match mme_fd_recv_inbound(INBOUND_POLL_TIMEOUT).await {
+            Ok(Some(inbound)) => {
+                log::info!("[{}] HSS-initiated S6a request received", inbound.imsi_bcd);
+                if let Err(e) = crate::s6a_handler::mme_s6a_process_inbound(&inbound) {
+                    // A request for a subscriber this MME does not hold is
+                    // routine (the HSS may not know the UE detached), so it is
+                    // reported without alarm; the answer already went out.
+                    log::warn!("[{}] could not be applied: {e:?}", inbound.imsi_bcd);
+                }
+            }
+            // Nothing pending within the poll window.
+            Ok(None) => return,
+            Err(DiameterError::NotInitialized) => {
+                // No S6a peer connected. Expected on every pass in a deployment
+                // with no HSS configured, so it must stay silent rather than
+                // filling the log ten times a second.
+                return;
+            }
+            Err(e) => {
+                log::debug!("S6a inbound poll failed: {e}");
+                return;
+            }
+        }
+        if handled + 1 == MAX_INBOUND_PER_PASS {
+            log::info!(
+                "Handled {MAX_INBOUND_PER_PASS} HSS-initiated requests this pass; any remainder \
+                 is read on the next one"
+            );
+        }
+    }
+}
+
 // ============================================================================
 // Unit Tests
 // ============================================================================

--- a/src/bins/nextgcore-mmed/src/main.rs
+++ b/src/bins/nextgcore-mmed/src/main.rs
@@ -260,6 +260,10 @@ impl MmeApp {
                 fd_path::poll_pending(ctx, rx).await;
             }
 
+            // Apply anything the HSS initiated (CLR/IDR). Also a no-op when no
+            // S6a peer is connected.
+            fd_path::poll_inbound().await;
+
             // Retransmit or abort NAS procedures whose timer has run out
             // (TS 24.301 §5.4.2.7, §5.4.4.6, §5.5.1.2.7). Cheap when idle: the
             // sweep walks the UE pool and does nothing unless a deadline passed.

--- a/src/bins/nextgcore-mmed/src/s6a_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s6a_handler.rs
@@ -636,6 +636,74 @@ mod tests {
         );
     }
 
+    /// Seed a connected UE on the process-global context under a dedicated
+    /// IMSI, which is how these tests stay isolated from each other (the context
+    /// is keyed by IMSI).
+    fn seed_connected_ue(imsi: &str, enb_ue_s1ap_id: u32) -> u64 {
+        let ctx = crate::context::mme_self();
+        let enb_id = ctx.enb_add(format!("127.0.0.1:{}", 36412).parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, enb_ue_s1ap_id);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        ctx.enb_ue_associate_mme_ue(enb_ue_id, mme_ue_id);
+        ctx.mme_ue_set_imsi(mme_ue_id, imsi);
+        mme_ue_id
+    }
+
+    fn clr(imsi: &str, cancellation_type: u32) -> crate::fd_path::InboundS6aRequest {
+        crate::fd_path::InboundS6aRequest {
+            imsi_bcd: imsi.to_string(),
+            message: crate::fd_path::S6aMessage::Clr(ClrMessage {
+                cancellation_type,
+                clr_flags: 0,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_process_inbound_clr_subscription_withdrawal_detaches_the_ue() {
+        // The effect the main-loop drain exists to produce. Before it was wired
+        // the Diameter layer answered CLA correctly and the UE context was
+        // untouched, so a withdrawn subscription left the UE attached.
+        const IMSI: &str = "999990000000777";
+        let mme_ue_id = seed_connected_ue(IMSI, 777);
+        let ctx = crate::context::mme_self();
+
+        mme_s6a_process_inbound(&clr(IMSI, cancellation_type::SUBSCRIPTION_WITHDRAWAL))
+            .expect("a known UE must be applied");
+
+        // TS 29.272 §5.2.2.2.2: subscription withdrawal is a *network-initiated
+        // detach*, so the UE is told and the context survives until it accepts.
+        let mme_ue = ctx
+            .mme_ue_find_by_id(mme_ue_id)
+            .expect("the context waits for the Detach Accept");
+        let detach = mme_ue
+            .t3422
+            .pkbuf
+            .as_ref()
+            .expect("a Detach Request must be armed on T3422");
+        // The stored message is security-encoded, so the plain NAS message starts
+        // after the 6-octet security header and its type is octet 7.
+        assert_eq!(
+            detach.get(7).copied(),
+            Some(crate::emm_build::NasEpsMessageType::DetachRequest as u8)
+        );
+    }
+
+    #[test]
+    fn test_process_inbound_clr_mme_update_removes_the_context_silently() {
+        // TS 23.401 §5.3.3.1: the UE moved to another MME, so the old context
+        // goes with no NAS signalling — there is no UE here to tell.
+        const IMSI: &str = "999990000000778";
+        let mme_ue_id = seed_connected_ue(IMSI, 778);
+        let ctx = crate::context::mme_self();
+
+        mme_s6a_process_inbound(&clr(IMSI, cancellation_type::MME_UPDATE_PROCEDURE))
+            .expect("a known UE must be applied");
+
+        assert!(ctx.mme_ue_find_by_id(mme_ue_id).is_none());
+        assert_eq!(ctx.mme_ue_find_by_imsi(IMSI), None);
+    }
+
     #[test]
     fn test_handle_idr() {
         let mut mme_ue = MmeUe::default();


### PR DESCRIPTION
Closes the **last gap** of the filed mmed S6a bring-up task.

`fd_path::mme_fd_recv_inbound` parses a peer-initiated CLR/IDR **and sends its
answer** (CLA/IDA); `s6a_handler::mme_s6a_process_inbound` applies it to the UE
context. Neither had a caller — `process_inbound`'s only reference in the crate
was a test asserting an error. So an HSS that cancelled a location or pushed new
subscriber data got a correct Diameter answer and **no effect** on the MME's
state: a withdrawn subscription left the UE attached, and an IDR's subscription
data was discarded.

`fd_path::poll_inbound` is now drained from the main loop, beside the
pending-request queue (#160) and the NAS timer sweep (#156).

## Decisions

**A poll, not a wait.** The loop also services S1AP, so the timeout is 5 ms and
the loop's own 100 ms cadence bounds how long a CLR sits unread. Waiting longer
here would trade S1AP latency for Diameter latency on a single-threaded loop.

**Bounded at 8 requests per pass, and the bound is logged.** A chatty or hostile
HSS must not starve the S1AP data path. The remainder is read on the next pass
rather than dropped, and hitting the cap says so instead of passing over it
quietly.

**`NotInitialized` is silent.** With no S6a peer connected it fires on every pass,
ten times a second — logging it would bury everything else. Other errors go to
`debug`. An unapplied request is a *warning*, not an alarm: a CLR for a subscriber
this MME does not hold is routine (the HSS may not know the UE detached), and the
answer has already gone out.

## A corrected assumption, found by the tests

My first test asserted that a subscription-withdrawal CLR removes the context. It
does not, and should not: TS 29.272 §5.2.2.2.2 makes it a network-initiated
**detach**, so `mme_s6a_handle_clr` returns `DetachUe`, the UE is told, and the
context survives until it accepts. Only `MME_UPDATE_PROCEDURE` and friends remove
it silently (TS 23.401 §5.3.3.1). The tests now pin both paths — that distinction
is the substance of this change.

## Verification

- `cargo test -p nextgcore-mmed`: **265 passed / 0 failed** (baseline 263).
- `cargo test --workspace`: **5480 passed / 0 failed** (baseline 5478).
- `cargo clippy --workspace --all-targets` identical to the pre-change baseline;
  `cargo fmt --all --check` clean.

The two new tests use dedicated IMSIs because the process-global context they
exercise is keyed by IMSI, and `s6a_handler` was run repeatedly to confirm they do
not interfere with the tests already sharing it.

## Not done

- ULR / subscription data for the Attach Accept (#46) and the S11 bearers under
  it (#51).
- DSR, NOR and Reset (#56 covers the HSS side of those).

Spec: `specs/fix-mmed-s6a-inbound-drain.md`
