### PR TITLE
fix(nwdafd): name the *Infos payload member per wire surface, not once for both (closes #172)

### DIFF
--- a/src/bins/nextgcore-nwdafd/src/context.rs
+++ b/src/bins/nextgcore-nwdafd/src/context.rs
@@ -202,13 +202,36 @@ impl AnalyticsId {
         SUPPORTED_EVENTS.contains(self)
     }
 
-    /// The per-event `*Infos` array key used in `AnalyticsData`
-    /// (Nnwdaf_AnalyticsInfo) and `EventNotification`
-    /// (Nnwdaf_EventsSubscription_Notify) bodies, per TS 29.520.
-    pub fn infos_key(&self) -> &'static str {
+    /// The per-event payload member name in a TS 29.520 `EventNotification`
+    /// body, i.e. what `Nnwdaf_EventsSubscription_Notify` emits.
+    ///
+    /// Read off `components.schemas.EventNotification` in
+    /// `TS29520_Nnwdaf_EventsSubscription.yaml` (yaml:802-966), never inferred
+    /// from the token name — several are abbreviated differently from what the
+    /// token suggests (`dataVlTrnsTmInfos`, `movBehavInfos`, `abnorBehavrs`).
+    ///
+    /// THIS IS NOT INTERCHANGEABLE WITH [`analytics_data_key`](Self::analytics_data_key)
+    /// (issue #172). The two service APIs name the same analytics differently, so
+    /// one shared accessor cannot be right for both — which is exactly how the
+    /// pre-#172 `infos_key()` was wrong on one surface or the other for seven
+    /// tokens. See `analytics_data_key` for the divergence table.
+    ///
+    /// Every one of the 25 `NwdafEvent` tokens maps to a distinct member here,
+    /// and those 25 are exactly the payload members of `EventNotification`
+    /// (its other 11 members are envelope fields: `event`, `start`, `expiry`,
+    /// `timeStampGen`, `failNotifyCode`, `rvWaitTime`, `anaMetaInfo`,
+    /// `accuInfo`, `cancelAccuInd`, `pauseInd`, `resumeInd`). The bijection is
+    /// asserted by `test_infos_keys_match_the_spec_for_every_token`.
+    pub fn notification_infos_key(&self) -> &'static str {
         match self {
             Self::NfLoad => "nfLoadLevelInfos",
-            Self::SliceLoadLevel | Self::NsiLoadLevel => "sliceLoadLevelInfos",
+            // Issue #172: NSI_LOAD_LEVEL has its OWN member; it used to share
+            // SLICE_LOAD_LEVEL's, so a consumer would have looked for
+            // `nsiLoadLevelInfos` and found nothing.
+            Self::NsiLoadLevel => "nsiLoadLevelInfos",
+            // Issue #172: singular, and an OBJECT not an array — see
+            // `notification_payload_is_single_object`.
+            Self::SliceLoadLevel => "sliceLoadLevelInfo",
             Self::NetworkPerformance => "nwPerfs",
             Self::UeMobility => "ueMobs",
             Self::UeCommunication => "ueComms",
@@ -218,14 +241,12 @@ impl AnalyticsId {
             Self::UserDataCongestion => "userDataCongInfos",
             Self::Dispersion => "disperInfos",
             Self::RedTransExp => "redTransInfos",
-            Self::WlanPerformance => "wlanPerfInfos",
+            // Issue #172: was `wlanPerfInfos`, which the yaml does not define.
+            Self::WlanPerformance => "wlanInfos",
             Self::DnPerformance => "dnPerfInfos",
-            Self::SmCongestion => "smcInfos",
+            // Issue #172: was `smcInfos`, which the yaml does not define.
+            Self::SmCongestion => "smccExps",
             Self::PduSessionTraffic => "pduSesTrafInfos",
-            // Issue #108: keys read off `EventNotification` in
-            // TS29520_Nnwdaf_EventsSubscription.yaml, not inferred from the
-            // token names — several of them are abbreviated differently from
-            // what the token would suggest (`dataVlTrnsTmInfos`, `movBehavInfos`).
             Self::PfdDetermination => "pfdDetermInfos",
             Self::E2eDataVolTransTime => "dataVlTrnsTmInfos",
             Self::MovementBehaviour => "movBehavInfos",
@@ -236,6 +257,79 @@ impl AnalyticsId {
             Self::AbnormalUpTraffic => "abnormalTrafficInfos",
             Self::TrafficPattern => "trafficPatternInfos",
         }
+    }
+
+    /// The per-event payload member name in a TS 29.520 `AnalyticsData` body,
+    /// i.e. what an `Nnwdaf_AnalyticsInfo` GET returns — or `None` when
+    /// `AnalyticsData` defines no member for this event.
+    ///
+    /// Read off `components.schemas.AnalyticsData` in
+    /// `TS29520_Nnwdaf_AnalyticsInfo.yaml` (yaml:212-361).
+    ///
+    /// WHY THIS IS A SEPARATE ACCESSOR (issue #172). The two service APIs do not
+    /// agree, so the single shared `infos_key()` this replaced was necessarily
+    /// wrong on one surface or the other:
+    ///
+    /// | token | `EventNotification` | `AnalyticsData` |
+    /// |---|---|---|
+    /// | `SLICE_LOAD_LEVEL` | `sliceLoadLevelInfo` (object) | `sliceLoadLevelInfos` (array) |
+    /// | `QOS_POLICY_ASSIST` | `qosPolAssistInfos` | `qosPlyAsstInfos` |
+    /// | `ABNORMAL_UP_TRAFFIC` | `abnormalTrafficInfos` | `abnormalTraffic` |
+    /// | `PFD_DETERMINATION` | `pfdDetermInfos` | *(no member)* |
+    ///
+    /// `PFD_DETERMINATION` is `None` because it is not even an `EventId` value:
+    /// the AnalyticsInfo API's enum has 24 tokens where `NwdafEvent` has 25, so
+    /// PFD determination analytics are subscribe/notify-only. A GET for it must
+    /// fail closed rather than invent a member name (see `sbi_handler`).
+    ///
+    /// The 24 `Some` values are exactly the payload members of `AnalyticsData`
+    /// (its other 7 are envelope fields: `start`, `expiry`, `timeStampGen`,
+    /// `anaMetaInfo`, `accuInfo`, `cancelAccuInd`, `suppFeat`).
+    pub fn analytics_data_key(&self) -> Option<&'static str> {
+        Some(match self {
+            Self::NfLoad => "nfLoadLevelInfos",
+            Self::NsiLoadLevel => "nsiLoadLevelInfos",
+            // An ARRAY here, unlike the notify surface's singular object.
+            Self::SliceLoadLevel => "sliceLoadLevelInfos",
+            Self::NetworkPerformance => "nwPerfs",
+            Self::UeMobility => "ueMobs",
+            Self::UeCommunication => "ueComms",
+            Self::QosSustainability => "qosSustainInfos",
+            Self::AbnormalBehaviour => "abnorBehavrs",
+            Self::ServiceExperience => "svcExps",
+            Self::UserDataCongestion => "userDataCongInfos",
+            Self::Dispersion => "disperInfos",
+            Self::RedTransExp => "redTransInfos",
+            Self::WlanPerformance => "wlanInfos",
+            Self::DnPerformance => "dnPerfInfos",
+            Self::SmCongestion => "smccExps",
+            Self::PduSessionTraffic => "pduSesTrafInfos",
+            Self::E2eDataVolTransTime => "dataVlTrnsTmInfos",
+            Self::MovementBehaviour => "movBehavInfos",
+            Self::LocAccuracy => "locAccInfos",
+            Self::RelativeProximity => "relProxInfos",
+            Self::SignallingStorm => "signalStormInfos",
+            // Differs from the notify surface's `qosPolAssistInfos`.
+            Self::QosPolicyAssist => "qosPlyAsstInfos",
+            // Differs from the notify surface's `abnormalTrafficInfos`.
+            Self::AbnormalUpTraffic => "abnormalTraffic",
+            Self::TrafficPattern => "trafficPatternInfos",
+            // Not an `EventId` value: no AnalyticsData member exists.
+            Self::PfdDetermination => return None,
+        })
+    }
+
+    /// Whether this event's `EventNotification` payload is a SINGLE object
+    /// rather than an array (issue #172).
+    ///
+    /// True only for `SLICE_LOAD_LEVEL`, whose notify member
+    /// `sliceLoadLevelInfo` is a bare `SliceLoadLevelInformation`
+    /// (`TS29520_Nnwdaf_EventsSubscription.yaml:835-836`) while every other
+    /// payload member — including its own `AnalyticsData` counterpart
+    /// `sliceLoadLevelInfos` — is a `minItems: 1` array. This is a *shape*
+    /// difference, not just a name, so it cannot be handled by the key alone.
+    pub fn notification_payload_is_single_object(&self) -> bool {
+        matches!(self, Self::SliceLoadLevel)
     }
 }
 
