### PR TITLE
fix(ausfd): route Nausf Deregister, clear the stale KAUSF, and serve the auth context as HAL (closes #82)

### DIFF
--- a/src/bins/nextgcore-ausfd/src/app.rs
+++ b/src/bins/nextgcore-ausfd/src/app.rs
@@ -410,6 +410,14 @@ pub async fn ausf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
             let auth_ctx_id = parts[3];
             handle_eap_session(auth_ctx_id, &request).await
         }
+        // Issue #82: TS 29.509 §5.2.2.3 Deregister. MUST precede the generic
+        // authenticate arm below, which would otherwise swallow `deregister` as
+        // an `AuthenticationInfo` body and reject it 400.
+        ("nausf-auth", "ue-authentications", "POST")
+            if parts.len() >= 4 && parts[3] == "deregister" =>
+        {
+            handle_ue_authentication_deregister(&request).await
+        }
         ("nausf-auth", "ue-authentications", "POST") => {
             // UE Authentication (5G-AKA or EAP-AKA')
             handle_ue_authentication(&request).await
@@ -439,11 +447,123 @@ pub async fn ausf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
             crate::upu_protection::handle_upu_protect(supi, &request)
         }
 
+        // Issue #82: paths the Nausf_UEAuthentication API DECLARES but this AUSF
+        // does not implement (optional Rel-16/17 features):
+        //   /rg-authentications                              (yaml:381)
+        //   /prose-authentications                           (yaml:451)
+        //   /prose-authentications/{authCtxId}/prose-auth    (yaml:514)
+        // `501 Not Implemented` is the right shape for a defined-but-unimplemented
+        // resource; `405 Method Not Allowed` (the fallthrough) claims the resource
+        // exists but rejects the method, which is false and misleads a consumer
+        // into retrying with another verb.
+        ("nausf-auth", "rg-authentications", _) | ("nausf-auth", "prose-authentications", _) => {
+            log::info!("AUSF: {method} {uri} is a declared but unimplemented Nausf resource");
+            send_problem(
+                501,
+                "NOT_IMPLEMENTED",
+                &format!("{resource} is declared by TS 29.509 but not implemented by this AUSF"),
+            )
+        }
+
         _ => {
             log::warn!("Unknown AUSF request: {method} {uri}");
             send_method_not_allowed(method, uri)
         }
     }
+}
+
+/// Handle `POST /nausf-auth/v1/ue-authentications/deregister` — the TS 29.509
+/// §5.2.2.3 Deregister service operation (issue #82).
+///
+/// Before this the path had no arm, so it fell through to the generic
+/// authenticate handler, which parsed the `DeregistrationInfo` body as an
+/// `AuthenticationInfo`, found no `servingNetworkName` and answered `400`. A
+/// conformant consumer could therefore never release a security context through
+/// the standard operation.
+///
+/// WHAT THIS CLEARS, AND WHY IT DIFFERS FROM [`handle_auth_context_delete`].
+/// §5.2.2.3.1 states the purpose explicitly: the consumer (**the UDM**, not the
+/// AMF) asks the AUSF "to clear the stale security context ... so as to ensure
+/// only latest Kausf is maintained in the network". So unlike the AMF's
+/// `DELETE ue-authentications/{authCtxId}` — which deliberately KEEPS the per-SUPI
+/// SoR/UPU anchor so Nausf_SoRProtection/Nausf_UPUProtection keep working
+/// (TS 33.501 §6.14.1) — deregister must purge the anchor too. Reusing the DELETE
+/// teardown verbatim would leave the stale anchor `K_AUSF` behind and so fail the
+/// operation's entire stated purpose.
+///
+/// `404` is returned only when the AUSF holds NEITHER an authentication context
+/// nor an anchor for the SUPI, i.e. genuinely nothing to clear. An anchor with no
+/// live authentication context is a real state to clear (the AMF may already have
+/// deleted the context), so that case is a success.
+pub async fn handle_ue_authentication_deregister(request: &SbiRequest) -> SbiResponse {
+    let body = match &request.http.content {
+        Some(content) => content,
+        None => return send_bad_request("Missing request body", Some("MISSING_BODY")),
+    };
+
+    let info: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+    };
+
+    // `DeregistrationInfo` requires ONLY `supi`
+    // (TS29509_Nausf_UEAuthentication.yaml:796-805). Deliberately NOT routed
+    // through `validate_authentication_info`: that demands `servingNetworkName`,
+    // which this body does not carry and the spec does not ask for.
+    let supi = match info.get("supi").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            return send_bad_request(
+                "supi is a mandatory IE of DeregistrationInfo",
+                Some("MANDATORY_IE_MISSING"),
+            )
+        }
+    };
+
+    log::info!("[{supi}] UE Authentication Deregister");
+
+    let ctx = ausf_self();
+
+    let ue_id = ctx
+        .read()
+        .ok()
+        .and_then(|context| context.ue_find_by_supi(supi).map(|ue| ue.id));
+
+    // Purge the SoR/UPU anchor: the whole point of the operation is that a stale
+    // KAUSF must not survive it.
+    let anchor_removed = ctx
+        .read()
+        .map(|context| context.anchor_remove(supi))
+        .unwrap_or(false);
+
+    let context_removed = match ue_id {
+        Some(id) => {
+            let removed = ctx.read().ok().and_then(|context| context.ue_remove(id));
+            match removed {
+                Some(mut ue) => {
+                    // Zeroize KAUSF/KSEAF/XRES* before the context is dropped.
+                    ue.zeroize();
+                    true
+                }
+                None => false,
+            }
+        }
+        None => false,
+    };
+
+    if !context_removed && !anchor_removed {
+        log::info!("[{supi}] Deregister: no security context or anchor held → 404");
+        return send_not_found(
+            "No security context for the requested SUPI",
+            Some("CONTEXT_NOT_FOUND"),
+        );
+    }
+
+    log::info!(
+        "[{supi}] Security context cleared and zeroized (auth context: {context_removed}, \
+         SoR/UPU anchor: {anchor_removed})"
+    );
+    SbiResponse::with_status(204)
 }
 
 // UE Authentication handlers
