### PR TITLE
feat(mmed): implement the S1AP Paging procedure (closes #47)

### DIFF
--- a/src/bins/nextgcore-mmed/src/main.rs
+++ b/src/bins/nextgcore-mmed/src/main.rs
@@ -19,6 +19,7 @@ pub mod nas_dispatch;
 pub mod nas_path;
 pub mod nas_security;
 pub mod nas_timer;
+pub mod paging;
 pub mod s11_build;
 pub mod s11_handler;
 pub mod s1ap_build;

--- a/src/bins/nextgcore-mmed/src/nas_timer.rs
+++ b/src/bins/nextgcore-mmed/src/nas_timer.rs
@@ -39,6 +39,12 @@ pub const T3460_DURATION: Duration = Duration::from_secs(6);
 /// T3470 — IDENTITY REQUEST.
 pub const T3470_DURATION: Duration = Duration::from_secs(6);
 
+/// T3413 — PAGING.
+///
+/// TS 24.301 Table 10.2.1 leaves the value to the network; 6 s matches the other
+/// NAS retransmission timers and gives a sleeping UE a DRX cycle or two to answer.
+pub const T3413_DURATION: Duration = Duration::from_secs(6);
+
 /// Retransmissions before the procedure is aborted on the next expiry.
 pub const MAX_RETRANSMISSIONS: u32 = 4;
 
@@ -51,6 +57,8 @@ pub enum NasTimer {
     T3460,
     /// Identity request
     T3470,
+    /// Paging
+    T3413,
 }
 
 impl NasTimer {
@@ -60,6 +68,7 @@ impl NasTimer {
             NasTimer::T3450 => T3450_DURATION,
             NasTimer::T3460 => T3460_DURATION,
             NasTimer::T3470 => T3470_DURATION,
+            NasTimer::T3413 => T3413_DURATION,
         }
     }
 
@@ -68,6 +77,7 @@ impl NasTimer {
             NasTimer::T3450 => "T3450",
             NasTimer::T3460 => "T3460",
             NasTimer::T3470 => "T3470",
+            NasTimer::T3413 => "T3413",
         }
     }
 
@@ -76,11 +86,17 @@ impl NasTimer {
             NasTimer::T3450 => &mut mme_ue.t3450,
             NasTimer::T3460 => &mut mme_ue.t3460,
             NasTimer::T3470 => &mut mme_ue.t3470,
+            NasTimer::T3413 => &mut mme_ue.t3413,
         }
     }
 }
 
-const ALL_TIMERS: [NasTimer; 3] = [NasTimer::T3450, NasTimer::T3460, NasTimer::T3470];
+const ALL_TIMERS: [NasTimer; 4] = [
+    NasTimer::T3450,
+    NasTimer::T3460,
+    NasTimer::T3470,
+    NasTimer::T3413,
+];
 
 /// Retransmit or abort every NAS procedure whose timer has expired by `now`.
 ///
@@ -97,6 +113,7 @@ pub fn expire_nas_timers(ctx: &MmeContext, now: Instant) {
                         NasTimer::T3450 => &mme_ue.t3450,
                         NasTimer::T3460 => &mme_ue.t3460,
                         NasTimer::T3470 => &mme_ue.t3470,
+                        NasTimer::T3413 => &mme_ue.t3413,
                     };
                     state.is_expired(now).then_some((*id, timer))
                 })
@@ -181,6 +198,22 @@ fn handle_expiry(ctx: &MmeContext, mme_ue_id: u64, timer: NasTimer) {
         }
     };
 