@@ -1281,6 +1375,177 @@ mod tests {
         // The old abbreviated tokens are rejected.
         assert_eq!(AnalyticsId::from_str("UE_COMM"), None);
         assert_eq!(AnalyticsId::from_str("SLICE_LOAD"), None);
+    }
+
+    /// **The issue #172 table test.** Every token's payload member name is
+    /// pinned against BOTH TS 29.520 schemas, transcribed from the yaml rather
+    /// than inferred, so the next added collector cannot inherit a wrong key.
+    ///
+    /// The table below is the whole point: the two service APIs name the same
+    /// analytics differently for four tokens, which is why one shared
+    /// `infos_key()` was necessarily wrong on one surface or the other. Sources:
+    /// `TS29520_Nnwdaf_EventsSubscription.yaml:802-966` (`EventNotification`) and
+    /// `TS29520_Nnwdaf_AnalyticsInfo.yaml:212-361` (`AnalyticsData`).
+    #[test]
+    fn test_infos_keys_match_the_spec_for_every_token() {
+        // (token, EventNotification member, AnalyticsData member or None)
+        let spec: &[(AnalyticsId, &str, Option<&str>)] = &[
+            (
+                AnalyticsId::NfLoad,
+                "nfLoadLevelInfos",
+                Some("nfLoadLevelInfos"),
+            ),
+            (AnalyticsId::NetworkPerformance, "nwPerfs", Some("nwPerfs")),
+            (AnalyticsId::UeMobility, "ueMobs", Some("ueMobs")),
+            (AnalyticsId::UeCommunication, "ueComms", Some("ueComms")),
+            (
+                AnalyticsId::AbnormalBehaviour,
+                "abnorBehavrs",
+                Some("abnorBehavrs"),
+            ),
+            (AnalyticsId::ServiceExperience, "svcExps", Some("svcExps")),
+            (
+                AnalyticsId::QosSustainability,
+                "qosSustainInfos",
+                Some("qosSustainInfos"),
+            ),
+            // ── the four #172 divergences ─────────────────────────────────────
+            // Shape differs too: singular OBJECT on notify, array in AnalyticsData.
+            (
+                AnalyticsId::SliceLoadLevel,
+                "sliceLoadLevelInfo",
+                Some("sliceLoadLevelInfos"),
+            ),
+            // Was sharing SLICE_LOAD_LEVEL's member; it has its own on both.
+            (
+                AnalyticsId::NsiLoadLevel,
+                "nsiLoadLevelInfos",
+                Some("nsiLoadLevelInfos"),
+            ),
+            // Was `wlanPerfInfos`, which neither schema defines.
+            (AnalyticsId::WlanPerformance, "wlanInfos", Some("wlanInfos")),
+            // Was `smcInfos`, which neither schema defines.
+            (AnalyticsId::SmCongestion, "smccExps", Some("smccExps")),
+            // ── divergences #172 did not list, found by diffing both schemas ──
+            (
+                AnalyticsId::QosPolicyAssist,
+                "qosPolAssistInfos",
+                Some("qosPlyAsstInfos"),
+            ),
+            (
+                AnalyticsId::AbnormalUpTraffic,
+                "abnormalTrafficInfos",
+                Some("abnormalTraffic"),
+            ),
+            // Not an `EventId` value at all → no AnalyticsData member exists.
+            (AnalyticsId::PfdDetermination, "pfdDetermInfos", None),
+            // ── the rest, identical on both surfaces ──────────────────────────
+            (
+                AnalyticsId::UserDataCongestion,
+                "userDataCongInfos",
+                Some("userDataCongInfos"),
+            ),
+            (AnalyticsId::Dispersion, "disperInfos", Some("disperInfos")),
+            (
+                AnalyticsId::RedTransExp,
+                "redTransInfos",
+                Some("redTransInfos"),
+            ),
+            (
+                AnalyticsId::DnPerformance,
+                "dnPerfInfos",
+                Some("dnPerfInfos"),
+            ),
+            (
+                AnalyticsId::PduSessionTraffic,
+                "pduSesTrafInfos",
+                Some("pduSesTrafInfos"),
+            ),
+            (
+                AnalyticsId::E2eDataVolTransTime,
+                "dataVlTrnsTmInfos",
+                Some("dataVlTrnsTmInfos"),
+            ),
+            (
+                AnalyticsId::MovementBehaviour,
+                "movBehavInfos",
+                Some("movBehavInfos"),
+            ),
+            (AnalyticsId::LocAccuracy, "locAccInfos", Some("locAccInfos")),
+            (
+                AnalyticsId::RelativeProximity,
+                "relProxInfos",
+                Some("relProxInfos"),
+            ),
+            (
+                AnalyticsId::SignallingStorm,
+                "signalStormInfos",
+                Some("signalStormInfos"),
+            ),
+            (
+                AnalyticsId::TrafficPattern,
+                "trafficPatternInfos",
+                Some("trafficPatternInfos"),
+            ),
+        ];
+
+        assert_eq!(
+            spec.len(),
+            AnalyticsId::ALL.len(),
+            "the spec table must cover every recognised NwdafEvent token"
+        );
+
+        for (event, notify_key, data_key) in spec {
+            assert_eq!(
+                event.notification_infos_key(),
+                *notify_key,
+                "{} EventNotification member",
+                event.as_str()
+            );
+            assert_eq!(
+                event.analytics_data_key(),
+                *data_key,
+                "{} AnalyticsData member",
+                event.as_str()
+            );
+        }
+
+        // Bijection: 25 distinct EventNotification members (its other 11
+        // properties are envelope fields), and 24 distinct AnalyticsData ones —
+        // no token may silently share another's member, which is the defect that
+        // hid NSI_LOAD_LEVEL behind SLICE_LOAD_LEVEL.
+        let notify: std::collections::BTreeSet<&str> = AnalyticsId::ALL
+            .iter()
+            .map(|e| e.notification_infos_key())
+            .collect();
+        assert_eq!(notify.len(), 25, "every token needs its OWN notify member");
+        let data: std::collections::BTreeSet<&str> = AnalyticsId::ALL
+            .iter()
+            .filter_map(|e| e.analytics_data_key())
+            .collect();
+        assert_eq!(
+            data.len(),
+            24,
+            "24 AnalyticsData members: every token but PFD_DETERMINATION, none shared"
+        );
+
+        // Only SLICE_LOAD_LEVEL's notify payload is a single object.
+        for event in AnalyticsId::ALL {
+            assert_eq!(
+                event.notification_payload_is_single_object(),
+                *event == AnalyticsId::SliceLoadLevel,
+                "{} payload shape",
+                event.as_str()
+            );
+        }
+
+        // The pre-#172 spellings are gone from both surfaces.
+        for wrong in ["wlanPerfInfos", "smcInfos"] {
+            assert!(
+                !notify.contains(wrong) && !data.contains(wrong),
+                "{wrong} is not defined by either schema"
+            );
+        }
     }
 
     /// G2-3 honesty: `SUPPORTED_EVENTS` is non-empty, a strict subset of the

