### PR TITLE
feat(nwdafd): drive subscription duration from evtReq and terminate with termCause (closes #108)

### DIFF
--- a/src/bins/nextgcore-nwdafd/src/context.rs
+++ b/src/bins/nextgcore-nwdafd/src/context.rs
@@ -441,6 +441,38 @@ pub struct AnalyticsSubscription {
     pub repetition_period_secs: Option<u64>,
     /// Unix timestamp of the last successfully dispatched notification.
     pub last_notification_time: Option<u64>,
+    /// `evtReq.maxReportNbr` (TS 29.523 `ReportingInformation`): stop after this
+    /// many notifications. `None` = unlimited (issue #108).
+    pub max_report_nbr: Option<u64>,
+    /// Notifications successfully dispatched so far, counted against
+    /// [`Self::max_report_nbr`].
+    pub reports_sent: u64,
+    /// Set once a termination notification carrying `termCause` has been sent,
+    /// so it is emitted exactly once (issue #108).
+    pub termination_notified: bool,
+}
+
+/// TS 29.520 `TerminationCause` — why the NWDAF stopped reporting.
+///
+/// Before issue #108 a subscription simply vanished from
+/// `get_all_active_subscriptions` when its bespoke `expiryTime` passed, with no
+/// notification at all: a consumer could not tell a deliberate termination from
+/// a lost subscription, so it could not re-subscribe deterministically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminationCause {
+    /// The monitoring duration (`evtReq.monDur`) elapsed.
+    MonitoringDurationExpiry,
+    /// The requested number of reports (`evtReq.maxReportNbr`) was reached.
+    MaxNumberOfReportsReached,
+}
+
+impl TerminationCause {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::MonitoringDurationExpiry => "MONITORING_DURATION_EXPIRY",
+            Self::MaxNumberOfReportsReached => "MAX_NUMBER_OF_REPORTS_REACHED",
+        }
+    }
 }
 
 impl AnalyticsSubscription {
@@ -479,6 +511,9 @@ impl AnalyticsSubscription {
             notification_correlation_id,
             repetition_period_secs: Some(60),
             last_notification_time: None,
+            max_report_nbr: None,
+            reports_sent: 0,
+            termination_notified: false,
         }
     }
 
@@ -505,6 +540,25 @@ impl AnalyticsSubscription {
         now > self.expiry
     }
 
+    /// Why this subscription should stop reporting, or `None` while it is live
+    /// (issue #108).
+    ///
+    /// Both causes are checked here rather than at the two former call sites so
+    /// `is_due_for_notification` and the dispatcher's termination pass cannot
+    /// disagree about whether a subscription is finished.
+    pub fn termination_cause(&self) -> Option<TerminationCause> {
+        if self
+            .max_report_nbr
+            .is_some_and(|max| self.reports_sent >= max)
+        {
+            return Some(TerminationCause::MaxNumberOfReportsReached);
+        }
+        if self.is_expired() {
+            return Some(TerminationCause::MonitoringDurationExpiry);
+        }
+        None
+    }
+
     /// Returns true if this subscription is due for a periodic notification.
     ///
     /// A subscription is due when:
