### PR TITLE
fix(udrd/sbi): bind the UDR's OAuth2 audience, and stop the exported verifier skipping it (Refs #64)

### DIFF
--- a/src/bins/nextgcore-udrd/src/main.rs
+++ b/src/bins/nextgcore-udrd/src/main.rs
@@ -271,6 +271,16 @@ async fn main() -> Result<()> {
         sbi_server_config.oauth2_jwks_uri = nrf_uri_cfg
             .as_deref()
             .map(|uri| JwksCache::for_nrf(uri).jwks_uri().to_string());
+        // Issue #64 gap 3: assert the token's `aud` names the UDR.
+        //
+        // Without this `oauth2_expected_audience` stays None, the server calls
+        // `authorize_bearer_aud(.., None)` and the audience check is SKIPPED -- so a
+        // token the NRF minted for any other producer was accepted here, on the NF
+        // that holds subscriber data. TS 33.501 13.4.1.2 requires the producer to
+        // verify it is the intended audience. Every other OAuth2-enforcing NF
+        // already did this; the UDR was the one that did not.
+        sbi_server_config =
+            sbi_server_config.with_expected_audience_nf_type(nextgcore_sbi::types::NfType::Udr);
         // Wave-6 H8 Phase A: install the process-wide OAuth2 client so outbound
         // SBI calls acquire and attach an NRF-issued Bearer token.
         if let Some(nrf_uri) = nrf_uri_cfg.as_deref() {

--- a/src/libs/nextgcore-sbi/src/security.rs
+++ b/src/libs/nextgcore-sbi/src/security.rs
@@ -10,7 +10,7 @@
 //! all SBI communication between NFs SHALL use TLS with mutual authentication.
 
 use crate::error::{SbiError, SbiResult};
-use crate::oauth::{authorize_bearer, AccessTokenClaims};
+use crate::oauth::AccessTokenClaims;
 use crate::types::NfType;
 
 // ============================================================================
@@ -216,9 +216,16 @@ pub fn extract_bearer_token(auth_header: &str) -> Option<&str> {
 ///
 /// Returns Ok(Some(claims)) when authorized, Ok(None) when the policy does
 /// not require OAuth2, Err otherwise.
+/// `expected_audience` is the producer's own identity (TS 29.510 `NfType` token,
+/// e.g. `"UDR"`). Issue #64 gap 3: this used to call the audience-SKIPPING
+/// `authorize_bearer`, so a token the NRF minted for producer A verified happily at
+/// producer B — an authorisation bypass (TS 33.501 §13.4.1.2 requires the producer
+/// to verify it is the intended audience). It is a required parameter rather than an
+/// `Option` so a caller cannot omit it by accident; pass the NF's own type.
 pub fn authorize_sbi_request(
     auth_header: Option<&str>,
     required_scope: &str,
+    expected_audience: &str,
     policy: &SbiSecurityPolicy,
     jwks: &serde_json::Value,
 ) -> SbiResult<Option<AccessTokenClaims>> {
@@ -226,8 +233,9 @@ pub fn authorize_sbi_request(
         return Ok(None);
     }
 
-    // Signature + expiry verification against the NRF public key set.
-    let claims = authorize_bearer(auth_header, jwks)?;
+    // Signature + expiry verification against the NRF public key set, plus the
+    // audience binding.
+    let claims = crate::oauth::authorize_bearer_aud(auth_header, jwks, Some(expected_audience))?;
 
     // Scope enforcement (TS 29.510 §6.3.5.2.4: space-delimited service names).
     let scopes: Vec<&str> = claims.scope.split_whitespace().collect();
@@ -453,23 +461,28 @@ mod tests {
         let auth = format!("Bearer {token}");
 
         // Properly signed token with the right scope is accepted.
-        let claims = authorize_sbi_request(Some(&auth), "nsmf-pdusession", &policy, &jwks)
+        let claims = authorize_sbi_request(Some(&auth), "nsmf-pdusession", "SMF", &policy, &jwks)
             .expect("signed token authorizes")
             .expect("claims returned");
         assert_eq!(claims.iss, "nrf-instance-1");
         assert_eq!(claims.sub, "amf-instance-1");
 
         // Wrong scope is rejected even with a valid signature.
-        assert!(authorize_sbi_request(Some(&auth), "nausf-auth", &policy, &jwks).is_err());
+        assert!(authorize_sbi_request(Some(&auth), "nausf-auth", "SMF", &policy, &jwks).is_err());
 
         // A token whose signature does not verify is rejected: there is no
         // signature-skipping path anymore.
         let mut tampered = token.clone();
         tampered.replace_range(0..1, "f");
         let tampered_auth = format!("Bearer {tampered}");
-        assert!(
-            authorize_sbi_request(Some(&tampered_auth), "nsmf-pdusession", &policy, &jwks).is_err()
-        );
+        assert!(authorize_sbi_request(
+            Some(&tampered_auth),
+            "nsmf-pdusession",
+            "SMF",
+            &policy,
+            &jwks
+        )
+        .is_err());
 
         // An unsigned/garbage-signature token is rejected too.
         use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -482,23 +495,33 @@ mod tests {
             URL_SAFE_NO_PAD.encode([0u8; 64])
         );
         let forged_auth = format!("Bearer {forged}");
-        assert!(
-            authorize_sbi_request(Some(&forged_auth), "nsmf-pdusession", &policy, &jwks).is_err()
-        );
+        assert!(authorize_sbi_request(
+            Some(&forged_auth),
+            "nsmf-pdusession",
+            "SMF",
+            &policy,
+            &jwks
+        )
+        .is_err());
 
         // Expired token is rejected.
         let (expired, jwks2) = signed_token_and_jwks("nsmf-pdusession", 1);
         let expired_auth = format!("Bearer {expired}");
-        assert!(
-            authorize_sbi_request(Some(&expired_auth), "nsmf-pdusession", &policy, &jwks2).is_err()
-        );
+        assert!(authorize_sbi_request(
+            Some(&expired_auth),
+            "nsmf-pdusession",
+            "SMF",
+            &policy,
+            &jwks2
+        )
+        .is_err());
     }
 
     #[test]
     fn test_authorize_sbi_request_not_required() {
         let policy = SbiSecurityPolicy::development();
         let jwks = serde_json::json!({"keys": []});
-        let result = authorize_sbi_request(None, "any-scope", &policy, &jwks);
+        let result = authorize_sbi_request(None, "any-scope", "SMF", &policy, &jwks);
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }
@@ -507,7 +530,7 @@ mod tests {
     fn test_authorize_sbi_request_missing_header() {
         let policy = SbiSecurityPolicy::production();
         let jwks = serde_json::json!({"keys": []});
-        let result = authorize_sbi_request(None, "nsmf-pdusession", &policy, &jwks);
+        let result = authorize_sbi_request(None, "nsmf-pdusession", "SMF", &policy, &jwks);
         assert!(result.is_err());
     }
 
@@ -549,5 +572,81 @@ mod tests {
         assert!(paths.cert.contains("server.crt"));
         assert!(paths.key.contains("server.key"));
         assert!(paths.ca_cert.contains("ca.crt"));
+    }
+}
+
+#[cfg(test)]
+mod audience_binding_guards {
+    /// Issue #64 gap 3: every NF that enforces OAuth2 must also assert the token's
+    /// audience, or it accepts tokens the NRF minted for a different producer.
+    ///
+    /// This guard is the thing that would have caught the UDR: 15 daemons set
+    /// `require_oauth2 = true` and only 13 set an expected audience, and nothing
+    /// compared the two lists. Read from the daemon sources so a new NF cannot enable
+    /// enforcement without making an explicit choice about `aud`.
+    #[test]
+    fn every_oauth2_enforcing_nf_asserts_an_audience() {
+        // pind is deliberately exempt AND documents why in-source: it is not a
+        // TS 29.510 NfType, so there is no NF-type `aud` for the NRF to mint or for
+        // it to assert. Any other exemption must be argued the same way, here.
+        const DOCUMENTED_EXEMPTIONS: &[&str] = &["nextgcore-pind"];
+
+        let bins = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("crate is at <root>/libs/nextgcore-sbi")
+            .join("bins");
+        assert!(bins.is_dir(), "expected {} to exist", bins.display());
+
+        let mut enforcing = Vec::new();
+        let mut asserting = Vec::new();
+
+        for entry in std::fs::read_dir(&bins).expect("read bins/") {
+            let path = entry.expect("dir entry").path();
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let src = path.join("src");
+            if !src.is_dir() {
+                continue;
+            }
+            let mut enforces = false;
+            let mut asserts = false;
+            for file in std::fs::read_dir(&src).expect("read src/") {
+                let f = file.expect("file entry").path();
+                if f.extension().is_none_or(|e| e != "rs") {
+                    continue;
+                }
+                let text = std::fs::read_to_string(&f).unwrap_or_default();
+                if text.contains("require_oauth2 = true") {
+                    enforces = true;
+                }
+                if text.contains("with_expected_audience") {
+                    asserts = true;
+                }
+            }
+            if enforces && !DOCUMENTED_EXEMPTIONS.contains(&name.as_str()) {
+                enforcing.push(name.clone());
+                if asserts {
+                    asserting.push(name);
+                }
+            }
+        }
+
+        assert!(
+            !enforcing.is_empty(),
+            "expected to find NFs enforcing OAuth2; the guard found none, so it is no \
+             longer checking anything"
+        );
+        enforcing.sort();
+        asserting.sort();
+        assert_eq!(
+            enforcing, asserting,
+            "these NFs verify OAuth2 tokens WITHOUT asserting the audience, so a token \
+             minted for another producer is accepted (TS 33.501 13.4.1.2). Set \
+             with_expected_audience_nf_type(<own NfType>), or add a documented \
+             exemption to this guard explaining why the NF has no NF-type aud."
+        );
     }
 }


### PR DESCRIPTION
`Refs #64` — ships **gap 3**. The other four gaps are a coordinated NRF-side change; see *why this ships alone*. The open count deliberately does not move.

## The defect

TS 33.501 §13.4.1.2 requires a producer to verify that an access token's `aud` names **it**. The SBI server supports this (`oauth2_expected_audience` + `with_expected_audience_nf_type`), and when it is `None` the server calls `authorize_bearer_aud(.., None)` and **skips the audience check entirely**.

Comparing the two populations across `bins/`:

* **15** daemons set `require_oauth2 = true`
* **13** set an expected audience

Nothing compared those lists. The two that didn't:

| NF | verdict |
|---|---|
| **`udrd`** | **A genuine bypass.** `NfType::Udr` exists, so nothing stopped it. A token the NRF minted for *any* other producer verified successfully at the UDR — the NF holding subscriber data, authentication material and policy data. **Fixed.** |
| `pind` | **Deliberately exempt, and it already said so in-source**: pind is not a TS 29.510 `NfType`, so there is no NF-type `aud` for the NRF to mint or for it to assert. Left alone, now recorded as a *documented* exemption rather than an omission. |

That difference is the point: one was reasoned, one was overlooked, and only reading the code distinguishes them.

## Also closed: the exported helper that made this easy to get wrong

`security::authorize_sbi_request` — public, re-exported from `lib.rs`, **no NF caller** — verified signature, expiry and scope through the audience-*skipping* `authorize_bearer`. Anyone wiring the next producer through the obvious-looking public API would have inherited the same bypass.

It now takes `expected_audience: &str` and verifies via `authorize_bearer_aud` — a **required parameter, not an `Option`**, so it cannot be omitted by accident.

## The guard

This is the part that would have caught the UDR. The information was already in the tree — **15 vs 13** — and nothing compared it. A test now reads the daemon sources and asserts every NF setting `require_oauth2` also sets `with_expected_audience*`, with `pind` allow-listed **by name and reason**, so adding an exemption means writing the argument down next to the allow-list.

**Revert-verified:** removing the UDR binding fails the guard and names it —
`left: [… "nextgcore-udrd"]`.

## Why this ships alone

CONVENTIONS permits a safety-critical part of an umbrella to ship as `Refs #N` when it shouldn't wait (precedent #167, and #63's client fix earlier today). An authorisation bypass on the subscriber-data NF qualifies.

#64's other four gaps are NRF-side and coordinated: unauthenticated token issuance (1) and subject/certificate binding (2) are one posture change needing client auth turned on together; the ephemeral signing key (4) needs a persisted key plus configurable `expires_in`; the mis-mapped claims (5 — `producerNfSetId` never populated, `producerNsiList` carrying NF Set IDs) is an independent interop fix in the token minter. **None is on the producer-side verification path this PR touches**, so nothing here pre-empts them.

## Verification

* Workspace **5624 passed / 0 failed** (baseline 5623). `nextgcore-sbi` **190**.
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace` 0 errors.

## #64 acceptance criteria addressed

- [x] Gap 3 — audience verified on the producer side; a token minted for another producer is rejected at the UDR.
- [ ] Gaps 1, 2, 4, 5 — NRF-side, coordinated; unchanged and untouched here.

Spec: `specs/fix-udr-oauth2-audience-binding.md`
