### PR TITLE
feat(mmed): register with the HSS and fetch subscription data (ULR/ULA)

### DIFF
--- a/src/bins/nextgcore-mmed/src/fd_path.rs
+++ b/src/bins/nextgcore-mmed/src/fd_path.rs
@@ -996,6 +996,15 @@ pub enum PendingS6aRequest {
         /// MME UE pool id the vectors are for
         mme_ue_id: u64,
     },
+    /// Register this MME as the subscriber's serving node and fetch the
+    /// subscription data (ULR/ULA, TS 29.272 §5.2.1.1).
+    UpdateLocation {
+        /// MME UE pool id the subscription is for
+        mme_ue_id: u64,
+        /// Whether this is an initial attach, which sets the ULR-Flags bit the
+        /// HSS uses to decide whether to cancel a previous MME's registration
+        initial_attach: bool,
+    },
 }
 
 /// Process-global sender for the pending-request queue.
@@ -1040,6 +1049,30 @@ pub fn queue_authentication_information(mme_ue_id: u64) -> bool {
     }
 }
 
+/// Register with the HSS and fetch subscription data for `mme_ue_id`.
+///
+/// Same contract as [`queue_authentication_information`]: safe from synchronous
+/// code, never fails the caller's procedure.
+pub fn queue_update_location(mme_ue_id: u64, initial_attach: bool) -> bool {
+    let Some(tx) = REQUEST_TX.get() else {
+        log::warn!("S6a request dropped: no queue installed (mme_ue_id={mme_ue_id})");
+        return false;
+    };
+    match tx.send(PendingS6aRequest::UpdateLocation {
+        mme_ue_id,
+        initial_attach,
+    }) {
+        Ok(()) => {
+            log::debug!("S6a ULR queued for UE {mme_ue_id} (initial_attach={initial_attach})");
+            true
+        }
+        Err(_) => {
+            log::warn!("S6a request dropped: queue closed (mme_ue_id={mme_ue_id})");
+            false
+        }
+    }
+}
+
 /// Run every queued S6a request that is ready, without waiting for more.
 ///
 /// Called from the main loop beside the NAS timer sweep. Each request is a full
@@ -1055,6 +1088,12 @@ pub async fn poll_pending(
         match request {
             PendingS6aRequest::AuthenticationInformation { mme_ue_id } => {
                 run_authentication_information(ctx, mme_ue_id).await;
+            }
+            PendingS6aRequest::UpdateLocation {
+                mme_ue_id,
+                initial_attach,
+            } => {
+                run_update_location(ctx, mme_ue_id, initial_attach).await;
             }
         }
     }
@@ -1141,6 +1180,93 @@ async fn run_authentication_information(ctx: &'static crate::context::MmeContext
             }
         }
         Err(e) => log::error!("[{}] AIA rejected: {e:?}", mme_ue.imsi_bcd),
