### PR TITLE
fix(sbi): fail closed when an OAuth2 token cannot be obtained (Refs #63)

### DIFF
--- a/src/libs/nextgcore-sbi/src/client.rs
+++ b/src/libs/nextgcore-sbi/src/client.rs
@@ -567,7 +567,10 @@ impl SbiClient {
     /// Stamp the standard outbound headers on `request` exactly once before the
     /// (possibly retried / redirected) send. Mutations are identical, and in the
     /// same order, to the pre-refactor inline code.
-    async fn prepare_request(&self, request: &mut SbiRequest) {
+    /// Returns `Err` when OAuth2 is configured for this client but a token could
+    /// not be obtained (issue #63). See the token block below for why that is not
+    /// a warning.
+    async fn prepare_request(&self, request: &mut SbiRequest) -> SbiResult<()> {
         // Automatically attach Bearer token if OAuth2 is configured
         // and the request does not already carry an Authorization header
         if let (Some(oauth2), Some(target_nf_type)) = (&self.oauth2, &self.target_nf_type) {
@@ -582,7 +585,30 @@ impl SbiClient {
                             request.http.set_header("Authorization", auth_value);
                         }
                         Err(e) => {
-                            log::warn!("OAuth2 token request failed, sending without token: {e}");
+                            // Issue #63: FAIL CLOSED. This used to log a warning
+                            // and send the request anyway, so a token endpoint
+                            // that was unreachable or misconfigured silently
+                            // stripped SBI authentication from every outbound
+                            // request -- the posture degraded to unauthenticated
+                            // with nothing but a warn-level line to show it, which
+                            // is precisely the regression an operator cannot see
+                            // (TS 33.501 13.4.1.1).
+                            //
+                            // Only reachable when OAuth2 IS configured on this
+                            // client, i.e. the deployment asked for authenticated
+                            // SBI. A client with no OAuth2 configured is untouched,
+                            // so this cannot break the default or E2E paths -- it
+                            // only stops a deployment that wanted authentication
+                            // from silently losing it.
+                            log::error!(
+                                "OAuth2 token acquisition failed; refusing to send {} {} \
+                                 unauthenticated: {e}",
+                                request.header.method,
+                                request.header.uri
+                            );
+                            return Err(SbiError::AuthenticationFailed(format!(
+                                "could not obtain an access token for scope '{scope}': {e}"
+                            )));
                         }
                     }
                 }
@@ -633,6 +659,8 @@ impl SbiClient {
             let traceparent = format!("00-{}-{}-01", hex::encode(trace_id), hex::encode(span_id),);
             request.http.set_header("traceparent", traceparent);
         }
+
+        Ok(())
     }
 
     /// sbi-05 retry wrapper. Only entered when `max_attempts > 1`. Re-runs the
@@ -693,7 +721,7 @@ impl SbiClient {
     /// by [`MAX_REDIRECTS`]. A normal (non-redirect) response takes a single
     /// `send_once` call against the pooled connection — identical to before.
     async fn send_following_redirects(&self, mut request: SbiRequest) -> SbiResult<SbiResponse> {
-        self.prepare_request(&mut request).await;
+        self.prepare_request(&mut request).await?;
 
         // First attempt uses the pooled connection (target = None).
         let mut target: Option<ConnectTarget> = None;
@@ -1671,6 +1699,71 @@ mod tests {
             count.load(Ordering::SeqCst),
             2,
             "exactly max_attempts tries"
+        );
+    }
+
+    // ── issue #63: the consumer client must not fail OPEN ──────────────────
+
+    /// **The #63 fail-open fix.** When OAuth2 is configured but a token cannot be
+    /// obtained, the request must FAIL rather than go out unauthenticated.
+    ///
+    /// The load-bearing assertion is the error KIND. Before this, token
+    /// acquisition failure logged a warning and the request proceeded, so the
+    /// caller saw whatever the target replied -- a success against a producer that
+    /// does not enforce tokens, or a connection error. Either way the token
+    /// failure was invisible. Now it surfaces as `AuthenticationFailed`, which is
+    /// distinguishable from `ConnectionError` and cannot be mistaken for the
+    /// target being down.
+    #[tokio::test]
+    async fn token_acquisition_failure_fails_the_request_not_the_authentication() {
+        // Token endpoint on a closed port: acquisition cannot succeed.
+        let oauth2 = std::sync::Arc::new(crate::oauth::OAuth2Client::new(
+            "http://127.0.0.1:1",
+            "amf-63-test",
+            NfType::Amf,
+        ));
+        // The TARGET is also unreachable, deliberately: if the fix regressed, the
+        // request would proceed and fail with ConnectionError instead, so the
+        // assertion below distinguishes "refused to send" from "sent and failed".
+        let client = SbiClient::with_host_port("127.0.0.1", 1).with_oauth2(oauth2, NfType::Udm);
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            client.send_request(SbiRequest::get("/nudm-sdm/v1/imsi-001010000000001/am-data")),
+        )
+        .await
+        .expect("must not hang");
+
+        let err = result.expect_err("a request with no obtainable token must fail");
+        assert!(
+            matches!(err, SbiError::AuthenticationFailed(_)),
+            "the token failure must surface as AuthenticationFailed, not as a \
+             transport error or a success: got {err:?}"
+        );
+        assert_eq!(
+            err.status_code(),
+            Some(401),
+            "the surfaced error should map to 401"
+        );
+    }
+
+    /// A client with NO OAuth2 configured is untouched: it still attempts the
+    /// send. This is why the fail-closed change cannot break the default or E2E
+    /// paths -- only a deployment that asked for authenticated SBI is affected.
+    #[tokio::test]
+    async fn a_client_without_oauth2_still_attempts_the_send() {
+        let client = SbiClient::with_host_port("127.0.0.1", 1);
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            client.send_request(SbiRequest::get("/nudm-sdm/v1/imsi-001010000000001/am-data")),
+        )
+        .await
+        .expect("must not hang");
+
+        let err = result.expect_err("the target is closed, so the send fails");
+        assert!(
+            !matches!(err, SbiError::AuthenticationFailed(_)),
+            "a client with no OAuth2 must not fail on authentication: got {err:?}"
         );
     }
 }


