### PR TITLE
fix(nwdafd): parse AnalyticsInfo event-id as an EventId, not a NwdafEvent (closes #175)

### DIFF
--- a/src/bins/nextgcore-nwdafd/src/context.rs
+++ b/src/bins/nextgcore-nwdafd/src/context.rs
@@ -135,6 +135,15 @@ impl AnalyticsId {
         Self::TrafficPattern,
     ];
 
+    /// The TS 29.520 **`NwdafEvent`** token for this event.
+    ///
+    /// This is the spelling used by Nnwdaf_EventsSubscription
+    /// (`eventSubscriptions[].event`), Nnwdaf_MLModelProvision
+    /// (`mLEventSubscs[].mLEvent`) and `NwdafInfo.nwdafEvents`.
+    ///
+    /// NOT the spelling for Nnwdaf_AnalyticsInfo (issue #175): that API types its
+    /// `event-id` as `EventId`, a different 24-value enumeration. Use
+    /// [`as_event_id`](Self::as_event_id) there.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::NfLoad => "NF_LOAD",
@@ -165,6 +174,12 @@ impl AnalyticsId {
         }
     }
 
+    /// Parse a TS 29.520 **`NwdafEvent`** token (the counterpart of
+    /// [`as_str`](Self::as_str)).
+    ///
+    /// Accepts all 25 `NwdafEvent` values. NOT for the Nnwdaf_AnalyticsInfo
+    /// `event-id` query parameter, which is an `EventId` — use
+    /// [`from_event_id`](Self::from_event_id) there (issue #175).
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "NF_LOAD" => Some(Self::NfLoad),
@@ -193,6 +208,60 @@ impl AnalyticsId {
             "ABNORMAL_UP_TRAFFIC" => Some(Self::AbnormalUpTraffic),
             "TRAFFIC_PATTERN" => Some(Self::TrafficPattern),
             _ => None,
+        }
+    }
+
+    /// The TS 29.520 **`EventId`** token for this event, or `None` when `EventId`
+    /// has no value for it (issue #175).
+    ///
+    /// `EventId` (`TS29520_Nnwdaf_AnalyticsInfo.yaml:939-1004`) is a DIFFERENT
+    /// enumeration from `NwdafEvent`, and the difference is not cosmetic:
+    ///
+    /// | | `NwdafEvent` (25) | `EventId` (24) |
+    /// |---|---|---|
+    /// | slice load level | `SLICE_LOAD_LEVEL` | `LOAD_LEVEL_INFORMATION` |
+    /// | PFD determination | `PFD_DETERMINATION` | *(absent)* |
+    ///
+    /// `EventId` is the type of the Nnwdaf_AnalyticsInfo `event-id` query
+    /// parameter (`yaml:35-40`) and of `NwdafInfo.eventIds` in the NRF profile
+    /// (`TS29510_Nnrf_NFManagement.yaml` `NwdafInfo`). `NwdafInfo` also carries a
+    /// separate `nwdafEvents` member typed `NwdafEvent`, which is how an event
+    /// with no `EventId` value can still be advertised — see
+    /// `main.rs::build_nf_profile`.
+    pub fn as_event_id(&self) -> Option<&'static str> {
+        Some(match self {
+            // The one token whose EventId spelling differs from its NwdafEvent
+            // spelling. Getting this wrong is what made a conformant
+            // `event-id=LOAD_LEVEL_INFORMATION` a 400 before #175.
+            Self::SliceLoadLevel => "LOAD_LEVEL_INFORMATION",
+            // Not an EventId value: PFD determination analytics are
+            // subscribe/notify-only, and `AnalyticsData` has no member for them
+            // either (see `analytics_data_key`).
+            Self::PfdDetermination => return None,
+            // Every other token is spelled identically in both enumerations.
+            other => other.as_str(),
+        })
+    }
+
+    /// Parse a TS 29.520 **`EventId`** token — the enumeration the
+    /// Nnwdaf_AnalyticsInfo `event-id` query parameter is typed as (issue #175).
+    ///
+    /// Accepts exactly `EventId`'s 24 values, so `LOAD_LEVEL_INFORMATION` is
+    /// recognised (it was rejected `400 INVALID_ANALYTICS_TYPE` before #175,
+    /// which is the spec's own token for that API) and the two `NwdafEvent`-only
+    /// spellings `SLICE_LOAD_LEVEL` / `PFD_DETERMINATION` are NOT — accepting a
+    /// token the called API does not define is the mirror-image of the same
+    /// confusion.
+    ///
+    /// The exact-inverse property (`from_event_id(as_event_id(e)) == Some(e)` for
+    /// every token with an `EventId` value, and no `EventId` value maps to two
+    /// tokens) is asserted by `test_event_id_and_nwdaf_event_are_distinct_enums`.
+    pub fn from_event_id(s: &str) -> Option<Self> {
+        match s {
+            "LOAD_LEVEL_INFORMATION" => Some(Self::SliceLoadLevel),
+            // Reject the NwdafEvent-only spellings on this surface.
+            "SLICE_LOAD_LEVEL" | "PFD_DETERMINATION" => None,
+            other => Self::from_str(other),
         }
     }
 