+    }
+}
+
+/// ULR/ULA for one UE: register this MME as the serving node and take the
+/// subscription data the Attach Accept is built from.
+async fn run_update_location(
+    ctx: &'static crate::context::MmeContext,
+    mme_ue_id: u64,
+    initial_attach: bool,
+) {
+    let Some(mme_ue) = ctx.mme_ue_find_by_id(mme_ue_id) else {
+        log::debug!("S6a ULR skipped: UE {mme_ue_id} is gone");
+        return;
+    };
+    if mme_ue.imsi_bcd.is_empty() {
+        log::warn!("S6a ULR skipped: UE {mme_ue_id} has no IMSI");
+        return;
+    }
+    if mme_ue.num_of_session != 0 {
+        // A retransmitted SECURITY MODE COMPLETE queues a second ULR for a
+        // context that already holds its subscription, same as the AIR path.
+        log::debug!("S6a ULR skipped: UE {mme_ue_id} already holds subscription data");
+        return;
+    }
+
+    let answer = mme_s6a_send_ulr(&mme_ue, initial_attach).await;
+
+    let enb_ue = ctx
+        .enb_ue_find_by_id(mme_ue.enb_ue_id)
+        .filter(|enb_ue| enb_ue.id != 0);
+
+    let mut pool = ctx.mme_ue_pool.write().unwrap();
+    let Some(mme_ue) = pool.get_mut(&mme_ue_id) else {
+        return;
+    };
+
+    let ula = match answer {
+        Ok(ula) => ula,
+        Err(e) => {
+            log::error!("[{}] S6a ULR failed: {e}", mme_ue.imsi_bcd);
+            reject_attach(&enb_ue, mme_ue, EmmCause::NetworkFailure);
+            return;
+        }
+    };
+
+    match crate::s6a_handler::mme_s6a_handle_ula(mme_ue, &ula) {
+        Ok(EmmCause::RequestAccepted) => {
+            log::info!(
+                "[{}] Subscription data received: {} APN(s), AMBR {}/{} bps",
+                mme_ue.imsi_bcd,
+                mme_ue.num_of_session,
+                mme_ue.ambr.uplink,
+                mme_ue.ambr.downlink
+            );
+            // The ATTACH ACCEPT itself is the remainder of #46: it needs the
+            // subscribed APNs turned into sessions and bearers, a GUTI, and the
+            // subscribed T3412 — none of which this change delivers.
+            log::info!(
+                "[{}] Attach Accept not yet built from this subscription (#46)",
+                mme_ue.imsi_bcd
+            );
+        }
+        Ok(cause) => {
+            // The HSS refused to register us: unknown subscriber, roaming not
+            // allowed, RAT not allowed. The UE is told the mapped EMM cause.
+            log::warn!(
+                "[{}] HSS refused location update: {cause:?}",
+                mme_ue.imsi_bcd
+            );
+            reject_attach(&enb_ue, mme_ue, cause);
+        }
+        Err(e) => log::error!("[{}] ULA rejected: {e:?}", mme_ue.imsi_bcd),
+    }
+}
+
+/// Tell the UE its attach failed, when there is still an S1 connection to say it
+/// on.
+fn reject_attach(enb_ue: &Option<crate::context::EnbUe>, mme_ue: &mut MmeUe, cause: EmmCause) {
+    let Some(enb_ue) = enb_ue else {
+        log::warn!(
+            "[{}] cannot send Attach Reject: no S1 connection",
+            mme_ue.imsi_bcd
+        );
+        return;
+    };
+    if let Err(e) = crate::nas_path::nas_eps_send_attach_reject(enb_ue, mme_ue, cause, None) {
+        log::error!("Attach Reject send failed: {e}");
     }
 }
 

--- a/src/bins/nextgcore-mmed/src/nas_dispatch.rs
+++ b/src/bins/nextgcore-mmed/src/nas_dispatch.rs
@@ -721,10 +721,34 @@ fn emm_security_mode_complete(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, 
         std::mem::take(&mut mme_ue.pdn_connectivity_request)
     };
 