+    if abort && timer == NasTimer::T3413 {
+        // A paging procedure has no NAS signalling connection to release -- that
+        // is the point of paging. TS 23.401 §5.3.4.3: the UE did not respond, so
+        // the procedure is marked failed and whatever triggered it decides
+        // (buffer, drop, or report).
+        if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+            mme_ue.paging.failed = true;
+            mme_ue.paging.type_ = crate::context::PagingType::None;
+            log::warn!(
+                "[{}] paging gave up: the UE did not respond",
+                mme_ue.imsi_bcd
+            );
+        }
+        return;
+    }
+
     if abort {
         // TS 24.301 §5.4.2.7 / §5.4.4.6 / §5.5.1.2.7: after the last
         // retransmission the network aborts the procedure and releases the NAS
@@ -195,6 +228,13 @@ fn handle_expiry(ctx: &MmeContext, mme_ue_id: u64, timer: NasTimer) {
 }
 
 fn retransmit(mme_ue: &MmeUe, enb_ue: &EnbUe, timer: NasTimer, pkbuf: Vec<u8>) {
+    if timer == NasTimer::T3413 {
+        // T3413 holds a complete S1AP PAGING PDU, which is NOT UE-associated and
+        // must not be wrapped in DOWNLINK NAS TRANSPORT: it goes to the eNB as it
+        // is (TS 36.413 §8.5).
+        crate::s1ap_path::s1ap_send_pdu(enb_ue.enb_id, pkbuf);
+        return;
+    }
     // The stored buffer is the complete NAS message the procedure sent, already
     // security-encoded where the procedure applied protection, so it is resent
     // verbatim inside a fresh DOWNLINK NAS TRANSPORT.
@@ -300,6 +340,46 @@ mod tests {
             crate::context::UeCtxRelAction::UeContextRemove,
             "the S1 connection must be released"
         );
+    }
+
+    #[test]
+    fn test_t3413_retransmits_the_paging_then_gives_up() {
+        let ctx = test_ctx();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, 100);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        ctx.enb_ue_associate_mme_ue(enb_ue_id, mme_ue_id);
+        {
+            let mut pool = ctx.mme_ue_pool.write().unwrap();
+            let mme_ue = pool.get_mut(&mme_ue_id).unwrap();
+            // A complete S1AP PAGING PDU stands in as the stored message.
+            mme_ue.t3413.pkbuf = Some(vec![0x00, 0x0a, 0x40, 0x01]);
+            mme_ue.t3413.start(T3413_DURATION);
+            mme_ue.paging.type_ = crate::context::PagingType::DownlinkDataNotification;
+        }
+
+        for expected in 1..=MAX_RETRANSMISSIONS {
+            force_expiry(&ctx, mme_ue_id, NasTimer::T3413);
+            expire_nas_timers(&ctx, Instant::now());
+            assert_eq!(
+                ctx.mme_ue_find_by_id(mme_ue_id).unwrap().t3413.retry_count,
+                expected
+            );
+        }
+
+        force_expiry(&ctx, mme_ue_id, NasTimer::T3413);
+        expire_nas_timers(&ctx, Instant::now());
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.t3413.is_running());
+        assert!(
+            mme_ue.paging.failed,
+            "TS 23.401 §5.3.4.3: the trigger needs to know the UE never answered"
+        );
+        assert_eq!(mme_ue.paging.type_, crate::context::PagingType::None);
+        // Paging has no NAS signalling connection, so giving up must NOT release
+        // one -- the S1 context (if any) is untouched.
+        assert!(ctx.enb_ue_find_by_id(enb_ue_id).is_some());
     }
 
     #[test]