@@ -514,7 +568,8 @@ impl AnalyticsSubscription {
     ///   If `repetition_period_secs` is `None` the subscription is treated as
     ///   a one-shot: due only on the very first dispatch.
     pub fn is_due_for_notification(&self) -> bool {
-        if !self.active || self.is_expired() {
+        // Issue #108: `maxReportNbr` is a stop condition as much as expiry is.
+        if !self.active || self.termination_cause().is_some() {
             return false;
         }
         let now = std::time::SystemTime::now()
@@ -1061,7 +1116,15 @@ impl NwdafContext {
             .read()
             .map(|subs| {
                 subs.values()
-                    .filter(|s| s.active && !s.is_expired())
+                    // Issue #108: a subscription that has just hit a stop
+                    // condition stays visible until its termCause notification
+                    // has gone out, otherwise it disappears silently — which is
+                    // the defect. `is_due_for_notification` still gates the
+                    // ordinary reports, so a terminating subscription emits its
+                    // termination and nothing else.
+                    .filter(|s| {
+                        s.active && (s.termination_cause().is_none() || !s.termination_notified)
+                    })
                     .cloned()
                     .collect()
             })
@@ -1078,6 +1141,19 @@ impl NwdafContext {
         if let Ok(mut subs) = self.analytics_subscriptions.write() {
             if let Some(sub) = subs.get_mut(subscription_id) {
                 sub.last_notification_time = Some(now);
+                // Issue #108: counted here rather than at the send site so a
+                // failed delivery does not consume one of `maxReportNbr`.
+                sub.reports_sent = sub.reports_sent.saturating_add(1);
+            }
+        }
+    }
+
+    /// Mark a subscription's termination notification as delivered, so the
+    /// `termCause` report is emitted exactly once (issue #108).
+    pub fn mark_subscription_terminated(&self, subscription_id: &str) {
+        if let Ok(mut subs) = self.analytics_subscriptions.write() {
+            if let Some(sub) = subs.get_mut(subscription_id) {
+                sub.termination_notified = true;
             }
         }
     }
@@ -1310,6 +1386,122 @@ mod tests {
 
         assert!(ctx.remove_ml_prov_subscription("mlsub-1").is_some());
         assert_eq!(ctx.ml_prov_subscription_count(), 0);
+    }
+
+    /// Issue #108: a subscription terminates for a NAMED reason, and the two
+    /// reasons are distinguishable — `maxReportNbr` reached vs monitoring
+    /// duration elapsed. Before this it just vanished with no `termCause`, so a
+    /// consumer could not tell a deliberate termination from a lost subscription.
+    #[test]
+    fn test_termination_cause_is_named_and_distinguishes_its_two_reasons() {
+        let live = |max: Option<u64>, sent: u64| {
+            let mut sub = AnalyticsSubscription::new(
+                "s1".into(),
+                AnalyticsId::NfLoad,
+                "http://x/y".into(),
+                u64::MAX, // not expired
+            );
+            sub.max_report_nbr = max;
+            sub.reports_sent = sent;
+            sub
+        };
+
+        // Live: no cause, and reporting is due.
+        let sub = live(Some(3), 1);
+        assert_eq!(sub.termination_cause(), None);
+        assert!(sub.is_due_for_notification());
+
+        // maxReportNbr reached → that cause, and no longer due.
+        let sub = live(Some(3), 3);
+        assert_eq!(
+            sub.termination_cause(),
+            Some(TerminationCause::MaxNumberOfReportsReached)
+        );
+        assert!(
+            !sub.is_due_for_notification(),
+            "maxReportNbr is a stop condition, not just a counter"
+        );
+
+        // Monitoring duration elapsed → the other cause.
+        let mut expired = live(None, 0);
+        expired.expiry = 1; // 1970
+        assert_eq!(
+            expired.termination_cause(),
+            Some(TerminationCause::MonitoringDurationExpiry)
+        );
+
+        // The two are distinct on the wire.
+        assert_eq!(
+            TerminationCause::MaxNumberOfReportsReached.as_str(),
+            "MAX_NUMBER_OF_REPORTS_REACHED"
+        );
+        assert_eq!(
+            TerminationCause::MonitoringDurationExpiry.as_str(),
+            "MONITORING_DURATION_EXPIRY"
+        );
+
+        // Unlimited reporting never terminates on count.
+        let unlimited = live(None, 10_000);
+        assert_eq!(unlimited.termination_cause(), None);
+    }
+
+    /// Issue #108: a terminating subscription must stay visible until its
+    /// termCause notification has gone out — disappearing silently is the defect.
+    #[test]
+    fn test_terminating_subscription_stays_visible_until_notified() {
+        let mut ctx = NwdafContext::new("nwdaf-test".to_string());
+        ctx.init(100);
+        let mut sub = AnalyticsSubscription::new(
+            "s-term".into(),
+            AnalyticsId::NfLoad,
+            "http://x/y".into(),
+            1, // already expired
+        );
+        sub.notification_correlation_id = "corr-term".into();
+        ctx.add_subscription(sub);
+
+        assert_eq!(
+            ctx.get_all_active_subscriptions().len(),
+            1,
+            "an expired subscription is still listed so its termCause can be sent"
+        );
+
+        ctx.mark_subscription_terminated("s-term");
+        assert!(
+            ctx.get_all_active_subscriptions().is_empty(),
+            "once notified it drops out"
+        );
+    }
+
+    /// A dispatched notification counts against `maxReportNbr` (issue #108).
+    #[test]
+    fn test_dispatched_notifications_count_against_max_report_nbr() {
+        let mut ctx = NwdafContext::new("nwdaf-test".to_string());
+        ctx.init(100);
+        let mut sub = AnalyticsSubscription::new(
+            "s-count".into(),
+            AnalyticsId::NfLoad,
+            "http://x/y".into(),
+            u64::MAX,
+        );
+        sub.max_report_nbr = Some(2);
+        sub.repetition_period_secs = None;
+        ctx.add_subscription(sub);
+
+        ctx.update_subscription_last_notification("s-count");
+        assert_eq!(ctx.get_subscription("s-count").unwrap().reports_sent, 1);
+        assert_eq!(
+            ctx.get_subscription("s-count").unwrap().termination_cause(),
+            None
+        );
+
+        ctx.update_subscription_last_notification("s-count");
+        assert_eq!(ctx.get_subscription("s-count").unwrap().reports_sent, 2);
+        assert_eq!(
+            ctx.get_subscription("s-count").unwrap().termination_cause(),
+            Some(TerminationCause::MaxNumberOfReportsReached),
+            "the second report reaches the limit"
+        );
     }
 
     /// nwafd-07: per-(subscription, event, instance) level state round-trips and

--- a/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
+++ b/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
@@ -414,6 +414,25 @@ pub fn build_notify_body(sub: &AnalyticsSubscription, event_notifications: Vec<V
     })
 }
 
+/// Build the termination callback body for a subscription that has stopped
+/// reporting (issue #108).
+///
+/// TS 29.520 `NnwdafEventsSubscriptionNotification` carries `termCause`; before
+/// this the NF just stopped appearing in `get_all_active_subscriptions` when its
+/// bespoke `expiryTime` passed, so a consumer could not distinguish a deliberate
+/// termination from a lost subscription and could not re-subscribe
+/// deterministically. Array-shaped like every other callback body.
+pub fn build_termination_callback_body(
+    sub: &AnalyticsSubscription,
+    cause: crate::context::TerminationCause,
+) -> Value {
+    json!([{
+        "subscriptionId": sub.subscription_id,
+        "notifCorrId":    sub.notification_correlation_id,
+        "termCause":      cause.as_str(),
+    }])
+}
+
 /// Build the Nnwdaf_EventsSubscription **callback body** (issue #108).
 ///
 /// TS 29.520 §4.2.2.2.2 declares the notify `requestBody` as
@@ -464,6 +483,48 @@ pub async fn dispatch_notifications(ctx: Arc<RwLock<NwdafContext>>) {
     };
 
     for sub in &subscriptions {
+        // Issue #108: a subscription that has hit a stop condition gets ONE
+        // termination notification carrying termCause, then nothing. It is still
+        // in `subscriptions` precisely so this can be sent; previously it just
+        // stopped appearing and the consumer was never told.
+        if let Some(cause) = sub.termination_cause() {
+            if !sub.termination_notified {
+                let body = build_termination_callback_body(sub, cause);
+                if let Some((host, port, path)) = parse_notify_uri(&sub.notification_uri) {
+                    let client = notify_client(&host, port);
+                    match client.post_json(&path, &body).await {
+                        Ok(resp) if resp.is_success() => log::info!(
+                            "dispatch: termination notified sub={} cause={}",
+                            sub.subscription_id,
+                            cause.as_str()
+                        ),
+                        Ok(resp) => log::warn!(
+                            "dispatch: termination notify non-success status={} sub={}",
+                            resp.status,
+                            sub.subscription_id
+                        ),
+                        Err(e) => log::warn!(
+                            "dispatch: termination notify POST failed sub={}: {e}",
+                            sub.subscription_id
+                        ),
+                    }
+                } else {
+                    log::warn!(
+                        "dispatch: invalid notificationUri '{}' for terminating sub={}",
+                        sub.notification_uri,
+                        sub.subscription_id
+                    );
+                }
+                // Marked regardless of delivery outcome: retrying forever would
+                // keep a finished subscription alive indefinitely, and the
+                // consumer's own subscription has already lapsed.
+                if let Ok(guard) = ctx.read() {
+                    guard.mark_subscription_terminated(&sub.subscription_id);
+                }
+            }
+            continue;
+        }
+
         if !sub.is_due_for_notification() {
             continue;
         }
@@ -994,6 +1055,33 @@ mod tests {
             80.0,
             MatchingDirection::Crossed
         ));
+    }
+
+    /// Issue #108: the termination notification carries `termCause`, in the same
+    /// array shape as every other callback body.
+    #[test]
+    fn test_termination_body_carries_term_cause() {
+        let (ctx_arc, sub_id) = make_ctx_with_sub("http://amf.local:8080/notify", Some(60));
+        let ctx = ctx_arc.read().unwrap();
+        let sub = ctx.get_subscription(&sub_id).unwrap();
+
+        for cause in [
+            crate::context::TerminationCause::MonitoringDurationExpiry,
+            crate::context::TerminationCause::MaxNumberOfReportsReached,
+        ] {
+            let body = build_termination_callback_body(&sub, cause);
+            let arr = body.as_array().expect("array-shaped like every callback");
+            assert_eq!(arr.len(), 1);
+            assert_eq!(arr[0]["subscriptionId"].as_str(), Some("sub-test-001"));
+            assert_eq!(arr[0]["notifCorrId"].as_str(), Some("corr-abc123"));
+            assert_eq!(
+                arr[0]["termCause"].as_str(),
+                Some(cause.as_str()),
+                "the consumer must be told WHY reporting stopped"
+            );
+            // A termination report is not an event report.
+            assert!(arr[0].get("eventNotifications").is_none());
+        }
     }
 
     /// Issue #108: a threshold beyond `nfLoadLvlThds[0]` must still fire. Only

--- a/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
+++ b/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
@@ -12,6 +12,21 @@ use nextgcore_sbi::server::{send_bad_request, send_not_found};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+/// Monitoring duration used when `evtReq.monDur` is absent (issue #108).
+///
+/// Keeps the pre-#108 window so a consumer that sends no `evtReq` sees unchanged
+/// behaviour — except that its subscription now terminates with a `termCause`
+/// instead of vanishing.
+const DEFAULT_MONITORING_DURATION_SECS: u64 = 3600;
+
+/// Seconds since the Unix epoch.
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::ZERO)
+        .as_secs()
+}
+
 // ── query-string + S-NSSAI parsing helpers ───────────────────────────────────
 
 /// Minimal application/x-www-form-urlencoded percent-decoder for query values.