@@ -1375,6 +1444,122 @@ mod tests {
         // The old abbreviated tokens are rejected.
         assert_eq!(AnalyticsId::from_str("UE_COMM"), None);
         assert_eq!(AnalyticsId::from_str("SLICE_LOAD"), None);
+    }
+
+    /// **The issue #175 table test.** `EventId` and `NwdafEvent` are DIFFERENT
+    /// enumerations, and each parse/emit pair is pinned against its own yaml so
+    /// the two cannot drift back together.
+    ///
+    /// Sources: `TS29520_Nnwdaf_AnalyticsInfo.yaml:939-1004` (`EventId`, 24
+    /// values, the type of the `event-id` query parameter at `yaml:35-40`) and
+    /// `TS29520_Nnwdaf_EventsSubscription.yaml` (`NwdafEvent`, 25 values).
+    #[test]
+    fn test_event_id_and_nwdaf_event_are_distinct_enums() {
+        // The EventId enumeration, transcribed from the yaml in its own order.
+        let event_id_tokens = [
+            "LOAD_LEVEL_INFORMATION",
+            "NETWORK_PERFORMANCE",
+            "NF_LOAD",
+            "SERVICE_EXPERIENCE",
+            "UE_MOBILITY",
+            "UE_COMMUNICATION",
+            "QOS_SUSTAINABILITY",
+            "ABNORMAL_BEHAVIOUR",
+            "USER_DATA_CONGESTION",
+            "NSI_LOAD_LEVEL",
+            "SM_CONGESTION",
+            "DISPERSION",
+            "RED_TRANS_EXP",
+            "WLAN_PERFORMANCE",
+            "DN_PERFORMANCE",
+            "PDU_SESSION_TRAFFIC",
+            "E2E_DATA_VOL_TRANS_TIME",
+            "MOVEMENT_BEHAVIOUR",
+            "LOC_ACCURACY",
+            "RELATIVE_PROXIMITY",
+            "SIGNALLING_STORM",
+            "QOS_POLICY_ASSIST",
+            "TRAFFIC_PATTERN",
+            "ABNORMAL_UP_TRAFFIC",
+        ];
+        assert_eq!(event_id_tokens.len(), 24, "EventId defines 24 values");
+        assert_eq!(AnalyticsId::ALL.len(), 25, "NwdafEvent defines 25");
+
+        // Every EventId value is accepted on the AnalyticsInfo surface.
+        for t in event_id_tokens {
+            assert!(
+                AnalyticsId::from_event_id(t).is_some(),
+                "EventId value {t} must be accepted as an event-id"
+            );
+        }
+
+        // The two NwdafEvent-only spellings are REJECTED there: accepting a token
+        // the called API does not define is the mirror image of the #175 defect.
+        assert_eq!(AnalyticsId::from_event_id("SLICE_LOAD_LEVEL"), None);
+        assert_eq!(AnalyticsId::from_event_id("PFD_DETERMINATION"), None);
+        // ...while both remain valid NwdafEvent values on the notify surface.
+        assert_eq!(
+            AnalyticsId::from_str("SLICE_LOAD_LEVEL"),
+            Some(AnalyticsId::SliceLoadLevel)
+        );
+        assert_eq!(
+            AnalyticsId::from_str("PFD_DETERMINATION"),
+            Some(AnalyticsId::PfdDetermination)
+        );
+        // And LOAD_LEVEL_INFORMATION is NOT a NwdafEvent value.
+        assert_eq!(AnalyticsId::from_str("LOAD_LEVEL_INFORMATION"), None);
+
+        // The one token whose spelling differs between the enums.
+        assert_eq!(
+            AnalyticsId::from_event_id("LOAD_LEVEL_INFORMATION"),
+            Some(AnalyticsId::SliceLoadLevel),
+            "LOAD_LEVEL_INFORMATION is EventId's name for slice load level"
+        );
+        assert_eq!(
+            AnalyticsId::SliceLoadLevel.as_event_id(),
+            Some("LOAD_LEVEL_INFORMATION")
+        );
+        assert_eq!(AnalyticsId::SliceLoadLevel.as_str(), "SLICE_LOAD_LEVEL");
+
+        // PFD_DETERMINATION has no EventId spelling at all.
+        assert_eq!(AnalyticsId::PfdDetermination.as_event_id(), None);
+
+        // Exact inverse: as_event_id round-trips for every token that has one,
+        // and the 24 emitted spellings are exactly the EventId enumeration with
+        // no token sharing another's spelling.
+        let mut emitted: Vec<&str> = Vec::new();
+        for event in AnalyticsId::ALL {
+            match event.as_event_id() {
+                Some(token) => {
+                    assert_eq!(
+                        AnalyticsId::from_event_id(token),
+                        Some(*event),
+                        "as_event_id/from_event_id must be inverses for {}",
+                        event.as_str()
+                    );
+                    emitted.push(token);
+                }
+                None => assert_eq!(
+                    *event,
+                    AnalyticsId::PfdDetermination,
+                    "only PFD_DETERMINATION lacks an EventId spelling, not {}",
+                    event.as_str()
+                ),
+            }
+        }
+        emitted.sort_unstable();
+        let mut expected = event_id_tokens;
+        expected.sort_unstable();
+        assert_eq!(
+            emitted, expected,
+            "the emitted EventId spellings must be exactly the EventId enumeration"
+        );
+
+        // Every token still round-trips on the NwdafEvent surface (#108's
+        // contract is untouched by the new pair).
+        for event in AnalyticsId::ALL {
+            assert_eq!(AnalyticsId::from_str(event.as_str()), Some(*event));
+        }
     }
 
     /// **The issue #172 table test.** Every token's payload member name is

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -446,8 +446,20 @@ async fn nwdaf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
 /// form, so a consumer that discovers the MTLF role can actually download a
 /// model. Advertising it unconditionally is what made it a facade — the notified
 /// URL 404'd.