### PR DESCRIPTION
`Refs #63` — ships **one** of its three defects. Please read *why this ships alone* before treating that as a convention violation; the open count deliberately does not move.

## The defect

`SbiClient::prepare_request` attached a Bearer token when OAuth2 was configured and, on **any** token-acquisition failure, did this and sent the request anyway:

```rust
Err(e) => {
    log::warn!("OAuth2 token request failed, sending without token: {e}");
}
```

So a token endpoint that was unreachable, misconfigured or erroring **silently stripped SBI authentication from every outbound request**. The posture degraded to unauthenticated with nothing but a `warn`-level line to show it.

This is the part of #63 that makes its other two invisible: with the client failing open, an operator who *has* configured OAuth2 cannot tell from outside whether requests are authenticated. TS 33.501 §13.4.1.1 expects the consumer to present a valid token — degrading silently is worse than refusing, because a refusal alarms and a downgrade does not.

## The fix

`prepare_request` returns `SbiResult<()>`; token failure returns `SbiError::AuthenticationFailed` (already maps to 401). The single call site propagates with `?`.

**The behaviour change is narrow by construction.** The error is only reachable inside `if let (Some(oauth2), Some(target_nf_type)) = (&self.oauth2, …)` — only on a client where the deployment *configured* OAuth2 and therefore asked for authenticated SBI. A client with no OAuth2 is untouched, so the default posture and existing docker/E2E flows cannot be affected, and a test asserts exactly that.

The load-bearing assertion is the error **kind**, not merely that the call fails. Before the fix the request proceeded and the caller saw whatever the target replied — a success against a producer that does not enforce tokens, or a transport error.

**Revert-verified:** with fail-open restored the test observes `ConnectionError("Connection refused")` — proving the request left the process unauthenticated.

## Why this ships alone, and why the count does not move

CONVENTIONS requires a whole-issue PR, with one stated exception: *a safety-critical defect inside an umbrella may ship alone as `Refs #N`, stating why it did not wait* (precedent: #167). A silently-fail-open authentication client is that case.

#63's other two parts are a **coordinated posture change** — wiring TLS into amfd/smfd/ausfd/udmd, flipping `require_oauth2` on, adopting `SbiSecurityPolicy::production()` behind a config profile — which the issue itself says should be profile-gated so it lands coordinated, and which needs an mTLS+OAuth2 E2E test. That should not block a one-function fix, because until it lands **any OAuth2-enabled deployment can lose authentication without noticing**.

**#63 stays open.** The spec carries the verified plan for the remainder so the next session does not re-derive it: the four startup sites (`amfd/lib.rs:819`, `smfd/main.rs:379`, `ausfd/app.rs:310`, `udmd/app.rs:468`), the amfd `https` advertisement at `sbi_path.rs:365`/`:1409` (otherwise peers discover an `http://` URL for a TLS listener), and the finding that `SbiSecurityPolicy::production()` currently has **no non-test runtime caller** — which is criterion 4 all by itself.

## Verification

* Workspace **5623 passed / 0 failed** (baseline 5621). `nextgcore-sbi` **189**.
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace` 0 errors.
* Two new tests: the fail-closed path, and the no-OAuth2 client proving the default is unaffected.

## #63 acceptance criteria addressed

- [x] Criterion 5 — the client no longer proceeds unauthenticated on token-acquisition failure; a unit test asserts the token error surfaces to the caller.
- [ ] Criteria 1–4, 6, 7 — the coordinated TLS/producer-OAuth2 posture change, planned in the spec.

Spec: `specs/fix-sbi-client-fail-open-oauth2.md`