@@ -527,10 +542,32 @@ fn parse_events_subscription(
         .map(String::from)
         .unwrap_or_else(|| format!("corr-{}", uuid::Uuid::new_v4()));
 
-    let expiry_seconds = data
-        .get("expiryTime")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(3600);
+    // Issue #108: duration comes from `evtReq` → TS 29.523 `ReportingInformation`,
+    // NOT a bespoke top-level `expiryTime`. The TS 29.520 subscription resource
+    // has no `expiryTime` member at all (yaml:414-433), so the old key was
+    // non-spec: a conformant consumer could not set it, and every subscription
+    // silently died after the 3600 s default with no termCause.
+    let evt_req = data.get("evtReq");
+    // `monDur` is an absolute DateTime in TS 29.523; `monDurOrDuration` styles
+    // vary by release, so accept either an RFC-3339 instant or a duration in
+    // seconds and fall back to the previous 3600 s window when neither is given.
+    let mon_dur_secs = evt_req
+        .and_then(|r| r.get("monDur"))
+        .and_then(|v| {
+            v.as_u64().or_else(|| {
+                v.as_str().and_then(|ts| {
+                    chrono::DateTime::parse_from_rfc3339(ts)
+                        .ok()
+                        .map(|dt| dt.timestamp().max(0) as u64)
+                        .map(|abs| abs.saturating_sub(now_secs()))
+                })
+            })
+        })
+        .unwrap_or(DEFAULT_MONITORING_DURATION_SECS);
+    let max_report_nbr = evt_req
+        .and_then(|r| r.get("maxReportNbr"))
+        .and_then(|v| v.as_u64());
+    let expiry_seconds = mon_dur_secs;
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -557,6 +594,7 @@ fn parse_events_subscription(
     subscription.notification_correlation_id = notif_corr_id;
     subscription.repetition_period_secs = rep_period;
     subscription.unknown_events = unknown_events;
+    subscription.max_report_nbr = max_report_nbr;
     if let Some(supi) = tgt_supi {
         subscription = subscription.with_target_supi(supi);
     }
@@ -1120,6 +1158,62 @@ mod tests {
                 event.as_str()
             );
         }
+    }
+
+    /// Issue #108: the non-spec top-level `expiryTime` is no longer honoured —
+    /// TS 29.520's subscription resource has no such member (yaml:414-433), so a
+    /// conformant consumer could never set it. Duration comes from `evtReq`.
+    #[tokio::test]
+    async fn test_duration_comes_from_evt_req_not_expiry_time() {
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
+
+        // A bespoke expiryTime of 1 second must NOT shorten the subscription.
+        let req = SbiRequest::post("/nnwdaf-eventssubscription/v1/subscriptions")
+            .with_json_body(&json!({
+                "notificationURI": "http://amf.example.org/notify",
+                "expiryTime": 1,
+                "eventSubscriptions": [{ "event": "NF_LOAD" }]
+            }))
+            .expect("valid JSON body");
+        assert_eq!(handle_subscription_create(&req).await.status, 201);
+        let ctx = nwdaf_self();
+        let stored = ctx
+            .read()
+            .unwrap()
+            .get_all_active_subscriptions()
+            .into_iter()
+            .next()
+            .expect("subscription stored");
+        assert!(
+            stored.expiry > now_secs() + 1000,
+            "the non-spec expiryTime must be ignored, not applied (expiry={}, now={})",
+            stored.expiry,
+            now_secs()
+        );
+        assert_eq!(stored.max_report_nbr, None, "no evtReq → unlimited reports");
+
+        // evtReq.maxReportNbr and a monDur duration ARE honoured.
+        nwdaf_context_init("nwdaf-test2".to_string(), 1024);
+        let req = SbiRequest::post("/nnwdaf-eventssubscription/v1/subscriptions")
+            .with_json_body(&json!({
+                "notificationURI": "http://amf.example.org/notify",
+                "evtReq": { "maxReportNbr": 5, "monDur": 120 },
+                "eventSubscriptions": [{ "event": "NF_LOAD" }]
+            }))
+            .expect("valid JSON body");
+        assert_eq!(handle_subscription_create(&req).await.status, 201);
+        let stored = nwdaf_self()
+            .read()
+            .unwrap()
+            .get_all_active_subscriptions()
+            .into_iter()
+            .find(|s| s.max_report_nbr == Some(5))
+            .expect("the evtReq subscription");
+        assert!(
+            stored.expiry <= now_secs() + 121 && stored.expiry > now_secs(),
+            "monDur must set the window (expiry={})",
+            stored.expiry
+        );
     }
 
     /// Issue #108: a subscription mixing a serviceable event with an