+///
+/// Issue #175: `NwdafInfo` has TWO event members with DIFFERENT enumerations —
+/// `eventIds` typed `EventId` (24 values, the Nnwdaf_AnalyticsInfo spelling) and
+/// `nwdafEvents` typed `NwdafEvent` (25, the Nnwdaf_EventsSubscription spelling).
+/// Both are advertised from the same [`SUPPORTED_EVENTS`], each in its own
+/// spelling, so a consumer discovering us for either API sees tokens that API
+/// actually defines. Previously `eventIds` carried `NwdafEvent` spellings, which
+/// is only invisible because NF_LOAD is spelled the same in both; a
+/// SLICE_LOAD_LEVEL or PFD_DETERMINATION collector would have advertised a token
+/// no `EventId` consumer could match. `eventIds` is omitted entirely rather than
+/// emitted empty if no supported event has an `EventId` value (it has
+/// `minItems: 1`).
 fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serde_json::Value {
-    let event_ids: Vec<&'static str> = SUPPORTED_EVENTS.iter().map(|e| e.as_str()).collect();
+    let nwdaf_info = nwdaf_info(SUPPORTED_EVENTS);
 
     let can_provision = nwdaf_self()
         .read()
@@ -461,10 +473,43 @@ fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serd
         "nfStatus": "REGISTERED",
         "ipv4Addresses": [sbi_addr],
         "nfServices": services,
-        "nwdafInfo": { "eventIds": event_ids },
+        "nwdafInfo": nwdaf_info,
         "allowedNfTypes": ["AMF", "SMF", "PCF", "NEF", "SCP"],
         "heartBeatTimer": 10
     })
