### PR TITLE
fix(nf): make --kill fail loudly instead of exiting 0 without signalling anything

### DIFF
--- a/src/bins/nextgcore-ausfd/src/app.rs
+++ b/src/bins/nextgcore-ausfd/src/app.rs
@@ -46,7 +46,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -229,10 +230,11 @@ pub async fn run() -> Result<()> {
 
     log::info!("NextGCore AUSF v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -65,7 +65,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -179,10 +180,11 @@ pub async fn run() -> Result<()> {
 
     log::info!("NextGCore BSF v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-hssd/src/main.rs
+++ b/src/bins/nextgcore-hssd/src/main.rs
@@ -39,7 +39,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -104,10 +105,11 @@ fn main() -> Result<()> {
 
     log::info!("NextGCore HSS v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -365,7 +365,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -484,10 +485,11 @@ async fn main() -> Result<()> {
 
     log::info!("NextGCore NRF v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-nssfd/src/main.rs
+++ b/src/bins/nextgcore-nssfd/src/main.rs
@@ -72,7 +72,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -218,10 +219,11 @@ async fn main() -> Result<()> {
 
     log::info!("NextGCore NSSF v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-pcfd/src/app.rs
+++ b/src/bins/nextgcore-pcfd/src/app.rs
@@ -56,7 +56,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -265,10 +266,11 @@ pub async fn run() -> Result<()> {
 
     log::info!("NextGCore PCF v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-pcrfd/src/main.rs
+++ b/src/bins/nextgcore-pcrfd/src/main.rs
@@ -38,7 +38,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -150,10 +151,11 @@ fn main() -> Result<()> {
 
     log::info!("NextGCore PCRF v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-scpd/src/main.rs
+++ b/src/bins/nextgcore-scpd/src/main.rs
@@ -69,7 +69,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -147,10 +148,11 @@ async fn main() -> Result<()> {
 
     log::info!("NextGCore SCP v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-seppd/src/main.rs
+++ b/src/bins/nextgcore-seppd/src/main.rs
@@ -68,7 +68,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -187,10 +188,11 @@ async fn main() -> Result<()> {
 
     log::info!("NextGCore SEPP v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -47,7 +47,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -298,10 +299,11 @@ pub async fn run() -> Result<()> {
 
     log::info!("NextGCore UDM v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-udrd/src/main.rs
+++ b/src/bins/nextgcore-udrd/src/main.rs
@@ -50,7 +50,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -159,10 +160,11 @@ async fn main() -> Result<()> {
 
     log::info!("NextGCore UDR v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/bins/nextgcore-upfd/src/main.rs
+++ b/src/bins/nextgcore-upfd/src/main.rs
@@ -63,7 +63,8 @@ struct Args {
     #[arg(short = 'm', long)]
     no_color: bool,
 
-    /// Kill running instance
+    /// Kill a running instance (NOT SUPPORTED: exits with an error;
+    /// stop the NF through its supervisor)
     #[arg(short = 'k', long)]
     kill: bool,
 
@@ -133,10 +134,11 @@ async fn main() -> Result<()> {
 
     log::info!("NextGCore UPF v{} starting...", env!("CARGO_PKG_VERSION"));
 
-    // Handle kill flag
+    // Issue: `--kill` was advertised as "Kill running instance" and did
+    // NOTHING -- it logged an intention and returned success, so the process
+    // exited 0 while the instance kept serving. Fail loudly instead.
     if args.kill {
-        log::info!("Kill flag set - would send SIGTERM to running instance");
-        return Ok(());
+        return Err(nextgcore_core::signal::kill_unsupported().into());
     }
 
     // Set up signal handlers

--- a/src/libs/nextgcore-core/src/signal.rs
+++ b/src/libs/nextgcore-core/src/signal.rs
@@ -367,3 +367,152 @@ mod tests {
         assert_eq!(rv, NEXTGCORE_OK);
     }
 }
+
+// ---------------------------------------------------------------------------
+// `--kill` handling shared by every NF daemon
+// ---------------------------------------------------------------------------
+
+/// Message returned when a daemon is invoked with `-k`/`--kill`.
+///
+/// Kept as a constant so the twelve daemons that accept the flag cannot drift
+/// apart in what they tell an operator.
+pub const KILL_UNSUPPORTED_MESSAGE: &str = concat!(
+    "--kill is not supported: this daemon cannot signal another instance. ",
+    "It has no pidfile and no way to identify a sibling process. ",
+    "Stop the NF through whatever supervises it -- `docker compose stop <svc>`, ",
+    "`kubectl delete pod`, `systemctl stop`, or send SIGTERM to the process directly. ",
+    "The daemon handles SIGTERM/SIGINT for graceful shutdown."
+);
+
+/// Report that `--kill` cannot be honoured.
+///
+/// Every NF declares `-k/--kill` (documented "Kill running instance") and NOT ONE
+/// implements it: each logged "would send SIGTERM to running instance" at info
+/// level and returned success. So `nextgcore-<nf> --kill` exited **0** while the
+/// instance kept serving traffic. A restart script that killed-then-started got two
+/// instances contending for the same SBI port or SCTP association, and an operator
+/// checking the exit status was told the NF was down when it was not.
+///
+/// This is the operator-facing form of the same defect issue #167 fixed on a
+/// protocol path: a stub whose `Ok` a caller converts into a success claim.
+///
+/// Deliberately an ERROR rather than an implementation. These are container
+/// workloads -- the compose healthchecks use `kill -0 1` and Kubernetes sends
+/// SIGTERM itself -- so process lifecycle belongs to the supervisor, and adding a
+/// pidfile so a container could kill a sibling it cannot see would be the wrong
+/// feature. Nothing in the tree scripts `--kill`, and any script that did was
+/// already silently broken, so failing loudly cannot break a working workflow: it
+/// converts a silent no-op into a visible one.
+pub fn kill_unsupported() -> std::io::Error {
+    log::error!("{KILL_UNSUPPORTED_MESSAGE}");
+    std::io::Error::new(std::io::ErrorKind::Unsupported, KILL_UNSUPPORTED_MESSAGE)
+}
+
+#[cfg(test)]
+mod kill_flag_tests {
+    use super::*;
+
+    /// Every daemon that accepts `--kill` must route it through
+    /// [`kill_unsupported`], and none may keep a hand-rolled stub.
+    ///
+    /// This existed as twelve independent copies of the same fictional log line,
+    /// which is how it stayed wrong in twelve places at once. The guard reads the
+    /// daemon sources so a thirteenth copy cannot be added quietly, and so a new NF
+    /// that adds the flag has to opt into the shared behaviour.
+    #[test]
+    fn every_daemon_routes_kill_through_the_shared_helper() {
+        let bins = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("crate is at <root>/libs/nextgcore-core")
+            .join("bins");
+        assert!(bins.is_dir(), "expected {} to exist", bins.display());
+
+        let mut declaring = Vec::new();
+        let mut routed = Vec::new();
+        let mut stubbed = Vec::new();
+
+        for entry in std::fs::read_dir(&bins).expect("read bins/") {
+            let dir = entry.expect("dir entry").path().join("src");
+            if !dir.is_dir() {
+                continue;
+            }
+            let name = dir
+                .parent()
+                .and_then(|p| p.file_name())
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let mut declares = false;
+            let mut uses_helper = false;
+            let mut has_stub = false;
+            for file in std::fs::read_dir(&dir).expect("read src/") {
+                let path = file.expect("file entry").path();
+                if path.extension().is_none_or(|e| e != "rs") {
+                    continue;
+                }
+                let src = std::fs::read_to_string(&path).unwrap_or_default();
+                if src.contains("kill: bool") {
+                    declares = true;
+                }
+                if src.contains("kill_unsupported") {
+                    uses_helper = true;
+                }
+                // The fictional wording, in any daemon.
+                if src.contains("would send SIGTERM") {
+                    has_stub = true;
+                }
+            }
+            if declares {
+                declaring.push(name.clone());
+                if uses_helper {
+                    routed.push(name.clone());
+                }
+            }
+            if has_stub {
+                stubbed.push(name);
+            }
+        }
+
+        assert!(
+            stubbed.is_empty(),
+            "these daemons still claim to send SIGTERM without doing so: {stubbed:?}"
+        );
+        assert!(
+            !declaring.is_empty(),
+            "expected to find daemons declaring --kill; the guard found none, so it \
+             is no longer checking anything"
+        );
+        declaring.sort();
+        routed.sort();
+        assert_eq!(
+            declaring, routed,
+            "every daemon declaring --kill must route it through kill_unsupported()"
+        );
+    }
+
+    /// `--kill` must fail, and must say what to do instead. The load-bearing part
+    /// is that this is an Err at all: it used to be `Ok(())` with an info log, so
+    /// the process exited 0 without signalling anything.
+    #[test]
+    fn kill_is_reported_as_unsupported_not_success() {
+        let err = kill_unsupported();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        let text = err.to_string();
+        assert!(
+            text.contains("not supported"),
+            "the message must say the flag is unsupported: {text}"
+        );
+        // It must point the operator somewhere real rather than just refusing.
+        for hint in ["SIGTERM", "compose", "kubectl"] {
+            assert!(
+                text.contains(hint),
+                "the message should name {hint} as the supported route: {text}"
+            );
+        }
+        // And it must not claim anything was signalled.
+        assert!(
+            !text.contains("would send"),
+            "the old fictional 'would send SIGTERM' wording must be gone: {text}"
+        );
+    }
+}


### PR DESCRIPTION
Continues the outstanding audit task from PR #167 — sweep the tree for stubs whose optimistic `Ok` a caller converts into a success claim. No issue number: this is the audit itself, and its finding.

## The finding

**Twelve** daemons (udmd, upfd, nrfd, bsfd, nssfd, scpd, pcrfd, seppd, hssd, pcfd, udrd, ausfd) declare `-k/--kill`, documented in `--help` as *"Kill running instance"*. **Not one implements it.** Every copy was:

```rust
if args.kill {
    log::info!("Kill flag set - would send SIGTERM to running instance");
    return Ok(());
}
```

So `nextgcore-<nf> --kill` exited **0** while the instance kept serving traffic. A restart script that killed-then-started got **two instances contending for the same SBI port or SCTP association**, and an operator checking `$?` was told the NF was down when it was not.

This is the operator-facing form of exactly what #167 fixed on a protocol path. Notably the **docs were already honest** — `docs/book/print.html` calls it a *"Stub: logs 'would send SIGTERM to running instance' and exits 0 without signaling anything"*. It was the binary that lied.

## Deliberately a refusal, not an implementation

`kill_unsupported()` returns `io::ErrorKind::Unsupported` with a message naming the supported route; `--help` now says NOT SUPPORTED.

These are **container workloads** — the compose healthchecks use `kill -0 1` and Kubernetes sends SIGTERM itself — so process lifecycle belongs to the supervisor. Adding a pidfile so a container could signal a sibling it cannot see would be the wrong feature.

Nothing in the tree scripts `--kill`, and any script that did was **already silently broken**, so failing loudly cannot break a working workflow: it converts a silent no-op into a visible one. Same shape as the ausfd #82 decision to answer `501` for a declared-but-unimplemented resource rather than fake success.

## One implementation, not twelve

Twelve independent copies of one fictional log line is *how this stayed wrong in twelve places at once*. The helper lives in `nextgcore-core`, which all twelve already depend on, and a guard test reads the daemon sources to assert:

* every daemon declaring `kill: bool` routes through the helper, **and**
* no daemon anywhere still contains the `"would send SIGTERM"` wording.

So a thirteenth copy cannot be added quietly, and a new NF adding the flag has to opt in.

## The rest of the audit — triaged, not silently skipped

36 files carried a stub marker; **15 sites** had one followed closely by an unconditional `Ok`.

| site | verdict |
|---|---|
| `--kill` × 11 | **fixed here** — reachable, exits 0, lies to the operator |
| `bsfd` `bsf_sbi_send_request` / `bsf_sbi_discover_and_send` → fabricated `Ok(1)` transaction id, sends nothing | **not urgent** — the only caller of the enclosing `bsf_nnrf_handle_nf_discover` is its own tests, so it is dead code rather than a peer-visible lie |
| `sgwud`/`sgwcd` `pfcp_open()` → `Ok(())` having opened no socket | **already tracked** by #59/#61 |

`nssfd::query_nrf_slice_availability` carries the marker but was **cleared**: the comment says a full implementation would query the NRF over HTTP, and it then honestly computes from locally-held `Nnssf_NSSAIAvailability` data — a narrower source, not a false claim.

## Verification

* Workspace **5621 passed / 0 failed** (baseline 5619). `nextgcore-core` **220**.
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace` 0 errors.
* **Both behaviours revert-verified:** returning one daemon to the `Ok` stub fails the guard and *names that daemon* (`these daemons still claim to send SIGTERM without doing so: ["nextgcore-ausfd"]`); weakening the error kind fails the helper test.

Spec: `specs/fix-kill-flag-false-success.md`