### PR DESCRIPTION
**Closes #108** — part 3, the last non-separable part. Parts 1, 2 and 4 landed in #170.

## The defect

TS 29.520's `NnwdafEventsSubscription` resource has **no `expiryTime` member** (`TS29520_Nnwdaf_EventsSubscription.yaml:414-433`); duration is governed by `evtReq` → TS 29.523 `ReportingInformation`. This NF drove everything from a bespoke top-level integer `expiryTime` defaulting to 3600 s — which a conformant consumer could not set — and when it lapsed the subscription simply stopped appearing in `get_all_active_subscriptions`.

There was **no `termCause` anywhere in the crate**, so a consumer could not distinguish a deliberate termination from a lost subscription, and could not re-subscribe deterministically.

## The design point: where "finished" is decided

`monDur` and `maxReportNbr` now come from `evtReq`, and a subscription hitting either stop condition emits exactly **one** termination notification carrying `termCause` before it goes away.

A new `termination_cause()` answers "is this done, and why" in **one place**, and both former call sites defer to it — so `is_due_for_notification` and the dispatcher's termination pass cannot disagree. The two causes stay distinguishable (`MAX_NUMBER_OF_REPORTS_REACHED` vs `MONITORING_DURATION_EXPIRY`), because collapsing them would tell a consumer no more than the old silence did.