@@ -461,18 +581,22 @@ pub async fn handle_ue_authentication(request: &SbiRequest) -> SbiResponse {
         Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
     };
 
-    let supi_or_suci = auth_info
-        .get("supiOrSuci")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
+    // Issue #82: `supiOrSuci` is a mandatory IE of `AuthenticationInfo`. It used
+    // to default to the literal "unknown", which the validator then accepted as a
+    // present value — so a body with no identity reached the UDM as a query for a
+    // subscriber called "unknown" instead of being rejected. Kept as an Option so
+    // absence stays distinguishable from an empty string all the way to the
+    // validator.
+    let supi_or_suci = auth_info.get("supiOrSuci").and_then(|v| v.as_str());
     let serving_network_name = auth_info.get("servingNetworkName").and_then(|v| v.as_str());
 
     // Validate required fields
     if let Err(msg) =
-        crate::nausf_handler::validate_authentication_info(Some(supi_or_suci), serving_network_name)
+        crate::nausf_handler::validate_authentication_info(supi_or_suci, serving_network_name)
     {
         return send_bad_request(msg, Some("INVALID_REQUEST"));
     }
+    let supi_or_suci = supi_or_suci.expect("validated non-empty above");
 
     let serving_network_name = serving_network_name.expect("value expected");
 
