### PR TITLE
feat(nwdafd): serve a real ML model artefact from MLModelProvision (closes #109)

### DIFF
--- a/src/bins/nextgcore-nwdafd/src/analytics.rs
+++ b/src/bins/nextgcore-nwdafd/src/analytics.rs
@@ -168,6 +168,13 @@ impl AnalyticsEngine {
         self.predictor.0.model_id()
     }
 
+    /// The active prediction model, so callers can ask what it *is* rather than
+    /// only what it predicts — `Nnwdaf_MLModelProvision` needs its linear form
+    /// to export a model artefact (issue #109).
+    pub fn predictor(&self) -> &dyn crate::ml_service::InferenceModel {
+        self.predictor.0.as_ref()
+    }
+
     /// Upsert the cached NRF profile metadata for an NF instance (G2-1).
     pub fn upsert_nf_meta(&mut self, nf_instance_id: &str, meta: NfProfileMeta) {
         self.nf_meta.insert(nf_instance_id.to_string(), meta);

--- a/src/bins/nextgcore-nwdafd/src/context.rs
+++ b/src/bins/nextgcore-nwdafd/src/context.rs
@@ -519,6 +519,13 @@ pub struct NwdafContext {
     nrf_status_subscription: RwLock<Option<NrfStatusSubscription>>,
     /// NRF collector configuration (G2-1), set by `main()` at startup.
     nrf_collector_config: RwLock<Option<NrfCollectorConfig>>,
+    /// This NF's own SBI base URI (e.g. `http://10.0.0.5:7777`), set by `main()`
+    /// at startup from the bound address.
+    ///
+    /// Needed because `Nnwdaf_MLModelProvision` notifies consumers of a model
+    /// URL that must resolve back to *this* NF (issue #109); the placeholder it
+    /// replaced was a hardcoded `http://nwdaf/...` that nothing served.
+    sbi_base_uri: RwLock<Option<String>>,
     /// Next internal ID generator
     next_id: AtomicUsize,
     /// Maximum subscriptions
@@ -551,6 +558,7 @@ impl NwdafContext {
             engine: Mutex::new(AnalyticsEngine::new()),
             nrf_status_subscription: RwLock::new(None),
             nrf_collector_config: RwLock::new(None),
+            sbi_base_uri: RwLock::new(None),
             next_id: AtomicUsize::new(1),
             max_subscriptions: 0,
             initialized: AtomicBool::new(false),
@@ -711,6 +719,45 @@ impl NwdafContext {
 
     /// Arm the NRF collector (G2-1): stores where to subscribe and the
     /// callback URI the NRF must POST NFStatusNotify to.
+    /// Record this NF's own SBI base URI (issue #109).
+    pub fn set_sbi_base_uri(&self, base: impl Into<String>) {
+        if let Ok(mut guard) = self.sbi_base_uri.write() {
+            *guard = Some(base.into());
+        }
+    }
+
+    /// This NF's own SBI base URI.
+    ///
+    /// Falls back to a loopback default when `main()` has not set one (unit
+    /// tests). That is a *local* address rather than a plausible-looking remote
+    /// one on purpose: a URL that only resolves on this host is obviously wrong
+    /// in a deployment, whereas the old `http://nwdaf/...` placeholder looked
+    /// routable and silently 404'd.
+    pub fn sbi_base_uri(&self) -> String {
+        self.sbi_base_uri
+            .read()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .unwrap_or_else(|| "http://127.0.0.1:7777".to_string())
+    }
+
+    /// The ONNX artefact for the active prediction model, or `None` when that
+    /// model has no fixed-window linear form and so cannot be provisioned
+    /// (issue #109).
+    ///
+    /// `None` is the signal that `nnwdaf-mlmodelprovision` must not be
+    /// advertised and no `mLModelUrl` emitted.
+    pub fn active_model_onnx(&self) -> Option<Vec<u8>> {
+        let engine = self.lock_engine();
+        crate::ml_service::active_model_onnx(engine.predictor())
+    }
+
+    /// Whether this NWDAF can currently provision a model artefact.
+    pub fn can_provision_model(&self) -> bool {
+        let engine = self.lock_engine();
+        engine.predictor().linear_form().is_some()
+    }
+
     pub fn set_nrf_collector_config(&self, config: NrfCollectorConfig) {
         if let Ok(mut slot) = self.nrf_collector_config.write() {
             *slot = Some(config);

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -24,7 +24,12 @@ pub mod federation;
 pub mod ml_service;
 pub mod notification_dispatcher;
 pub mod nrf_collector;
-#[cfg(feature = "onnx-model")]
+pub mod onnx_export; // issue #109: export the active model as an ONNX artefact
+                     // The reader is no longer gated at the module level: #109 serves an ONNX model
+                     // built by `onnx_export`, and the reader is how we prove those bytes round-trip
+                     // and reproduce our own prediction. Reading *operator-supplied* files stays the
+                     // opt-in part — the `onnx:<path>` arm of `ml_service::load_model` is still behind
+                     // the `onnx-model` feature.
 pub mod onnx_model; // issue #26: zero-dep ONNX LinearRegressor subset backend
 mod sbi_handler;
 
@@ -200,6 +205,29 @@ async fn main() -> Result<()> {
 
     nwdaf_context_init(nf_instance_id.clone(), args.max_subscriptions);
 
+    // Issue #109: the model URL notified to MLModelProvision consumers has to
+    // resolve back to this NF, so record our own SBI base. Uses the advertised
+    // address rather than the bind address: `0.0.0.0` is what we listen on, not
+    // somewhere a consumer can fetch from.
+    {
+        let scheme = if args.tls { "https" } else { "http" };
+        let host = if args.sbi_addr == "0.0.0.0" || args.sbi_addr == "::" {
+            log::warn!(
+                "SBI bound to {} — the ML model URL will advertise 127.0.0.1; set --sbi-addr \
+                 to a reachable address for consumers to download models (issue #109)",
+                args.sbi_addr
+            );
+            "127.0.0.1"
+        } else {
+            args.sbi_addr.as_str()
+        };
+        let base = format!("{scheme}://{host}:{}", args.sbi_port);
+        let ctx = nwdaf_self();
+        let guard = ctx.read().unwrap_or_else(|e| e.into_inner());
+        guard.set_sbi_base_uri(&base);
+        log::info!("SBI base URI for model provisioning: {base}");
+    }
+
     // Issue #26: optional prediction-model selection. Default (env unset) is
     // the OLS baseline — behavior-identical to the pre-#26 inline math.
     if let Ok(model_id) = std::env::var("NWDAF_PREDICTION_MODEL") {
@@ -353,8 +381,18 @@ async fn nwdaf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
             _ => send_method_not_allowed(method, "subscriptions/{id}"),
         },
 
+        // Nnwdaf_MLModelProvision model artefact (issue #109). The Subscribe/
+        // Notify half notifies an `mLFileAddr.mLModelUrl`; this is the route it
+        // resolves to, serving the active predictor as an ONNX LinearRegressor.
+        // The path segments identify the notification, not distinct models —
+        // there is one active predictor, so each URL serves the same artefact.
+        ["nnwdaf-mlmodelprovision", "v1", "models", _event, _sub_id] => match method {
+            "GET" => handle_ml_model_download().await,
+            _ => send_method_not_allowed(method, "models/{event}/{subscriptionId}"),
+        },
+
         // Nnwdaf_MLModelProvision service — TS 29.520 is a Subscribe/Notify
-        // resource on /subscriptions (there is no /models resource).
+        // resource on /subscriptions.
         ["nnwdaf-mlmodelprovision", "v1", "subscriptions"] => match method {
             "POST" => handle_ml_prov_subscription_create(&request).await,
             _ => send_method_not_allowed(method, "subscriptions"),
@@ -394,39 +432,59 @@ async fn nwdaf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
 /// [`SUPPORTED_EVENTS`] so consumers discover only analytics with a live
 /// collector. Additive JSON: the NRF ignores unknown NFProfile members, so
 /// registration behavior is otherwise unchanged.
+///
+/// The same honesty rule now applies to `nnwdaf-mlmodelprovision` (issue #109):
+/// it is advertised only when this NWDAF's active predictor has an exportable
+/// form, so a consumer that discovers the MTLF role can actually download a
+/// model. Advertising it unconditionally is what made it a facade — the notified
+/// URL 404'd.
 fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serde_json::Value {
     let event_ids: Vec<&'static str> = SUPPORTED_EVENTS.iter().map(|e| e.as_str()).collect();
+
+    let mut services = vec![
+        serde_json::json!({
+            "serviceInstanceId": format!("{}-nnwdaf-eventssubscription", nf_instance_id),
+            "serviceName": "nnwdaf-eventssubscription",
+            "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
+            "scheme": "http",
+            "nfServiceStatus": "REGISTERED",
+            "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
+        }),
+        serde_json::json!({
+            "serviceInstanceId": format!("{}-nnwdaf-analyticsinfo", nf_instance_id),
+            "serviceName": "nnwdaf-analyticsinfo",
+            "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
+            "scheme": "http",
+            "nfServiceStatus": "REGISTERED",
+            "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
+        }),
+    ];
+    if nwdaf_self()
+        .read()
+        .map(|ctx| ctx.can_provision_model())
+        .unwrap_or(false)
+    {
+        services.push(serde_json::json!({
+            "serviceInstanceId": format!("{}-nnwdaf-mlmodelprovision", nf_instance_id),
+            "serviceName": "nnwdaf-mlmodelprovision",
+            "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
+            "scheme": "http",
+            "nfServiceStatus": "REGISTERED",
+            "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
+        }));
+    } else {
+        log::warn!(
+            "not advertising nnwdaf-mlmodelprovision: the active prediction model has no \
+             exportable form, so no model artefact could be served (issue #109)"
+        );
+    }
+
     serde_json::json!({
         "nfInstanceId": nf_instance_id,
         "nfType": "NWDAF",
         "nfStatus": "REGISTERED",
         "ipv4Addresses": [sbi_addr],
-        "nfServices": [
-            {
-                "serviceInstanceId": format!("{}-nnwdaf-eventssubscription", nf_instance_id),
-                "serviceName": "nnwdaf-eventssubscription",
-                "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
-                "scheme": "http",
-                "nfServiceStatus": "REGISTERED",
-                "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
-            },
-            {
-                "serviceInstanceId": format!("{}-nnwdaf-analyticsinfo", nf_instance_id),
-                "serviceName": "nnwdaf-analyticsinfo",
-                "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
-                "scheme": "http",
-                "nfServiceStatus": "REGISTERED",
-                "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
-            },
-            {
-                "serviceInstanceId": format!("{}-nnwdaf-mlmodelprovision", nf_instance_id),
-                "serviceName": "nnwdaf-mlmodelprovision",
-                "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
-                "scheme": "http",
-                "nfServiceStatus": "REGISTERED",
-                "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
-            }
-        ],
+        "nfServices": services,
         "nwdafInfo": { "eventIds": event_ids },
         "allowedNfTypes": ["AMF", "SMF", "PCF", "NEF", "SCP"],
         "heartBeatTimer": 10
@@ -691,14 +749,122 @@ mod tests {
         assert_eq!(resp.status, 405, "GET on the notify callback must be 405");
     }
 
-    // --- nwafd-05: Nnwdaf_MLModelProvision is Subscribe/Notify, not /models ---
+    // --- nwafd-05 / issue #109: Nnwdaf_MLModelProvision is Subscribe/Notify on
+    //     /subscriptions, plus a model-artefact route the notified
+    //     mLFileAddr.mLModelUrl resolves to ---
 
     #[tokio::test]
-    async fn test_routing_mlmodelprovision_models_gone() {
-        // The bespoke /models registry resource no longer exists → 404.
+    async fn test_routing_mlmodelprovision_bespoke_registry_still_gone() {
+        // The old bespoke /models *registry* resource stays gone: the artefact
+        // route added by #109 is a GET on /models/{event}/{subscriptionId}, not
+        // a POST-able collection.
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
         let req = SbiRequest::post("/nnwdaf-mlmodelprovision/v1/models");
         let resp = nwdaf_sbi_request_handler(req).await;
-        assert_eq!(resp.status, 404, "the /models resource must be removed");
+        assert_eq!(resp.status, 404, "the /models registry must stay removed");
+    }
+
+    /// **The #109 acceptance test.** A GET on the notified `mLModelUrl` must
+    /// return 200 with a non-empty artefact — and not merely a well-formed one:
+    /// the bytes must parse back to a model that predicts what this NWDAF
+    /// predicts. Before #109 the URL was fabricated and this route 404'd.
+    #[tokio::test]
+    async fn test_ml_model_url_serves_a_real_downloadable_artefact() {
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
+
+        // Exactly the path a notification advertises.
+        let url = ml_service::model_url("http://x", "mlsub-1", AnalyticsId::NfLoad);
+        let path = url.strip_prefix("http://x").expect("built from the base");
+        let resp = nwdaf_sbi_request_handler(SbiRequest::get(path)).await;
+
+        assert_eq!(resp.status, 200, "the advertised model URL must be live");
+        assert_eq!(
+            resp.http.get_header("Content-Type").map(String::as_str),
+            Some(onnx_export::ONNX_CONTENT_TYPE)
+        );
+        let bytes = resp
+            .http
+            .binary_content
+            .as_ref()
+            .expect("the artefact is served as bytes, not JSON");
+        assert!(!bytes.is_empty(), "a non-empty model-file body");
+
+        // The load-bearing assertion: this really is the NWDAF's model.
+        let parsed = onnx_model::OnnxLinearRegressor::from_bytes(bytes, "onnx:served")
+            .expect("the served bytes are a valid ONNX LinearRegressor");
+        let series = [0.2, 0.35, 0.4, 0.55, 0.6];
+        let (expected, _) =
+            ml_service::InferenceModel::predict_series(&ml_service::OlsLinearModel, &series)
+                .expect("baseline predicts");
+        let (actual, _) = ml_service::InferenceModel::predict_series(&parsed, &series)
+            .expect("served model predicts");
+        assert!(
+            (expected - actual).abs() < 1e-6,
+            "the downloaded model must reproduce the NWDAF's own prediction \
+             (expected {expected}, got {actual})"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ml_model_route_rejects_non_get() {
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
+        let req = SbiRequest::post("/nnwdaf-mlmodelprovision/v1/models/NF_LOAD/mlsub-1");
+        let resp = nwdaf_sbi_request_handler(req).await;
+        assert_eq!(resp.status, 405);
+    }
+
+    /// The profile advertises the MTLF service only when a model can actually be
+    /// served. Advertising it unconditionally is what made it a facade.
+    #[tokio::test]
+    async fn test_profile_advertises_mlmodelprovision_only_when_exportable() {
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
+
+        let profile = build_nf_profile("nwdaf-test", "10.0.0.5", 7777);
+        let names: Vec<&str> = profile["nfServices"]
+            .as_array()
+            .expect("nfServices")
+            .iter()
+            .filter_map(|s| s["serviceName"].as_str())
+            .collect();
+        assert!(
+            names.contains(&"nnwdaf-mlmodelprovision"),
+            "the default OLS predictor is exportable, so the service is advertised: {names:?}"
+        );
+
+        // Swap in a predictor with no fixed-window linear form.
+        {
+            let ctx = nwdaf_self();
+            let guard = ctx.read().expect("ctx");
+            guard
+                .lock_engine()
+                .set_predictor(Box::new(ml_service::EwmaModel::default()));
+        }
+        let profile = build_nf_profile("nwdaf-test", "10.0.0.5", 7777);
+        let names: Vec<&str> = profile["nfServices"]
+            .as_array()
+            .expect("nfServices")
+            .iter()
+            .filter_map(|s| s["serviceName"].as_str())
+            .collect();
+        assert!(
+            !names.contains(&"nnwdaf-mlmodelprovision"),
+            "a NWDAF that cannot serve a model must not claim the MTLF role: {names:?}"
+        );
+        // ...and the route says so rather than serving something wrong.
+        let resp = nwdaf_sbi_request_handler(SbiRequest::get(
+            "/nnwdaf-mlmodelprovision/v1/models/NF_LOAD/mlsub-1",
+        ))
+        .await;
+        assert_eq!(resp.status, 404);
+
+        // Restore the default so test order cannot leak this predictor.
+        {
+            let ctx = nwdaf_self();
+            let guard = ctx.read().expect("ctx");
+            guard
+                .lock_engine()
+                .set_predictor(Box::new(ml_service::OlsLinearModel));
+        }
     }
 
     #[tokio::test]

--- a/src/bins/nextgcore-nwdafd/src/ml_service.rs
+++ b/src/bins/nextgcore-nwdafd/src/ml_service.rs
@@ -440,18 +440,47 @@ pub fn ml_prov_subsc_json(sub: &MlProvSubscription) -> Value {
     Value::Object(obj)
 }
 
-/// Synthesize the model-file address advertised in a notification.
+/// The model-file address advertised in a notification.
 ///
-/// HONESTY NOTE: this NWDAF is a linear-regression analytics prototype, not an
-/// MTLF that trains and exports real ML model files. The URL is a stable,
-/// well-formed placeholder so a conformant consumer can parse `mLFileAddr`; no
-/// downloadable model artefact exists behind it.
-fn synthetic_model_url(sub_id: &str, event: AnalyticsId) -> String {
+/// SCOPE NOTE (issue #109): this NWDAF is a linear-regression analytics engine,
+/// not an MTLF with a training pipeline. What it *can* do honestly is export the
+/// predictor it actually runs: the URL below resolves to a live route on this NF
+/// serving an ONNX `LinearRegressor` whose output equals this NWDAF's own
+/// prediction (see [`crate::onnx_export`]). It replaced a fabricated
+/// `http://nwdaf/...` placeholder that no route served, so a consumer that
+/// dereferenced it got a 404.
+///
+/// `Nnwdaf_MLModelMonitor`, `Nnwdaf_MLModelInfo` and `/transfers` subscription
+/// continuity (`prevSub` / `consNfInfo`) remain **unimplemented** and are out of
+/// scope for #109, which tracks only the MLModelProvision artefact.
+///
+/// The `{event}`/`{sub_id}` segments identify the notification, not distinct
+/// models: there is one active predictor, so every URL serves the same artefact.
+/// They are kept because a consumer echoes back the URL it was given.
+pub fn model_url(base: &str, sub_id: &str, event: AnalyticsId) -> String {
     format!(
-        "http://nwdaf/nnwdaf-mlmodelprovision/v1/models/{}/{}",
+        "{}/nnwdaf-mlmodelprovision/v1/models/{}/{}",
+        base.trim_end_matches('/'),
         event.as_str(),
         sub_id
     )
+}
+
+/// The ONNX bytes this NWDAF serves for its active predictor, or `None` when the
+/// predictor has no fixed-window linear form and therefore cannot be provisioned.
+///
+/// `None` is what makes the advertisement honest: the caller must then neither
+/// register `nnwdaf-mlmodelprovision` in the NF profile nor emit an
+/// `mLFileAddr.mLModelUrl`.
+pub fn active_model_onnx(model: &dyn InferenceModel) -> Option<Vec<u8>> {
+    let (coefficients, intercept) = model.linear_form()?;
+    if coefficients.is_empty() {
+        return None;
+    }
+    Some(crate::onnx_export::encode_linear_regressor(
+        &coefficients,
+        intercept,
+    ))
 }
 
 /// Build the `Nnwdaf_MLModelProvision` notification callback body for a
@@ -461,7 +490,16 @@ fn synthetic_model_url(sub_id: &str, event: AnalyticsId) -> String {
 /// (minItems 1); each carries the required `subscriptionId` and `eventNotifs[]`
 /// of `MLEventNotif`, where every `MLEventNotif` satisfies the `oneOf` by
 /// supplying `mLFileAddr.mLModelUrl`.
-pub fn build_ml_model_prov_notif_body(sub: &MlProvSubscription) -> Value {
+///
+/// `model_base_uri` is `None` when this NWDAF's active predictor has no
+/// exportable form, in which case `mLFileAddr` is omitted rather than pointing
+/// at a URL that would 404 — the defect #109 fixed. A build in that state also
+/// does not advertise the service, so a conformant consumer never subscribes and
+/// never sees the truncated notification.
+pub fn build_ml_model_prov_notif_body(
+    sub: &MlProvSubscription,
+    model_base_uri: Option<&str>,
+) -> Value {
     let event_notifs: Vec<Value> = sub
         .ml_events
         .iter()
@@ -471,10 +509,12 @@ pub fn build_ml_model_prov_notif_body(sub: &MlProvSubscription) -> Value {
             if let Some(corr) = &sub.notif_corr_id {
                 notif.insert("notifCorreId".to_string(), json!(corr));
             }
-            notif.insert(
-                "mLFileAddr".to_string(),
-                json!({ "mLModelUrl": synthetic_model_url(&sub.subscription_id, *ev) }),
-            );
+            if let Some(base) = model_base_uri {
+                notif.insert(
+                    "mLFileAddr".to_string(),
+                    json!({ "mLModelUrl": model_url(base, &sub.subscription_id, *ev) }),
+                );
+            }
             Value::Object(notif)
         })
         .collect();
@@ -688,7 +728,7 @@ mod tests {
             Some("corr-9".to_string()),
             vec![AnalyticsId::NfLoad],
         );
-        let body = build_ml_model_prov_notif_body(&sub);
+        let body = build_ml_model_prov_notif_body(&sub, Some("http://10.0.0.5:7777"));
 
         let arr = body.as_array().expect("callback body is an array");
         assert_eq!(arr.len(), 1, "minItems 1 array of NwdafMLModelProvNotif");
@@ -701,13 +741,59 @@ mod tests {
         assert_eq!(evns.len(), 1);
         assert_eq!(evns[0]["event"].as_str(), Some("NF_LOAD"));
         assert_eq!(evns[0]["notifCorreId"].as_str(), Some("corr-9"));
-        assert!(
-            evns[0]["mLFileAddr"]["mLModelUrl"].as_str().is_some(),
-            "MLEventNotif must satisfy the oneOf via mLFileAddr.mLModelUrl"
+        // Issue #109: the URL must point at THIS NF's live route, not the old
+        // fabricated `http://nwdaf/...` that nothing served.
+        assert_eq!(
+            evns[0]["mLFileAddr"]["mLModelUrl"].as_str(),
+            Some("http://10.0.0.5:7777/nnwdaf-mlmodelprovision/v1/models/NF_LOAD/mlsub-9")
         );
         // No bespoke registry keys leak into the notification.
         assert!(notif.get("modelCount").is_none());
         assert!(notif.get("accuracy").is_none());
+    }
+
+    /// With no exportable model there is no URL to advertise, so `mLFileAddr` is
+    /// omitted rather than pointing somewhere that would 404 — the #109 defect.
+    #[test]
+    fn test_notif_body_omits_model_addr_when_nothing_is_exportable() {
+        let sub = MlProvSubscription::new(
+            "mlsub-10".to_string(),
+            "http://anlf.local/ml-cb".to_string(),
+            None,
+            vec![AnalyticsId::NfLoad],
+        );
+        let body = build_ml_model_prov_notif_body(&sub, None);
+        let evns = body[0]["eventNotifs"].as_array().expect("eventNotifs");
+        assert!(
+            evns[0].get("mLFileAddr").is_none(),
+            "a URL that cannot be served must not be emitted at all"
+        );
+    }
+
+    /// The two baselines differ in whether they can be provisioned at all, and
+    /// that difference is what gates the advertisement (#109).
+    #[test]
+    fn test_only_fixed_window_models_are_exportable() {
+        let (coefs, intercept) = OlsLinearModel
+            .linear_form()
+            .expect("OLS extrapolation is a fixed-window linear function");
+        assert_eq!(coefs.len(), OLS_EXPORT_WINDOW);
+        assert_eq!(intercept, 0.0);
+        // n = 5 closed form, verified against the OLS fit in onnx_export tests.
+        let expected = [-0.4, -0.1, 0.2, 0.5, 0.8];
+        for (got, want) in coefs.iter().zip(expected) {
+            assert!((got - want).abs() < 1e-9, "got {coefs:?}");
+        }
+        assert!(active_model_onnx(&OlsLinearModel).is_some());
+
+        // EWMA's weights span the whole observed series, so no fixed-window
+        // artefact could reproduce it; exporting a truncation would ship bytes
+        // that disagree with this NWDAF's own analytics.
+        assert!(
+            EwmaModel::default().linear_form().is_none(),
+            "EWMA must report no exportable form rather than a truncated one"
+        );
+        assert!(active_model_onnx(&EwmaModel::default()).is_none());
     }
 }
 
@@ -728,7 +814,61 @@ pub trait InferenceModel: Send + Sync {
     /// Returns `(prediction clamped to 0..=1, confidence 0..=1)`, or `None`
     /// when the series is empty or shorter than the model's input window.
     fn predict_series(&self, series: &[f64]) -> Option<(f64, f64)>;
+
+    /// This model as a fixed-window linear function — `(coefficients, intercept)`
+    /// applied to the last `coefficients.len()` samples, oldest first — or `None`
+    /// when it has no such form.
+    ///
+    /// This is what `Nnwdaf_MLModelProvision` can export as an ONNX
+    /// `LinearRegressor` (issue #109). Returning `None` is a real answer, not a
+    /// gap to fill: a model whose weights depend on the whole observed series
+    /// rather than a fixed window cannot be truncated into a fixed-window
+    /// artefact without predicting differently from the NWDAF that served it,
+    /// and shipping bytes that disagree with our own analytics would be the same
+    /// class of dishonesty as the placeholder URL #109 removed. Callers must
+    /// treat `None` as "this NWDAF cannot provision a model" and neither
+    /// advertise the service nor emit an `mLModelUrl`.
+    fn linear_form(&self) -> Option<(Vec<f64>, f64)> {
+        None
+    }
 }
+
+/// Weights of the ordinary-least-squares one-step extrapolator over a window of
+/// `n` samples, oldest first.
+///
+/// [`OlsLinearModel`] stores no coefficients — it re-fits OLS on every call — but
+/// the fit over a *fixed* window width is a fixed linear function of that window,
+/// which is what makes the model exportable (issue #109). Fitting `y = a + b·x`
+/// at `x = 0..n-1` and evaluating at `x = n` gives, per sample `i`:
+///
+/// ```text
+/// w_i = 1/n + (i - x̄)·(n - x̄) / Σ(i - x̄)²        x̄ = (n - 1) / 2
+/// ```
+///
+/// For `n = 5` that is `[-0.4, -0.1, 0.2, 0.5, 0.8]`. The weights always sum to
+/// 1 (a flat series predicts itself) and map the ramp `0..n-1` to `n`.
+///
+/// Returns an empty vector for `n < 2`, which has no fit — matching
+/// `predict_series`, which reports the last sample with zero confidence there.
+pub fn ols_window_weights(n: usize) -> Vec<f64> {
+    if n < 2 {
+        return Vec::new();
+    }
+    let nf = n as f64;
+    let x_bar = (nf - 1.0) / 2.0;
+    let s_xx: f64 = (0..n).map(|i| (i as f64 - x_bar).powi(2)).sum();
+    (0..n)
+        .map(|i| 1.0 / nf + (i as f64 - x_bar) * (nf - x_bar) / s_xx)
+        .collect()
+}
+
+/// The window width [`OlsLinearModel`] settles on once it has enough history.
+///
+/// `predict_series` uses `min(series.len(), 5)`, so this is the widest — and for
+/// any series the analytics engine has been running on, the actual — window. It
+/// is the one exported, because a narrower export would disagree with the
+/// NWDAF's own prediction on exactly the series a consumer cares about.
+pub const OLS_EXPORT_WINDOW: usize = 5;
 
 /// Default baseline: ordinary-least-squares linear fit over the last ≤5
 /// samples — byte-for-byte the math `AnalyticsEngine::compute_nf_load`
@@ -777,6 +917,11 @@ impl InferenceModel for OlsLinearModel {
             (1.0 - ss_res / ss_tot).clamp(0.0, 1.0)
         };
         Some((predicted, r_squared))
+    }
+
+    fn linear_form(&self) -> Option<(Vec<f64>, f64)> {
+        // Exact, not an approximation: see `ols_window_weights`.
+        Some((ols_window_weights(OLS_EXPORT_WINDOW), 0.0))
     }
 }
 
@@ -830,6 +975,13 @@ impl InferenceModel for EwmaModel {
         let confidence = (1.0 - abs_err_sum / rest.len() as f64).clamp(0.0, 1.0);
         Some((ewma.clamp(0.0, 1.0), confidence))
     }
+
+    // `linear_form` is deliberately left at the `None` default. EWMA *is* a
+    // weighted sum, but its weights decay over the whole observed series rather
+    // than a fixed window: the prediction after k samples depends on all k. Any
+    // fixed-window export would therefore predict differently from this NWDAF,
+    // so there is no honest artefact to serve and #109's answer here is to
+    // advertise nothing.
 }
 
 /// Wrapper giving the boxed active model `Debug` + `Default` (the analytics

--- a/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
+++ b/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
@@ -481,8 +481,15 @@ pub async fn dispatch_notifications(ctx: Arc<RwLock<NwdafContext>>) {
 /// to its `notifUri` and, on success, mark it delivered so it is not re-sent.
 /// This reuses the same URI parsing + client plumbing as the analytics path.
 async fn dispatch_ml_prov_notifications(ctx: Arc<RwLock<NwdafContext>>) {
-    let pending = match ctx.read() {
-        Ok(guard) => guard.get_pending_ml_prov_subscriptions(),
+    // The model URL must resolve back to this NF, and is only emitted when the
+    // active predictor is actually exportable (issue #109). Both are read once
+    // here, under the same guard as the pending list, rather than per
+    // subscription.
+    let (pending, model_base_uri) = match ctx.read() {
+        Ok(guard) => {
+            let base = guard.can_provision_model().then(|| guard.sbi_base_uri());
+            (guard.get_pending_ml_prov_subscriptions(), base)
+        }
         Err(e) => {
             log::error!("dispatch_ml_prov_notifications: failed to read context: {e}");
             return;
@@ -490,7 +497,8 @@ async fn dispatch_ml_prov_notifications(ctx: Arc<RwLock<NwdafContext>>) {
     };
 
     for sub in &pending {
-        let body = crate::ml_service::build_ml_model_prov_notif_body(sub);
+        let body =
+            crate::ml_service::build_ml_model_prov_notif_body(sub, model_base_uri.as_deref());
 
         let (host, port, path) = match parse_notify_uri(&sub.notif_uri) {
             Some(t) => t,

--- a/src/bins/nextgcore-nwdafd/src/onnx_export.rs
+++ b/src/bins/nextgcore-nwdafd/src/onnx_export.rs
@@ -1,0 +1,182 @@
+//! ONNX export for the NWDAF's active prediction model (issue #109).
+//!
+//! The counterpart to [`crate::onnx_model`]'s reader: a zero-dependency writer
+//! for the same minimal subset — a single `ai.onnx.ml` `LinearRegressor` node
+//! with `coefficients` and `intercepts` attributes. Hand-rolled protobuf, in the
+//! house style of the reader and of this repo's other wire codecs.
+//!
+//! ## Why this can be honest
+//!
+//! `Nnwdaf_MLModelProvision` (TS 29.520 §4.2.2.5) exists to hand a consumer a
+//! model it can download and run. Before #109 the NWDAF advertised the service
+//! and notified a fabricated URL that no route served, so a conformant AnLF got
+//! a 404 — a facade.
+//!
+//! What makes a real export possible is that the default predictor's arithmetic
+//! *is* a fixed-window linear model. `OlsLinearModel` re-fits ordinary least
+//! squares over its window on every call and stores no coefficients, but OLS
+//! extrapolation over a window of fixed width `n` is a fixed linear function of
+//! that window (see [`crate::ml_service::ols_window_weights`]). So the bytes
+//! served here reproduce the NWDAF's own prediction rather than approximating
+//! it — verified by test against `OlsLinearModel::predict_series`.
+//!
+//! A model whose weights are *not* a fixed-window linear form (EWMA, whose
+//! weights depend on the whole observed series) reports no linear form and is
+//! never exported, rather than being truncated into something that would predict
+//! differently from the NWDAF that served it.
+
+/// Protobuf wire type for length-delimited fields.
+const WT_LEN: u64 = 2;
+/// Protobuf wire type for varint fields.
+const WT_VARINT: u64 = 0;
+
+/// The media type a model artefact is served with.
+pub const ONNX_CONTENT_TYPE: &str = "application/octet-stream";
+
+fn put_varint(buf: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let byte = (v & 0x7f) as u8;
+        v >>= 7;
+        if v == 0 {
+            buf.push(byte);
+            break;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
+fn put_len_field(buf: &mut Vec<u8>, field: u64, payload: &[u8]) {
+    put_varint(buf, (field << 3) | WT_LEN);
+    put_varint(buf, payload.len() as u64);
+    buf.extend_from_slice(payload);
+}
+
+/// One `AttributeProto` carrying a packed `floats` list.
+///
+/// The reader accepts both the packed and the per-element proto2 encodings; the
+/// packed form is written here because it is the more compact of the two.
+fn attr_floats(name: &str, values: &[f64]) -> Vec<u8> {
+    let mut attr = Vec::new();
+    put_len_field(&mut attr, 1, name.as_bytes()); // AttributeProto.name
+    let mut packed = Vec::with_capacity(values.len() * 4);
+    for v in values {
+        // ONNX AttributeProto.floats is float32; the reader widens back to f64.
+        packed.extend_from_slice(&(*v as f32).to_le_bytes());
+    }
+    put_len_field(&mut attr, 7, &packed); // AttributeProto.floats
+    attr
+}
+
+fn attr_int(name: &str, v: u64) -> Vec<u8> {
+    let mut attr = Vec::new();
+    put_len_field(&mut attr, 1, name.as_bytes()); // AttributeProto.name
+    put_varint(&mut attr, (3 << 3) | WT_VARINT); // AttributeProto.i
+    put_varint(&mut attr, v);
+    attr
+}
+
+/// Serialize a single-output `ai.onnx.ml LinearRegressor` `ModelProto`.
+///
+/// `coefficients` are the weights applied to the last `coefficients.len()`
+/// samples of the input series, oldest first — the same orientation the reader
+/// expects. `targets: 1` is written explicitly so a consumer (and our own
+/// reader, which rejects `targets != 1`) sees the model is single-output rather
+/// than having to infer it.
+pub fn encode_linear_regressor(coefficients: &[f64], intercept: f64) -> Vec<u8> {
+    let mut node = Vec::new();
+    put_len_field(&mut node, 4, b"LinearRegressor"); // NodeProto.op_type
+    put_len_field(&mut node, 7, b"ai.onnx.ml"); // NodeProto.domain
+    put_len_field(&mut node, 5, &attr_floats("coefficients", coefficients));
+    put_len_field(&mut node, 5, &attr_floats("intercepts", &[intercept]));
+    put_len_field(&mut node, 5, &attr_int("targets", 1));
+
+    let mut graph = Vec::new();
+    put_len_field(&mut graph, 1, &node); // GraphProto.node
+
+    let mut model = Vec::new();
+    put_len_field(&mut model, 7, &graph); // ModelProto.graph
+    model
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ml_service::{ols_window_weights, InferenceModel, OlsLinearModel};
+    use crate::onnx_model::OnnxLinearRegressor;
+
+    /// The exported bytes must parse back through our own reader, and the
+    /// resulting model must predict what the NWDAF itself predicts. This is the
+    /// assertion that separates a real artefact from a merely well-formed one:
+    /// a consumer that downloads this file and runs it gets the NWDAF's answer.
+    #[test]
+    fn exported_ols_model_reproduces_the_nwdaf_prediction() {
+        let (coefficients, intercept) = OlsLinearModel
+            .linear_form()
+            .expect("the OLS baseline is exportable");
+        let bytes = encode_linear_regressor(&coefficients, intercept);
+        let parsed = OnnxLinearRegressor::from_bytes(&bytes, "onnx:exported").expect("round-trips");
+
+        // Series long enough for the exported window, with varied shapes.
+        let cases: [&[f64]; 5] = [
+            &[0.1, 0.15, 0.2, 0.25, 0.3],
+            &[0.9, 0.7, 0.5, 0.3, 0.1],
+            &[0.5, 0.5, 0.5, 0.5, 0.5],
+            &[0.2, 0.9, 0.1, 0.8, 0.3],
+            &[0.05, 0.1, 0.2, 0.4, 0.8],
+        ];
+        for series in cases {
+            let (expected, _) = OlsLinearModel
+                .predict_series(series)
+                .expect("baseline predicts");
+            let (actual, _) = parsed.predict_series(series).expect("export predicts");
+            assert!(
+                (expected - actual).abs() < 1e-6,
+                "exported model must reproduce the NWDAF's prediction for {series:?}: \
+                 expected {expected}, got {actual}"
+            );
+        }
+    }
+
+    /// The closed-form weights must equal the OLS fit for every window width the
+    /// baseline can use, not just the one that is exported.
+    #[test]
+    fn window_weights_match_the_ols_fit_for_every_width() {
+        for n in 2..=5 {
+            let weights = ols_window_weights(n);
+            assert_eq!(weights.len(), n);
+            // A flat series predicts itself, so the weights sum to 1.
+            let sum: f64 = weights.iter().sum();
+            assert!((sum - 1.0).abs() < 1e-9, "n={n} weights sum to {sum}");
+
+            // A ramp 0,1,..,n-1 extrapolates to n.
+            let ramp: Vec<f64> = (0..n).map(|i| i as f64).collect();
+            let predicted: f64 = weights.iter().zip(&ramp).map(|(w, y)| w * y).sum();
+            assert!(
+                (predicted - n as f64).abs() < 1e-9,
+                "n={n} ramp extrapolation gave {predicted}, expected {n}"
+            );
+        }
+    }
+
+    #[test]
+    fn encoded_model_declares_single_output_and_the_ml_domain() {
+        let bytes = encode_linear_regressor(&[-0.4, -0.1, 0.2, 0.5, 0.8], 0.0);
+        // The reader rejects targets != 1 and non-LinearRegressor ops, so a
+        // successful parse pins both.
+        let parsed = OnnxLinearRegressor::from_bytes(&bytes, "x").expect("parses");
+        assert_eq!(parsed.model_id(), "x");
+        assert!(bytes.windows(10).any(|w| w == b"ai.onnx.ml"));
+        assert!(!bytes.is_empty());
+    }
+
+    /// An intercept must survive the round trip, since a loaded ONNX model may
+    /// carry a non-zero one even though the OLS export does not.
+    #[test]
+    fn intercept_round_trips() {
+        let bytes = encode_linear_regressor(&[0.5, 0.5], 0.25);
+        let parsed = OnnxLinearRegressor::from_bytes(&bytes, "x").expect("parses");
+        // 0.25 + 0.5*0.1 + 0.5*0.1 = 0.35
+        let (pred, _) = parsed.predict_series(&[0.1, 0.1]).expect("predicts");
+        assert!((pred - 0.35).abs() < 1e-6, "got {pred}");
+    }
+}

--- a/src/bins/nextgcore-nwdafd/src/onnx_model.rs
+++ b/src/bins/nextgcore-nwdafd/src/onnx_model.rs
@@ -199,6 +199,13 @@ impl InferenceModel for OnnxLinearRegressor {
         &self.model_id
     }
 
+    fn linear_form(&self) -> Option<(Vec<f64>, f64)> {
+        // Already a fixed-window linear model, so re-exporting it is lossless
+        // apart from the f64 -> f32 narrowing ONNX's `floats` attribute imposes,
+        // which the input file had already been through.
+        Some((self.coefficients.clone(), self.intercept))
+    }
+
     fn predict_series(&self, series: &[f64]) -> Option<(f64, f64)> {
         let n = self.coefficients.len();
         if n == 0 || series.len() < n {
@@ -509,6 +516,11 @@ mod tests {
             .contains("duplicate ModelProto.graph"));
     }
 
+    /// Gated on the feature, not on the module: #109 ungated this module so the
+    /// reader can verify what `onnx_export` writes, but loading an
+    /// *operator-supplied file* via `onnx:<path>` is still the opt-in part, and
+    /// `ml_service::load_model` refuses it without the feature.
+    #[cfg(feature = "onnx-model")]
     #[test]
     fn load_model_via_ml_service_roundtrips_a_file() {
         let bytes = model_bytes("LinearRegressor", &[-1.0, 2.0], &[0.0]);

--- a/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
+++ b/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
@@ -825,6 +825,46 @@ pub async fn handle_ml_prov_subscription_delete(subscription_id: &str) -> SbiRes
     }
 }
 
+/// Serve the ML model artefact a `Nnwdaf_MLModelProvision` notification pointed
+/// at (issue #109, TS 29.520 §4.2.2.5).
+///
+/// Returns the active predictor serialized as an ONNX `ai.onnx.ml
+/// LinearRegressor` — bytes that reproduce this NWDAF's own prediction, not a
+/// stand-in. Before #109 the notified URL was a fabricated `http://nwdaf/...`
+/// that no route served, so a consumer following it got a 404.
+///
+/// A 404 here means this NWDAF's active predictor has no exportable
+/// fixed-window linear form (e.g. EWMA), which is also the state in which the
+/// service is not advertised and no URL is emitted — so a conformant consumer
+/// should never reach this branch.
+pub async fn handle_ml_model_download() -> SbiResponse {
+    let ctx = nwdaf_self();
+    let bytes = match ctx.read() {
+        Ok(context) => context.active_model_onnx(),
+        Err(e) => {
+            log::error!("ML model download: failed to read context: {e}");
+            None
+        }
+    };
+
+    match bytes {
+        Some(bytes) => {
+            log::debug!("Serving ONNX model artefact ({} bytes)", bytes.len());
+            let mut response = SbiResponse::with_status(200);
+            response
+                .http
+                .set_header("Content-Type", crate::onnx_export::ONNX_CONTENT_TYPE);
+            response.http.binary_content = Some(bytes.into());
+            response
+        }
+        None => send_not_found(
+            "this NWDAF's active prediction model has no exportable form, so no \
+             model artefact can be provisioned",
+            Some("MODEL_NOT_AVAILABLE"),
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/libs/nextgcore-sbi/src/message.rs
+++ b/src/libs/nextgcore-sbi/src/message.rs
@@ -192,6 +192,17 @@ pub struct SbiHttpMessage {
     pub headers: HashMap<String, String>,
     /// Body content
     pub content: Option<String>,
+    /// Binary body content, for responses whose payload is not text.
+    ///
+    /// `content` is a `String`, so it cannot carry an arbitrary octet stream —
+    /// a downloadable artefact (e.g. the NWDAF's ONNX model file, TS 29.520
+    /// §4.2.2.5) would otherwise have to be base64'd into JSON or wrapped in
+    /// `multipart/related`, neither of which is what a consumer dereferencing a
+    /// file URL expects. When this is set and [`Self::parts`] is empty, the
+    /// server writes these bytes as the whole body verbatim.
+    ///
+    /// Defaults to `None`, so every existing response is byte-unchanged.
+    pub binary_content: Option<Bytes>,
     /// Multipart parts
     pub parts: Vec<SbiPart>,
 }

--- a/src/libs/nextgcore-sbi/src/server.rs
+++ b/src/libs/nextgcore-sbi/src/server.rs
@@ -695,6 +695,11 @@ fn convert_response(mut sbi_response: SbiResponse) -> Response<Full<Bytes>> {
             &sbi_response.http.parts,
             &boundary,
         ))
+    } else if let Some(binary) = sbi_response.http.binary_content.clone() {
+        // A non-text body (e.g. a downloadable model artefact) goes out
+        // verbatim. Checked after `parts` so multipart still wins, and before
+        // `content` so a handler cannot accidentally send both.
+        binary
     } else {
         sbi_response
             .http
@@ -1284,6 +1289,50 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("SMF-54804518-abcd")
         );
+    }
+
+    /// `binary_content` carries a non-text body verbatim (the NWDAF's ONNX model
+    /// artefact, issue #109), and — the part that matters for every other NF —
+    /// leaving it `None` keeps the JSON path byte-identical.
+    #[tokio::test]
+    async fn test_convert_response_binary_body_is_verbatim_and_opt_in() {
+        use http_body_util::BodyExt;
+
+        async fn body_bytes(resp: Response<Full<Bytes>>) -> Vec<u8> {
+            resp.into_body()
+                .collect()
+                .await
+                .expect("collect body")
+                .to_bytes()
+                .to_vec()
+        }
+
+        // Not valid UTF-8, so this could not have gone through `content`.
+        let artefact: Vec<u8> = vec![0x08, 0x01, 0xFF, 0xFE, 0x00, 0x7F];
+        let mut resp = SbiResponse::with_status(200);
+        resp.http
+            .set_header("Content-Type", "application/octet-stream");
+        resp.http.binary_content = Some(Bytes::from(artefact.clone()));
+        let hyper = convert_response(resp);
+        assert_eq!(hyper.status(), 200);
+        assert_eq!(
+            body_bytes(hyper).await,
+            artefact,
+            "bytes must go out unchanged"
+        );
+
+        // The default: no binary content → the text body wins, exactly as before.
+        let json = SbiResponse::ok().with_body("{\"a\":1}", "application/json");
+        assert!(json.http.binary_content.is_none());
+        assert_eq!(
+            body_bytes(convert_response(json)).await,
+            b"{\"a\":1}".to_vec()
+        );
+
+        // Neither set → empty body, as before.
+        assert!(body_bytes(convert_response(SbiResponse::with_status(204)))
+            .await
+            .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #109.

The NWDAF advertised `nnwdaf-mlmodelprovision` in its NRF profile and notified `mLFileAddr.mLModelUrl = http://nwdaf/...` — a fabricated placeholder no route served, so any AnLF that dereferenced it got a 404. #109 offered two honest resolutions: withdraw the advertisement, or serve a real artefact. **Serving**, per the maintainer's call.

## What makes this honest rather than a nicer placeholder

`OlsLinearModel` — the default predictor — stores no coefficients: it re-fits ordinary least squares over the last ≤5 samples on every call, so there is seemingly nothing to export. But OLS extrapolation over a **fixed** window is algebraically a fixed linear function of that window:

```
w_i = 1/n + (i - x̄)·(n - x̄) / Σ(i - x̄)²        x̄ = (n-1)/2
```

For `n = 5` that is `[-0.4, -0.1, 0.2, 0.5, 0.8]`, intercept 0 — the weights sum to 1, so a flat series predicts itself, and the ramp `0..n-1` maps to `n`. Derived on paper, then **checked numerically against the live `predict_series`** over 4000 random windows for `n = 2..5`: max absolute difference `8.9e-16`, i.e. exact to floating point.

So the exported ONNX `ai.onnx.ml LinearRegressor` **is** this NWDAF's predictor, not a stand-in for it. The test closes the loop rather than checking shape: it serves the bytes, parses them back through our own reader, and asserts the parsed model predicts what `OlsLinearModel` predicts. "Returns 200 with a non-empty body" would have passed for a well-formed lie.

A useful cross-check: the `n = 2` case is `[-1.0, 2.0]`, which is independently the model the pre-existing `onnx_model` test uses as an *"exact one-step extrapolation of any arithmetic series"*.

## Capability now gates the advertisement

`InferenceModel` gained `linear_form() -> Option<(Vec<f64>, f64)>`:

| Model | `linear_form()` | Why |
|---|---|---|
| `OlsLinearModel` | `Some(n=5 closed form, 0.0)` | exact, per the algebra above |
| `OnnxLinearRegressor` | `Some((coefficients, intercept))` | it already *is* one |
| `EwmaModel` | **`None`** | weights decay over the whole observed series, not a fixed window |

`EwmaModel` returning `None` is the load-bearing decision. A truncated EWMA export would ship bytes that **disagree with our own analytics** — the same class of dishonesty as the placeholder URL. So rather than special-casing it, capability became the gate: `build_nf_profile` advertises the service, and the notification carries an `mLFileAddr`, **only** when the active predictor is exportable.

That means this PR satisfies #109's *serve* criteria in the default configuration **and** its *withdraw* criteria wherever serving is impossible — instead of advertising unconditionally and hoping. The default trait impl is `None`, so a future non-linear model is automatically un-advertised rather than silently mis-exported.

## One additive change to the shared SBI crate

`SbiHttpMessage.content` is an `Option<String>`, so a single-part body cannot carry protobuf. Both alternatives were facades for a model-**download** URL: base64-in-JSON, or `multipart/related` (which the crate does support, but 3GPP uses it for N1N2 containers, not artefacts).

So `SbiHttpMessage` gained `binary_content: Option<Bytes>`, preferred by `convert_response` when `parts` is empty. Default `None`, so no other NF's bytes change — and that is **pinned by a test rather than asserted**: non-UTF-8 bytes go out verbatim, an unset field still takes the `content` path, and neither set is still an empty body.

## Feature-gating change worth reviewing

`onnx_model` stops being feature-gated at the module level, so the reader can verify what the new writer produces. Reading **operator-supplied** files is still the opt-in part — the `onnx:<path>` arm of `load_model` stays behind `onnx-model`, and the one test that exercises file loading moved behind the feature with it. Its premise was "this module only exists with the feature", which is now narrower than the module.

## Also

- The model URL is built from this NF's own SBI base, recorded at startup from the **advertised** address rather than the bind address — `0.0.0.0` is where we listen, not somewhere a consumer can fetch from — with a warning when that is all we have.
- The in-source HONESTY NOTE is rewritten as a SCOPE NOTE.
- `Nnwdaf_MLModelMonitor`, `Nnwdaf_MLModelInfo` and `/transfers` subscription continuity are documented in-source as unimplemented and out of scope for #109 (acceptance criterion 6).

## Not fixed here

No training pipeline, no model versioning, no persistence. The artefact is the active predictor's closed form — which is precisely what lets it be truthful about what it is.

## Verification

Workspace **5567 passed / 0 failed** (baseline 5553). nwdafd **122 passed without** the `onnx-model` feature and **123 with** it — both configurations were run, because ungating the module changed which tests compile. `cargo fmt` clean; `clippy -D warnings` clean on `nextgcore-sbi` and `nextgcore-nwdafd`.

The replaced `test_routing_mlmodelprovision_models_gone` asserted that `/models` must 404 — exactly what this issue reverses. Its successor keeps the POST-registry 404 and adds the GET-artefact 200.

Spec: `specs/fix-nwdaf-mlmodelprovision-artefact.md`