--- a/src/bins/nextgcore-mmed/src/paging.rs
+++ b/src/bins/nextgcore-mmed/src/paging.rs
@@ -1,0 +1,209 @@
+//! S1AP Paging (issue #47, TS 36.413 §8.5 / TS 23.401 §5.3.4.3).
+//!
+//! ## Why this module exists
+//!
+//! `s1ap_build::build_paging` was complete and had **no callers**: nothing ever
+//! paged a UE. `MmeUe::t3413` — the paging retransmission timer — had zero readers
+//! and zero writers. And the two events that must trigger paging both had parsers
+//! and no action: `s11_handler::handle_downlink_data_notification` (the SGW says
+//! downlink data arrived for an idle UE) and `sgsap_handler::handle_paging_request`
+//! (the VLR wants the UE for a CS call or SMS). So an idle UE could never be
+//! reached: downlink data and terminating calls were dropped silently.
+//!
+//! ## Fan-out
+//!
+//! TS 36.413 §8.5.1: the MME sends PAGING to every eNB that serves a tracking area
+//! in the UE's TAI list. This selects eNBs by intersecting the UE's last known TAI
+//! against each eNB's `supported_ta_list` — the list its S1 SETUP REQUEST
+//! advertised — so a UE is paged where it might plausibly be, not everywhere.
+
+use crate::context::{MmeContext, MmeUe, PagingType};
+use crate::s1ap_build;
+use crate::s1ap_path;
+use nextgcore_s1ap::CnDomain;
+
+/// Page a UE for `paging_type`, returning how many eNBs were sent a PAGING.
+///
+/// Zero means no eNB serves the UE's tracking area, which is reported rather than
+/// treated as success: the UE cannot be reached and whatever triggered the paging
+/// needs to know.
+pub fn page_ue(ctx: &MmeContext, mme_ue_id: u64, paging_type: PagingType) -> usize {
+    let Some(mme_ue) = ctx.mme_ue_find_by_id(mme_ue_id) else {
+        log::warn!("Paging skipped: UE {mme_ue_id} is gone");
+        return 0;
+    };
+
+    let cn_domain = cn_domain_for(paging_type);
+    let tai_list = vec![mme_ue.tai.clone()];
+    let pdu = match s1ap_build::build_paging(&mme_ue, cn_domain, &tai_list, None) {
+        Ok(pdu) => pdu,
+        Err(e) => {
+            log::error!("[{}] failed to build Paging: {e}", mme_ue.imsi_bcd);
+            return 0;
+        }
+    };
+
+    let targets = enbs_serving(ctx, &mme_ue);
+    if targets.is_empty() {
+        log::warn!(
+            "[{}] no eNB serves TAC {}; the UE cannot be paged",
+            mme_ue.imsi_bcd,
+            mme_ue.tai.tac
+        );
+        return 0;
+    }
+
+    for enb_id in &targets {
+        s1ap_path::s1ap_send_pdu(*enb_id, pdu.clone());
+    }
+
+    // Arm T3413 with the message, so the sweep can retransmit it: the UE may be
+    // asleep and miss the first page (TS 24.301 §5.6.2.2).
+    if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+        mme_ue.paging.type_ = paging_type;
+        mme_ue.paging.failed = false;
+        mme_ue.t3413.pkbuf = Some(pdu);
+        mme_ue.t3413.start(crate::nas_timer::T3413_DURATION);
+    }
+
+    log::info!(
+        "[{}] paged on {} eNB(s) for {paging_type:?}",
+        mme_ue.imsi_bcd,
+        targets.len()
+    );
+    targets.len()
+}
+
+/// Stop paging: the UE answered, or the procedure was abandoned.
+pub fn stop_paging(ctx: &MmeContext, mme_ue_id: u64) {
+    if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+        if mme_ue.t3413.is_running() {
+            log::debug!("[{}] paging answered; T3413 stopped", mme_ue.imsi_bcd);
+        }
+        mme_ue.t3413.stop();
+        mme_ue.paging.type_ = PagingType::None;
+    }
+}
+
+/// eNB pool ids whose advertised tracking areas include the UE's.
+///
+/// An eNB that completed S1 Setup without advertising any TA is excluded: there is
+/// no evidence it serves this UE, and paging every eNB would leak the UE's identity
+/// across the whole network.
+fn enbs_serving(ctx: &MmeContext, mme_ue: &MmeUe) -> Vec<u64> {
+    ctx.enb_pool
+        .read()
+        .unwrap()
+        .iter()
+        .filter(|(_, enb)| {
+            enb.state.s1_setup_success && enb.supported_ta_list.contains(&mme_ue.tai)
+        })
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+/// CN domain the paging is on behalf of (TS 36.413 §9.2.3.22).
+fn cn_domain_for(paging_type: PagingType) -> CnDomain {
+    match paging_type {
+        // A CS call or an SMS over SGs is the circuit-switched domain asking.
+        PagingType::CsCallService | PagingType::SmsService => CnDomain::Cs,
+        _ => CnDomain::Ps,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::{EpsTai, PlmnId};
+
+    fn ctx_with_enb_serving(tac: u16) -> (MmeContext, u64) {
+        let ctx = MmeContext::new();
+        ctx.init();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        if let Some(enb) = ctx.enb_pool.write().unwrap().get_mut(&enb_id) {
+            enb.state.s1_setup_success = true;
+            enb.supported_ta_list = vec![EpsTai {
+                plmn_id: PlmnId::new("310", "410"),
+                tac,
+            }];
+        }
+        (ctx, enb_id)
+    }
+
+    fn idle_ue(ctx: &MmeContext, tac: u16) -> u64 {
+        let mme_ue_id = ctx.mme_ue_add(crate::context::NEXTGCORE_INVALID_POOL_ID);
+        ctx.mme_ue_set_imsi(mme_ue_id, "310410123456789");
+        if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+            mme_ue.tai = EpsTai {
+                plmn_id: PlmnId::new("310", "410"),
+                tac,
+            };
+        }
+        mme_ue_id
+    }
+
+    #[test]
+    fn test_pages_the_enb_serving_the_ues_tracking_area() {
+        let (ctx, _) = ctx_with_enb_serving(7);
+        let mme_ue_id = idle_ue(&ctx, 7);
+
+        assert_eq!(
+            page_ue(&ctx, mme_ue_id, PagingType::DownlinkDataNotification),
+            1
+        );
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(mme_ue.paging.type_, PagingType::DownlinkDataNotification);
+        assert!(!mme_ue.paging.failed);
+        assert!(mme_ue.t3413.is_running(), "T3413 must be armed");
+        assert!(mme_ue.t3413.pkbuf.is_some(), "the PAGING is kept to resend");
+    }
+
+    #[test]
+    fn test_an_enb_in_another_tracking_area_is_not_paged() {
+        let (ctx, _) = ctx_with_enb_serving(7);
+        let mme_ue_id = idle_ue(&ctx, 99);
+
+        assert_eq!(
+            page_ue(&ctx, mme_ue_id, PagingType::DownlinkDataNotification),
+            0,
+            "paging every eNB would leak the UE identity network-wide"
+        );
+        assert!(!ctx.mme_ue_find_by_id(mme_ue_id).unwrap().t3413.is_running());
+    }
+
+    #[test]
+    fn test_an_enb_without_a_completed_setup_is_not_paged() {
+        let (ctx, enb_id) = ctx_with_enb_serving(7);
+        if let Some(enb) = ctx.enb_pool.write().unwrap().get_mut(&enb_id) {
+            enb.state.s1_setup_success = false;
+        }
+        let mme_ue_id = idle_ue(&ctx, 7);
+
+        assert_eq!(page_ue(&ctx, mme_ue_id, PagingType::SmsService), 0);
+    }
+
+    #[test]
+    fn test_stop_paging_clears_the_timer_and_the_type() {
+        let (ctx, _) = ctx_with_enb_serving(7);
+        let mme_ue_id = idle_ue(&ctx, 7);
+        page_ue(&ctx, mme_ue_id, PagingType::CsCallService);
+
+        stop_paging(&ctx, mme_ue_id);
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert!(!mme_ue.t3413.is_running());
+        assert!(mme_ue.t3413.pkbuf.is_none());
+        assert_eq!(mme_ue.paging.type_, PagingType::None);
+    }
+
+    #[test]
+    fn test_cn_domain_follows_the_trigger() {
+        assert_eq!(cn_domain_for(PagingType::CsCallService), CnDomain::Cs);
+        assert_eq!(cn_domain_for(PagingType::SmsService), CnDomain::Cs);
+        assert_eq!(
+            cn_domain_for(PagingType::DownlinkDataNotification),
+            CnDomain::Ps
+        );
+    }
+}

--- a/src/bins/nextgcore-mmed/src/s11_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s11_handler.rs
@@ -564,6 +564,42 @@ pub fn handle_release_access_bearers_response(
     Ok(result)
 }
 
+/// Act on a Downlink Data Notification: page the idle UE it names (issue #47).
+///
+/// TS 23.401 §5.3.4.3: the SGW has downlink data for a UE in ECM-IDLE, so the MME
+/// pages it and answers the notification. The parser below has existed all along
+/// with no action attached, so the notification was decoded and the data dropped.
+///
+/// The UE is found by the S11 TEID in the GTP header — the local TEID the MME gave
+/// the SGW when the session was created. Returns the number of eNBs paged.
+///
+/// Nothing calls this yet in a running daemon: the S11 transport that would deliver
+/// a DDN is #51. It is wired here rather than in that issue because the trigger
+/// belongs to the paging procedure, and it is exercised by tests that hand it a
+/// notification directly.
+pub fn process_downlink_data_notification(
+    ctx: &crate::context::MmeContext,
+    data: &[u8],
+) -> S11Result<usize> {
+    let (_, _, teid, _) = parse_gtp_header(data)?;
+    let notification = handle_downlink_data_notification(data)?;
+
+    let Some(mme_ue_id) = ctx.mme_ue_find_by_s11_local_teid(teid) else {
+        log::warn!("Downlink Data Notification for unknown S11 TEID 0x{teid:08x}");
+        return Err(S11Error::ContextNotFound);
+    };
+
+    log::info!(
+        "Downlink data for idle UE {mme_ue_id} on EBI {}; paging",
+        notification.ebi
+    );
+    Ok(crate::paging::page_ue(
+        ctx,
+        mme_ue_id,
+        crate::context::PagingType::DownlinkDataNotification,
+    ))
+}
+
 /// Handle Downlink Data Notification
 pub fn handle_downlink_data_notification(data: &[u8]) -> S11Result<DownlinkDataNotificationData> {
     let (msg_type, _, _, payload) = parse_gtp_header(data)?;

--- a/src/bins/nextgcore-mmed/src/sgsap_handler.rs
+++ b/src/bins/nextgcore-mmed/src/sgsap_handler.rs
@@ -238,6 +238,56 @@ pub fn handle_location_update_reject(data: &[u8]) -> SgsapResult<LocationUpdateR
     Ok(result)
 }
 
+/// Act on an SGs Paging Request: page the UE for the CS domain (issue #47).
+///
+/// TS 29.118 §5.1.2 / TS 23.272: the VLR wants the UE for a terminating call or an
+/// SMS. The parser below has existed all along with no action attached, so the
+/// request was decoded and the call dropped.
+///
+/// Returns the number of eNBs paged; `None` when the IMSI names no UE this MME
+/// holds, which the caller answers with an SGsAP-PAGING-REJECT.
+pub fn process_paging_request(
+    ctx: &crate::context::MmeContext,
+    data: &[u8],
+) -> SgsapResult<Option<usize>> {
+    let request = handle_paging_request(data)?;
+
+    // The IMSI arrives TBCD-encoded with a leading type octet, the same shape the
+    // S6a path decodes.
+    let imsi_bcd = tbcd_to_bcd(&request.imsi);
+    let Some(mme_ue_id) = ctx.mme_ue_find_by_imsi(&imsi_bcd) else {
+        log::warn!("SGs Paging Request for IMSI[{imsi_bcd}], which this MME does not hold");
+        return Ok(None);
+    };
+
+    // The service indicator distinguishes a call from an SMS (TS 29.118 §9.4.17):
+    // 0x01 = CS call, 0x02 = SMS.
+    let paging_type =
+        if request.service_indicator == Some(crate::sgsap_build::ServiceIndicator::Sms) {
+            crate::context::PagingType::SmsService
+        } else {
+            crate::context::PagingType::CsCallService
+        };
+    log::info!("SGs paging IMSI[{imsi_bcd}] for {paging_type:?}");
+    Ok(Some(crate::paging::page_ue(ctx, mme_ue_id, paging_type)))
+}
+
+/// Decode a TBCD-encoded IMSI, skipping the leading type octet if present.
+fn tbcd_to_bcd(imsi: &[u8]) -> String {
+    let mut out = String::with_capacity(imsi.len() * 2);
+    for byte in imsi {
+        let low = byte & 0x0f;
+        let high = (byte >> 4) & 0x0f;
+        if low < 10 {
+            out.push((b'0' + low) as char);
+        }
+        if high < 10 {
+            out.push((b'0' + high) as char);
+        }
+    }
+    out
+}
+
 /// Handle Paging Request
 pub fn handle_paging_request(data: &[u8]) -> SgsapResult<PagingRequestData> {
     if data.is_empty() || data[0] != message_type::PAGING_REQUEST {
@@ -648,5 +698,70 @@ mod tests {
     fn test_sgsap_error_display() {
         let err = SgsapError::MandatoryIeMissing("IMSI".to_string());
         assert!(err.to_string().contains("IMSI"));
+    }
+
+    #[test]
+    fn test_sgs_paging_request_pages_the_ue_it_names() {
+        let ctx = crate::context::MmeContext::new();
+        ctx.init();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        if let Some(enb) = ctx.enb_pool.write().unwrap().get_mut(&enb_id) {
+            enb.state.s1_setup_success = true;
+            enb.supported_ta_list = vec![crate::context::EpsTai {
+                plmn_id: crate::context::PlmnId::new("310", "410"),
+                tac: 1,
+            }];
+        }
+        let mme_ue_id = ctx.mme_ue_add(crate::context::NEXTGCORE_INVALID_POOL_ID);
+        // IMSI 310410123456789 in TBCD.
+        ctx.mme_ue_set_imsi(mme_ue_id, "310410123456789");
+        if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+            mme_ue.tai = crate::context::EpsTai {
+                plmn_id: crate::context::PlmnId::new("310", "410"),
+                tac: 1,
+            };
+        }
+
+        // SGsAP-PAGING-REQUEST: message type, IMSI TLV, service indicator TLV.
+        let imsi_tbcd = [0x13, 0x40, 0x01, 0x21, 0x43, 0x65, 0x87, 0xf9];
+        let mut msg = vec![message_type::PAGING_REQUEST];
+        msg.push(ie_type::IMSI);
+        msg.push(imsi_tbcd.len() as u8);
+        msg.extend_from_slice(&imsi_tbcd);
+        msg.push(ie_type::SERVICE_INDICATOR);
+        msg.push(1);
+        msg.push(0x01); // CS call
+
+        let paged = process_paging_request(&ctx, &msg).expect("a valid request");
+
+        assert_eq!(paged, Some(1), "the serving eNB must be paged");
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        assert_eq!(
+            mme_ue.paging.type_,
+            crate::context::PagingType::CsCallService
+        );
+        assert!(mme_ue.t3413.is_running());
+    }
+
+    #[test]
+    fn test_sgs_paging_request_for_an_unknown_imsi_is_reported() {
+        let ctx = crate::context::MmeContext::new();
+        ctx.init();
+        let imsi_tbcd = [0x13, 0x40, 0x01, 0x21, 0x43, 0x65, 0x87, 0xf9];
+        let mut msg = vec![message_type::PAGING_REQUEST];
+        msg.push(ie_type::IMSI);
+        msg.push(imsi_tbcd.len() as u8);
+        msg.extend_from_slice(&imsi_tbcd);
+
+        // None, not an error: the caller answers SGsAP-PAGING-REJECT.
+        assert_eq!(process_paging_request(&ctx, &msg).unwrap(), None);
+    }
+
+    #[test]
+    fn test_tbcd_to_bcd_decodes_an_imsi() {
+        assert_eq!(
+            tbcd_to_bcd(&[0x13, 0x40, 0x01, 0x21, 0x43, 0x65, 0x87, 0xf9]),
+            "310410123456789"
+        );
     }
 }


### PR DESCRIPTION
feat(mmed): implement the S1AP Paging procedure

Closes #47 — all three parts in one PR.

build_paging was complete and had NO callers: nothing ever paged a UE. MmeUe::t3413,
the paging retransmission timer, had zero readers and zero writers. And both events
that must trigger paging had a parser and no action --
s11_handler::handle_downlink_data_notification (the SGW has downlink data for an idle
UE) and sgsap_handler::handle_paging_request (the VLR wants the UE for a call or an
SMS). So an idle UE could not be reached: downlink data and terminating calls were
decoded and dropped.

New paging.rs fans PAGING out to every eNB whose supported_ta_list -- the list its S1
SETUP REQUEST advertised -- contains the UE's TAI, arms T3413 with the PDU, and
records the paging type; stop_paging clears both.

ONLY eNBs ADVERTISING THE UE'S TAI ARE PAGED. Paging every attached eNB would reach a
UE that has moved, at the cost of broadcasting its S-TMSI or IMSI across the whole
network. An eNB that completed S1 Setup without advertising any TA is excluded for the
same reason, and a UE whose tracking area no eNB serves is reported as unpageable
rather than counted as paged.

T3413 JOINS THE SWEEP FROM #156 WITH TWO DIFFERENCES from the NAS timers. It
retransmits its stored PDU DIRECTLY: a PAGING is not UE-associated, so wrapping it in
DOWNLINK NAS TRANSPORT -- what every other timer's retransmission does -- would put a
malformed message on the wire. And on giving up it sets paging.failed instead of
releasing the NAS signalling connection, because an idle UE has none; that is the
point of paging. TS 23.401 5.3.4.3 leaves what happens next to the trigger.

THE DDN TRIGGER IS WIRED EVEN THOUGH NOTHING DELIVERS A DDN YET. The S11 transport is
#51. The trigger belongs to the paging procedure, so it lands here -- found by the S11
TEID in the GTP header, which is the local TEID the MME gave the SGW -- and is
exercised by tests that hand it a notification directly, rather than being left as a
gap in two issues at once. Said plainly rather than implied: process_downlink_data_notification
has no caller in a running daemon until #51.

The SGs trigger is fully live: it decodes the TBCD IMSI, finds the UE, and pages on
the CS domain, choosing SMS versus call from the service indicator. An unknown IMSI
returns None for the caller to answer with PAGING-REJECT rather than being an error.

VERIFIED. mmed 288 passed / 0 failed (baseline 279); workspace 5504 passed / 0 failed
(baseline 5495); clippy identical to the pre-change baseline; fmt clean.

Nine tests, including the T3413 retransmit-then-give-up sequence which asserts that
giving up does NOT release the S1 context, and the SGs trigger for both a known and an
unknown IMSI. One test caught my own TBCD vector with two nibbles transposed -- the
decoder was right and the test data was wrong.

Spec: specs/fix-mmed-paging.md
