### PR TITLE
fix(nrfd): map producerNsiList and producerNfSetId to the right NFProfile members (Refs #64)

### DIFF
--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -2217,11 +2217,41 @@ fn build_access_token_claims(
                 serde_json::Value::Array(snssais),
             );
         }
-        if let Some(set_id) = p.attributes.get("nfSetIdList").cloned() {
-            obj.insert("producerNsiList".to_string(), set_id);
+        // Issue #64 gap 5: both producer claims read the WRONG NFProfile member.
+        //
+        // `producerNsiList` is an array of NSI-IDs
+        // (TS29510_Nnrf_AccessToken.yaml:400-404) whose source is
+        // `NFProfile.nsiList` (TS29510_Nnrf_NFManagement.yaml:1498-1502). It was
+        // filled from `nfSetIdList`, i.e. NF SET IDs, so any consumer or producer
+        // keying slice scoping on this claim received NF Set IDs and mis-scoped.
+        //
+        // `producerNfSetId` is a SINGLE `NfSetId` (yaml:405-406) and was read from
+        // a `nfSetId` attribute that `NFProfile` does not define at all -- only
+        // `nfSetIdList` exists (yaml:1743-1747) -- so in production the claim was
+        // NEVER populated and anything gating on it silently saw nothing.
+        if let Some(nsi_list) = p
+            .attributes
+            .get("nsiList")
+            .and_then(|v| v.as_array())
+            .filter(|a| !a.is_empty())
+        {
+            obj.insert(
+                "producerNsiList".to_string(),
+                serde_json::Value::Array(nsi_list.clone()),
+            );
         }
-        if let Some(set_id) = p.attributes.get("nfSetId").cloned() {
-            obj.insert("producerNfSetId".to_string(), set_id);
+        // The claim is singular where the profile member is a list, so the first
+        // entry is the only representable one. A producer belonging to several NF
+        // Sets cannot be fully expressed in this claim -- that is a shape
+        // limitation of TS 29.510 §6.3.5.2.4, not a choice made here.
+        if let Some(set_id) = p
+            .attributes
+            .get("nfSetIdList")
+            .and_then(|v| v.as_array())
+            .and_then(|a| a.first())
+            .filter(|v| v.is_string())
+        {
+            obj.insert("producerNfSetId".to_string(), set_id.clone());
         }
     }
     claims
@@ -4108,7 +4138,12 @@ mod tests {
             "nfInstanceId": "p-1", "nfType": "UDM", "nfStatus": "REGISTERED",
             "plmnList": [{"mcc": "001", "mnc": "01"}],
             "sNssais": [{"sst": 1, "sd": "010203"}],
-            "nfSetId": "set-udm-1"
+            // Issue #64 gap 5: the REAL TS 29.510 NFProfile members. This fixture
+            // used to carry `"nfSetId": "set-udm-1"`, which NFProfile does not
+            // define -- it was only constructible because profile attributes are
+            // stored unvalidated, so the test passed while pinning the bug.
+            "nfSetIdList": ["set-udm-1", "set-udm-2"],
+            "nsiList": ["nsi-001", "nsi-002"]
         }))
         .unwrap();
 
@@ -4130,7 +4165,40 @@ mod tests {
         );
         assert_eq!(claims["consumerPlmnId"], json!({"mcc": "001", "mnc": "01"}));
         assert_eq!(claims["producerPlmnId"], json!({"mcc": "001", "mnc": "01"}));
+        // producerNfSetId is a SINGLE NfSetId taken from nfSetIdList.
         assert_eq!(claims["producerNfSetId"], json!("set-udm-1"));