-    if held_esm.is_empty() {
+    // TS 23.401 §5.3.2.1 step 12: with the security context in place the MME
+    // registers itself with the HSS and takes the subscription data, which is
+    // what an ATTACH ACCEPT is built from. `mme_s6a_send_ulr` is async, so the
+    // request goes on the same queue the AIR uses.
+    if !held_esm.is_empty() {
+        forward_to_esm(ctx, enb_ue, mme_ue_id, &held_esm);
+    }
+    request_subscription_data(ctx, mme_ue_id);
+}
+
+/// Ask the HSS to register this MME and return the subscriber's data.
+fn request_subscription_data(ctx: &MmeContext, mme_ue_id: u64) {
+    let Some(mme_ue) = ctx.mme_ue_find_by_id(mme_ue_id) else {
+        return;
+    };
+    if mme_ue.num_of_session != 0 {
+        // Already subscribed: a retransmitted SECURITY MODE COMPLETE must not
+        // re-register with the HSS.
         return;
     }
-    forward_to_esm(ctx, enb_ue, mme_ue_id, &held_esm);
+    // ULR-Flags "initial attach indicator" (TS 29.272 §7.3.7): set for an attach
+    // so the HSS cancels any previous MME's registration, clear for a TAU.
+    let initial_attach = mme_ue.nas_eps.type_ == MmeEpsType::AttachRequest;
+    log::info!(
+        "[{}] Requesting subscription data from the HSS (initial_attach={initial_attach})",
+        mme_ue.imsi_bcd
+    );
+    crate::fd_path::queue_update_location(mme_ue_id, initial_attach);
 }
 
 fn emm_tau_request(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, body: &[u8]) {
@@ -2091,6 +2115,43 @@ mod tests {
             "no challenge goes out until a vector arrives"
         );
         assert!(!mme_ue.security_context_available);
+    }
+
+    #[test]
+    fn test_security_mode_complete_requests_subscription_data() {
+        let ctx = test_ctx();
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+            mme_ue.nas_eps.type_ = MmeEpsType::AttachRequest;
+        }
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        let complete = protect_uplink(
+            &mme_ue,
+            1,
+            &[
+                NAS_PROTOCOL_DISCRIMINATOR_EMM,
+                NasEpsMessageType::SecurityModeComplete as u8,
+            ],
+        );
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &complete));
+
+        // No queue is installed in a unit test, so the request is dropped and
+        // reported; what matters is that the procedure now ASKS, and that no
+        // subscription is invented while it waits.
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(mme_ue.security_context_available);
+        assert_eq!(mme_ue.num_of_session, 0, "no subscription may be invented");
+        assert_eq!(mme_ue.ambr.uplink, 0);
+    }
+
+    #[test]
+    fn test_update_location_queue_helper_reports_a_dropped_request() {
+        assert!(!crate::fd_path::queue_update_location(4242, true));
     }
 
     #[test]


### PR DESCRIPTION
Refs #46 — the location-update step. The issue stays **open**: this is one of its
four parts.

`fd_path::mme_s6a_send_ulr` and `s6a_handler::mme_s6a_handle_ula` are complete and
had **no production caller** — their only references were their own tests. So the
MME never registered itself with the HSS as the subscriber's serving node, and
never received the subscription data an ATTACH ACCEPT is built from: APN
configurations, AMBR, MSISDN, network access mode, charging characteristics.

After #160 the MME can authenticate a UE and establish a NAS security context. The
next step in TS 23.401 §5.3.2.1 is the location update, and nothing did it.

## Decisions

**Reuse the queue rather than add a second mechanism.** #160 established the
sync→async crossing for S6a; a ULR is the same shape as an AIR, so it is a second
variant on that queue, not a new channel. The runner shares the same discipline —
re-read the context when it runs, skip a UE that already holds subscription data —
so a retransmitted SECURITY MODE COMPLETE cannot re-register the subscriber with
the HSS.

**`initial_attach` is derived from `nas_eps.type_`.** The ULR-Flags initial-attach
indicator (TS 29.272 §7.3.7) tells the HSS whether to cancel a previous MME's
registration: right for an attach, wrong for a TAU.

**An HSS refusal reaches the UE.** Unknown subscriber, roaming not allowed, RAT not
allowed all map to an EMM cause through the existing `emm_cause_from_diameter`, and
that cause goes out as an ATTACH REJECT rather than the procedure stalling.

## What this does *not* do

Deliberately out of scope, so #46 stays open:

- Turning the subscribed APNs into `MmeSess`/`MmeBearer` contexts.
- GUTI allocation — which stays dormant, and with it #43's S-TMSI lookup, because a
  UE only learns its GUTI from an ATTACH ACCEPT that is not built yet.
- The subscribed T3412 and the accept's result IEs.
- The S11 Create Session the default bearer needs (#51).

The ULA's data now lands on the context, which is the prerequisite for all four —
and the log says plainly that the accept is not built from it yet.

## Verification

- `cargo test -p nextgcore-mmed`: **267 passed / 0 failed** (baseline 265).
- `cargo test --workspace`: **5482 passed / 0 failed** (baseline 5480).
- `cargo clippy --workspace --all-targets` identical to the pre-change baseline;
  `cargo fmt --all --check` clean.

The tests cover the sync half: SECURITY MODE COMPLETE now **asks**, and a dropped
request leaves no invented subscription (`num_of_session` and AMBR stay zero). The
ULR/ULA exchange itself needs a real hssd.

Spec: `specs/fix-mmed-s6a-update-location.md`