## The subtle part: the visibility window

A terminating subscription must **remain** in `get_all_active_subscriptions` until its `termCause` has been sent — otherwise it vanishes before the notification can go out, which is the defect itself. The filter keeps it while `termination_cause().is_some() && !termination_notified`, and `is_due_for_notification` still gates ordinary reports, so a terminating subscription emits its termination and nothing else.

Two related choices:

- `maxReportNbr` counts in `update_subscription_last_notification`, i.e. only on **successful** delivery, so a failed POST does not consume one of the consumer's requested reports.
- The termination notification is marked delivered **regardless** of outcome: retrying forever would keep a finished subscription alive indefinitely, and the consumer's subscription has already lapsed.

`monDur` is accepted as either an RFC-3339 instant or a duration in seconds (styling varies by release) and falls back to the previous 3600 s window when `evtReq` is absent — so a consumer sending no `evtReq` sees unchanged timing, except that its subscription now terminates with a cause instead of vanishing.

## #108 close condition

Criteria 1–6 and 8 are met across #170 and this PR. Criterion 7 is the one the issue itself marks **"(Separable)"** and directs to a separate lower-priority issue — filed as #171 (AnalyticsInfo `tgt-ue`/`ana-req`, target-period window, `BOTH_STAT_PRED_NOT_ALLOWED`/`UNAVAILABLE_DATA`, `/context` routing), per the issue's own instruction rather than growing this PR.

Also filed #172 for four **latent** `infos_key()` disagreements with the yaml found during #170 — latent because `SUPPORTED_EVENTS` is `[NF_LOAD]` only, so those keys are never emitted today.

## Verification

Workspace **5580 passed / 0 failed** (baseline 5575). nwdafd **135 passed** (baseline 130). `cargo fmt` clean; `clippy -D warnings` clean.

Five new assertions: the two termination causes are distinguishable and each stops reporting; a terminating subscription stays listed until notified and drops out after; a delivered notification counts against `maxReportNbr`; a bespoke `expiryTime` of 1 second is **ignored** while `evtReq.monDur`/`maxReportNbr` are honoured; and the termination body carries `termCause` in the same array shape as every other callback body.

Spec: `specs/fix-nwdaf-events-notify-array-and-tokens.md`