### PR TITLE
fix(sbi): outbound peer calls follow the SBI security profile (Closes #63)

### DIFF
--- a/deploy/helm/nextgcore/values.yaml
+++ b/deploy/helm/nextgcore/values.yaml
@@ -19,7 +19,11 @@ global:
   # This chart mounts no SBI certificates, so it ships the explicit "dev"
   # opt-out: cleartext h2c, no client-certificate verification, no token
   # verification. Set to "production" only once those certs are provisioned and
-  # mounted at /etc/nextgcore/tls/{server.crt,server.key,ca.crt}.
+  # mounted at /etc/nextgcore/tls/{server.crt,server.key,ca.crt} -- plus the
+  # CLIENT pair those NFs present when they DIAL a peer
+  # (/etc/nextgcore/tls/{client.crt,client.key}), since under mTLS an NF is both
+  # server and client. Override any path with NEXTGCORE_SBI_TLS_CERT / _KEY / _CA
+  # / _CLIENT_CERT / _CLIENT_KEY.
   sbiProfile: dev
   logLevel: info
   max:

--- a/docs-book/src/configuration/overview.md
+++ b/docs-book/src/configuration/overview.md
@@ -78,7 +78,8 @@ Common sub-blocks seen in the Docker configs:
 | `AMF_NAS_SECURITY=nextgcore` | Forces the strict NAS-security path, overriding `nas.use_nextgcore_security` in YAML | amfd `lib.rs` |
 | `NEXTGCORE_SBI_OAUTH2_REQUIRE` | Forces OAuth2 enforcement on the SBI server regardless of YAML | amfd `lib.rs` |
 | `NEXTGCORE_SBI_PROFILE` | SBI security profile for amf/smf/ausf/udm. **Defaults to `production`** (mutually-authenticated TLS + a required OAuth2 access token). `dev`/`development`/`insecure`/`local`/`test` opt out to cleartext h2c; **any other value, including a typo, stays `production`** so a mistake cannot silently downgrade security | `nextgcore-sbi` `security.rs` |
-| `NEXTGCORE_SBI_TLS_CERT` / `_KEY` / `_CA` | Override the production profile's certificate paths (defaults under `/etc/nextgcore/tls/`), so the certs can be mounted wherever the deployment puts them | `nextgcore-sbi` `security.rs` |
+| `NEXTGCORE_SBI_TLS_CERT` / `_KEY` / `_CA` | Override the production profile's **server** certificate paths (defaults under `/etc/nextgcore/tls/`), so the certs can be mounted wherever the deployment puts them | `nextgcore-sbi` `security.rs` |
+| `NEXTGCORE_SBI_TLS_CLIENT_CERT` / `_CLIENT_KEY` | Override the certificate this NF **presents when it dials a peer**. Under mTLS an NF is both server and client, and a deployment may mount the two roles' material separately | `nextgcore-sbi` `security.rs` |
 | `TLS_ENABLED`, `SBI_SCHEME` | Docker-compose knobs to enable SBI TLS | config comments |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector (default `http://jaeger:4317`; no-op if absent) | `init.rs` |
 
@@ -87,21 +88,30 @@ Precedence, where both exist: **environment variable > YAML > compiled-in defaul
 ### SBI security profile (issue #63)
 
 `amf`, `smf`, `ausf` and `udm` resolve `NEXTGCORE_SBI_PROFILE` at startup. Under
-`production` they serve SBI over mutually-authenticated TLS and require an OAuth2
-access token whose audience is their own NF type, and they **refuse to start**
-when the certificates named above are missing rather than falling back to
-cleartext.
+`production`:
+
+* their **listener** serves SBI over mutually-authenticated TLS and requires an
+  OAuth2 access token whose audience is their own NF type;
+* their **outbound peer calls** use `https`, presenting this NF's client
+  certificate and verifying the peer against the configured CA;
+* they **refuse to start** when any certificate named above is missing —
+  including the client material, since an NF that cannot dial its peers is not
+  usable — rather than falling back to cleartext.
+
+The outbound half also covers the shared peer-client cache in
+`nextgcore-sbi`'s global context, so **peripheral NFs that resolve peers through
+it follow the profile too**. Their own listeners are still configured by their
+individual `--tls` flags rather than by this profile.
 
 Every artefact this repo ships — `docker/rust/docker-compose.yml`,
 `k8s/manifests/`, and the Helm chart via `global.sbiProfile` — sets the explicit
 `dev` opt-out, because none of them mount SBI certificates. Local development and
 the matched-simulator E2E are therefore unchanged.
 
-**Known incomplete:** the profile configures the *inbound* listener. Those four
-NFs still build their *outbound* peer clients as cleartext http with no client
-certificate, so a call between two production-profile NFs fails at the TLS layer;
-the production profile logs a warning saying so at startup. Until that lands, run
-a uniformly dev-profile deployment or terminate TLS at a proxy.
+**Mixed deployments are not supported:** the scheme comes from the profile, not
+from a peer's advertised URI, so run either a uniformly `production` or a
+uniformly `dev` core. (Before this, the scheme was hardcoded `http` regardless of
+what a peer advertised, so mixed was already broken.)
 
 ## Common parameters and code defaults
 

--- a/specs/fix-sbi-outbound-client-profile.md
+++ b/specs/fix-sbi-outbound-client-profile.md
@@ -1,0 +1,130 @@
+# nextgcore #63 (part 3 of 3): outbound peer calls follow the SBI security profile
+
+Verified against `main` @ `1cb487c`, on top of commit `56c84f7` (PR #188).
+
+Completes #63. **Closes it.**
+
+## The defect
+
+Commit `56c84f7` made the production SBI profile the default for amfd, smfd,
+ausfd and udmd — but only on the **inbound** listener. Those four still built
+their outbound peer clients with `SbiClient::with_host_port`, which is cleartext
+`http` with no client certificate. So under the production profile:
+
+* NF A's listener required mutually-authenticated TLS and a valid access token;
+* NF A's own call to NF B went out as cleartext `http`;
+* NF B's listener refused it at the TLS layer.
+
+**Every inter-NF call failed.** The production default was a configuration that
+could not work, rescued only by every shipped artefact carrying the dev opt-out.
+
+An NF is both a server and a client on the SBI; configuring one direction is
+half a posture. That is recorded as a learning, because nothing written for
+`56c84f7` could have caught it: every acceptance criterion in #63 is phrased
+about the *producer*, the E2E built its client by hand, and the source guard only
+proved the four daemons called the *server* helper.
+
+## The fix
+
+### `sbi_client_config_for_profile(host, port, profile)`
+
+Under `Production`: `https`, this NF's client certificate and key, and the CA to
+verify the peer against — all from `TlsPaths::from_env()`. Under `Dev`: exactly
+`SbiClientConfig::new`, so the cleartext path is byte-identical.
+
+`SbiClient::for_peer(host, port)` wraps it with the profile resolved from the
+environment. **`SbiClient::with_host_port` deliberately stays profile-blind** —
+plain `http` always — because that is what a test spinning up a loopback
+plaintext server needs.
+
+### Why not make the general constructor profile-aware
+
+Because `cargo test` sets no `NEXTGCORE_SBI_PROFILE`, so it would resolve to
+`Production` and every existing client test — each of which starts a plaintext
+server on loopback — would try to speak TLS to it. `cfg!(test)` does not help:
+it is false when `nextgcore-sbi` is compiled as a dependency of the binaries, so
+the binaries' own tests would still break. Hence an explicit helper at 22
+deliberate call sites rather than one clever change.
+
+### The shared peer-client cache
+
+`GlobalContext::get_client(host, port)` built a cleartext config. It hands out
+clients for dialling **peer NFs**, so leaving it cleartext would have silently
+undone the fix for every NF that resolves peers through it. One line there covers
+more than the four core NFs — pcfd and others use it too, which is why their
+tests surfaced during verification.
+
+### Client material is now required at startup
+
+`apply_sbi_security_profile`'s production check gained the client certificate and
+key. An NF whose listener comes up but which cannot dial any peer is not usable,
+and "the listener started fine" is a bad way to discover that. This immediately
+caught that the tests written for `56c84f7` supplied incomplete production
+material — which is what the check is for.
+
+### `NEXTGCORE_SBI_TLS_CLIENT_CERT` / `_CLIENT_KEY`
+
+Separate from the server pair, because under mTLS an NF fills both roles and a
+deployment may mount their material separately.
+
+## Scheme comes from the profile, not from a discovered URI
+
+In a uniformly production deployment every peer is `https`; in a uniformly dev
+one every peer is `http`. A deployment mixing the two per-NF is **not
+supported** — and was already broken before this, since the scheme was hardcoded
+`http` regardless of what a peer advertised. Stated in the docs rather than left
+implicit.
+
+## Call sites
+
+22 production sites; test-module sites keep `with_host_port` on purpose.
+
+| NF | file | production sites |
+|---|---|---|
+| amfd | `sbi_path.rs` | 14 |
+| amfd | `namf_server.rs` | 1 (`notify_client`) |
+| smfd | `policy.rs` | 4 |
+| smfd | `main.rs` | 1 (`SmContextStatusNotification`) |
+| ausfd | `app.rs` | 1 (peer-client helper) |
+| udmd | `app.rs` | 1 (peer-client helper) |
+| — | `nextgcore-sbi` `context.rs` | 1 (shared cache, covers all consumers) |
+
+## Verification
+
+`peer_client_built_by_the_profile_helper_completes_the_transaction` extends the
+mTLS + OAuth2 E2E with a consumer built **by the helper the NFs call**, not by
+hand — with the certificate paths supplied through the same env vars a deployment
+uses. If the helper stopped setting `https`, or dropped the client certificate,
+this fails where the hand-built case would not. **Revert-verified:** restoring
+the cleartext peer config fails exactly this test and no other, which is the
+point — it is the only case that could catch it.
+
+`dev_profile_peer_client_stays_cleartext` pins that dev is unchanged.
+
+`core_nf_peer_call_paths_do_not_build_cleartext_clients` reads
+`amfd/sbi_path.rs` and `smfd/policy.rs` — the two all-production peer-call files —
+and fails if either reaches for `with_host_port` again. That constructor has to
+keep existing for tests, which makes it exactly the thing a future edit could
+grab in production code without noticing.
+
+### Tests that now declare their profile
+
+19 tests across amfd, ausfd, udmd, smfd, lmfd and pcfd drive **production**
+peer-call code against loopback **plaintext** peers — they describe a dev-profile
+deployment. Each now says so with `set_sbi_profile_override(SbiProfile::Dev)`
+rather than inheriting whatever the environment holds. That is a clarification,
+not a concession: in a real dev deployment (which is what every shipped artefact
+configures) those paths *are* http, so the tests assert the deployment they were
+always describing.
+
+`set_sbi_profile_override` is a relaxed atomic store; parallel tests all storing
+`Dev` is benign, so no serialisation is needed.
+
+## Definition of done
+
+- [x] All four core NFs dial peers through the profile-aware helper.
+- [x] The shared peer-client cache honours the profile.
+- [x] Client certificate/key are required at startup under production.
+- [x] E2E proves a transaction with the consumer built by the NFs' own helper.
+- [x] Dev profile byte-identical; guard prevents regression to `with_host_port`.
+- [x] Workspace green; docs state the mixed-deployment limitation.

--- a/src/bins/nextgcore-amfd/src/namf_server.rs
+++ b/src/bins/nextgcore-amfd/src/namf_server.rs
@@ -794,7 +794,7 @@ fn handle_event_subscription_delete(subscription_id: &str) -> SbiResponse {
 
 /// Build a notification SBI client with bounded connect/request timeouts
 fn notify_client(host: &str, port: u16) -> SbiClient {
-    let config = nextgcore_sbi::client::SbiClientConfig::new(host, port)
+    let config = nextgcore_sbi::security::sbi_peer_client_config(host, port)
         .with_connect_timeout(std::time::Duration::from_secs(NOTIFY_CONNECT_TIMEOUT_SECS))
         .with_request_timeout(std::time::Duration::from_secs(NOTIFY_REQUEST_TIMEOUT_SECS));
     SbiClient::new(config)
@@ -2529,6 +2529,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_event_notification_post_delivery() {
+        // This test drives production code against a loopback PLAINTEXT peer, i.e.
+        // it describes a dev-profile deployment (issue #63). Declared explicitly
+        // rather than inherited from the environment.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         amf_context_init(64, 1024, 4096);
         let supi = "imsi-001010000060010";
         let (server, port, mut rx) = start_capture_server().await;
@@ -2807,6 +2811,10 @@ mod tests {
     /// into the relay is covered by the connected-UE test above.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_n1n2_updp_to_idle_ue_504_not_fake_200() {
+        // This test drives production code against a loopback PLAINTEXT peer, i.e.
+        // it describes a dev-profile deployment (issue #63). Declared explicitly
+        // rather than inherited from the environment.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _serial = updp_queue_test_lock().lock().await;
         amf_context_init(64, 1024, 4096);
         let supi = "imsi-001010000060033";
@@ -3407,6 +3415,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_n1n2_failure_callback_http_delivery() {
+        // This test drives production code against a loopback PLAINTEXT peer, i.e.
+        // it describes a dev-profile deployment (issue #63). Declared explicitly
+        // rather than inherited from the environment.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         // Idle UE + PDU_RES_REL_CMD + skipInd: N1 message is not transferred,
         // the response is 504 UE_NOT_REACHABLE and the failure notification
         // is POSTed to n1n2FailureTxfNotifURI.

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -7276,6 +7276,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_uplink_ue_associated_nrppa_relays_to_lmf_callback() {
+        // This test drives production code against a loopback PLAINTEXT peer, i.e.
+        // it describes a dev-profile deployment (issue #63). Declared explicitly
+        // rather than inherited from the environment.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         use nextgcore_asn1c::ngap::ies::{AmfUeNgapId, NrppaPdu, RanUeNgapId, RoutingId};
         use nextgcore_asn1c::ngap::pdu::build_uplink_ue_associated_nrppa_transport;
         crate::context::amf_context_init(64, 1024, 4096);
@@ -7431,6 +7435,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_uplink_non_ue_associated_nrppa_relays_to_registered_lmf() {
+        // This test drives production code against a loopback PLAINTEXT peer, i.e.
+        // it describes a dev-profile deployment (issue #63). Declared explicitly
+        // rather than inherited from the environment.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         use nextgcore_asn1c::ngap::ies::{NrppaPdu, RoutingId};
         use nextgcore_asn1c::ngap::pdu::build_uplink_non_ue_associated_nrppa_transport;
         crate::context::amf_context_init(64, 1024, 4096);

--- a/src/bins/nextgcore-amfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-amfd/src/sbi_path.rs
@@ -843,7 +843,7 @@ pub async fn call_smf_create_sm_context(
     );
 
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(smf_host, smf_port),
+        SbiClient::for_peer(smf_host, smf_port),
         nextgcore_sbi::types::NfType::Smf,
     );
 
@@ -935,7 +935,7 @@ pub async fn call_smf_update_sm_context(
     );
 
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(smf_host, smf_port),
+        SbiClient::for_peer(smf_host, smf_port),
         nextgcore_sbi::types::NfType::Smf,
     );
 
@@ -995,7 +995,7 @@ pub async fn call_smf_update_sm_context_with_n1(
     );
 
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(smf_host, smf_port),
+        SbiClient::for_peer(smf_host, smf_port),
         nextgcore_sbi::types::NfType::Smf,
     );
 
@@ -1061,7 +1061,7 @@ pub async fn call_smf_release_sm_context(
     log::info!("Calling SMF SM Context Release: ref={sm_context_ref}");
 
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(smf_host, smf_port),
+        SbiClient::for_peer(smf_host, smf_port),
         nextgcore_sbi::types::NfType::Smf,
     );
 
@@ -1131,7 +1131,7 @@ pub async fn call_ausf_authenticate_with_resync(
     );
 
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(ausf_host, ausf_port),
+        SbiClient::for_peer(ausf_host, ausf_port),
         nextgcore_sbi::types::NfType::Ausf,
     );
 
@@ -1225,7 +1225,7 @@ pub async fn call_ausf_5g_aka_confirm(
     );
 
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(ausf_host, ausf_port),
+        SbiClient::for_peer(ausf_host, ausf_port),
         nextgcore_sbi::types::NfType::Ausf,
     );
 
@@ -1461,7 +1461,7 @@ pub async fn call_udm_uecm_registration(
     amf_id_hex: &str,
 ) -> SbiResult<()> {
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(udm_host, udm_port),
+        SbiClient::for_peer(udm_host, udm_port),
         nextgcore_sbi::types::NfType::Udm,
     );
 
@@ -1515,7 +1515,7 @@ pub async fn call_udm_sdm_get_am_data(
     supi: &str,
 ) -> SbiResult<AmDataResponse> {
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(udm_host, udm_port),
+        SbiClient::for_peer(udm_host, udm_port),
         nextgcore_sbi::types::NfType::Udm,
     );
     let path = format!("/nudm-sdm/v2/{supi}/am-data");
@@ -1569,7 +1569,7 @@ pub async fn call_udm_sdm_subscribe(
     amf_instance_id: &str,
 ) -> SbiResult<String> {
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(udm_host, udm_port),
+        SbiClient::for_peer(udm_host, udm_port),
         nextgcore_sbi::types::NfType::Udm,
     );
 
@@ -1621,7 +1621,7 @@ pub async fn call_pcf_am_policy_create(
     serving_plmn_mnc: &str,
 ) -> SbiResult<String> {
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(pcf_host, pcf_port),
+        SbiClient::for_peer(pcf_host, pcf_port),
         nextgcore_sbi::types::NfType::Pcf,
     );
 
@@ -1699,7 +1699,7 @@ pub async fn call_pcf_ue_policy_create(
     guami_amf_id_hex: &str,
 ) -> SbiResult<String> {
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(pcf_host, pcf_port),
+        SbiClient::for_peer(pcf_host, pcf_port),
         nextgcore_sbi::types::NfType::Pcf,
     );
 
@@ -1757,7 +1757,7 @@ pub async fn call_pcf_ue_policy_delete(
     pol_asso_id: &str,
 ) -> SbiResult<()> {
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(pcf_host, pcf_port),
+        SbiClient::for_peer(pcf_host, pcf_port),
         nextgcore_sbi::types::NfType::Pcf,
     );
 
@@ -1809,7 +1809,7 @@ pub async fn call_nsacf_ue_admission(
     update_flag: bool,
 ) -> SbiResult<NsacfUeAdmissionResult> {
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(nsacf_host, nsacf_port),
+        SbiClient::for_peer(nsacf_host, nsacf_port),
         nextgcore_sbi::types::NfType::Nsacf,
     );
 
@@ -1882,7 +1882,7 @@ pub async fn call_udm_uecm_deregistration(
     supi: &str,
 ) -> SbiResult<()> {
     let client = crate::attach_oauth2(
-        SbiClient::with_host_port(udm_host, udm_port),
+        SbiClient::for_peer(udm_host, udm_port),
         nextgcore_sbi::types::NfType::Udm,
     );
 
@@ -1996,6 +1996,10 @@ mod tests {
 
     #[tokio::test]
     async fn nsacf_ue_admission_204_403_200_failure_list() {
+        // This test drives production code against a loopback PLAINTEXT peer, i.e.
+        // it describes a dev-profile deployment (issue #63). Declared explicitly
+        // rather than inherited from the environment.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let port = nsacf_free_port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
         let server = nextgcore_sbi::server::SbiServer::new(
@@ -2401,6 +2405,10 @@ mod tests {
     /// the polAssoId out of the Location header.
     #[tokio::test]
     async fn ue_policy_create_posts_spec_body_and_parses_location() {
+        // This test drives production code against a loopback PLAINTEXT peer, i.e.
+        // it describes a dev-profile deployment (issue #63). Declared explicitly
+        // rather than inherited from the environment.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let (server, port) = start_pcf_ue_policy_stub().await;
 
         let assoc = call_pcf_ue_policy_create(
@@ -2465,6 +2473,10 @@ mod tests {
     /// §4.2.4) and maps 204 → Ok, 404 → Err.
     #[tokio::test]
     async fn ue_policy_delete_deletes_resource() {
+        // This test drives production code against a loopback PLAINTEXT peer, i.e.
+        // it describes a dev-profile deployment (issue #63). Declared explicitly
+        // rather than inherited from the environment.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let (server, port) = start_pcf_ue_policy_stub().await;
 
         call_pcf_ue_policy_delete("127.0.0.1", port, "pol-ue-42")

--- a/src/bins/nextgcore-ausfd/src/app.rs
+++ b/src/bins/nextgcore-ausfd/src/app.rs
@@ -146,7 +146,7 @@ async fn peer_client(
 ) -> Arc<nextgcore_sbi::client::SbiClient> {
     match oauth2_client() {
         Some(oauth2) => Arc::new(
-            nextgcore_sbi::client::SbiClient::new(nextgcore_sbi::client::SbiClientConfig::new(
+            nextgcore_sbi::client::SbiClient::new(nextgcore_sbi::security::sbi_peer_client_config(
                 host, port,
             ))
             .with_oauth2(oauth2, target),
@@ -2278,6 +2278,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
     async fn test_http_auth_flows_5g_aka_and_eap_aka_prime() {
+        // Drives production code against a loopback PLAINTEXT peer, i.e. describes a
+        // dev-profile deployment (issue #63). Declared, not inherited from the env.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
@@ -2643,6 +2646,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
     async fn test_confirmation_response_shaping() {
+        // Drives production code against a loopback PLAINTEXT peer, i.e. describes a
+        // dev-profile deployment (issue #63). Declared, not inherited from the env.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
@@ -2936,6 +2942,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
     async fn test_sor_upu_anchor_survives_auth_context_delete() {
+        // Drives production code against a loopback PLAINTEXT peer, i.e. describes a
+        // dev-profile deployment (issue #63). Declared, not inherited from the env.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
@@ -3069,6 +3078,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
     async fn test_deregister_clears_context_and_the_sor_upu_anchor() {
+        // Drives production code against a loopback PLAINTEXT peer, i.e. describes a
+        // dev-profile deployment (issue #63). Declared, not inherited from the env.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _guard = crate::test_support::lock_context();
         let _ = env_logger::try_init();
         let _lock = TEST_MUTEX.lock().await;
@@ -3256,6 +3268,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
     async fn test_ue_authentication_ctx_is_served_as_hal_json() {
+        // Drives production code against a loopback PLAINTEXT peer, i.e. describes a
+        // dev-profile deployment (issue #63). Declared, not inherited from the env.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _guard = crate::test_support::lock_context();
         let _ = env_logger::try_init();
         let _lock = TEST_MUTEX.lock().await;
@@ -3383,6 +3398,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
     async fn test_snn_entitlement_against_consumer_token() {
+        // Drives production code against a loopback PLAINTEXT peer, i.e. describes a
+        // dev-profile deployment (issue #63). Declared, not inherited from the env.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.
@@ -3529,6 +3547,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global AUSF state (current-thread test)
     async fn test_sor_upu_protection_http_end_to_end() {
+        // Drives production code against a loopback PLAINTEXT peer, i.e. describes a
+        // dev-profile deployment (issue #63). Declared, not inherited from the env.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         // Serialize on ausfd's global-context/env guard: re-inits the process-
         // global AUSF context and/or sets UDM/UDR_SBI_* env vars, which races any
         // other ausfd test doing the same under parallel `cargo test`.

--- a/src/bins/nextgcore-lmfd/src/main.rs
+++ b/src/bins/nextgcore-lmfd/src/main.rs
@@ -4435,6 +4435,9 @@ mod positioning_chain_strict_peer {
     /// returns a measurement-derived fix, driven end-to-end across BOTH real NFs.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_positioning_chain_returns_200_computed_fix_via_real_amfd() {
+        // Drives REAL amfd peer-call code against a loopback PLAINTEXT stub, i.e.
+        // describes a dev-profile deployment (issue #63). Declared, not inherited.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _serial = chain_lock().lock().await;
         let supi = "imsi-001010000000701".to_string();
 
@@ -4553,6 +4556,9 @@ mod positioning_chain_strict_peer {
     /// POSITIONING_FAILED (TS 29.572 Table 6.1.7.3-1), never a fabricated fix.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_positioning_chain_corrupt_lpp_reply_maps_to_500() {
+        // Drives REAL amfd peer-call code against a loopback PLAINTEXT stub, i.e.
+        // describes a dev-profile deployment (issue #63). Declared, not inherited.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _serial = chain_lock().lock().await;
         let supi = "imsi-001010000000703".to_string();
 

--- a/src/bins/nextgcore-pcfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-pcfd/src/sbi_path.rs
@@ -1282,6 +1282,10 @@ mod tests {
     /// stay mocked (H1 policy).
     #[tokio::test]
     async fn discover_and_send_udr_mock() {
+        // pcfd resolves peers through the shared client cache, which now honours the
+        // SBI security profile (issue #63). This test uses a loopback PLAINTEXT NRF
+        // stub, i.e. a dev-profile deployment; declared rather than inherited.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         use nextgcore_sbi::message::SbiRequest as Req;
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
         use std::time::Duration;

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_bsfd.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_bsfd.rs
@@ -94,6 +94,9 @@ fn binding_id_from_location(resp: &SbiResponse, prefix: &str) -> String {
 /// DELETE -> 204. A 400 here fails the test (the pre-fix behavior).
 #[tokio::test]
 async fn pcfd_production_binding_accepted_at_session_site() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     init_peers();
     let body = production_body("imsi-001010000000701", "10.45.0.71");
 
@@ -130,6 +133,9 @@ async fn pcfd_production_binding_accepted_at_session_site() {
 /// /pcfBindings), so there is no builder to re-key -- the mapping lives here.
 #[tokio::test]
 async fn pcfd_production_binding_accepted_at_ue_site() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     init_peers();
     let src = production_body("imsi-001010000000702", "10.45.0.72");
     let mut body = serde_json::json!({ "supi": src["supi"].clone() });
@@ -159,6 +165,9 @@ async fn pcfd_production_binding_accepted_at_ue_site() {
 /// PCF-address members under test come from the real builder) -> 201.
 #[tokio::test]
 async fn pcfd_production_binding_accepted_at_mbs_site() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     init_peers();
     let mut body = production_body("imsi-001010000000703", "10.45.0.73");
     body["mbsSessionId"] = mbs_session_id("000703");
@@ -181,6 +190,9 @@ async fn pcfd_production_binding_accepted_at_mbs_site() {
 /// If bsfd is ever loosened instead of pcfd being fixed, this fails.
 #[tokio::test]
 async fn legacy_binding_still_rejected_400_at_all_three_sites() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     init_peers();
     let body = legacy_body("imsi-001010000000704", "10.45.0.74");
 

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_udr_ue_policy.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_udr_ue_policy.rs
@@ -68,6 +68,9 @@ fn provisioned_ims_doc() -> serde_json::Value {
 /// command vector (reflects the provisioned DNN "ims" / S-NSSAI SST=1).
 #[test]
 fn provisioned_via_real_udrd_store_matches_golden() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     std::env::remove_var("PCF_URSP_RULES");
     let supi = "imsi-001010000003001";
     let ds = data_store::store();
@@ -99,6 +102,9 @@ fn provisioned_via_real_udrd_store_matches_golden() {
 /// No provisioning for a SUPI → pcfd delivers the static default (E1(f)).
 #[test]
 fn no_provisioning_delivers_static_default() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     std::env::remove_var("PCF_URSP_RULES");
     let supi = "imsi-001010000003002";
     let ds = data_store::store();
@@ -118,6 +124,9 @@ fn no_provisioning_delivers_static_default() {
 /// offending component (grep-able WARN source).
 #[test]
 fn malformed_provisioning_falls_back_via_real_store() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     std::env::remove_var("PCF_URSP_RULES");
     let supi = "imsi-001010000003003";
     let ds = data_store::store();

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_updp.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_updp.rs
@@ -90,6 +90,9 @@ fn body_cause(resp: &nextgcore_sbi::message::SbiResponse) -> String {
 /// egress are byte-identical to pcfd's E1(f) command (no re-encoding, no drop).
 #[test]
 fn pcfd_updp_accepted_by_real_amfd_and_enqueued_verbatim() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     let _serial = CONTEXT_GUARD.lock().unwrap_or_else(|e| e.into_inner());
     let supi = "imsi-001010000004001";
     let ue_id = seed_ue(supi, true);
@@ -128,6 +131,9 @@ fn pcfd_updp_accepted_by_real_amfd_and_enqueued_verbatim() {
 /// non-2xx that pcfd's delivery path records as `DeliveryState::Failed`.
 #[test]
 fn pcfd_updp_to_idle_ue_rejected_504_by_real_amfd() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     let _serial = CONTEXT_GUARD.lock().unwrap_or_else(|e| e.into_inner());
     let supi = "imsi-001010000004002";
     let ue_id = seed_ue(supi, false);

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_updp_result.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_updp_result.rs
@@ -61,6 +61,9 @@ fn amfd_notify_request(pol_asso_id: &str, n1_payload: &[u8]) -> nextgcore_sbi::m
 /// the association Pending→Delivered (records the UPSC as installed UPSI).
 #[tokio::test]
 async fn complete_via_real_amfd_notify_delivers() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     let id = seed_pending_association(0x91);
     let complete = nas_updp::ManageUePolicyComplete { pti: 0x91 }
         .encode()
@@ -82,6 +85,9 @@ async fn complete_via_real_amfd_notify_delivers() {
 /// D.6.3 per-instruction cause.
 #[tokio::test]
 async fn reject_via_real_amfd_notify_fails_with_cause() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     let id = seed_pending_association(0x92);
     let reject = nas_updp::ManageUePolicyCommandReject {
         pti: 0x92,
@@ -119,6 +125,9 @@ async fn reject_via_real_amfd_notify_fails_with_cause() {
 /// Pending — Delivered is reached ONLY via a matching PTI.
 #[tokio::test]
 async fn wrong_pti_complete_is_dropped() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     let id = seed_pending_association(0x93);
     let stale = nas_updp::ManageUePolicyComplete { pti: 0x9F }
         .encode()

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -2823,7 +2823,7 @@ async fn send_sm_context_status_notification(
     let path = uri_path(uri);
     let body = build_sm_context_status_notification(resource_status, cause);
     let client = nextgcore_sbi::client::SbiClient::new(
-        nextgcore_sbi::client::SbiClientConfig::new(host, port)
+        nextgcore_sbi::security::sbi_peer_client_config(&host, port)
             .with_connect_timeout(std::time::Duration::from_secs(2))
             .with_request_timeout(std::time::Duration::from_secs(3)),
     );

--- a/src/bins/nextgcore-smfd/src/policy.rs
+++ b/src/bins/nextgcore-smfd/src/policy.rs
@@ -19,7 +19,7 @@
 //! warning. When a PCF *is* configured, a rejection or transport failure is a
 //! hard failure for the PDU session (no silent fallback).
 
-use nextgcore_sbi::client::{SbiClient, SbiClientConfig};
+use nextgcore_sbi::client::SbiClient;
 use std::time::Duration;
 
 // ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ impl PcfEndpoint {
         // when OAuth2 enforcement is on (Wave-6 H8 Phase A); no-op otherwise.
         crate::attach_oauth2(
             SbiClient::new(
-                SbiClientConfig::new(self.host.clone(), self.port)
+                nextgcore_sbi::security::sbi_peer_client_config(&self.host, self.port)
                     .with_connect_timeout(Duration::from_secs(2))
                     .with_request_timeout(Duration::from_secs(3)),
             ),
@@ -246,7 +246,7 @@ pub async fn resolve_pcf_endpoint() -> Option<PcfEndpoint> {
         .await?;
     let (nrf_host, nrf_port) = split_host_port(&nrf_uri)?;
     let client = SbiClient::new(
-        SbiClientConfig::new(nrf_host, nrf_port)
+        nextgcore_sbi::security::sbi_peer_client_config(&nrf_host, nrf_port)
             .with_connect_timeout(Duration::from_secs(2))
             .with_request_timeout(Duration::from_secs(3)),
     );
@@ -315,7 +315,7 @@ impl NsacfEndpoint {
         // enforcement is on (Wave-6 H8 Phase A); no-op otherwise.
         crate::attach_oauth2(
             SbiClient::new(
-                SbiClientConfig::new(self.host.clone(), self.port)
+                nextgcore_sbi::security::sbi_peer_client_config(&self.host, self.port)
                     .with_connect_timeout(Duration::from_secs(2))
                     .with_request_timeout(Duration::from_secs(3)),
             ),
@@ -342,7 +342,7 @@ pub async fn resolve_nsacf_endpoint() -> Option<NsacfEndpoint> {
         .await?;
     let (nrf_host, nrf_port) = split_host_port(&nrf_uri)?;
     let client = SbiClient::new(
-        SbiClientConfig::new(nrf_host, nrf_port)
+        nextgcore_sbi::security::sbi_peer_client_config(&nrf_host, nrf_port)
             .with_connect_timeout(Duration::from_secs(2))
             .with_request_timeout(Duration::from_secs(3)),
     );
@@ -1665,6 +1665,9 @@ mod tests {
 
     #[tokio::test]
     async fn sm_policy_lifecycle_http_round_trip() {
+        // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+        // dev-profile deployment (issue #63). Declared rather than inherited.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let port = free_port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
         let server = nextgcore_sbi::server::SbiServer::new(
@@ -1788,6 +1791,9 @@ mod tests {
 
     #[tokio::test]
     async fn nsac_pdu_session_admit_admitted_and_rejected() {
+        // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+        // dev-profile deployment (issue #63). Declared rather than inherited.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let port = free_port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
         let server = nextgcore_sbi::server::SbiServer::new(

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -215,7 +215,7 @@ pub(crate) async fn peer_client(
 ) -> Arc<nextgcore_sbi::client::SbiClient> {
     match oauth2_client() {
         Some(oauth2) => Arc::new(
-            nextgcore_sbi::client::SbiClient::new(nextgcore_sbi::client::SbiClientConfig::new(
+            nextgcore_sbi::client::SbiClient::new(nextgcore_sbi::security::sbi_peer_client_config(
                 host, port,
             ))
             .with_oauth2(oauth2, target),
@@ -2396,6 +2396,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state (current-thread test)
     async fn test_http_generate_auth_data_flows() {
+        // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+        // dev-profile deployment (issue #63). Declared rather than inherited.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         // Serialize on udmd's global-context/UDR-env guard: this test re-inits
         // the process-global UDM context and/or sets UDR_SBI_* env vars, which
         // races any other udmd test doing the same (the CI-flaky AUTS-resync).

--- a/src/bins/nextgcore-udmd/tests/sor_upu_strict_peer.rs
+++ b/src/bins/nextgcore-udmd/tests/sor_upu_strict_peer.rs
@@ -200,6 +200,9 @@ fn parse(body: &str) -> serde_json::Value {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn sor_upu_strict_peer_end_to_end() {
+    // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
+    // dev-profile deployment (issue #63). Declared rather than inherited from env.
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
     let _ = env_logger::try_init();
 
     // Serialize against any other in-process consumer of the two NF contexts

--- a/src/libs/nextgcore-sbi/src/client.rs
+++ b/src/libs/nextgcore-sbi/src/client.rs
@@ -334,6 +334,23 @@ impl SbiClient {
         Self::new(SbiClientConfig::new(host, port))
     }
 
+    /// A client for dialling a **peer NF**, honouring the process-wide SBI
+    /// security profile (issue #63): `https` with this NF's client certificate
+    /// under `production`, plain `http` under `dev`.
+    ///
+    /// This is what production code should use to reach another NF.
+    /// [`SbiClient::with_host_port`] deliberately stays profile-blind: it is
+    /// plain `http` always, which is what tests spinning up a loopback server
+    /// need. Making the general constructor profile-aware instead would have
+    /// broken every such test — `cargo test` sets no `NEXTGCORE_SBI_PROFILE`, so
+    /// it resolves to `production` and the client would try to speak TLS to a
+    /// plaintext server. `cfg!(test)` is no help either: it is false when this
+    /// crate is compiled as a dependency of the binaries, so the binaries' own
+    /// tests would still break.
+    pub fn for_peer(host: impl Into<String>, port: u16) -> Self {
+        Self::new(crate::security::sbi_peer_client_config(&host.into(), port))
+    }
+
     /// Attach an OAuth2 client for automatic Bearer token attachment.
     ///
     /// When set, the client will request a token from the NRF before each

--- a/src/libs/nextgcore-sbi/src/context.rs
+++ b/src/libs/nextgcore-sbi/src/context.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use crate::client::{SbiClient, SbiClientConfig};
+use crate::client::SbiClient;
 use crate::message::{PlmnId, SNssai};
 use crate::types::{NfType, SbiServiceType, UriScheme};
 
@@ -234,7 +234,10 @@ impl SbiContext {
         }
 
         // Create new client
-        let config = SbiClientConfig::new(host, port);
+        // Issue #63: this cache hands out clients for dialling PEER NFs, so it
+        // must honour the SBI security profile. Left cleartext it would silently
+        // undo the outbound half for every NF that resolves peers through it.
+        let config = crate::security::sbi_peer_client_config(host, port);
         let client = Arc::new(SbiClient::new(config));
 
         let mut clients = self.clients.write().await;

--- a/src/libs/nextgcore-sbi/src/security.rs
+++ b/src/libs/nextgcore-sbi/src/security.rs
@@ -74,6 +74,11 @@ impl TlsPaths {
     pub const CERT_ENV: &'static str = "NEXTGCORE_SBI_TLS_CERT";
     pub const KEY_ENV: &'static str = "NEXTGCORE_SBI_TLS_KEY";
     pub const CA_ENV: &'static str = "NEXTGCORE_SBI_TLS_CA";
+    /// The certificate this NF presents when it DIALS a peer. Under mTLS an NF is
+    /// both a server and a client, and a deployment may well mount the two roles'
+    /// material separately.
+    pub const CLIENT_CERT_ENV: &'static str = "NEXTGCORE_SBI_TLS_CLIENT_CERT";
+    pub const CLIENT_KEY_ENV: &'static str = "NEXTGCORE_SBI_TLS_CLIENT_KEY";
 
     /// [`TlsPaths::default`] with each path overridden by its environment
     /// variable when that variable is set and non-empty.
@@ -84,13 +89,19 @@ impl TlsPaths {
                 _ => fallback,
             }
         };
+        let or_env_opt = |var: &str, fallback: Option<String>| -> Option<String> {
+            match std::env::var(var) {
+                Ok(v) if !v.trim().is_empty() => Some(v.trim().to_string()),
+                _ => fallback,
+            }
+        };
         let d = Self::default();
         Self {
             cert: or_env(Self::CERT_ENV, d.cert),
             key: or_env(Self::KEY_ENV, d.key),
             ca_cert: or_env(Self::CA_ENV, d.ca_cert),
-            client_cert: d.client_cert,
-            client_key: d.client_key,
+            client_cert: or_env_opt(Self::CLIENT_CERT_ENV, d.client_cert),
+            client_key: or_env_opt(Self::CLIENT_KEY_ENV, d.client_key),
         }
     }
 }
@@ -205,10 +216,43 @@ pub enum SbiProfile {
 /// security, which is the failure mode this issue is about.
 pub const SBI_PROFILE_ENV: &str = "NEXTGCORE_SBI_PROFILE";
 
+/// Tri-state programmatic override of the profile: `0` = consult
+/// [`SBI_PROFILE_ENV`], `1` = force [`SbiProfile::Dev`], `2` = force
+/// [`SbiProfile::Production`].
+static SBI_PROFILE_MODE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+/// Force the process-wide profile, overriding [`SBI_PROFILE_ENV`].
+///
+/// Exists for tests that exercise production code paths against a loopback
+/// **plaintext** peer: such a test is describing a dev-profile deployment, and
+/// saying so explicitly is better than depending on whatever the environment
+/// happens to hold. Storing the same value from several threads is benign, so
+/// parallel tests that all want `Dev` do not need to serialise.
+pub fn set_sbi_profile_override(profile: SbiProfile) {
+    SBI_PROFILE_MODE.store(
+        match profile {
+            SbiProfile::Dev => 1,
+            SbiProfile::Production => 2,
+        },
+        std::sync::atomic::Ordering::Relaxed,
+    );
+}
+
+/// Clear an override set by [`set_sbi_profile_override`], restoring env-driven
+/// resolution.
+pub fn reset_sbi_profile_override() {
+    SBI_PROFILE_MODE.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
 impl SbiProfile {
-    /// Resolve the process-wide profile from [`SBI_PROFILE_ENV`].
+    /// Resolve the process-wide profile: the programmatic override
+    /// ([`set_sbi_profile_override`]) first, then [`SBI_PROFILE_ENV`].
     pub fn resolve() -> Self {
-        Self::from_env_value(std::env::var(SBI_PROFILE_ENV).ok().as_deref())
+        match SBI_PROFILE_MODE.load(std::sync::atomic::Ordering::Relaxed) {
+            1 => Self::Dev,
+            2 => Self::Production,
+            _ => Self::from_env_value(std::env::var(SBI_PROFILE_ENV).ok().as_deref()),
+        }
     }
 
     /// Pure resolution of an env value, unit-testable without touching the
@@ -314,12 +358,25 @@ pub fn apply_sbi_security_policy(
         )));
     }
 
+    // Every file the posture needs, checked at startup so a missing one names
+    // itself here rather than surfacing later as a handshake error. Under mTLS an
+    // NF is both server and client, so the client material it presents when
+    // DIALLING a peer is just as required as the server material -- omitting it
+    // from this check is how "the listener came up fine" turns into every
+    // outbound call failing.
     let paths = &policy.tls_paths;
-    for (label, path) in [
+    let mut required: Vec<(&str, &str)> = vec![
         ("certificate", paths.cert.as_str()),
         ("private key", paths.key.as_str()),
         ("client CA certificate", paths.ca_cert.as_str()),
-    ] {
+    ];
+    if let Some(cc) = paths.client_cert.as_deref() {
+        required.push(("client certificate (for outbound peer calls)", cc));
+    }
+    if let Some(ck) = paths.client_key.as_deref() {
+        required.push(("client private key (for outbound peer calls)", ck));
+    }
+    for (label, path) in required {
         if !std::path::Path::new(path).is_file() {
             return Err(SbiError::TlsError(format!(
                 "SBI production profile requires a TLS {label} at {path}, which does not \
@@ -359,20 +416,6 @@ pub fn apply_sbi_security_policy(
         }
     }
 
-    // KNOWN INCOMPLETE (issue #63, remaining half of criterion 1). This function
-    // configures the INBOUND listener. The four core NFs still build their
-    // OUTBOUND peer clients with `SbiClient::with_host_port`, which defaults to
-    // cleartext http with no client certificate -- so NF-to-NF calls between two
-    // production-profile NFs fail at the TLS layer. Said out loud here because the
-    // alternative is an operator debugging a connection error on the callee side
-    // with nothing pointing at the caller's scheme.
-    log::warn!(
-        "SBI production profile: OUTBOUND peer calls are NOT yet profile-aware. This NF's \
-         listener requires mutually-authenticated TLS, but its own calls to other NFs \
-         still use cleartext http with no client certificate, so inter-NF requests to \
-         another production-profile NF will fail to connect. Until that lands, run a \
-         uniformly dev-profile deployment or terminate TLS at a proxy."
-    );
     log::info!(
         "SBI security profile PRODUCTION for {}: TLS cert={} mTLS={} \
          require_oauth2={} JWKS={}",
@@ -383,6 +426,49 @@ pub fn apply_sbi_security_policy(
         config.oauth2_jwks_uri.as_deref().unwrap_or("UNCONFIGURED"),
     );
     Ok(config)
+}
+
+/// The client configuration for DIALLING a peer NF under the resolved profile
+/// (issue #63, the outbound half of criterion 1).
+///
+/// An NF is both a server and a client on the SBI. Configuring only the listener
+/// leaves a "secure by default" posture that cannot talk to itself: the callee
+/// requires mutually-authenticated TLS while the caller still dials cleartext
+/// http with no certificate, so every inter-NF request fails at the TLS layer —
+/// and it fails on the *callee* side, with nothing pointing at the caller's
+/// scheme.
+///
+/// Under [`SbiProfile::Production`] this returns an `https` config presenting
+/// this NF's client certificate and verifying the peer against the configured CA.
+/// Under [`SbiProfile::Dev`] it is exactly `SbiClientConfig::new`, so the
+/// cleartext path is byte-identical.
+///
+/// **Scheme comes from the profile, not from a discovered URI.** In a uniformly
+/// production deployment every peer is `https`; in a uniformly dev one every peer
+/// is `http`. A deployment that mixes the two per-NF is not supported here — it
+/// was already broken before this, since the scheme was hardcoded `http`
+/// regardless of what a peer advertised.
+pub fn sbi_client_config_for_profile(
+    host: &str,
+    port: u16,
+    profile: SbiProfile,
+) -> crate::client::SbiClientConfig {
+    let config = crate::client::SbiClientConfig::new(host, port);
+    if profile == SbiProfile::Dev {
+        return config;
+    }
+    let paths = TlsPaths::from_env();
+    let mut config = config.with_https();
+    config.ca_cert = Some(paths.ca_cert);
+    config.client_cert = paths.client_cert;
+    config.client_key = paths.client_key;
+    config
+}
+
+/// [`sbi_client_config_for_profile`] with the profile resolved from the
+/// environment.
+pub fn sbi_peer_client_config(host: &str, port: u16) -> crate::client::SbiClientConfig {
+    sbi_client_config_for_profile(host, port, SbiProfile::resolve())
 }
 
 // ============================================================================
@@ -750,6 +836,10 @@ mod profile_tests {
                 cert: cert.display().to_string(),
                 key: key.display().to_string(),
                 ca_cert: ca.display().to_string(),
+                // The production posture needs client material too (an NF dials
+                // peers as well as serving them), so these must exist.
+                client_cert: Some(cert.display().to_string()),
+                client_key: Some(key.display().to_string()),
                 ..TlsPaths::default()
             },
             ..SbiSecurityPolicy::production()
@@ -807,6 +897,10 @@ mod profile_tests {
                 cert: cert.display().to_string(),
                 key: key.display().to_string(),
                 ca_cert: ca.display().to_string(),
+                // The production posture needs client material too (an NF dials
+                // peers as well as serving them), so these must exist.
+                client_cert: Some(cert.display().to_string()),
+                client_key: Some(key.display().to_string()),
                 ..TlsPaths::default()
             },
             ..SbiSecurityPolicy::production()
@@ -843,6 +937,10 @@ mod profile_tests {
                 cert: cert.display().to_string(),
                 key: key.display().to_string(),
                 ca_cert: ca.display().to_string(),
+                // The production posture needs client material too (an NF dials
+                // peers as well as serving them), so these must exist.
+                client_cert: Some(cert.display().to_string()),
+                client_key: Some(key.display().to_string()),
                 ..TlsPaths::default()
             },
             ..SbiSecurityPolicy::production()
@@ -1039,6 +1137,8 @@ mod mtls_oauth2_e2e {
                 cert: pki.server_cert.clone(),
                 key: pki.server_key.clone(),
                 ca_cert: pki.ca.clone(),
+                client_cert: Some(pki.client_cert.clone()),
+                client_key: Some(pki.client_key.clone()),
                 ..TlsPaths::default()
             },
             ..SbiSecurityPolicy::production()
@@ -1071,6 +1171,79 @@ mod mtls_oauth2_e2e {
         cfg.client_cert = Some(pki.client_cert.clone());
         cfg.client_key = Some(pki.client_key.clone());
         cfg
+    }
+
+    /// The consumer config **as the NFs actually build it** — through
+    /// `sbi_client_config_for_profile`, with the certificate paths supplied via
+    /// the same env vars a deployment would use.
+    ///
+    /// [`consumer_config`] hand-builds the equivalent, which proves the transport
+    /// works but not that the helper the NFs call produces it. This closes that
+    /// gap: if the helper stopped setting `https`, or dropped the client
+    /// certificate, this test would fail where the hand-built one would not.
+    /// Serialised because it mutates process environment.
+    fn consumer_config_via_profile_helper(pki: &Pki, port: u16) -> SbiClientConfig {
+        static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var(TlsPaths::CA_ENV, &pki.ca);
+        std::env::set_var(TlsPaths::CLIENT_CERT_ENV, &pki.client_cert);
+        std::env::set_var(TlsPaths::CLIENT_KEY_ENV, &pki.client_key);
+        let cfg = sbi_client_config_for_profile("localhost", port, SbiProfile::Production);
+        std::env::remove_var(TlsPaths::CA_ENV);
+        std::env::remove_var(TlsPaths::CLIENT_CERT_ENV);
+        std::env::remove_var(TlsPaths::CLIENT_KEY_ENV);
+        cfg
+    }
+
+    /// **Issue #63, the outbound half of criterion 1.** The transaction succeeds
+    /// with the consumer built by the profile helper the NFs call — not by hand.
+    ///
+    /// Before this, the four core NFs dialled peers with `SbiClient::with_host_port`
+    /// (cleartext http, no client certificate) while their own listeners required
+    /// mutually-authenticated TLS, so a call between two production-profile NFs
+    /// failed at the TLS layer. That made the production default a configuration
+    /// that could not work.
+    #[tokio::test]
+    async fn peer_client_built_by_the_profile_helper_completes_the_transaction() {
+        let pki = pki("helper");
+        let signing = crate::oauth::generate_es256_key();
+        let token = mint_token(&signing, "UDM", "nudm-sdm");
+
+        let (nrf, nrf_port) = start_stub_nrf(token).await;
+        let (producer, producer_port) = start_producer(&pki, jwks(signing.verifying_key())).await;
+
+        let cfg = consumer_config_via_profile_helper(&pki, producer_port);
+        // The helper must have produced a TLS config carrying THIS NF's client
+        // certificate; without the certificate the mTLS listener refuses it, and
+        // without https it never gets that far.
+        assert_eq!(cfg.scheme, crate::types::UriScheme::Https);
+        assert!(cfg.client_cert.is_some() && cfg.client_key.is_some());
+
+        let oauth2 = Arc::new(OAuth2Client::new(
+            format!("http://127.0.0.1:{nrf_port}"),
+            "consumer-1",
+            NfType::Amf,
+        ));
+        let resp = SbiClient::new(cfg)
+            .with_oauth2(oauth2, NfType::Udm)
+            .send_request(SbiRequest::get("/nudm-sdm/v1/imsi-001010000000001/am-data"))
+            .await
+            .expect("the profile-built peer client must complete the transaction");
+        assert_eq!(resp.status, 200);
+
+        producer.stop().await.ok();
+        nrf.stop().await.ok();
+    }
+
+    /// Issue #63: under the dev profile the peer client is byte-identical to
+    /// today's cleartext one, so existing deployments and tests are untouched.
+    #[test]
+    fn dev_profile_peer_client_stays_cleartext() {
+        let cfg = sbi_client_config_for_profile("peer", 7777, SbiProfile::Dev);
+        assert_eq!(cfg.scheme, crate::types::UriScheme::Http);
+        assert!(cfg.ca_cert.is_none());
+        assert!(cfg.client_cert.is_none() && cfg.client_key.is_none());
+        assert_eq!(cfg.base_uri(), "http://peer:7777");
     }
 
     #[tokio::test]
@@ -1554,6 +1727,52 @@ mod audience_binding_guards {
              before building the SbiServer.",
             crate::security::SBI_PROFILE_ENV
         );
+    }
+
+    /// **Issue #63, the outbound half of criterion 1.** The files that hold the
+    /// core NFs' peer-call code must not build cleartext clients.
+    ///
+    /// `SbiClient::with_host_port` is plain http always, on purpose — tests that
+    /// start a loopback plaintext server need it. That makes it exactly the thing
+    /// a future edit could reach for in production code without noticing, putting
+    /// that NF back to dialling cleartext while its own listener demands mTLS.
+    /// These two files contain only peer-call code (their test modules use
+    /// separate helpers), so a hit here is unambiguous.
+    #[test]
+    fn core_nf_peer_call_paths_do_not_build_cleartext_clients() {
+        let bins = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("crate is at <root>/libs/nextgcore-sbi")
+            .join("bins");
+
+        // (file, first line of its test module) — everything before it is
+        // production peer-call code.
+        let files = [
+            ("nextgcore-amfd/src/sbi_path.rs", "mod tests {"),
+            ("nextgcore-smfd/src/policy.rs", "mod tests {"),
+        ];
+        for (rel, test_marker) in files {
+            let path = bins.join(rel);
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let production = match text.find(test_marker) {
+                Some(i) => &text[..i],
+                None => &text[..],
+            };
+            assert!(
+                !production.contains("SbiClient::with_host_port"),
+                "{rel} builds a peer client with SbiClient::with_host_port, which is \
+                 cleartext http with no client certificate regardless of the SBI security \
+                 profile. Use SbiClient::for_peer (or \
+                 security::sbi_peer_client_config) so the call follows the profile."
+            );
+            assert!(
+                production.contains("for_peer") || production.contains("sbi_peer_client_config"),
+                "{rel} should reach peers through the profile-aware helper; if its peer \
+                 calls moved elsewhere, move this guard with them rather than deleting it"
+            );
+        }
     }
 
     /// Issue #63 criterion 2: amfd must not hardcode the scheme it advertises.


### PR DESCRIPTION
`Closes #63`. Completes criterion 1 by wiring the direction #188 left out.

## The defect #188 introduced

#188 made the production SBI profile the default for amfd/smfd/ausfd/udmd — but only on the **inbound** listener. Those four still built peer clients with `SbiClient::with_host_port`: cleartext `http`, no client certificate. So under the production profile:

* NF A's listener demanded mutually-authenticated TLS and a valid access token;
* NF A's own call to NF B went out as cleartext `http`;
* NF B's listener refused it at the TLS layer.

**Every inter-NF call failed.** The production default was a configuration that could not work, rescued only by every shipped artefact carrying the dev opt-out.

An NF is both a server and a client on the SBI, so configuring one direction is half a posture. Nothing written for #188 could have caught it: every acceptance criterion in #63 is phrased about the **producer**, its E2E built the client by hand, and its source guard only proved the four daemons called the **server** helper.

## The fix

`sbi_client_config_for_profile(host, port, profile)` — under `Production`: `https`, this NF's client certificate and key, and the CA to verify the peer, all from `TlsPaths::from_env()`. Under `Dev`: exactly `SbiClientConfig::new`, so the cleartext path is byte-identical. `SbiClient::for_peer` wraps it with the profile resolved from the environment.

### Why not make the general constructor profile-aware

That was the tempting one-liner — cover all 43 construction sites at once. It breaks every existing client test: `cargo test` sets no `NEXTGCORE_SBI_PROFILE`, so the constructor resolves to `Production` and tries to speak TLS to the plaintext loopback server the test just started. **`cfg!(test)` is not an escape hatch** — it is false when `nextgcore-sbi` is compiled as a *dependency* of the binaries, so only the library's own tests would be spared and the binaries' would still break.

Hence an explicit helper at 22 deliberate production call sites. `with_host_port` stays profile-blind on purpose, which is exactly why there is a guard on it (below).

### The shared peer-client cache

`GlobalContext::get_client` built a cleartext config, and it hands out clients for dialling **peer NFs** — leaving it would have silently undone the fix for every NF that resolves peers through it. One line there reaches beyond the four core NFs: pcfd and others use it, which is how their tests surfaced during verification. Peripheral NFs now follow the profile outbound too, though their own listeners remain governed by their individual `--tls` flags.

### Client material is now required at startup

The production check gained the client certificate and key. An NF whose listener comes up but which cannot dial any peer is not usable, and "the listener started fine" is a bad way to discover that.

**It immediately caught that #188's own tests supplied incomplete production material** — first outing, real finding.

`NEXTGCORE_SBI_TLS_CLIENT_CERT` / `_CLIENT_KEY` are separate from the server pair, because under mTLS an NF fills both roles and a deployment may mount their material separately.

### Scheme comes from the profile, not a discovered URI

Uniformly production ⇒ every peer is `https`; uniformly dev ⇒ every peer is `http`. **Mixed per-NF deployments are not supported** — and were already broken before this, since the scheme was hardcoded `http` regardless of what a peer advertised. Now stated in the docs rather than left implicit.

## Call sites

22 production sites; test-module sites keep `with_host_port` on purpose.

| NF | file | sites |
|---|---|---|
| amfd | `sbi_path.rs` | 14 |
| amfd | `namf_server.rs` | 1 (`notify_client`) |
| smfd | `policy.rs` | 4 |
| smfd | `main.rs` | 1 (`SmContextStatusNotification`) |
| ausfd | `app.rs` | 1 (peer-client helper) |
| udmd | `app.rs` | 1 (peer-client helper) |
| — | `nextgcore-sbi/context.rs` | 1 (shared cache — covers all consumers) |

## Verification

`peer_client_built_by_the_profile_helper_completes_the_transaction` extends the mTLS + OAuth2 E2E with a consumer built **by the helper the NFs call**, with certificate paths supplied through the same env vars a deployment uses. If the helper stopped setting `https`, or dropped the client certificate, this fails where the hand-built case would not.

**Revert-verified:** restoring the cleartext peer config fails *exactly* that one test and no other — which is the point, since it is the only case that could catch it.

`dev_profile_peer_client_stays_cleartext` pins dev unchanged. `core_nf_peer_call_paths_do_not_build_cleartext_clients` reads `amfd/sbi_path.rs` and `smfd/policy.rs` and fails if either reaches for `with_host_port` again — that constructor has to keep existing for tests, which makes it precisely what a future edit could grab in production code without noticing.

### 19 tests now declare their profile

Across amfd, ausfd, udmd, smfd, lmfd and pcfd, 19 tests drive **production** peer-call code against loopback **plaintext** peers — they describe a dev-profile deployment. Each now says so with `set_sbi_profile_override(SbiProfile::Dev)` instead of inheriting whatever the environment holds.

That is a clarification, not a concession: every shipped artefact configures dev, so those paths genuinely are `http` and the tests assert the deployment they were always describing. The override is a relaxed atomic store, so parallel tests all storing `Dev` is benign — unlike `std::env::set_var`, which would race.

## Results

* Workspace **5655 passed / 0 failed** (baseline 5652), `cargo test` exit 0.
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets` 0 errors, no new warnings in touched files.
* `kubectl kustomize deploy/eks` still renders.
* **Not verified:** no deployment was started. CI skips Docker E2E, so a real two-container mTLS core remains untested here — #187 tracks standing that up.

## #63 status after this PR

- [x] Criterion 1 — TLS/mTLS wired for the four core NFs, **both directions**
- [x] Criterion 2 — amfd advertises `https`; cleartext refused (#188)
- [x] Criterion 3 — `require_oauth2`; tokenless 401, unconfigured JWKS 503 (#188)
- [x] Criterion 4 — `SbiSecurityPolicy::production()` has a non-test runtime caller (#188)
- [x] Criterion 5 — consumer client no longer fails open (#181)
- [x] Criterion 6 — mTLS + OAuth2 end to end, including the consumer built by the NFs' own helper
- [x] Criterion 7 — dev/E2E preserved via an explicit opt-out in every shipped artefact (#188)

Spec: `specs/fix-sbi-outbound-client-profile.md`