+        // producerNsiList carries NSI-IDs from nsiList -- NOT the NF Set IDs it
+        // used to be filled with, which is the interop half of gap 5.
+        assert_eq!(claims["producerNsiList"], json!(["nsi-001", "nsi-002"]));
+        assert_ne!(
+            claims["producerNsiList"],
+            json!(["set-udm-1", "set-udm-2"]),
+            "producerNsiList must not carry NF Set IDs"
+        );
+
+        // A profile carrying ONLY the non-spec `nfSetId` yields neither claim:
+        // that member does not exist in TS 29.510, so nothing may be derived from
+        // it. This is the assertion the old fixture made impossible.
+        let bogus = NfProfile::from_json(&json!({
+            "nfInstanceId": "p-2", "nfType": "UDM", "nfStatus": "REGISTERED",
+            "nfSetId": "set-udm-9"
+        }))
+        .unwrap();
+        let bogus_claims = build_access_token_claims(
+            "nrf-iss",
+            "c-1",
+            "UDM",
+            Some(&bogus),
+            &consumer,
+            "nudm-sdm",
+            100,
+            3700,
+        );
+        assert!(
+            bogus_claims.get("producerNfSetId").is_none(),
+            "a non-spec nfSetId member must not populate the claim: {bogus_claims}"
+        );
+        assert!(bogus_claims.get("producerNsiList").is_none());
 
         // Type-scoped (no instance): aud is the bare NF type string.
         let claims2 = build_access_token_claims(


### PR DESCRIPTION
`Refs #64` — ships **gap 5**, which the issue itself calls *"independently a high-severity interop bug"*. Independent of gaps 1/2/4 (the coordinated NRF posture change). The open count deliberately does not move.

## The defect

`build_access_token_claims` populated two `AccessTokenClaims` members from the wrong source. Verified against the schemas, not inferred:

| claim | declared type | correct source | what the code read |
|---|---|---|---|
| `producerNsiList` | array of NSI-ID strings (`TS29510_Nnrf_AccessToken.yaml:400-404`) | `NFProfile.nsiList` (`TS29510_Nnrf_NFManagement.yaml:1498-1502`) | `nfSetIdList` — **NF Set IDs** |
| `producerNfSetId` | a single `NfSetId` (`:405-406`) | first entry of `NFProfile.nfSetIdList` (`:1743-1747`) | `nfSetId` — **a member `NFProfile` does not define** |

So `producerNsiList` carried NF Set IDs, and anything keying slice/NSI scoping on it mis-scoped across vendors. And `producerNfSetId` was **never populated in production** — `NFProfile` has only `nfSetIdList`, never a singular `nfSetId` — so anything gating on that claim silently saw nothing.

`producerNfSetId` is singular where the profile member is a list, so the first entry is the only representable one. A producer in several NF Sets cannot be fully expressed — that's a shape limitation of TS 29.510 §6.3.5.2.4, not a choice made here, and it's documented in-source.

## The test was pinning the bug

`test_nrfd_07_instance_scoped_claims` asserted `claims["producerNfSetId"] == "set-udm-1"` and **passed** — because its fixture registered a profile with `"nfSetId": "set-udm-1"`, constructible only because `NfProfile::from_json` stores attributes unvalidated. The test therefore *proved the claim was populated from a field no real NRF registration carries*.

That is precisely the failure mode already recorded in this project's LEARNINGS — *"a made-up fixture identifier is a tell that the code never validated the field … the fixture and the defect are mutually load-bearing"* — and it is why the mapping survived review.

The fixture now uses the real members (`nfSetIdList`, `nsiList`), plus a second case asserting that a profile carrying **only** the non-spec `nfSetId` produces **neither** claim — the assertion the old fixture made impossible.

## Verification

* Workspace **5624 passed / 0 failed**. nrfd **73 + 41**.
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace` 0 errors.
* **Revert-verified:** restoring the old sources fails `test_nrfd_07_instance_scoped_claims`.

## #64 acceptance criteria addressed

- [x] Gap 5 — `producerNfSetId` populated from the right member; `producerNsiList` carries NSI-IDs, provably not NF Set IDs.
- [ ] Gaps 1, 2, 4 — NRF-side posture change and signing-key persistence; untouched.

Spec: `specs/fix-nrf-access-token-producer-claims.md`