+}
+
+/// Build TS 29.510 `NwdafInfo` for a set of supported analytics (issue #175).
+///
+/// `NwdafInfo` has two event members typed as two DIFFERENT TS 29.520
+/// enumerations, so each is emitted in its own spelling:
+///
+/// - `eventIds` → `EventId` (24 values, the Nnwdaf_AnalyticsInfo spelling). An
+///   event with no `EventId` value is skipped, because a consumer discovering us
+///   for that API could not name it anyway.
+/// - `nwdafEvents` → `NwdafEvent` (25 values, the Nnwdaf_EventsSubscription
+///   spelling). Covers every supported event, which is how one with no `EventId`
+///   value is still advertised.
+///
+/// Both have `minItems: 1`, so an empty member is omitted rather than emitted.
+///
+/// Taken as a parameter rather than read from [`SUPPORTED_EVENTS`] so the
+/// spelling logic is testable with events whose two spellings actually differ —
+/// same reason `nwdaf_services` takes `can_provision`. With `SUPPORTED_EVENTS`
+/// hardcoded, a test could only ever see NF_LOAD, which is spelled identically in
+/// both enumerations and therefore proves nothing about the divergence.
+fn nwdaf_info(events: &[AnalyticsId]) -> serde_json::Value {
+    let event_ids: Vec<&'static str> = events.iter().filter_map(|e| e.as_event_id()).collect();
+    let nwdaf_events: Vec<&'static str> = events.iter().map(|e| e.as_str()).collect();
+
+    let mut info = serde_json::Map::new();
+    if !event_ids.is_empty() {
+        info.insert("eventIds".to_string(), serde_json::json!(event_ids));
+    }
+    if !nwdaf_events.is_empty() {
+        info.insert("nwdafEvents".to_string(), serde_json::json!(nwdaf_events));
+    }
+    serde_json::Value::Object(info)
 }
 
 /// The `nfServices[]` this NWDAF advertises.
