### PR TITLE
feat(mmed): match the requested APN against the subscription

### DIFF
--- a/src/bins/nextgcore-mmed/src/fd_path.rs
+++ b/src/bins/nextgcore-mmed/src/fd_path.rs
@@ -1259,10 +1259,41 @@ async fn run_update_location(
         // Turn the subscribed APNs into session and bearer contexts, which is
         // what the ATTACH ACCEPT and the S11 Create Session are built from.
         let created = crate::s6a_handler::materialise_subscribed_sessions(ctx, mme_ue_id);
-        log::info!(
-            "{created} session(s) created from subscription for UE {mme_ue_id}; the ATTACH ACCEPT \
-             itself still needs a GUTI, the subscribed T3412 and its result IEs (#46)"
-        );
+        log::debug!("{created} session(s) created from subscription for UE {mme_ue_id}");
+
+        // Pair the APN the UE asked for with the subscription. A UE asking for an
+        // APN it is not subscribed to is told so (TS 24.301 §6.5.1.4) instead of
+        // being left waiting.
+        match crate::s6a_handler::reconcile_requested_apn(ctx, mme_ue_id) {
+            Ok(sess_id) => log::info!(
+                "UE {mme_ue_id} will be activated on session {sess_id}; the ATTACH ACCEPT itself \
+                 still needs a GUTI, the subscribed T3412 and its result IEs (#46)"
+            ),
+            Err(esm_cause) => {
+                let enb_ue = ctx
+                    .enb_ue_find_by_id(
+                        ctx.mme_ue_find_by_id(mme_ue_id)
+                            .map(|mme_ue| mme_ue.enb_ue_id)
+                            .unwrap_or(0),
+                    )
+                    .filter(|enb_ue| enb_ue.id != 0);
+                let mut pool = ctx.mme_ue_pool.write().unwrap();
+                if let (Some(enb_ue), Some(mme_ue)) = (enb_ue, pool.get_mut(&mme_ue_id)) {
+                    log::warn!("[{}] rejecting the attach: {esm_cause:?}", mme_ue.imsi_bcd);
+                    // TS 24.301 §5.5.1.2.5: an ESM failure during attach is EMM
+                    // cause #19, with the ESM cause piggybacked so the UE learns
+                    // which APN was refused.
+                    if let Err(e) = crate::nas_path::nas_eps_send_attach_reject(
+                        &enb_ue,
+                        mme_ue,
+                        EmmCause::EsmFailure,
+                        Some(esm_cause),
+                    ) {
+                        log::error!("Attach Reject send failed: {e}");
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/bins/nextgcore-mmed/src/s6a_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s6a_handler.rs
@@ -518,6 +518,81 @@ pub fn materialise_subscribed_sessions(ctx: &crate::context::MmeContext, mme_ue_
     created
 }
 
+/// Match the APN the UE asked for against the subscription (TS 23.401 §5.3.2.1).
+///
+/// The UE's request arrives as an ESM PDN CONNECTIVITY REQUEST, which
+/// `nas_dispatch` turns into a session carrying the UE's procedure transaction
+/// identity; the subscribed APNs are the sessions
+/// [`materialise_subscribed_sessions`] created with PTI 0. This pairs them.
+///
+/// `Ok(sess_id)` is the subscribed session to activate, with the UE's PTI and
+/// requested PDN type copied onto it. `Err(cause)` is what the UE is owed:
+/// TS 24.301 §6.5.1.4 gives ESM cause #27 for an APN the subscription does not
+/// contain, and #33 when the subscription contains nothing at all.
+pub fn reconcile_requested_apn(
+    ctx: &crate::context::MmeContext,
+    mme_ue_id: u64,
+) -> Result<u64, crate::esm_build::EsmCause> {
+    use crate::esm_build::EsmCause;
+
+    let sessions: Vec<crate::context::MmeSess> = ctx
+        .mme_ue_find_by_id(mme_ue_id)
+        .map(|mme_ue| {
+            mme_ue
+                .sess_list
+                .iter()
+                .filter_map(|id| ctx.sess_find_by_id(*id))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // What the UE asked for: the session `nas_dispatch` created for its
+    // procedure transaction. An empty APN means "give me the default".
+    let requested = sessions
+        .iter()
+        .find(|sess| sess.pti != 0)
+        .map(|sess| (sess.pti, sess.ue_request_pdn_type, sess.apn.clone()));
+
+    let subscribed: Vec<&crate::context::MmeSess> =
+        sessions.iter().filter(|sess| sess.pti == 0).collect();
+    if subscribed.is_empty() {
+        return Err(EsmCause::RequestedServiceOptionNotSubscribed);
+    }
+
+    let (pti, pdn_type, requested_apn) = requested.unwrap_or_default();
+
+    let chosen = if requested_apn.is_empty() {
+        // TS 23.401 §5.3.2.1: with no APN in the request the MME uses the
+        // subscriber's default. Selecting it by Context-Identifier needs a
+        // per-APN context id that `SessionData` does not carry yet, so the first
+        // subscribed APN stands in — the shipped subscriptions have one APN, and
+        // the approximation is visible in the log rather than silent.
+        log::info!("No APN requested; using the first subscribed APN as the default");
+        subscribed.first().copied()
+    } else {
+        subscribed
+            .iter()
+            .copied()
+            .find(|sess| sess.apn.eq_ignore_ascii_case(&requested_apn))
+    };
+
+    let Some(chosen) = chosen else {
+        log::warn!("Requested APN '{requested_apn}' is not in the subscription");
+        return Err(EsmCause::MissingOrUnknownApn);
+    };
+
+    // Carry the UE's transaction onto the session that will be activated, so the
+    // ESM procedure that follows addresses the subscribed session rather than the
+    // placeholder the request created.
+    let chosen_id = chosen.id;
+    if let Some(sess) = ctx.sess_pool.write().unwrap().get_mut(&chosen_id) {
+        sess.pti = pti;
+        sess.ue_request_pdn_type = pdn_type;
+    }
+    log::info!("Activating subscribed APN '{}' (pti={pti})", chosen.apn);
+    Ok(chosen_id)
+}
+
 /// Convert buffer to BCD string
 fn buffer_to_bcd(buffer: &[u8]) -> String {
     let mut result = String::with_capacity(buffer.len() * 2);
@@ -858,6 +933,82 @@ mod tests {
         assert_eq!(materialise_subscribed_sessions(&ctx, mme_ue_id), 2);
         assert_eq!(ctx.sess_pool.read().unwrap().len(), 2);
         assert_eq!(ctx.bearer_pool.read().unwrap().len(), 2);
+    }
+
+    /// A UE with one subscribed APN materialised, plus the session the UE's own
+    /// PDN CONNECTIVITY REQUEST created under its procedure transaction.
+    fn ue_with_subscription_and_request(
+        requested_apn: &str,
+        pti: u8,
+    ) -> (crate::context::MmeContext, u64) {
+        let ctx = crate::context::MmeContext::new();
+        ctx.init();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, 901);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+            mme_ue.imsi_bcd = "999990000000125".to_string();
+            mme_ue.session = vec![crate::context::SessionData {
+                name: "internet".to_string(),
+                ..Default::default()
+            }];
+            mme_ue.num_of_session = 1;
+        }
+        materialise_subscribed_sessions(&ctx, mme_ue_id);
+
+        // What nas_dispatch's ESM path leaves behind for the UE's request.
+        let requested = ctx.sess_add(mme_ue_id, pti);
+        if let Some(sess) = ctx.sess_pool.write().unwrap().get_mut(&requested) {
+            sess.apn = requested_apn.to_string();
+        }
+        if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+            mme_ue.sess_list.push(requested);
+        }
+        (ctx, mme_ue_id)
+    }
+
+    #[test]
+    fn test_requested_apn_matches_the_subscription() {
+        let (ctx, mme_ue_id) = ue_with_subscription_and_request("internet", 3);
+
+        let sess_id = reconcile_requested_apn(&ctx, mme_ue_id).expect("subscribed APN");
+
+        let sess = ctx.sess_find_by_id(sess_id).unwrap();
+        assert_eq!(sess.apn, "internet");
+        assert_eq!(sess.pti, 3, "the UE's transaction moves onto it");
+    }
+
+    #[test]
+    fn test_no_requested_apn_uses_the_default() {
+        let (ctx, mme_ue_id) = ue_with_subscription_and_request("", 4);
+
+        let sess_id = reconcile_requested_apn(&ctx, mme_ue_id).expect("default APN");
+
+        assert_eq!(ctx.sess_find_by_id(sess_id).unwrap().apn, "internet");
+    }
+
+    #[test]
+    fn test_unsubscribed_apn_is_refused_with_cause_27() {
+        let (ctx, mme_ue_id) = ue_with_subscription_and_request("not-subscribed", 5);
+
+        assert_eq!(
+            reconcile_requested_apn(&ctx, mme_ue_id),
+            Err(crate::esm_build::EsmCause::MissingOrUnknownApn)
+        );
+    }
+
+    #[test]
+    fn test_no_subscription_at_all_is_refused() {
+        let ctx = crate::context::MmeContext::new();
+        ctx.init();
+        let mme_ue_id = ctx.mme_ue_add(1);
+
+        assert_eq!(
+            reconcile_requested_apn(&ctx, mme_ue_id),
+            Err(crate::esm_build::EsmCause::RequestedServiceOptionNotSubscribed)
+        );
     }
 
     #[test]


### PR DESCRIPTION
feat(mmed): match the requested APN against the subscription

Refs #46.

After #163 the MME holds both halves and paired neither: the APN the UE asked for
(a session carrying the UE's procedure transaction identity, created by the ESM
path) and the subscribed APNs (sessions with PTI 0, from the ULA). A UE asking for
an APN it is not subscribed to was neither served nor told -- the procedure simply
stopped.

s6a_handler::reconcile_requested_apn now pairs them, from the ULR runner after
materialisation. A subscribed APN is chosen and the UE's PTI and requested PDN type
move onto that session, so the ESM procedure that follows addresses the subscribed
session rather than the placeholder the request created. No APN requested takes the
default. An APN the subscription does not contain is refused with ESM cause #27
(missing or unknown APN), sent as ATTACH REJECT with EMM cause #19 (ESM failure)
and the ESM cause piggybacked -- so the UE learns WHICH APN was refused, which is
what TS 24.301 6.5.1.4 and 5.5.1.2.5 ask for. An empty subscription is #33.

THE DEFAULT APN IS THE FIRST SUBSCRIBED ONE, AND THE LOG SAYS SO. TS 23.401
5.3.2.1 selects it by Context-Identifier, but SessionData carries no per-APN
context id -- mme_ue.context_identifier holds only the subscription-level value.
The shipped subscriptions have a single APN so the approximation is invisible in
practice, but it is logged rather than hidden, and carrying the per-APN id is a
follow-up rather than something quietly assumed away.

RECONCILIATION LIVES AFTER THE ULA, NOT IN THE ESM PATH. The ESM container is
replayed synchronously at SECURITY MODE COMPLETE while the ULR is queued at the
same moment, so at ESM time the subscription has not arrived yet. Only after the
ULA are both halves present -- putting the check in the ESM handler would have
compared against an empty list and refused every APN.

APN comparison is case-insensitive: they are DNS labels (TS 23.003 9.1).

VERIFIED. mmed 273 passed / 0 failed (baseline 269); workspace 5488 passed / 0
failed (baseline 5484); clippy identical to the pre-change baseline; fmt clean.
Four cases are pinned -- subscribed APN, no APN requested, unsubscribed APN, empty
subscription -- all against a local MmeContext rather than the process-global one.

Remaining on #46: GUTI allocation, the subscribed T3412, and the ATTACH ACCEPT's
result IEs, plus the S11 Create Session that gives the chosen bearer its TEIDs
(#51).

Spec: specs/fix-mmed-apn-reconciliation.md