--- a/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
+++ b/src/bins/nextgcore-nwdafd/src/notification_dispatcher.rs
@@ -240,8 +240,12 @@ fn nf_status_json(status: &str) -> Value {
     }
 }
 
-/// Compute the per-event `*Infos` **array** (the value stored under
-/// `event.infos_key()`) for a single analytics event.
+/// Compute the per-event `*Infos` **array** for a single analytics event.
+///
+/// Always an array, whichever surface consumes it: the per-surface member NAME
+/// comes from `AnalyticsId::notification_infos_key` / `analytics_data_key`, and
+/// the one event whose notify payload is a single object is reshaped by
+/// [`notification_payload`] at emission time (issue #172).
 ///
 /// Shared by `Nnwdaf_AnalyticsInfo` (GET → `AnalyticsData`) and the
 /// `Nnwdaf_EventsSubscription_Notify` dispatcher so both stay wire-aligned on
@@ -326,9 +330,30 @@ pub fn compute_event_infos(
     }
 }
 
+/// Shape the computed per-event `*Infos` array for the `EventNotification`
+/// surface (issue #172).
+///
+/// Almost every payload member of `EventNotification` is a `minItems: 1` array
+/// and the computed value is emitted unchanged. `SLICE_LOAD_LEVEL` is the sole
+/// exception: its member `sliceLoadLevelInfo` is a bare
+/// `SliceLoadLevelInformation` object
+/// (`TS29520_Nnwdaf_EventsSubscription.yaml:835-836`), so the first computed
+/// entry is unwrapped. Returns `None` when there is nothing to emit, which the
+/// caller turns into "do not report this event" — the same fail-closed rule the
+/// empty-array check above applies.
+fn notification_payload(event: AnalyticsId, infos: Value) -> Option<Value> {
+    if !event.notification_payload_is_single_object() {
+        return Some(infos);
+    }
+    match infos {
+        Value::Array(mut entries) if !entries.is_empty() => Some(entries.swap_remove(0)),
+        _ => None,
+    }
+}
+
 /// Build the TS 29.520 `eventNotifications[]` array for a subscription: one
 /// `EventNotification` per subscribed event, each carrying `event`,