@@ -629,47 +674,116 @@ mod tests {
 
     // --- G2-3: NF profile advertises supported events (contract test) ---
 
-    /// G2-3 honesty contract: the registered NFProfile carries
-    /// `nwdafInfo.eventIds` (TS 29.510 `NwdafInfo`), the array equals
-    /// `SUPPORTED_EVENTS` exactly (same tokens, same order), and every token is
-    /// a recognised TS 29.520 `NwdafEvent`/`EventId` value ("NF_LOAD" is valid
-    /// in both enums). Field names pinned against
-    /// TS29510_Nnrf_NFManagement.yaml `NwdafInfo` (eventIds → EventId).
+    /// G2-3 honesty contract: the registered NFProfile advertises the supported
+    /// analytics, and — issue #175 — it does so in BOTH of `NwdafInfo`'s event
+    /// members, each in the enumeration that member is typed as:
+    /// `eventIds` → `EventId`, `nwdafEvents` → `NwdafEvent`
+    /// (`TS29510_Nnrf_NFManagement.yaml` `NwdafInfo`). Advertising `NwdafEvent`
+    /// spellings under `eventIds` is only invisible while every supported event
+    /// happens to be spelled the same in both enums.
     #[test]
     fn test_honesty_profile_advertises_supported_event_ids() {
         let profile = build_nf_profile("nwdaf-contract-test", "127.0.0.1", 7815);
 
-        let event_ids = profile
-            .get("nwdafInfo")
-            .and_then(|i| i.get("eventIds"))
-            .and_then(|v| v.as_array())
-            .expect("NFProfile must carry nwdafInfo.eventIds (TS 29.510 NwdafInfo)");
+        let member = |name: &str| -> Vec<String> {
+            profile
+                .get("nwdafInfo")
+                .and_then(|i| i.get(name))
+                .and_then(|v| v.as_array())
+                .unwrap_or_else(|| panic!("NFProfile must carry nwdafInfo.{name}"))
+                .iter()
+                .map(|v| {
+                    v.as_str()
+                        .unwrap_or_else(|| panic!("{name} entries are strings"))
+                        .to_string()
+                })
+                .collect()
+        };
+
+        // eventIds is the EventId spelling, in SUPPORTED_EVENTS order, skipping
+        // any event EventId does not define.
+        let event_ids = member("eventIds");
         assert!(
             !event_ids.is_empty(),
             "nwdafInfo.eventIds has minItems 1 in the yaml"
         );
-
-        let tokens: Vec<&str> = event_ids
+        let expected_ids: Vec<&str> = SUPPORTED_EVENTS
             .iter()
-            .map(|v| v.as_str().expect("eventIds entries are strings"))
+            .filter_map(|e| e.as_event_id())
             .collect();
-        let supported: Vec<&str> = SUPPORTED_EVENTS.iter().map(|e| e.as_str()).collect();
-        assert_eq!(
-            tokens, supported,
-            "advertised eventIds must equal SUPPORTED_EVENTS exactly"
-        );
-
-        // ⊆ NwdafEvent tokens: every advertised id round-trips through the
-        // recognised event enum (no bespoke tokens on the wire).
-        for t in &tokens {
+        assert_eq!(event_ids, expected_ids);
+        for t in &event_ids {
             assert!(
-                AnalyticsId::from_str(t).is_some(),
-                "advertised eventId {t} must be a recognised NwdafEvent token"
+                AnalyticsId::from_event_id(t).is_some(),
+                "advertised eventId {t} must be a TS 29.520 EventId value"
             );
         }
 
-        // Initially exactly NF_LOAD (the only live collector, G2-1).
-        assert_eq!(tokens, vec!["NF_LOAD"]);
+        // nwdafEvents is the NwdafEvent spelling, covering every supported event.
+        let nwdaf_events = member("nwdafEvents");
+        let expected_events: Vec<&str> = SUPPORTED_EVENTS.iter().map(|e| e.as_str()).collect();
+        assert_eq!(nwdaf_events, expected_events);
+        for t in &nwdaf_events {
+            assert!(
+                AnalyticsId::from_str(t).is_some(),
+                "advertised nwdafEvent {t} must be a TS 29.520 NwdafEvent value"
+            );
+        }
+        assert_eq!(
+            nwdaf_events.len(),
+            SUPPORTED_EVENTS.len(),
+            "nwdafEvents must cover every supported event, even those EventId omits"
+        );
+
+        // Initially exactly NF_LOAD (the only live collector, G2-1), which is
+        // spelled identically in both enumerations.
+        assert_eq!(event_ids, vec!["NF_LOAD"]);
+        assert_eq!(nwdaf_events, vec!["NF_LOAD"]);
+    }
+
+    /// **The load-bearing half of the #175 profile fix.** The test above can only
+    /// ever see NF_LOAD, which is spelled the same in both enumerations, so it
+    /// cannot tell `eventIds` built from `EventId` spellings apart from one built
+    /// from `NwdafEvent` spellings. This drives the pure builder with events whose
+    /// spellings DO differ.
+    #[test]
+    fn test_nwdaf_info_emits_each_member_in_its_own_enumeration() {
+        let info = nwdaf_info(&[
+            AnalyticsId::NfLoad,
+            AnalyticsId::SliceLoadLevel,
+            AnalyticsId::PfdDetermination,
+        ]);
+
+        // eventIds is EventId: SLICE_LOAD_LEVEL becomes LOAD_LEVEL_INFORMATION,
+        // and PFD_DETERMINATION is dropped because EventId has no value for it.
+        assert_eq!(
+            info["eventIds"],
+            serde_json::json!(["NF_LOAD", "LOAD_LEVEL_INFORMATION"]),
+            "eventIds must carry EventId spellings only"
+        );
+
+        // nwdafEvents is NwdafEvent: all three, in their own spelling. This is
+        // how an event with no EventId value is still advertised at all.
+        assert_eq!(
+            info["nwdafEvents"],
+            serde_json::json!(["NF_LOAD", "SLICE_LOAD_LEVEL", "PFD_DETERMINATION"]),
+            "nwdafEvents must carry NwdafEvent spellings for every supported event"
+        );
+
+        // An event with no EventId value at all → eventIds omitted, not empty
+        // (minItems 1), while nwdafEvents still advertises it.
+        let only_pfd = nwdaf_info(&[AnalyticsId::PfdDetermination]);
+        assert!(
+            only_pfd.get("eventIds").is_none(),
+            "an empty eventIds would violate minItems 1: {only_pfd}"
+        );
+        assert_eq!(
+            only_pfd["nwdafEvents"],
+            serde_json::json!(["PFD_DETERMINATION"])
+        );
+
+        // No supported events at all → both omitted.
+        assert_eq!(nwdaf_info(&[]), serde_json::json!({}));
     }
 
     // --- nwafd-02: Nnwdaf_AnalyticsInfo is GET-only at the routing layer ---

--- a/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
+++ b/src/bins/nextgcore-nwdafd/src/sbi_handler.rs
@@ -495,11 +495,17 @@ pub async fn handle_analytics_info_query_with_ctx(
         return isac_sensing_summary_with_ctx(ctx);
     }
 
-    let analytics_id = match AnalyticsId::from_str(event_token) {
+    // Issue #175: `event-id` is typed `EventId`
+    // (`TS29520_Nnwdaf_AnalyticsInfo.yaml:35-40`), NOT the `NwdafEvent` the
+    // EventsSubscription API uses. The two enumerations differ, so parsing this
+    // with `from_str` rejected `LOAD_LEVEL_INFORMATION` — the spec's own token for
+    // slice load level on THIS API — while accepting `SLICE_LOAD_LEVEL` and
+    // `PFD_DETERMINATION`, which `EventId` does not define.
+    let analytics_id = match AnalyticsId::from_event_id(event_token) {
         Some(id) => id,
         None => {
             return send_bad_request(
-                &format!("Invalid event-id: {event_token}"),
+                &format!("Invalid event-id: {event_token} is not a TS 29.520 EventId value"),
                 Some("INVALID_ANALYTICS_TYPE"),
             )
         }
@@ -1773,6 +1779,115 @@ mod tests {
         assert_eq!(resp.status, 400, "malformed event-filter must be 400");
     }
 
+    // ── issue #175: event-id is an EventId, not a NwdafEvent ─────────────────
+
+    /// **The #175 acceptance test.** `event-id` is typed `EventId`
+    /// (`TS29520_Nnwdaf_AnalyticsInfo.yaml:35-40`), so
+    /// `LOAD_LEVEL_INFORMATION` — the spec's own token for slice load level on
+    /// THIS API — must be accepted. Before #175 it was rejected
+    /// `400 INVALID_ANALYTICS_TYPE`, which is a live defect a conformant consumer
+    /// hits immediately, unlike #172's latent member names.
+    ///
+    /// It resolves to the same analytics as `SLICE_LOAD_LEVEL` does on the
+    /// subscribe surface, so with no collector for it the honest answer is 204 —
+    /// the supported-events gate, NOT a parse rejection. The distinction is the
+    /// whole point: 400 says "no such analytics type", 204 says "that analytics
+    /// type exists but has no data".
+    #[tokio::test]
+    async fn test_analytics_info_accepts_the_event_id_spelling() {
+        // NF_LOAD data exists, so a 204 can only come from the supported-events
+        // gate rather than from a globally empty engine.
+        let ctx = ctx_with_loads("AMF", "amf-eventid-01", &[50]);
+
+        let resp = handle_analytics_info_query_with_ctx(
+            &ctx,
+            &SbiRequest::get("/nnwdaf-analyticsinfo/v1/analytics?event-id=LOAD_LEVEL_INFORMATION"),
+        )
+        .await;
+        assert_eq!(
+            resp.status, 204,
+            "LOAD_LEVEL_INFORMATION is an EventId value: it must reach the \
+             supported-events gate (204), not be rejected as an unknown type (400)"
+        );
+
+        // The two NwdafEvent-only spellings are NOT EventId values, so on this
+        // surface they are a genuine 400 INVALID_ANALYTICS_TYPE.
+        for token in ["SLICE_LOAD_LEVEL", "PFD_DETERMINATION"] {
+            let uri = format!("/nnwdaf-analyticsinfo/v1/analytics?event-id={token}");
+            let resp = handle_analytics_info_query_with_ctx(&ctx, &SbiRequest::get(&uri)).await;
+            assert_eq!(
+                resp.status, 400,
+                "{token} is not an EventId value, so event-id={token} must be 400"
+            );
+            assert_eq!(
+                body_json(&resp)["cause"].as_str(),
+                Some("INVALID_ANALYTICS_TYPE")
+            );
+        }
+
+        // Every other EventId value keeps reaching the gate, and a token outside
+        // both enumerations is still a 400.
+        let resp = handle_analytics_info_query_with_ctx(
+            &ctx,
+            &SbiRequest::get("/nnwdaf-analyticsinfo/v1/analytics?event-id=NF_LOAD"),
+        )
+        .await;
+        assert_eq!(
+            resp.status, 200,
+            "NF_LOAD is spelled the same in both enums"
+        );
+        let resp = handle_analytics_info_query_with_ctx(
+            &ctx,
+            &SbiRequest::get("/nnwdaf-analyticsinfo/v1/analytics?event-id=NOT_AN_EVENT"),
+        )
+        .await;
+        assert_eq!(resp.status, 400);
+    }
+
+    /// The subscribe surface is unchanged: `eventSubscriptions[].event` really is
+    /// a `NwdafEvent`, so `SLICE_LOAD_LEVEL` belongs there and
+    /// `LOAD_LEVEL_INFORMATION` does not — the exact opposite of the GET surface.
+    #[tokio::test]
+    async fn test_subscription_event_stays_a_nwdaf_event() {
+        nwdaf_context_init("nwdaf-test".to_string(), 1024);
+
+        let create = |token: &str| {
+            SbiRequest::post("/nnwdaf-eventssubscription/v1/subscriptions")
+                .with_json_body(&json!({
+                    "notificationURI": "http://amf.example.org/notify",
+                    "eventSubscriptions": [{ "event": token }]
+                }))
+                .expect("valid JSON body")
+        };
+
+        // SLICE_LOAD_LEVEL is a NwdafEvent → carried as a recognised event.
+        let resp = handle_subscription_create(&create("SLICE_LOAD_LEVEL")).await;
+        assert_eq!(resp.status, 201);
+        assert_eq!(
+            body_json(&resp)["eventSubscriptions"][0]["event"].as_str(),
+            Some("SLICE_LOAD_LEVEL"),
+            "the notify surface keeps the NwdafEvent spelling"
+        );
+
+        // LOAD_LEVEL_INFORMATION is NOT a NwdafEvent. Per #108 an unrecognised
+        // token is reported per-event in failEventReports rather than rejecting
+        // the subscription, so it lands there — echoed verbatim.
+        let resp = handle_subscription_create(&create("LOAD_LEVEL_INFORMATION")).await;
+        assert_eq!(resp.status, 201);
+        let body = body_json(&resp);
+        assert!(
+            body["eventSubscriptions"]
+                .as_array()
+                .is_none_or(Vec::is_empty),
+            "LOAD_LEVEL_INFORMATION is not a NwdafEvent, so it is not carried as one: {body}"
+        );
+        assert_eq!(
+            body["failEventReports"][0]["event"].as_str(),
+            Some("LOAD_LEVEL_INFORMATION"),
+            "it is reported unserviceable, echoed verbatim (#108)"
+        );
+    }
+
     // ── issue #171: tgt-ue, the analytics target period, and its errors ───────
 
     /// Percent-encode a JSON value for use as a query-parameter value, so tests
@@ -2452,20 +2567,24 @@ mod tests {
         );
 
         // Every recognised-but-unsupported event behaves identically.
+        //
+        // Issue #175: iterated by the event's `EventId` spelling, because that is
+        // what this API's `event-id` parameter is typed as. A token with no
+        // EventId value (PFD_DETERMINATION) is not "unsupported analytics" on this
+        // surface at all — it is an unknown analytics type, so 400 rather than
+        // 204, which `test_analytics_info_accepts_the_event_id_spelling` pins.
         for event in AnalyticsId::ALL {
             if event.is_supported() {
                 continue;
             }
-            let uri = format!(
-                "/nnwdaf-analyticsinfo/v1/analytics?event-id={}",
-                event.as_str()
-            );
+            let Some(token) = event.as_event_id() else {
+                continue;
+            };
+            let uri = format!("/nnwdaf-analyticsinfo/v1/analytics?event-id={token}");
             let resp = handle_analytics_info_query_with_ctx(&ctx, &SbiRequest::get(&uri)).await;
             assert_eq!(
-                resp.status,
-                204,
-                "GET {} must be 204 (a 200 here is empty-200 dishonesty)",
-                event.as_str()
+                resp.status, 204,
+                "GET event-id={token} must be 204 (a 200 here is empty-200 dishonesty)"
             );
         }
     }


### PR DESCRIPTION
Closes #175.

## The defect

TS 29.520 defines **two** analytics-event enumerations, and the two service APIs use different ones:

| enum | used by | count | difference |
|---|---|---|---|
| `NwdafEvent` | EventsSubscription `event`, MLModelProvision `mLEvent`, `NwdafInfo.nwdafEvents` | 25 | `SLICE_LOAD_LEVEL`, `PFD_DETERMINATION` |
| `EventId` (`TS29520_Nnwdaf_AnalyticsInfo.yaml:939-1004`) | AnalyticsInfo `event-id` (`yaml:35-40`), `NwdafInfo.eventIds` | 24 | `LOAD_LEVEL_INFORMATION` instead of `SLICE_LOAD_LEVEL`; no `PFD_DETERMINATION` |

`AnalyticsId::from_str` knew only the `NwdafEvent` spellings and served both surfaces, so:

1. **`GET /analytics?event-id=LOAD_LEVEL_INFORMATION` → `400 INVALID_ANALYTICS_TYPE`.** The spec's own token for slice-load-level analytics *on that API*. Unlike #172's member names this is **live** — it needs no collector, only a conformant consumer.
2. `event-id=SLICE_LOAD_LEVEL` and `event-id=PFD_DETERMINATION` were **accepted** although `EventId` defines neither — the mirror image of the same confusion.
3. `NFProfile.nwdafInfo.eventIds` was built from `as_str()`, i.e. `NwdafEvent` spellings, although `TS29510_Nnrf_NFManagement.yaml` types that member as `EventId`.

## The fix

A **per-surface parse/emit pair**, so the crate is now surface-explicit in *both* directions — #172 did this for member names, this does it for tokens:

* `AnalyticsId::from_event_id(&str)` — accepts exactly `EventId`'s 24 values, maps `LOAD_LEVEL_INFORMATION` → `SliceLoadLevel`, rejects the two `NwdafEvent`-only spellings.
* `AnalyticsId::as_event_id() -> Option<&'static str>` — `None` for `PFD_DETERMINATION`.
* `from_str`/`as_str` remain the `NwdafEvent` pair, now documented as such with a pointer to the `EventId` pair. Not renamed: `as_str` has 35 call sites and is the natural "the token this enum is named by", so the doc note is the cheaper guard.

Exactly **one** production parse site moves. `eventSubscriptions[].event` and MLModelProvision's `mLEvent` genuinely are `NwdafEvent` (`TS29520_Nnwdaf_MLModelProvision.yaml:339-340`), so they keep `from_str` — and a test now pins that the two surfaces disagree *on purpose*.

**Why 204 and not 400 for `LOAD_LEVEL_INFORMATION`.** It resolves to the same analytics `SLICE_LOAD_LEVEL` does on the subscribe surface, and that has no collector, so the honest answer is the supported-events gate. `400` says "no such analytics type"; `204` says "that type exists but has no data". The API was giving the first answer to a conformant request.

**Both profile members.** `NwdafInfo` carries `eventIds` (`EventId`) *and* `nwdafEvents` (`NwdafEvent`), so each is emitted in its own spelling from the same `SUPPORTED_EVENTS`. That is also what lets an event with no `EventId` value be advertised at all rather than vanishing from discovery. Both have `minItems: 1`, so an empty member is omitted.

## The existing test proved nothing — worth calling out

The profile contract test asserts `eventIds` against `SUPPORTED_EVENTS`, which is `[NF_LOAD]` — spelled **identically in both enumerations**. So it could not distinguish an `EventId`-built array from a `NwdafEvent`-built one, and it passed unchanged with the bug in place.

`nwdaf_info(events)` is therefore factored out as a pure builder taking the event list (same reason `nwdaf_services` takes `can_provision`) and driven with `[NF_LOAD, SLICE_LOAD_LEVEL, PFD_DETERMINATION]`, where the spellings differ:

```
eventIds    -> ["NF_LOAD", "LOAD_LEVEL_INFORMATION"]        // PFD dropped: no EventId value
nwdafEvents -> ["NF_LOAD", "SLICE_LOAD_LEVEL", "PFD_DETERMINATION"]
```

## Verification

* Workspace **5601 passed / 0 failed** (baseline 5597).
* `nextgcore-nwdafd` **156 passed** (baseline 152); **160** with `--all-features`.
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace` 0 errors; `clippy -D warnings` clean on nwdafd with `--all-targets --all-features`.
* **All three new tests revert-verified:** pointing the handler back at `from_str` fails the acceptance test *and* the unsupported-event sweep; dropping the two rejections from `from_event_id` fails the table test *and* the acceptance test; rebuilding `eventIds` from `as_str()` fails the new pure-builder test **and nothing else** — which is precisely the gap the old test left.

## Acceptance criteria

- [x] `event-id=LOAD_LEVEL_INFORMATION` is no longer `400 INVALID_ANALYTICS_TYPE`, with a test.
- [x] The accepted set on the AnalyticsInfo surface is exactly `EventId`'s 24 values; the notify surface still accepts all 25 `NwdafEvent` values.
- [x] A table test pins both accepted sets against their yaml enums, plus the exact-inverse property of `as_event_id`/`from_event_id` and that no `EventId` spelling is shared by two tokens.
- [x] `cargo test -p nextgcore-nwdafd` and `cargo clippy --workspace` pass.

Spec: `specs/fix-nwdaf-analyticsinfo-event-id-enum.md`
