### PR TITLE
feat(s1ap): act on setup failure and error indication, encode Criticality Diagnostics, restore S1 on eNB restart (closes #50)

### DIFF
--- a/src/bins/nextgcore-mmed/src/s1ap_build.rs
+++ b/src/bins/nextgcore-mmed/src/s1ap_build.rs
@@ -535,11 +535,13 @@ pub fn build_error_indication(
     mme_ue_s1ap_id: Option<u32>,
     cause_group: S1apCauseGroup,
     cause_value: i64,
+    criticality_diagnostics: Option<nextgcore_s1ap::CriticalityDiagnostics>,
 ) -> S1apResult<Vec<u8>> {
     builder::build_error_indication(&ErrorIndication {
         mme_ue_s1ap_id,
         enb_ue_s1ap_id,
         cause: Some(cause_to_s1ap(cause_group, cause_value)),
+        criticality_diagnostics,
     })
 }
 
@@ -894,6 +896,7 @@ mod tests {
             Some(42),
             S1apCauseGroup::Protocol,
             protocol_cause::SEMANTIC_ERROR,
+            None,
         )
         .unwrap();
         match decode_s1ap_pdu(&bytes).unwrap() {

--- a/src/bins/nextgcore-mmed/src/s1ap_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s1ap_handler.rs
@@ -17,11 +17,12 @@ use crate::s1ap_build::{
     radio_network_cause, tai_from_s1ap, transport_address_to_ip, ue_security_capabilities_from,
 };
 use nextgcore_s1ap::{
-    builder, decode_s1ap_pdu, Cause, EnbId, ErabSwitchedItem, ErabToBeSetupItemHoReq,
-    HandoverCancel, HandoverCancelAcknowledge, HandoverCommand, HandoverFailure, HandoverNotify,
+    builder, decode_s1ap_pdu, Cause, CauseRadioNetwork, CriticalityDiagnostics, EnbId,
+    ErabSwitchedItem, ErabToBeSetupItemHoReq, ErrorIndication, HandoverCancel,
+    HandoverCancelAcknowledge, HandoverCommand, HandoverFailure, HandoverNotify,
     HandoverPreparationFailure, HandoverRequest, HandoverRequestAcknowledge, HandoverRequired,
-    HandoverType as S1apHandoverType, InitialContextSetupResponse, InitialUeMessage,
-    NasNonDeliveryIndication, PathSwitchRequest, PathSwitchRequestAcknowledge,
+    HandoverType as S1apHandoverType, InitialContextSetupFailure, InitialContextSetupResponse,
+    InitialUeMessage, NasNonDeliveryIndication, PathSwitchRequest, PathSwitchRequestAcknowledge,
     PathSwitchRequestFailure, Reset, ResetAcknowledge, ResetType, S1SetupRequest, S1apMessage,
     SecurityContext, TargetId, TimeToWait, UeAmbr, UeCapabilityInfoIndication,
     UeContextReleaseComplete, UeContextReleaseRequest, UlNasTransport,
@@ -113,12 +114,21 @@ pub fn handle_s1ap_message(ctx: &MmeContext, enb_id: u64, data: &[u8]) -> Vec<S1
         Ok(message) => message,
         Err(e) => {
             log::error!("Failed to decode S1AP PDU from eNB {enb_id}: {e}");
-            return error_indication(
+            // The PDU did not decode, so its procedure code is unknown; the
+            // diagnostics can still say that an initiating message was what
+            // failed, which is more than the bare cause conveys.
+            return error_indication_with_diagnostics(
                 enb_id,
                 None,
                 None,
                 S1apCauseGroup::Protocol,
                 protocol_cause::TRANSFER_SYNTAX_ERROR,
+                Some(CriticalityDiagnostics {
+                    triggering_message: Some(
+                        nextgcore_s1ap::triggering_message::INITIATING_MESSAGE,
+                    ),
+                    ..Default::default()
+                }),
             );
         }
     };
@@ -186,12 +196,7 @@ pub fn handle_s1ap_message(ctx: &MmeContext, enb_id: u64, data: &[u8]) -> Vec<S1
             Vec::new()
         }
         S1apMessage::ErrorIndication(msg) => {
-            log::warn!(
-                "Error Indication from eNB {enb_id}: mme_ue={:?} enb_ue={:?} cause={:?}",
-                msg.mme_ue_s1ap_id,
-                msg.enb_ue_s1ap_id,
-                msg.cause
-            );
+            handle_error_indication(ctx, enb_id, &msg);
             Vec::new()
         }
         S1apMessage::UeCapabilityInfoIndication(msg) => {
@@ -211,12 +216,7 @@ pub fn handle_s1ap_message(ctx: &MmeContext, enb_id: u64, data: &[u8]) -> Vec<S1
             Vec::new()
         }
         S1apMessage::InitialContextSetupFailure(msg) => {
-            log::error!(
-                "Initial Context Setup Failure from eNB {enb_id}: mme_ue={} cause={:?}",
-                msg.mme_ue_s1ap_id,
-                msg.cause
-            );
-            Vec::new()
+            handle_initial_context_setup_failure(ctx, enb_id, &msg)
         }
         S1apMessage::ErabSetupResponse(msg) => {
             handle_erab_setup_response(ctx, enb_id, msg.mme_ue_s1ap_id, &msg.erab_setup_list);
@@ -263,12 +263,19 @@ pub fn handle_s1ap_message(ctx: &MmeContext, enb_id: u64, data: &[u8]) -> Vec<S1
             log::error!(
                 "Unknown S1AP {message_type} (procedure code {procedure_code}) from eNB {enb_id}"
             );
-            error_indication(
+            error_indication_with_diagnostics(
                 enb_id,
                 None,
                 None,
                 S1apCauseGroup::Protocol,
                 protocol_cause::ABSTRACT_SYNTAX_ERROR_REJECT,
+                Some(CriticalityDiagnostics {
+                    procedure_code: Some(procedure_code),
+                    triggering_message: Some(
+                        nextgcore_s1ap::triggering_message::INITIATING_MESSAGE,
+                    ),
+                    ..Default::default()
+                }),
             )
         }
     }
@@ -281,7 +288,27 @@ fn error_indication(
     group: S1apCauseGroup,
     value: i64,
 ) -> Vec<S1apSend> {
-    match s1ap_build::build_error_indication(enb_ue_s1ap_id, mme_ue_s1ap_id, group, value) {
+    error_indication_with_diagnostics(enb_id, enb_ue_s1ap_id, mme_ue_s1ap_id, group, value, None)
+}
+
+/// Error Indication carrying Criticality Diagnostics (TS 36.413 §9.2.1.21), so the
+/// peer learns which procedure and which IEs were at fault rather than only that
+/// something was rejected.
+fn error_indication_with_diagnostics(
+    enb_id: u64,
+    enb_ue_s1ap_id: Option<u32>,
+    mme_ue_s1ap_id: Option<u32>,
+    group: S1apCauseGroup,
+    value: i64,
+    diagnostics: Option<CriticalityDiagnostics>,
+) -> Vec<S1apSend> {
+    match s1ap_build::build_error_indication(
+        enb_ue_s1ap_id,
+        mme_ue_s1ap_id,
+        group,
+        value,
+        diagnostics,
+    ) {
         Ok(pdu) => S1apSend::to_origin(enb_id, pdu),
         Err(e) => {
             log::error!("Failed to build Error Indication: {e}");
@@ -349,6 +376,22 @@ pub fn handle_s1_setup_request(
             S1apCauseGroup::Misc,
             misc_cause::UNSPECIFIED,
             Some(TimeToWait::V10s),
+        );
+    }
+
+    // TS 23.007 §17: a second S1 SETUP REQUEST from an eNB we have already set up
+    // means that eNB restarted, so every UE context we hold for it is stale. They
+    // are released before the setup is accepted, otherwise they linger until
+    // something else happens to clear them and their MME-UE-S1AP-IDs collide with
+    // the ids the restarted eNB is about to use.
+    let already_setup = ctx
+        .enb_find_by_id(enb_id)
+        .is_some_and(|enb| enb.state.s1_setup_success);
+    if already_setup {
+        let released = release_all_s1_connections(ctx, enb_id);
+        log::warn!(
+            "eNB 0x{enb_id_value:x} restarted (repeat S1 Setup); released {released} stale UE \
+             context(s)"
         );
     }
 
@@ -456,6 +499,94 @@ pub fn handle_uplink_nas_transport(
 /// The NAS PDU could not be delivered over the radio. The MME logs the cause
 /// and, when the failed PDU was paging-triggered, marks the paging procedure
 /// failed so it is re-attempted on the next downlink trigger.
+/// Handle Initial Context Setup Failure (TS 36.413 §8.3.1.3).
+///
+/// The eNB could not set up the UE context, so the MME must not go on believing
+/// the UE is being served: the UE-associated logical S1 connection is released
+/// with the cause the eNB reported. Previously this only logged, leaving the
+/// context and the connection in place for a UE that has no radio bearers.
+pub fn handle_initial_context_setup_failure(
+    ctx: &MmeContext,
+    enb_id: u64,
+    msg: &InitialContextSetupFailure,
+) -> Vec<S1apSend> {
+    log::error!(
+        "Initial Context Setup Failure from eNB {enb_id}: mme_ue={} cause={:?}",
+        msg.mme_ue_s1ap_id,
+        msg.cause
+    );
+
+    let Some(enb_ue_id) = ctx.enb_ue_find_by_mme_ue_s1ap_id(msg.mme_ue_s1ap_id) else {
+        // Nothing of ours to release; tell the eNB its id means nothing here.
+        return error_indication(
+            enb_id,
+            Some(msg.enb_ue_s1ap_id),
+            Some(msg.mme_ue_s1ap_id),
+            S1apCauseGroup::RadioNetwork,
+            radio_network_cause::UNKNOWN_MME_UE_S1AP_ID,
+        );
+    };
+
+    let cause = cause_from_s1ap(&msg.cause);
+    if let Some(enb_ue) = ctx.enb_ue_pool.write().unwrap().get_mut(&enb_ue_id) {
+        enb_ue.relcause.group = cause.group;
+        enb_ue.relcause.cause = cause.cause;
+        enb_ue.ue_ctx_rel_action = UeCtxRelAction::UeContextRemove;
+    }
+
+    match s1ap_build::build_ue_context_release_command(
+        Some(msg.enb_ue_s1ap_id),
+        msg.mme_ue_s1ap_id,
+        cause.group,
+        cause.cause,
+    ) {
+        Ok(pdu) => S1apSend::to_origin(enb_id, pdu),
+        Err(e) => {
+            log::error!("Failed to build UE Context Release Command: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Handle Error Indication (TS 36.413 §8.7.5, §10.6).
+///
+/// An indication naming one of our UE S1AP ids with an unknown-id cause is the eNB
+/// telling us *our* context is stale: it is released locally, with no release
+/// command, because the eNB already has nothing to release. Any other cause is
+/// informational. Previously every indication was logged and dropped, so a stale
+/// context survived until something else happened to clear it.
+pub fn handle_error_indication(ctx: &MmeContext, enb_id: u64, msg: &ErrorIndication) {
+    log::warn!(
+        "Error Indication from eNB {enb_id}: mme_ue={:?} enb_ue={:?} cause={:?} diagnostics={:?}",
+        msg.mme_ue_s1ap_id,
+        msg.enb_ue_s1ap_id,
+        msg.cause,
+        msg.criticality_diagnostics
+    );
+
+    let stale = matches!(
+        msg.cause,
+        Some(Cause::RadioNetwork(CauseRadioNetwork::UnknownMmeUeS1apId))
+            | Some(Cause::RadioNetwork(CauseRadioNetwork::UnknownEnbUeS1apId))
+            | Some(Cause::RadioNetwork(CauseRadioNetwork::UnknownPairUeS1apId))
+    );
+    if !stale {
+        return;
+    }
+
+    let Some(mme_ue_s1ap_id) = msg.mme_ue_s1ap_id else {
+        return;
+    };
+    let Some(enb_ue_id) = ctx.enb_ue_find_by_mme_ue_s1ap_id(mme_ue_s1ap_id) else {
+        return;
+    };
+
+    log::info!(
+        "eNB {enb_id} does not know mme_ue_s1ap_id={mme_ue_s1ap_id}; releasing the local S1 context"
+    );
+    release_s1_connection(ctx, enb_ue_id);
+}
+
 pub fn handle_nas_non_delivery_indication(
     ctx: &MmeContext,
     enb_id: u64,
@@ -556,18 +687,7 @@ pub fn handle_reset(ctx: &MmeContext, enb_id: u64, msg: &Reset) -> Vec<S1apSend>
 
     let acked_connections = match &msg.reset_type {
         ResetType::S1Interface => {
-            // Release every UE-associated logical S1 connection on this eNB
-            let affected: Vec<u64> = ctx
-                .enb_ue_pool
-                .read()
-                .unwrap()
-                .iter()
-                .filter(|(_, ue)| ue.enb_id == enb_id)
-                .map(|(id, _)| *id)
-                .collect();
-            for enb_ue_id in affected {
-                release_s1_connection(ctx, enb_ue_id);
-            }
+            release_all_s1_connections(ctx, enb_id);
             Vec::new()
         }
         ResetType::PartOfS1Interface(connections) => {
@@ -613,6 +733,28 @@ pub fn handle_reset(ctx: &MmeContext, enb_id: u64, msg: &Reset) -> Vec<S1apSend>
 /// UE context (the UE moves to idle) and free the eNB UE context. The MME UE
 /// association is only cleared when it still points at this connection (it
 /// may already have moved to a handover target).
+/// Release every UE-associated logical S1 connection on `enb_id`, returning how
+/// many there were.
+///
+/// Shared by Reset with `ResetType::S1Interface` (TS 36.413 §8.7.1) and by eNB
+/// restart detection (TS 23.007 §17): both mean every UE context the MME holds for
+/// that eNB is stale.
+fn release_all_s1_connections(ctx: &MmeContext, enb_id: u64) -> usize {
+    let affected: Vec<u64> = ctx
+        .enb_ue_pool
+        .read()
+        .unwrap()
+        .iter()
+        .filter(|(_, ue)| ue.enb_id == enb_id)
+        .map(|(id, _)| *id)
+        .collect();
+    let count = affected.len();
+    for enb_ue_id in affected {
+        release_s1_connection(ctx, enb_ue_id);
+    }
+    count
+}
+
 fn release_s1_connection(ctx: &MmeContext, enb_ue_id: u64) {
     if let Some(enb_ue) = ctx.enb_ue_find_by_id(enb_ue_id) {
         if enb_ue.mme_ue_id != NEXTGCORE_INVALID_POOL_ID {
@@ -2156,6 +2298,167 @@ mod tests {
             ctx.mme_ue_find_by_imsi("001010123456789").is_some(),
             "a known S1 connection must have its NAS PDU dispatched"
         );
+    }
+
+    #[test]
+    fn test_initial_context_setup_failure_releases_the_ue() {
+        let ctx = ctx_with_gummei();
+        let (enb_id, enb_ue_id, _, mme_ue_s1ap_id) = add_ue(&ctx);
+
+        let out = handle_initial_context_setup_failure(
+            &ctx,
+            enb_id,
+            &InitialContextSetupFailure {
+                mme_ue_s1ap_id,
+                enb_ue_s1ap_id: 100,
+                cause: Cause::RadioNetwork(CauseRadioNetwork::RadioResourcesNotAvailable),
+            },
+        );
+
+        // TS 36.413 §8.3.1.3: the setup failed, so the connection is released
+        // rather than left in place for a UE with no radio bearers.
+        assert_eq!(out.len(), 1, "a UE Context Release Command is due");
+        assert!(matches!(
+            decode_s1ap_pdu(&out[0].pdu).unwrap(),
+            S1apMessage::UeContextReleaseCommand(_)
+        ));
+        let enb_ue = ctx.enb_ue_find_by_id(enb_ue_id).unwrap();
+        assert_eq!(enb_ue.ue_ctx_rel_action, UeCtxRelAction::UeContextRemove);
+        assert_eq!(enb_ue.relcause.group, S1apCauseGroup::RadioNetwork);
+    }
+
+    #[test]
+    fn test_initial_context_setup_failure_for_unknown_ue_reports_it() {
+        let ctx = ctx_with_gummei();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+
+        let out = handle_initial_context_setup_failure(
+            &ctx,
+            enb_id,
+            &InitialContextSetupFailure {
+                mme_ue_s1ap_id: 4242,
+                enb_ue_s1ap_id: 7,
+                cause: Cause::RadioNetwork(CauseRadioNetwork::RadioResourcesNotAvailable),
+            },
+        );
+
+        assert_eq!(out.len(), 1);
+        assert!(matches!(
+            decode_s1ap_pdu(&out[0].pdu).unwrap(),
+            S1apMessage::ErrorIndication(_)
+        ));
+    }
+
+    #[test]
+    fn test_error_indication_with_unknown_id_releases_the_stale_context() {
+        let ctx = ctx_with_gummei();
+        let (enb_id, enb_ue_id, mme_ue_id, mme_ue_s1ap_id) = add_ue(&ctx);
+
+        // The eNB says it does not know this id: OUR context is the stale one.
+        handle_error_indication(
+            &ctx,
+            enb_id,
+            &ErrorIndication {
+                mme_ue_s1ap_id: Some(mme_ue_s1ap_id),
+                enb_ue_s1ap_id: Some(100),
+                cause: Some(Cause::RadioNetwork(CauseRadioNetwork::UnknownMmeUeS1apId)),
+                criticality_diagnostics: None,
+            },
+        );
+
+        assert!(
+            ctx.enb_ue_find_by_id(enb_ue_id).is_none(),
+            "the S1 connection is released locally"
+        );
+        // The UE context survives, idle, as it does for any S1 release.
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(mme_ue.enb_ue_id, NEXTGCORE_INVALID_POOL_ID);
+    }
+
+    #[test]
+    fn test_error_indication_with_another_cause_is_informational() {
+        let ctx = ctx_with_gummei();
+        let (enb_id, enb_ue_id, _, mme_ue_s1ap_id) = add_ue(&ctx);
+
+        handle_error_indication(
+            &ctx,
+            enb_id,
+            &ErrorIndication {
+                mme_ue_s1ap_id: Some(mme_ue_s1ap_id),
+                enb_ue_s1ap_id: Some(100),
+                cause: Some(Cause::Protocol(
+                    nextgcore_s1ap::CauseProtocol::SemanticError,
+                )),
+                criticality_diagnostics: None,
+            },
+        );
+
+        assert!(
+            ctx.enb_ue_find_by_id(enb_ue_id).is_some(),
+            "a semantic error says nothing about our context being stale"
+        );
+    }
+
+    #[test]
+    fn test_repeat_s1_setup_releases_the_restarted_enbs_contexts() {
+        let ctx = ctx_with_gummei();
+        let (enb_id, enb_ue_id, _, _) = add_ue(&ctx);
+        // Mark the eNB as already set up, as its first S1 Setup would have.
+        if let Some(enb) = ctx.enb_pool.write().unwrap().get_mut(&enb_id) {
+            enb.state.s1_setup_success = true;
+        }
+
+        let request = S1SetupRequest {
+            global_enb_id: GlobalEnbId {
+                plmn_identity: s1ap_build::encode_plmn_id(&PlmnId::new("310", "410")),
+                enb_id: nextgcore_s1ap::EnbId::Macro(0x1234),
+            },
+            enb_name: Some("restarted-enb".to_string()),
+            supported_tas: vec![SupportedTaItem {
+                tac: 1,
+                broadcast_plmns: vec![s1ap_build::encode_plmn_id(&PlmnId::new("310", "410"))],
+            }],
+            default_paging_drx: nextgcore_s1ap::PagingDrx::V64,
+        };
+        let out = handle_s1ap_message(
+            &ctx,
+            enb_id,
+            &builder::build_s1_setup_request(&request).unwrap(),
+        );
+
+        // TS 23.007 §17: the setup is still accepted, but the stale contexts are
+        // gone — otherwise their MME-UE-S1AP-IDs collide with the ids the
+        // restarted eNB is about to allocate.
+        assert!(matches!(
+            decode_s1ap_pdu(&out[0].pdu).unwrap(),
+            S1apMessage::S1SetupResponse(_)
+        ));
+        assert!(
+            ctx.enb_ue_find_by_id(enb_ue_id).is_none(),
+            "the restarted eNB's stale UE context must be released"
+        );
+    }
+
+    #[test]
+    fn test_protocol_errors_carry_criticality_diagnostics() {
+        let ctx = ctx_with_gummei();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+
+        let out = handle_s1ap_message(&ctx, enb_id, &[0xff, 0x00, 0xff]);
+
+        assert_eq!(out.len(), 1);
+        match decode_s1ap_pdu(&out[0].pdu).unwrap() {
+            S1apMessage::ErrorIndication(ind) => {
+                let diag = ind
+                    .criticality_diagnostics
+                    .expect("a protocol error must say what it was about");
+                assert_eq!(
+                    diag.triggering_message,
+                    Some(nextgcore_s1ap::triggering_message::INITIATING_MESSAGE)
+                );
+            }
+            other => panic!("expected ErrorIndication, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/libs/nextgcore-s1ap/src/builder.rs
+++ b/src/libs/nextgcore-s1ap/src/builder.rs
@@ -628,6 +628,12 @@ pub fn build_error_indication(msg: &ErrorIndication) -> S1apResult<Vec<u8>> {
         ie::encode_cause(&mut container, cause)?;
     }
 
+    // IE: Criticality Diagnostics (optional) — tells the peer which procedure and
+    // which IEs the error was about (TS 36.413 §9.2.1.21).
+    if let Some(ref diag) = msg.criticality_diagnostics {
+        ie::encode_criticality_diagnostics(&mut container, diag)?;
+    }
+
     encode_pdu(&initiating(
         ProcedureCode::ERROR_INDICATION,
         Criticality::Ignore,

--- a/src/libs/nextgcore-s1ap/src/ie.rs
+++ b/src/libs/nextgcore-s1ap/src/ie.rs
@@ -1034,6 +1034,130 @@ pub fn decode_nas_pdu(field: &ProtocolIeField) -> S1apResult<Vec<u8>> {
     Ok(pdu.0)
 }
 
+/// ASN.1 enumeration index for `TypeOfError` (not-understood(0), missing(1)).
+fn type_of_error_to_index(t: TypeOfError) -> i64 {
+    match t {
+        TypeOfError::NotUnderstood => 0,
+        TypeOfError::Missing => 1,
+    }
+}
+
+fn index_to_type_of_error(index: i64) -> TypeOfError {
+    match index {
+        1 => TypeOfError::Missing,
+        // Unknown extension values are reported as not-understood, which is what
+        // they are from this node's point of view.
+        _ => TypeOfError::NotUnderstood,
+    }
+}
+
+/// Encode the Criticality Diagnostics IE (TS 36.413 §9.2.1.21).
+///
+/// Ported from `nextgcore_ngap::ie::encode_criticality_diagnostics`: the S1AP and
+/// NGAP definitions of this IE are structurally identical, differing only in the
+/// protocol IE id (58 here, 7 in NGAP).
+pub fn encode_criticality_diagnostics(
+    container: &mut ProtocolIeContainer,
+    diag: &CriticalityDiagnostics,
+) -> S1apResult<()> {
+    let mut encoder = AperEncoder::new();
+    // CriticalityDiagnostics ::= SEQUENCE { procedureCode OPTIONAL,
+    //   triggeringMessage OPTIONAL, procedureCriticality OPTIONAL,
+    //   iEsCriticalityDiagnostics OPTIONAL, iE-Extensions OPTIONAL, ... }
+    let ies_present = !diag.ies.is_empty();
+    encoder.write_bit(false); // extension marker
+    encoder.write_bit(diag.procedure_code.is_some());
+    encoder.write_bit(diag.triggering_message.is_some());
+    encoder.write_bit(diag.procedure_criticality.is_some());
+    encoder.write_bit(ies_present);
+    encoder.write_bit(false); // no iE-Extensions
+
+    if let Some(code) = diag.procedure_code {
+        encoder.encode_constrained_whole_number(code as i64, &Constraint::new(0, 255))?;
+    }
+    if let Some(tm) = diag.triggering_message {
+        encoder.encode_enumerated(tm as i64, &Constraint::new(0, 2))?;
+    }
+    if let Some(crit) = diag.procedure_criticality {
+        encoder.encode_enumerated(crit as i64, &Constraint::new(0, 2))?;
+    }
+    if ies_present {
+        // CriticalityDiagnostics-IE-List ::= SEQUENCE (SIZE(1..maxnoofErrors))
+        // OF CriticalityDiagnostics-IE-Item, maxnoofErrors = 256.
+        encoder.encode_constrained_length(diag.ies.len(), 1, 256)?;
+        for item in &diag.ies {
+            encoder.write_bit(false); // extension marker
+            encoder.write_bit(false); // no iE-Extensions
+            item.ie_criticality.encode_aper(&mut encoder)?;
+            encoder
+                .encode_constrained_whole_number(item.ie_id as i64, &Constraint::new(0, 65535))?;
+            encoder.encode_enumerated(
+                type_of_error_to_index(item.type_of_error),
+                &Constraint::extensible(0, 1),
+            )?;
+        }
+    }
+    encoder.align();
+
+    container.push(ProtocolIeField {
+        id: ProtocolIeId::CRITICALITY_DIAGNOSTICS,
+        criticality: Criticality::Ignore,
+        value: encoder.into_bytes().to_vec(),
+    });
+    Ok(())
+}
+
+/// Decode the Criticality Diagnostics IE (TS 36.413 §9.2.1.21).
+pub fn decode_criticality_diagnostics(
+    field: &ProtocolIeField,
+) -> S1apResult<CriticalityDiagnostics> {
+    let mut decoder = AperDecoder::new(&field.value);
+    let _ext = decoder.read_bit()?;
+    let pc_present = decoder.read_bit()?;
+    let tm_present = decoder.read_bit()?;
+    let crit_present = decoder.read_bit()?;
+    let ies_present = decoder.read_bit()?;
+    let _ie_ext = decoder.read_bit()?;
+
+    let procedure_code = pc_present
+        .then(|| decoder.decode_constrained_whole_number(&Constraint::new(0, 255)))
+        .transpose()?
+        .map(|v| v as u8);
+    let triggering_message = tm_present
+        .then(|| decoder.decode_enumerated(&Constraint::new(0, 2)))
+        .transpose()?
+        .map(|v| v as u8);
+    let procedure_criticality = crit_present
+        .then(|| decoder.decode_enumerated(&Constraint::new(0, 2)))
+        .transpose()?
+        .map(|v| v as u8);
+
+    let mut ies = Vec::new();
+    if ies_present {
+        let count = decoder.decode_constrained_length(1, 256)?;
+        for _ in 0..count {
+            let _item_ext = decoder.read_bit()?;
+            let _item_ie_ext = decoder.read_bit()?;
+            let ie_criticality = Criticality::decode_aper(&mut decoder)?;
+            let ie_id = decoder.decode_constrained_whole_number(&Constraint::new(0, 65535))? as u16;
+            let type_of_error =
+                index_to_type_of_error(decoder.decode_enumerated(&Constraint::extensible(0, 1))?);
+            ies.push(IeCriticalityDiagnostics {
+                ie_criticality,
+                ie_id,
+                type_of_error,
+            });
+        }
+    }
+
+    Ok(CriticalityDiagnostics {
+        procedure_code,
+        triggering_message,
+        procedure_criticality,
+        ies,
+    })
+}
+
 pub fn encode_cause(container: &mut ProtocolIeContainer, cause: &Cause) -> S1apResult<()> {
     container.push(make_ie_field(
         ProtocolIeId::CAUSE,

--- a/src/libs/nextgcore-s1ap/src/parser.rs
+++ b/src/libs/nextgcore-s1ap/src/parser.rs
@@ -932,6 +932,7 @@ fn parse_error_indication(container: ProtocolIeContainer) -> S1apResult<ErrorInd
     let mut mme_ue_s1ap_id = None;
     let mut enb_ue_s1ap_id = None;
     let mut cause = None;
+    let mut criticality_diagnostics = None;
 
     for field in &container.ies {
         match field.id {
@@ -944,6 +945,9 @@ fn parse_error_indication(container: ProtocolIeContainer) -> S1apResult<ErrorInd
             ProtocolIeId::CAUSE => {
                 cause = Some(ie::decode_cause(field)?);
             }
+            ProtocolIeId::CRITICALITY_DIAGNOSTICS => {
+                criticality_diagnostics = Some(ie::decode_criticality_diagnostics(field)?);
+            }
             _ => {}
         }
     }
@@ -952,6 +956,7 @@ fn parse_error_indication(container: ProtocolIeContainer) -> S1apResult<ErrorInd
         mme_ue_s1ap_id,
         enb_ue_s1ap_id,
         cause,
+        criticality_diagnostics,
     })
 }
 

--- a/src/libs/nextgcore-s1ap/src/types.rs
+++ b/src/libs/nextgcore-s1ap/src/types.rs
@@ -352,6 +352,62 @@ pub struct ErrorIndication {
     pub enb_ue_s1ap_id: Option<u32>,
     /// Cause (optional)
     pub cause: Option<Cause>,
+    /// Criticality Diagnostics (optional, TS 36.413 §9.2.1.21)
+    pub criticality_diagnostics: Option<CriticalityDiagnostics>,
+}
+
+/// Which part of a received IE was wrong (TS 36.413 §9.2.1.21).
+///
+/// ASN.1: `TypeOfError ::= ENUMERATED { not-understood, missing, ... }`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeOfError {
+    /// The IE was present but could not be interpreted
+    NotUnderstood,
+    /// A mandatory IE was absent
+    Missing,
+}
+
+/// One offending IE inside [`CriticalityDiagnostics`].
+///
+/// ASN.1: `CriticalityDiagnostics-IE-Item ::= SEQUENCE { iECriticality,
+/// iE-ID, typeOfError, iE-Extensions OPTIONAL, ... }`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IeCriticalityDiagnostics {
+    /// Criticality the offending IE was received with
+    pub ie_criticality: nextgcore_asn1c::s1ap::types::Criticality,
+    /// Protocol IE id of the offending IE
+    pub ie_id: u16,
+    /// What was wrong with it
+    pub type_of_error: TypeOfError,
+}
+
+/// Criticality Diagnostics (TS 36.413 §9.2.1.21).
+///
+/// Tells the peer *which* procedure and *which* IEs a protocol error was about,
+/// so it can correct the message rather than only learning that something was
+/// rejected. Structurally identical to the NGAP IE of the same name
+/// (TS 38.413 §9.3.1.3).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CriticalityDiagnostics {
+    /// Procedure the error was detected in
+    pub procedure_code: Option<u8>,
+    /// Which message of that procedure (initiating/successful/unsuccessful)
+    pub triggering_message: Option<u8>,
+    /// Criticality the procedure was received with
+    pub procedure_criticality: Option<u8>,
+    /// The offending IEs; an empty list means the field is absent on the wire
+    pub ies: Vec<IeCriticalityDiagnostics>,
+}
+
+/// `TriggeringMessage ::= ENUMERATED { initiating-message, successful-outcome,
+/// unsuccessful-outcome }` (TS 36.413 §9.2.1.21).
+pub mod triggering_message {
+    /// initiating-message(0)
+    pub const INITIATING_MESSAGE: u8 = 0;
+    /// successful-outcome(1)
+    pub const SUCCESSFUL_OUTCOME: u8 = 1;
+    /// unsuccessful-outcome(2)
+    pub const UNSUCCESSFUL_OUTCOME: u8 = 2;
 }
 
 // ============================================================================

--- a/src/libs/nextgcore-s1ap/tests/roundtrip.rs
+++ b/src/libs/nextgcore-s1ap/tests/roundtrip.rs
@@ -733,6 +733,7 @@ fn error_indication_roundtrip() {
         mme_ue_s1ap_id: Some(99),
         enb_ue_s1ap_id: None,
         cause: Some(Cause::Protocol(CauseProtocol::SemanticError)),
+        criticality_diagnostics: None,
     };
     let bytes = build_error_indication(&msg).unwrap();
     match decode_s1ap_pdu(&bytes).unwrap() {
@@ -1330,5 +1331,49 @@ proptest! {
             bytes[byte_index] ^= 1 << bit;
         }
         let _ = decode_s1ap_pdu(&bytes);
+    }
+}
+
+/// Criticality Diagnostics survives a round trip (TS 36.413 §9.2.1.21).
+///
+/// The IE had no encoder at all before, so an Error Indication could never say
+/// which procedure or which IEs a protocol error was about.
+#[test]
+fn error_indication_criticality_diagnostics_roundtrip() {
+    use nextgcore_s1ap::{
+        triggering_message, CriticalityDiagnostics, IeCriticalityDiagnostics, TypeOfError,
+    };
+
+    let diagnostics = CriticalityDiagnostics {
+        procedure_code: Some(9),
+        triggering_message: Some(triggering_message::INITIATING_MESSAGE),
+        procedure_criticality: Some(0),
+        ies: vec![
+            IeCriticalityDiagnostics {
+                ie_criticality: nextgcore_asn1c::s1ap::types::Criticality::Reject,
+                ie_id: 8,
+                type_of_error: TypeOfError::Missing,
+            },
+            IeCriticalityDiagnostics {
+                ie_criticality: nextgcore_asn1c::s1ap::types::Criticality::Ignore,
+                ie_id: 100,
+                type_of_error: TypeOfError::NotUnderstood,
+            },
+        ],
+    };
+
+    let bytes = build_error_indication(&ErrorIndication {
+        mme_ue_s1ap_id: Some(5),
+        enb_ue_s1ap_id: Some(6),
+        cause: Some(Cause::Protocol(CauseProtocol::AbstractSyntaxErrorReject)),
+        criticality_diagnostics: Some(diagnostics.clone()),
+    })
+    .unwrap();
+
+    match decode_s1ap_pdu(&bytes).unwrap() {
+        S1apMessage::ErrorIndication(decoded) => {
+            assert_eq!(decoded.criticality_diagnostics, Some(diagnostics));
+        }
+        other => panic!("expected ErrorIndication, got {other:?}"),
     }
 }


### PR DESCRIPTION
feat(s1ap): act on setup failure and error indication, encode Criticality Diagnostics, restore S1 on eNB restart

Closes #50 — all four parts, in one PR, because delivering one part per PR is what
left #46 open after three.

PART 1: INITIAL CONTEXT SETUP FAILURE WAS LOGGED AND DROPPED (s1ap_handler.rs:213).
The eNB could not set up the UE context, and the MME went on believing the UE was
being served. It now releases the UE-associated logical S1 connection with the cause
the eNB reported, and answers an unknown MME-UE-S1AP-ID with an Error Indication
instead of silence.

PART 2: ERROR INDICATION WAS LOGGED AND DROPPED (s1ap_handler.rs:188). An indication
naming one of our ids with unknown-mme-ue / unknown-enb-ue / unknown-pair-ue is the
eNB telling us OUR context is stale, so it is released locally with no release
command -- the eNB already has nothing to release. Any other cause stays
informational, which is the distinction that matters: releasing on a semantic error
would drop a live UE.

PART 3: CRITICALITY DIAGNOSTICS DID NOT EXIST IN THE CODEC AT ALL. A grep for
CriticalityDiagnostics across libs/nextgcore-s1ap returned nothing, so an Error
Indication could never say WHICH procedure or WHICH IEs a protocol error was about
-- a peer learned only that something was rejected. The IE is now modelled
(procedureCode, triggeringMessage, procedureCriticality, and the
iEsCriticalityDiagnostics list of {iECriticality, iE-ID, typeOfError}) with an APER
encoder and decoder, threaded through build_error_indication, and populated on the
dispatcher's transfer-syntax and unknown-procedure paths.

The encoder is a PORT, not a fresh design: nextgcore-ngap already had a working
encoder for the same IE (TS 38.413 9.3.1.3 is structurally identical to TS 36.413
9.2.1.21, differing only in the protocol IE id -- 58 here, 7 there). Finding that
is what made this part fit; writing the APER by hand would not have.

PART 4: AN eNB RESTART WENT UNNOTICED. handle_s1_setup_request set
state.s1_setup_success without ever checking whether it was ALREADY set, and a
second S1 SETUP REQUEST from the same eNB means that eNB restarted (TS 23.007 17).
Every UE context the MME held for it was stale, and worse, their MME-UE-S1AP-IDs
collide with the ids the restarted eNB is about to allocate. The setup is still
accepted, but the stale contexts are released first. handle_reset's
ResetType::S1Interface branch already had the release loop, so it is factored into
release_all_s1_connections and called from both.

VERIFIED. mmed 279 passed / 0 failed (baseline 273); nextgcore-s1ap 52 passed
including a Criticality Diagnostics round trip that asserts the decoded IE equals
what was encoded, two items and all three optional fields; workspace 5495 passed /
0 failed (baseline 5488); clippy identical to the pre-change baseline; fmt clean.

Six new handler tests: the release on setup failure and on an unknown id, the
unknown-id release versus an informational cause left alone, the restart release
alongside an accepted setup, and a garbage PDU whose Error Indication now carries
diagnostics.

Spec: specs/fix-s1ap-error-handling.md