-/// `start`/`expiry` and the event-specific `*Infos` array.
+/// `start`/`expiry` and the event-specific payload member.
 ///
 /// nwafd-07: events whose `notificationMethod` is `THRESHOLD` are only emitted
 /// when their computed analytic crosses the configured threshold in the
@@ -409,7 +434,15 @@ fn build_event_notifications(
             obj.insert("event".to_string(), json!(e.event.as_str()));
             obj.insert("start".to_string(), json!(start));
             obj.insert("expiry".to_string(), json!(expiry));
-            obj.insert(e.event.infos_key().to_string(), infos);
+            // Issue #172: the member name AND its shape come from
+            // `EventNotification`, not from the AnalyticsInfo `AnalyticsData`
+            // schema — the two disagree for four tokens. SLICE_LOAD_LEVEL's
+            // notify payload is a single object, so the computed array is
+            // unwrapped rather than emitted as-is.
+            obj.insert(
+                e.event.notification_infos_key().to_string(),
+                notification_payload(e.event, infos)?,
+            );
             Some(Value::Object(obj))
         })
         .collect()
@@ -1247,6 +1280,93 @@ mod tests {
             1,
             "PERIODIC subscription must always report when data exists"
         );
+    }
+
+    // ── issue #172: per-surface payload member names and shapes ─────────────
+
+    /// **Issue #172, the shape half.** `SLICE_LOAD_LEVEL`'s `EventNotification`
+    /// member is a bare `SliceLoadLevelInformation` object
+    /// (`TS29520_Nnwdaf_EventsSubscription.yaml:835-836`), not the `minItems: 1`
+    /// array every other payload member is — and not the array its own
+    /// `AnalyticsData` counterpart `sliceLoadLevelInfos` is either. So the
+    /// computed array is unwrapped for that one event and passed through for the
+    /// rest.
+    #[test]
+    fn test_notification_payload_unwraps_only_slice_load_level() {
+        let entry = || json!({ "loadLevelInformation": 42 });
+        let two = Value::Array(vec![entry(), json!({ "loadLevelInformation": 7 })]);
+
+        // SLICE_LOAD_LEVEL: a single OBJECT, not an array.
+        let shaped = notification_payload(AnalyticsId::SliceLoadLevel, two.clone())
+            .expect("non-empty input yields a payload");
+        assert!(
+            shaped.is_object(),
+            "sliceLoadLevelInfo is an object in EventNotification, got {shaped}"
+        );
+        assert_eq!(shaped, entry(), "the first computed entry is the payload");
+
+        // Every other event keeps the array — including NSI_LOAD_LEVEL, which
+        // used to share SLICE_LOAD_LEVEL's member and would otherwise inherit
+        // its shape.
+        for event in AnalyticsId::ALL {
+            if *event == AnalyticsId::SliceLoadLevel {
+                continue;
+            }
+            let shaped = notification_payload(*event, two.clone()).expect("payload");
+            assert!(
+                shaped.is_array(),
+                "{} must stay a minItems:1 array, got {shaped}",
+                event.as_str()
+            );
+            assert_eq!(shaped.as_array().map(Vec::len), Some(2));
+        }
+
+        // Nothing to unwrap → no payload, so the caller drops the event rather
+        // than emitting `sliceLoadLevelInfo: null`.
+        assert!(notification_payload(AnalyticsId::SliceLoadLevel, json!([])).is_none());
+        assert!(notification_payload(AnalyticsId::SliceLoadLevel, Value::Null).is_none());
+    }
+
+    /// The emitted `EventNotification` keys its payload by the notify-surface
+    /// member name, and NF_LOAD's stays the array it has always been — a
+    /// regression guard on the #172 accessor split for the one event with a
+    /// live collector.
+    #[test]
+    fn test_event_notification_uses_the_notify_surface_member() {
+        let ctx = NwdafContext::new("nwdaf-test".to_string());
+        ingest_loads(&ctx, "AMF", "amf-key-surface", &[40, 60]);
+        let sub = AnalyticsSubscription::new(
+            "sub-key-surface".into(),
+            AnalyticsId::NfLoad,
+            "http://x/y".into(),
+            u64::MAX,
+        );
+
+        let engine = ctx.lock_engine();
+        let notifications = build_event_notifications(&ctx, &engine, &sub);
+        assert_eq!(notifications.len(), 1);
+        let notification = &notifications[0];
+
+        assert_eq!(
+            AnalyticsId::NfLoad.notification_infos_key(),
+            "nfLoadLevelInfos"
+        );
+        assert!(
+            notification["nfLoadLevelInfos"].is_array(),
+            "NF_LOAD's notify payload is a minItems:1 array: {notification}"
+        );
+        // No stray member from the other surface or the pre-#172 spellings.
+        for absent in [
+            "wlanPerfInfos",
+            "smcInfos",
+            "sliceLoadLevelInfo",
+            "abnormalTraffic",
+        ] {
+            assert!(
+                notification.get(absent).is_none(),
+                "{absent} must not appear in an NF_LOAD EventNotification"
+            );
+        }
     }
 
     // ── G2-3: supported-events honesty in the dispatcher ────────────────────