@@ -581,9 +705,14 @@ pub async fn handle_ue_authentication(request: &SbiRequest) -> SbiResponse {
             let hxres_star_hex = crate::nudm_handler::bytes_to_hex(&ausf_ue.hxres_star);
             let auth_ctx_id = ausf_ue.ctx_id.clone();
 
+            // Issue #82: the 201 UEAuthenticationCtx is declared
+            // `application/3gppHal+json` ONLY
+            // (TS29509_Nausf_UEAuthentication.yaml:44-48) — it carries the
+            // `_links` map the consumer follows to confirm, so a strict HAL
+            // client may reject or mis-parse it as plain application/json.
             SbiResponse::with_status(201)
                 .with_header("Location", format!("/nausf-auth/v1/ue-authentications/{auth_ctx_id}"))
-                .with_json_body(&serde_json::json!({
+                .with_hal_json_body(&serde_json::json!({
                     "authType": "5G_AKA",
                     "5gAuthData": {
                         "rand": rand_hex,
@@ -639,12 +768,13 @@ pub async fn handle_ue_authentication(request: &SbiRequest) -> SbiResponse {
             }
 
             let auth_ctx_id = ausf_ue.ctx_id.clone();
+            // Issue #82: HAL media type, as for the 5G-AKA branch above.
             SbiResponse::with_status(201)
                 .with_header(
                     "Location",
                     format!("/nausf-auth/v1/ue-authentications/{auth_ctx_id}"),
                 )
-                .with_json_body(&serde_json::json!({
+                .with_hal_json_body(&serde_json::json!({
                     "authType": "EAP_AKA_PRIME",
                     "5gAuthData": eap_payload_b64,
                     "_links": {
@@ -2135,7 +2265,7 @@ mod tests {
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
-        let _guard = crate::test_support::CONTEXT_GUARD.lock().unwrap();
+        let _guard = crate::test_support::lock_context();
         let _ = env_logger::try_init();
         let _lock = TEST_MUTEX.lock().await;
         tokio::time::timeout(Duration::from_secs(60), async {
@@ -2500,7 +2630,7 @@ mod tests {
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
-        let _guard = crate::test_support::CONTEXT_GUARD.lock().unwrap();
+        let _guard = crate::test_support::lock_context();
         let _ = env_logger::try_init();
         let _lock = TEST_MUTEX.lock().await;
 
@@ -2745,7 +2875,7 @@ mod tests {
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
-        let _guard = crate::test_support::CONTEXT_GUARD.lock().unwrap();
+        let _guard = crate::test_support::lock_context();
         let _lock = TEST_MUTEX.lock().await;
         ausf_context_init(128);
 
@@ -2793,7 +2923,7 @@ mod tests {
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
-        let _guard = crate::test_support::CONTEXT_GUARD.lock().unwrap();
+        let _guard = crate::test_support::lock_context();
         let _ = env_logger::try_init();
         let _lock = TEST_MUTEX.lock().await;
 
@@ -2905,6 +3035,333 @@ mod tests {
     }
 
     // ====================================================================
+    // Issue #82: TS 29.509 §5.2.2.3 Deregister, HAL media type, and the
+    // declared-but-unimplemented resources.
+    // ====================================================================
+
+    /// **The #82 acceptance test, and the design point.** Deregister clears the
+    /// stale security context INCLUDING the per-SUPI SoR/UPU anchor, which is the
+    /// exact opposite of `handle_auth_context_delete` (whose companion test
+    /// `test_sor_upu_anchor_survives_auth_context_delete` asserts the anchor
+    /// SURVIVES).
+    ///
+    /// TS 29.509 §5.2.2.3.1 states the purpose: the consumer (the UDM) asks the
+    /// AUSF "to clear the stale security context ... so as to ensure only latest
+    /// Kausf is maintained in the network". Reusing the DELETE teardown verbatim
+    /// would leave the anchor `K_AUSF` behind and fail that purpose, so the two
+    /// operations deliberately differ and both are pinned.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
+    async fn test_deregister_clears_context_and_the_sor_upu_anchor() {
+        let _guard = crate::test_support::lock_context();
+        let _ = env_logger::try_init();
+        let _lock = TEST_MUTEX.lock().await;
+
+        tokio::time::timeout(Duration::from_secs(60), async {
+            ausf_context_init(128);
+
+            let udm_port = free_port();
+            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
+                [127, 0, 0, 1],
+                udm_port,
+            ))));
+            udm_server.start(mock_udm_handler).await.expect("udm start");
+            std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
+            std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
+
+            let ausf_port = free_port();
+            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
+                [127, 0, 0, 1],
+                ausf_port,
+            ))));
+            ausf_server
+                .start(ausf_sbi_request_handler)
+                .await
+                .expect("ausf start");
+            let client = nextgcore_sbi::client::SbiClient::with_host_port("127.0.0.1", ausf_port);
+
+            // Fresh SUPI so no earlier test can have seeded state for it.
+            let supi = "imsi-001010000000821";
+
+            // Real 5G-AKA flow so the anchor is populated by the production hook.
+            let (href, rand) = initiate_5g_aka(&client, supi, TEST_SNN).await;
+            let (res, ck, ik, _ak, _akstar) =
+                nextgcore_crypt::milenage::milenage_f2345(&TEST_OPC, &TEST_K, &rand).unwrap();
+            let res_star =
+                nextgcore_crypt::kdf::nextgcore_kdf_xres_star(&ck, &ik, TEST_SNN, &rand, &res);
+            let resp = client
+                .put_json(
+                    &href,
+                    &serde_json::json!({
+                        "resStar": crate::nudm_handler::bytes_to_hex(&res_star)
+                    }),
+                )
+                .await
+                .expect("confirmation");
+            assert_eq!(resp.status, 200);
+
+            // Both pieces of state exist before deregistration.
+            let kausf = ausf_self()
+                .read()
+                .unwrap()
+                .anchor_lookup_kausf(supi)
+                .expect("anchor after successful primary auth");
+            assert_ne!(kausf, [0u8; 32], "anchor KAUSF must not be zero");
+            assert!(
+                ausf_self().read().unwrap().ue_find_by_supi(supi).is_some(),
+                "auth context exists before deregistration"
+            );
+
+            // ── UDM-style deregistration, through the REAL router ─────────────
+            // `DeregistrationInfo` carries ONLY `supi` — no servingNetworkName.
+            // Before #82 this fell through to the authenticate handler, which
+            // demanded one and answered 400.
+            let resp = client
+                .post_json(
+                    "/nausf-auth/v1/ue-authentications/deregister",
+                    &serde_json::json!({ "supi": supi }),
+                )
+                .await
+                .expect("deregister");
+            assert_eq!(
+                resp.status, 204,
+                "a conformant DeregistrationInfo must be 204, not the pre-#82 400"
+            );
+
+            // The authentication context is gone (and was zeroized on removal)...
+            assert!(
+                ausf_self().read().unwrap().ue_find_by_supi(supi).is_none(),
+                "deregister must remove the authentication context"
+            );
+            // ...and so is the anchor: THIS is what distinguishes deregister from
+            // DELETE, and what makes "only the latest KAUSF is maintained" true.
+            assert!(
+                ausf_self()
+                    .read()
+                    .unwrap()
+                    .anchor_lookup_kausf(supi)
+                    .is_none(),
+                "deregister must purge the stale SoR/UPU anchor KAUSF (TS 29.509 §5.2.2.3.1)"
+            );
+            // With no anchor, the SoR/UPU counter lifecycle refuses to serve.
+            assert_eq!(
+                ausf_self().read().unwrap().anchor_next_sor_counter(supi),
+                Err(crate::AnchorCounterError::NoAnchor),
+                "no anchor means SoR/UPU can no longer be protected with a stale key"
+            );
+
+            // Nothing left to clear → 404 on a repeat.
+            let resp = client
+                .post_json(
+                    "/nausf-auth/v1/ue-authentications/deregister",
+                    &serde_json::json!({ "supi": supi }),
+                )
+                .await
+                .expect("second deregister");
+            assert_eq!(resp.status, 404, "a second deregister has nothing to clear");
+        })
+        .await
+        .expect("test timed out");
+    }
+
+    /// Deregister input validation (issue #82). The load-bearing case is the
+    /// LAST one: a body with `supi` and no `servingNetworkName` must NOT be run
+    /// through `validate_authentication_info`, which is what produced the 400
+    /// before the dedicated route existed.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
+    async fn test_deregister_validation_and_unknown_supi() {
+        let _guard = crate::test_support::lock_context();
+        let _lock = TEST_MUTEX.lock().await;
+        ausf_context_init(128);
+
+        let post = |body: Option<serde_json::Value>| {
+            let req = SbiRequest::post("/nausf-auth/v1/ue-authentications/deregister");
+            match body {
+                Some(v) => req.with_json_body(&v).expect("valid JSON"),
+                None => req,
+            }
+        };
+
+        // No body → 400.
+        assert_eq!(
+            ausf_sbi_request_handler(post(None)).await.status,
+            400,
+            "a missing body must be 400"
+        );
+
+        // Malformed JSON → 400.
+        assert_eq!(
+            ausf_sbi_request_handler(
+                SbiRequest::post("/nausf-auth/v1/ue-authentications/deregister")
+                    .with_body("{not json", "application/json")
+            )
+            .await
+            .status,
+            400,
+            "malformed JSON must be 400"
+        );
+
+        // `supi` absent or empty → 400 (it is the only required member).
+        for body in [
+            serde_json::json!({}),
+            serde_json::json!({ "supi": "" }),
+            serde_json::json!({ "supportedFeatures": "0" }),
+        ] {
+            assert_eq!(
+                ausf_sbi_request_handler(post(Some(body.clone())))
+                    .await
+                    .status,
+                400,
+                "a DeregistrationInfo without supi must be 400: {body}"
+            );
+        }
+
+        // A well-formed body for a SUPI the AUSF holds nothing for → 404, NOT the
+        // 400 the authenticate handler would have produced for the missing
+        // servingNetworkName. The status is what proves the request was parsed as
+        // a DeregistrationInfo.
+        let resp = ausf_sbi_request_handler(post(Some(
+            serde_json::json!({ "supi": "imsi-001019999999999" }),
+        )))
+        .await;
+        assert_eq!(
+            resp.status, 404,
+            "an unknown SUPI is 404 (a 400 here would mean it was parsed as \
+             AuthenticationInfo again)"
+        );
+    }
+
+    /// Issue #82: the `201 UEAuthenticationCtx` is declared
+    /// `application/3gppHal+json` ONLY (`TS29509_Nausf_UEAuthentication.yaml:44-48`)
+    /// on BOTH the 5G-AKA and EAP-AKA' branches, because it carries the `_links`
+    /// map the consumer must follow. A strict HAL client content-negotiating on
+    /// that type can reject or mis-parse a body served as `application/json`.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
+    async fn test_ue_authentication_ctx_is_served_as_hal_json() {
+        let _guard = crate::test_support::lock_context();
+        let _ = env_logger::try_init();
+        let _lock = TEST_MUTEX.lock().await;
+
+        tokio::time::timeout(Duration::from_secs(60), async {
+            ausf_context_init(64);
+
+            let udm_port = free_port();
+            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
+                [127, 0, 0, 1],
+                udm_port,
+            ))));
+            udm_server.start(mock_udm_handler).await.expect("udm start");
+            std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
+            std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
+
+            let ausf_port = free_port();
+            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
+                [127, 0, 0, 1],
+                ausf_port,
+            ))));
+            ausf_server
+                .start(ausf_sbi_request_handler)
+                .await
+                .expect("ausf start");
+            let client = nextgcore_sbi::client::SbiClient::with_host_port("127.0.0.1", ausf_port);
+
+            // SUPI_5G_AKA selects 5G-AKA at the mock UDM, SUPI_EAP selects
+            // EAP-AKA' — so both 201 branches are exercised.
+            for (identity, expected_auth_type) in
+                [(SUPI_5G_AKA, "5G_AKA"), (SUPI_EAP, "EAP_AKA_PRIME")]
+            {
+                let resp = client
+                    .post_json(
+                        "/nausf-auth/v1/ue-authentications",
+                        &serde_json::json!({
+                            "supiOrSuci": identity,
+                            "servingNetworkName": TEST_SNN
+                        }),
+                    )
+                    .await
+                    .expect("POST ue-authentications");
+                assert_eq!(resp.status, 201, "{expected_auth_type} must be 201");
+
+                assert_eq!(
+                    resp.http.get_header("Content-Type").map(String::as_str),
+                    Some(nextgcore_sbi::constants::content_type::APPLICATION_3GPP_HAL_JSON),
+                    "the {expected_auth_type} 201 UEAuthenticationCtx must be HAL, got {:?}",
+                    resp.http.get_header("Content-Type")
+                );
+
+                // Still the same body, and it really does carry the _links map
+                // that is the reason the media type is HAL.
+                let body: serde_json::Value =
+                    serde_json::from_str(resp.http.content.as_deref().expect("body")).unwrap();
+                assert_eq!(
+                    body.get("authType").and_then(|v| v.as_str()),
+                    Some(expected_auth_type)
+                );
+                assert!(
+                    body.get("_links").is_some_and(|l| l.is_object()),
+                    "the HAL body must carry _links: {body}"
+                );
+            }
+        })
+        .await
+        .expect("test timed out");
+    }
+
+    /// Issue #82: a body with no `supiOrSuci` is rejected 400 instead of being
+    /// coerced to the literal `"unknown"` and queried against the UDM.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
+    async fn test_missing_supi_or_suci_is_rejected() {
+        let _guard = crate::test_support::lock_context();
+        let _lock = TEST_MUTEX.lock().await;
+        ausf_context_init(64);
+
+        // No UDM is configured for this test on purpose: if the handler still
+        // defaulted to "unknown" it would try to reach one, so a 400 also proves
+        // no UDM query was attempted.
+        for body in [
+            serde_json::json!({ "servingNetworkName": TEST_SNN }),
+            serde_json::json!({ "supiOrSuci": "", "servingNetworkName": TEST_SNN }),
+        ] {
+            let req = SbiRequest::post("/nausf-auth/v1/ue-authentications")
+                .with_json_body(&body)
+                .expect("valid JSON");
+            let resp = ausf_sbi_request_handler(req).await;
+            assert_eq!(
+                resp.status, 400,
+                "supiOrSuci is a mandatory IE; {body} must be 400"
+            );
+        }
+    }
+
+    /// Issue #82: resources TS 29.509 DECLARES but this AUSF does not implement
+    /// answer `501 Not Implemented`, not `405 Method Not Allowed`. A 405 claims
+    /// the resource exists but rejects the verb, which is false and invites a
+    /// consumer to retry with another method.
+    #[tokio::test]
+    async fn test_declared_but_unimplemented_resources_are_501() {
+        for path in [
+            "/nausf-auth/v1/rg-authentications",
+            "/nausf-auth/v1/prose-authentications",
+            "/nausf-auth/v1/prose-authentications/ctx-1/prose-auth",
+        ] {
+            let resp = ausf_sbi_request_handler(SbiRequest::post(path)).await;
+            assert_eq!(resp.status, 501, "POST {path} must be 501");
+        }
+
+        // A genuinely unknown resource is still a fallthrough, not a 501 —
+        // 501 means "declared by the API but unimplemented here".
+        let resp =
+            ausf_sbi_request_handler(SbiRequest::post("/nausf-auth/v1/not-a-resource")).await;
+        assert_ne!(
+            resp.status, 501,
+            "an undeclared resource must not claim 501"
+        );
+    }
+
+    // ====================================================================
     // ausfd-05: serving-network-name entitlement vs consumer token PLMN
     // ====================================================================
     #[tokio::test]
@@ -2913,7 +3370,7 @@ mod tests {
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
-        let _guard = crate::test_support::CONTEXT_GUARD.lock().unwrap();
+        let _guard = crate::test_support::lock_context();
         let _ = env_logger::try_init();
         let _lock = TEST_MUTEX.lock().await;
 
@@ -3059,7 +3516,7 @@ mod tests {
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
-        let _guard = crate::test_support::CONTEXT_GUARD.lock().unwrap();
+        let _guard = crate::test_support::lock_context();
         let _ = env_logger::try_init();
         let _lock = TEST_MUTEX.lock().await;
 

--- a/src/bins/nextgcore-ausfd/src/lib.rs
+++ b/src/bins/nextgcore-ausfd/src/lib.rs
@@ -61,12 +61,32 @@ pub use app::{
 /// boundaries; a dev-dependency test in a peer crate must seed the
 /// process-global AUSF context.
 pub mod test_support {
-    use std::sync::Mutex;
+    use std::sync::{Mutex, MutexGuard};
 
     /// Process-wide lock so strict-peer tests that touch the global AUSF
     /// context run serially (the context is process-global; parallel tests
     /// race).
+    ///
+    /// Take it via [`lock_context`], never `CONTEXT_GUARD.lock().unwrap()`.
     pub static CONTEXT_GUARD: Mutex<()> = Mutex::new(());
+
+    /// Acquire [`CONTEXT_GUARD`], recovering from poisoning.
+    ///
+    /// The guard is held across assertions, so the FIRST test to fail poisons it
+    /// and every later test that unwrapped the lock died with `PoisonError`
+    /// instead of running. That turned one genuine assertion failure into an
+    /// avalanche of unrelated ones and buried the real message — which is exactly
+    /// what makes a CI failure, or a revert-verification, unreadable.
+    ///
+    /// Poisoning carries no information here: the mutex guards `()`, so there is
+    /// no invariant a panicking test could have left broken. Every test re-seeds
+    /// the global context with `ausf_context_init` after taking the lock anyway.
+    /// So recovering is strictly better than propagating.
+    pub fn lock_context() -> MutexGuard<'static, ()> {
+        CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     /// Initialize the process-global AUSF context for in-process strict-peer
     /// tests (wraps [`crate::context::ausf_context_init`] with test capacity).

--- a/src/libs/nextgcore-sbi/src/message.rs
+++ b/src/libs/nextgcore-sbi/src/message.rs
@@ -569,6 +569,29 @@ impl SbiResponse {
         Ok(self)
     }
 
+    /// Set a JSON body served as `application/3gppHal+json` (issue #82).
+    ///
+    /// A handful of 3GPP resources are declared HAL-only rather than plain JSON —
+    /// e.g. the `201 UEAuthenticationCtx` of `POST /nausf-auth/v1/ue-authentications`
+    /// (`TS29509_Nausf_UEAuthentication.yaml:44-48`), whose body carries a `_links`
+    /// map the consumer must follow to continue authentication. A strict client
+    /// content-negotiating on the HAL type can reject or mis-parse such a body
+    /// served as `application/json`.
+    ///
+    /// Deliberately a SEPARATE method rather than a change to
+    /// [`with_json_body`](Self::with_json_body): plain `application/json` is right
+    /// for the overwhelming majority of SBI responses, so the HAL type is opt-in at
+    /// the call site that the spec declares it for.
+    pub fn with_hal_json_body<T: Serialize>(mut self, body: &T) -> Result<Self, serde_json::Error> {
+        let json = serde_json::to_string(body)?;
+        self.http.set_content(json);
+        self.http.set_header(
+            crate::constants::header::CONTENT_TYPE,
+            crate::constants::content_type::APPLICATION_3GPP_HAL_JSON,
+        );
+        Ok(self)
+    }
+
     /// Set raw body content
     pub fn with_body(
         mut self,
@@ -1373,5 +1396,34 @@ mod tests {
             .content
             .unwrap()
             .contains("RESOURCE_NOT_FOUND"));
+    }
+
+    /// Issue #82: `with_hal_json_body` serves `application/3gppHal+json` for the
+    /// handful of resources 3GPP declares HAL-only, and — the regression half —
+    /// `with_json_body` still defaults to plain `application/json` for everything
+    /// else. The HAL type is opt-in per call site precisely so this stays true.
+    #[test]
+    fn test_hal_json_body_is_opt_in_and_json_stays_the_default() {
+        let body = serde_json::json!({ "authType": "5G_AKA", "_links": { "5g-aka": {} } });
+
+        let hal = SbiResponse::with_status(201)
+            .with_hal_json_body(&body)
+            .expect("serializes");
+        assert_eq!(
+            hal.http.get_header("content-type").map(String::as_str),
+            Some(crate::constants::content_type::APPLICATION_3GPP_HAL_JSON)
+        );
+
+        let plain = SbiResponse::with_status(200)
+            .with_json_body(&body)
+            .expect("serializes");
+        assert_eq!(
+            plain.http.get_header("content-type").map(String::as_str),
+            Some(crate::constants::content_type::APPLICATION_JSON),
+            "with_json_body must keep its application/json default"
+        );
+
+        // Only the media type differs; the serialized body is identical.
+        assert_eq!(hal.http.content, plain.http.content);
     }
 }


### PR DESCRIPTION
Closes #82 — all seven acceptance criteria. The issue's "secondary" list explicitly says not to block on SNN fail-closed hardening or the non-normative UDM auth-result forward, and those are left alone.

## 1. Deregister was unrouted — and the suggested teardown would have been wrong

`POST /nausf-auth/v1/ue-authentications/deregister` had no arm, so it fell through to the generic authenticate handler, which parsed the `DeregistrationInfo` body as an `AuthenticationInfo`, found no `servingNetworkName`, and answered **400**. A conformant UDM could never release a security context through the standard operation.

The new arm precedes the generic one; the handler parses only what the schema requires — `supi` (`TS29509_Nausf_UEAuthentication.yaml:796-805`) — deliberately **not** via `validate_authentication_info`, which demands a `servingNetworkName` the body does not carry.

**Where this departs from the issue.** #82 says to "reuse the teardown already in `handle_auth_context_delete`". That teardown deliberately **keeps** the per-SUPI SoR/UPU anchor `K_AUSF`, because the AMF deleting an authentication context must not break Nausf_SoRProtection/UPUProtection (TS 33.501 §6.14.1) — and there is an existing test, `test_sor_upu_anchor_survives_auth_context_delete`, pinning exactly that.

But TS 29.509 §5.2.2.3.1 states Deregister's purpose outright:

> The NF Service Consumer (e.g. **UDM**) uses this service operation to request the AUSF to **clear the stale security context** … so as to ensure **only latest Kausf is maintained in the network**.

Reusing the DELETE teardown verbatim would leave the stale anchor behind and fail the operation's entire stated purpose — which is the very defect #82's own *Production impact* section describes ("never releases the anchor `K_AUSF` through the standard operation"). So deregister purges the anchor too, the DELETE carve-out is untouched, and the two tests now reference each other so neither can later be "simplified" into the other.

Worth noting the consumer here is the **UDM**, not the AMF — this is a UDM-facing cleanup operation.

**404 semantics:** only when the AUSF holds *neither* an authentication context *nor* an anchor. An anchor with no live context is real state (the AMF may have deleted the context already), so clearing it succeeds.

## 2. HAL media type on the 201 `UEAuthenticationCtx`

The 201 is declared `application/3gppHal+json` **only** (`yaml:44-48`) — no `application/json` alternative — because it carries the `_links` map the consumer must follow. Both the 5G-AKA and EAP-AKA' branches served plain JSON.

New `SbiResponse::with_hal_json_body`, added as a **separate** method rather than changing `with_json_body`'s default: plain JSON is right for almost every SBI response, so HAL is opt-in at the call sites the spec declares it for. A regression test pins the default. `APPLICATION_3GPP_HAL_JSON` already existed in `constants`.

The `eap-session` 200 is deliberately untouched — it declares **both** media types (`yaml:280-300`), so its `application/json` is already conformant.

## 3. `supiOrSuci` was coerced to the literal `"unknown"`

Absence defaulted to the string `"unknown"`, which the validator then accepted as present — so an identity-less body reached the UDM as a query for a subscriber called "unknown". Now an `Option`, so the validator's existing `"No supiOrSuci"` branch is finally reachable. Revert-verified: with the default restored the test sees **503**, i.e. a real UDM query was attempted.

## 4. `501` for declared-but-unimplemented resources

`/rg-authentications` (`yaml:381`), `/prose-authentications` (`yaml:451`) and `/prose-authentications/{authCtxId}/prose-auth` (`yaml:514`) fell through to `405`, which claims the resource exists but rejects the verb and invites a retry with another method. Now `501`, while a genuinely undeclared path still falls through — asserted, so `501` keeps meaning "declared but unimplemented".

## Found in passing and fixed — a test-infra broken window

Revert-verifying this was nearly unreadable. `test_support::CONTEXT_GUARD` was taken as `.lock().unwrap()` at all 10 sites, and the guard is held across assertions — so the **first** failing test poisoned it and six or more unrelated tests died with `PoisonError` instead of running. One genuine assertion failure became an avalanche that buried the real message.

Poisoning carries no information here: the mutex guards `()`, so no invariant can be left broken, and every test re-seeds the global context after taking the lock. A `lock_context()` helper now recovers via `into_inner()`.

**Proven, not asserted:** reintroducing one defect used to produce 7 failures; it now produces exactly 1.

## Verification

* Workspace **5607 passed / 0 failed** (baseline 5601).
* `nextgcore-ausfd` **145 passed** (baseline 140); `nextgcore-sbi` **187** (baseline 186).
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace` 0 errors; `clippy -D warnings` clean on ausfd + sbi with `--all-targets`.
* **All five behaviours revert-verified individually:**

| reverted | failing assertion |
|---|---|
| deregister route removed | *"a 400 here would mean it was parsed as AuthenticationInfo again"* |
| anchor kept (the naive teardown reuse) | *"deregister must purge the stale SoR/UPU anchor KAUSF (TS 29.509 §5.2.2.3.1)"* |
| either 201 back to plain JSON | *"the 5G_AKA 201 UEAuthenticationCtx must be HAL, got Some("application/json")"* |
| `"unknown"` default restored | got `503` — a UDM query really was attempted |
| 501 arm removed | got `405` |

## Acceptance criteria

- [x] Deregister with a valid `DeregistrationInfo` (`supi` only) → `204`, context removed.
- [x] The removed context is zeroized (same `AusfUe::zeroize` path DELETE uses).
- [x] Unknown SUPI → `404`; malformed / `supi`-less body → `400`; not routed through `validate_authentication_info`.
- [x] Both 201 `UEAuthenticationCtx` responses carry `Content-Type: application/3gppHal+json`, asserted on both paths.
- [x] `with_json_body`'s `application/json` default unchanged, with a test.
- [x] Missing `supiOrSuci` → `400` rather than querying UDM for `"unknown"`.
- [x] `rg-authentications` / `prose-authentications` → `501`.
- [x] Workspace lint and tests pass; new tests cover the deregister happy path plus the `404`/`400` cases.

**Beyond the criteria:** the SoR/UPU anchor `K_AUSF` is purged, so §5.2.2.3.1's "only latest Kausf is maintained" actually holds.

Spec: `specs/fix-ausf-deregister-and-hal-media-type.md`