--- a/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
+++ b/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
@@ -644,9 +644,26 @@ pub async fn handle_analytics_info_query_with_ctx(
     let start = period_start.to_rfc3339();
     let expiry = period_end.to_rfc3339();
 
-    // Build the AnalyticsData object with the event-specific *Infos key.
+    // Build the AnalyticsData object with the event-specific payload member.
+    //
+    // Issue #172: the member name comes from `AnalyticsData`, NOT from the
+    // EventsSubscription `EventNotification` schema — they disagree for four
+    // tokens. `None` means `AnalyticsData` defines no member for this event
+    // (PFD_DETERMINATION, which is not even an `EventId` value), so there is no
+    // conformant body to return and the honest answer is 204 rather than a
+    // fabricated member name. Unreachable while that event has no collector, but
+    // it is the guard a future collector needs.
+    let Some(infos_key) = analytics_id.analytics_data_key() else {
+        log::info!(
+            "AnalyticsInfo {}: TS 29.520 AnalyticsData defines no member for this event (it is \
+             not an EventId value — subscribe/notify only), so no conformant response body \
+             exists → 204",
+            analytics_id.as_str()
+        );
+        return SbiResponse::with_status(204);
+    };
     let mut analytics_data = serde_json::Map::new();
-    analytics_data.insert(analytics_id.infos_key().to_string(), infos);
+    analytics_data.insert(infos_key.to_string(), infos);
     analytics_data.insert("start".to_string(), serde_json::json!(start));
     analytics_data.insert("expiry".to_string(), serde_json::json!(expiry));
     analytics_data.insert(


### PR DESCRIPTION
Closes #172.

## The issue's premise needed correcting first

#172 asks for **one** `infos_key()` that "matches `EventNotification` in the yaml for all 25 tokens". That premise does not hold. `infos_key()` feeds **two** schemas:

* `sbi_handler.rs` → `AnalyticsData` (Nnwdaf_AnalyticsInfo GET)
* `notification_dispatcher.rs` → `EventNotification` (Nnwdaf_EventsSubscription_Notify)

Diffing them mechanically shows **they disagree**, so doing what the issue literally asks would have fixed four defects and *introduced two new ones*:

| token | `EventNotification` | `AnalyticsData` |
|---|---|---|
| `SLICE_LOAD_LEVEL` | `sliceLoadLevelInfo` (**object**) | `sliceLoadLevelInfos` (**array**) |
| `QOS_POLICY_ASSIST` | `qosPolAssistInfos` | `qosPlyAsstInfos` |
| `ABNORMAL_UP_TRAFFIC` | `abnormalTrafficInfos` | `abnormalTraffic` |
| `PFD_DETERMINATION` | `pfdDetermInfos` | *(no member at all)* |

Sources: `TS29520_Nnwdaf_EventsSubscription.yaml:802-966`, `TS29520_Nnwdaf_AnalyticsInfo.yaml:212-361`.

So the real defect count is **seven**, not four — #172's four, plus `QOS_POLICY_ASSIST` and `ABNORMAL_UP_TRAFFIC` (whose current values are the *notify* spellings and are therefore wrong on the AnalyticsInfo surface), plus `PFD_DETERMINATION`, which `AnalyticsData` does not model because it is not even an `EventId` value.

## The design point

`infos_key()` is **deleted**, not corrected. One shared accessor is what let a single wrong string be wrong in two places at once, and it would invite the same bug back the moment a collector is added. `AnalyticsId` now carries:

* `notification_infos_key() -> &'static str`
* `analytics_data_key() -> Option<&'static str>`
* `notification_payload_is_single_object() -> bool`

A caller must now say which wire it is writing to, and the `Option` makes the "no such member" case impossible to ignore.

Both tables were transcribed from the yaml and then **verified bijective against it**: the 25 notify keys are exactly `EventNotification`'s 25 payload members (its other 11 properties are envelope fields — `event`, `start`, `expiry`, `timeStampGen`, `failNotifyCode`, `rvWaitTime`, `anaMetaInfo`, `accuInfo`, `cancelAccuInd`, `pauseInd`, `resumeInd`), and the 24 `Some` AnalyticsData keys are exactly `AnalyticsData`'s 24. No key is shared by two tokens — that sharing is precisely what hid `NSI_LOAD_LEVEL` behind `SLICE_LOAD_LEVEL`.

**Shape, not just name.** `SLICE_LOAD_LEVEL`'s notify member is a bare `SliceLoadLevelInformation` object, so a new `notification_payload` unwraps the computed array to its first entry for that one event and returns `None` when there is nothing to emit — so the caller drops the event rather than sending `sliceLoadLevelInfo: null`. `compute_event_infos` still returns an array on both paths; only emission reshapes.

**Fail-closed guard.** An AnalyticsInfo GET for an event with no `AnalyticsData` member answers 204 with a log line rather than inventing a member name. Unreachable today, but it is the guard a future collector needs.

## Why this is still worth doing while latent

`SUPPORTED_EVENTS` is `[NF_LOAD]`, whose member name is identical on both surfaces and was already correct — so **no emitted byte changes today**. All seven go live the moment a collector is added for any affected event, at which point a conformant consumer silently fails to find the data. Same class of interop defect as the notify array shape #108 fixed: cheap now, an interop break later.

## Found in passing → filed as #175, not fixed here

The two APIs also use **different event enumerations**: `NwdafEvent` has 25 tokens; `EventId` (`TS29520_Nnwdaf_AnalyticsInfo.yaml:939-1004`) has 24, with `LOAD_LEVEL_INFORMATION` in place of `SLICE_LOAD_LEVEL` and no `PFD_DETERMINATION`. Since `AnalyticsId::from_str` only knows the `NwdafEvent` spellings, `GET /analytics?event-id=LOAD_LEVEL_INFORMATION` — the spec's own `EventId` value — is rejected **400 `INVALID_ANALYTICS_TYPE` today.

That one is **live, not latent**, but it is about *accepted tokens* (#108's family) rather than *emitted member names* (#172's), and it needs its own design decision about representing per-API token sets. Filed as **#175** rather than growing this PR.

**Count arithmetic, stated plainly per CONVENTIONS:** closing #172 while filing one honest follow-up moves the open count 65 → 65, not down.

## Verification

* Workspace **5597 passed / 0 failed** (baseline 5594).
* `nextgcore-nwdafd` **152 passed** (baseline 149); **156** with `--all-features`.
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace` 0 errors.
* **All three new tests revert-verified:** restoring the `wlanPerfInfos` spelling fails the table test; pointing `analytics_data_key` at the notify spelling for `QOS_POLICY_ASSIST` fails it too; disabling the `SLICE_LOAD_LEVEL` unwrap fails the shape test.

## Acceptance criteria

- [x] `infos_key()` matches the yaml for all 25 tokens — *split per surface, because one accessor cannot.*
- [x] `SLICE_LOAD_LEVEL` emits a singular object on the notify surface (and keeps the array on the AnalyticsInfo surface, where the yaml has one).
- [x] A table test pins every token's key on both surfaces plus the payload shape, so the next added collector cannot inherit a wrong key.

Spec: `specs/fix-nwdaf-infos-key-per-surface.md`
