### PR TITLE
feat(docker): enable UDR durable state by default, with a writable state dir in the image (Closes #66)

### DIFF
--- a/docker/rust/Dockerfile.core
+++ b/docker/rust/Dockerfile.core
@@ -25,8 +25,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN groupadd -r nextgcore && useradd -r -g nextgcore -s /bin/false nextgcore
 
 # Create standard directories
-RUN mkdir -p /etc/nextgcore /var/log/nextgcore /var/run/nextgcore && \
-    chown -R nextgcore:nextgcore /etc/nextgcore /var/log/nextgcore /var/run/nextgcore
+# /var/lib/nextgcore holds durable NF state snapshots (issue #66). It must exist
+# in the image AND be owned by `nextgcore`: a Docker named volume mounted onto a
+# path the image does not create is initialised root-owned, and these processes
+# run as `nextgcore`, so the first snapshot write would fail with EACCES. Creating
+# it here lets the volume inherit the right ownership.
+RUN mkdir -p /etc/nextgcore /var/log/nextgcore /var/run/nextgcore /var/lib/nextgcore && \
+    chown -R nextgcore:nextgcore /etc/nextgcore /var/log/nextgcore /var/run/nextgcore \
+        /var/lib/nextgcore
 
 ENV RUST_LOG=info
 

--- a/docker/rust/docker-compose.yml
+++ b/docker/rust/docker-compose.yml
@@ -148,10 +148,24 @@ services:
       TLS_CERT: /etc/nextgcore/certs/udr.crt
       TLS_KEY: /etc/nextgcore/certs/udr.key
       TLS_CA: /etc/nextgcore/certs/ca.crt
+      # Issue #66 criterion 3: durable state ON BY DEFAULT for the UDR.
+      #
+      # The UDR is the most severe member of that issue: memory-only, a restart
+      # erases every subscriber's amf-3gpp-access and smf-registration at once,
+      # and consumers then get authoritative-looking "not registered" answers for
+      # subscribers that are registered. The mechanism already existed
+      # (--state-file / NEXTGCORE_UDR_STATE_FILE) but nothing switched it on.
+      #
+      # Backed by the udr_state named volume below so it survives `docker compose
+      # restart` AND `up -d` recreating the container. A corrupt snapshot is now
+      # refused rather than overwritten (see nextgcore-core state_store), so
+      # enabling this cannot silently destroy what it fails to read.
+      NEXTGCORE_UDR_STATE_FILE: /var/lib/nextgcore/udr-state.json
     command: ["-c", "/etc/nextgcore/udr.yaml"]
     volumes:
       - ./configs/5gc/udr.yaml:/etc/nextgcore/udr.yaml:ro
       - ./certs:/etc/nextgcore/certs:ro
+      - udr_state:/var/lib/nextgcore
     networks:
       core:
         ipv4_address: 172.23.0.20
@@ -617,6 +631,10 @@ networks:
           gateway: 172.23.0.1
 
 volumes:
+  # Durable UDR state snapshot (issue #66). Named rather than a bind mount so it
+  # is owned by the image's `nextgcore` user -- the NF processes run non-root, and
+  # a bind mount would arrive owned by the host user.
+  udr_state:
   mongodb_data:
   prometheus_data:
   grafana_data:

--- a/docs-book/src/configuration/udr.md
+++ b/docs-book/src/configuration/udr.md
@@ -93,7 +93,7 @@ From the clap `Args` struct in `src/bins/nextgcore-udrd/src/main.rs`:
 | `--tls` | flag | off | Enable TLS on the SBI server. |
 | `--tls-cert` | path | unset | TLS certificate file. |
 | `--tls-key` | path | unset | TLS private key file. |
-| `--state-file` | path | unset | JSON snapshot file for the non-subscriber resource trees (exposure-data, application-data, smf-registrations, subs-to-notify, policy provisioning, amf-3gpp-access). Falls back to `NEXTGCORE_UDR_STATE_FILE`; empty strings are treated as unset. When neither is set the trees are in-memory only and lost on restart. |
+| `--state-file` | path | unset (but **set in the shipped Docker compose**, see below) | JSON snapshot file for the non-subscriber resource trees (exposure-data, application-data, smf-registrations, subs-to-notify, policy provisioning, amf-3gpp-access). Falls back to `NEXTGCORE_UDR_STATE_FILE`; empty strings are treated as unset. When neither is set the trees are in-memory only and lost on restart. |
 
 ## Behavior notes
 
@@ -102,4 +102,30 @@ From the clap `Args` struct in `src/bins/nextgcore-udrd/src/main.rs`:
 - **Change notifications are fire-and-forget.** `subs-to-notify` subscriptions on the subscription-data, exposure-data, influenceData, and application-data trees trigger real HTTP POSTs to the registered callback URI with a 2 s connect / 3 s request timeout; delivery failures are logged and never retried.
 - **UE identifier handling** (TS 29.571 `VarUeId` forms per code comments): null-scheme SUCIs are converted to IMSI locally; syntactically valid but unprovisioned `nai-`/`gci-`/`gli-` identifiers get **404** `NOT_FOUND` (not 400); `extgroupid-` gets **501** `NOT_SUPPORTED`; anything else is **400** `INVALID_SUPI`.
 - **PATCH on `authentication-subscription` stores exactly what is written** — the UDR applies the `/sequenceNumber/sqn` PatchItem verbatim with no SQN side effects; SQN advancement is the UDM/ARPF's job per the TS 33.102 Annex C.3 code comment (a previous unconditional +32 SEQ increment here was a bug, WSB-6).
+
+## Durable state is on by default in Docker
+
+`docker/rust/docker-compose.yml` sets `NEXTGCORE_UDR_STATE_FILE=/var/lib/nextgcore/udr-state.json`
+and backs it with the `udr_state` named volume, so the resource trees survive both
+`docker compose restart` and `up -d` recreating the container (issue #66).
+
+The UDR is the most severe member of that issue: memory-only, a restart erases
+every subscriber's `amf-3gpp-access` and `smf-registration` at once, and consumers
+then receive authoritative-looking "not registered" answers for subscribers that
+*are* registered.
+
+Two things make enabling it safe rather than merely convenient:
+
+* a **corrupt** snapshot is refused, not overwritten — the NF logs an error, starts
+  empty, and declines to persist, so the unreadable file survives for recovery
+  (see the shared-store section in [Configuration Overview](./overview.md));
+* snapshots are written atomically, fsynced and `0600` — this file is keyed by
+  IMSI.
+
+**Kubernetes and Helm are not covered.** The `udr` manifest is a `Deployment` with
+no volume for this, so persistence there still needs a `PersistentVolumeClaim` plus
+`strategy: Recreate` (or conversion to a `StatefulSet`, as MongoDB uses). That is a
+storage-topology decision rather than a config line, so it is deliberately left
+out.
+
 - **Environment variables**: `DB_URI` (MongoDB URI; read only when the YAML has no `db_uri` line), `NEXTGCORE_UDR_STATE_FILE` (state-file path; read only when `--state-file` is absent — the flag wins), and `OTEL_EXPORTER_OTLP_ENDPOINT` (OpenTelemetry OTLP exporter endpoint, default `http://jaeger:4317`).

--- a/specs/fix-udr-persistence-on-by-default.md
+++ b/specs/fix-udr-persistence-on-by-default.md
@@ -1,0 +1,89 @@
+# nextgcore #66 criterion 3: UDR durable state on by default in the shipped Docker config
+
+Verified against `main` @ `77aa0f8`.
+
+Closes #66 criterion 3. The remaining criteria are filed as #191, #192 and #193,
+so **this closes #66**.
+
+## The defect
+
+The UDR's durable store existed — `--state-file` / `NEXTGCORE_UDR_STATE_FILE`,
+wired since before this issue — and **nothing anywhere switched it on**.
+`grep -rn NEXTGCORE_UDR_STATE_FILE docker/ k8s/ deploy/` returned nothing.
+
+#66 calls the UDR its most severe member, and the reason is the shape of the
+failure rather than its size: a restart erases every subscriber's
+`amf-3gpp-access` and `smf-registration` at once, after which the UDR answers
+"not registered" — authoritatively, with a 404 — for subscribers that *are*
+registered. A consumer cannot distinguish that from a genuine deprovisioning.
+
+## Why this was not bundled into #190
+
+#190 built the shared store and fixed the corrupt-snapshot data-loss defect. This
+is a deployment change, and it turned out to need an image change too, which is
+exactly why it was worth separating:
+
+**The container runs as `nextgcore`, not root** (`Dockerfile.nf` ends `USER
+nextgcore`), and the core image creates only `/etc/nextgcore`,
+`/var/log/nextgcore` and `/var/run/nextgcore`. A Docker named volume mounted onto
+a path the image does **not** create is initialised root-owned, so the first
+snapshot write would have failed `EACCES` — persistence configured, and silently
+not working.
+
+So `Dockerfile.core` now creates `/var/lib/nextgcore` owned by `nextgcore`, and the
+volume inherits that ownership. This also prepares the ground for #191 and #192,
+whose NFs will want the same directory.
+
+## The change
+
+* `Dockerfile.core` — `/var/lib/nextgcore`, owned by `nextgcore`.
+* `docker-compose.yml` — `NEXTGCORE_UDR_STATE_FILE=/var/lib/nextgcore/udr-state.json`
+  on the `udr` service, backed by a new `udr_state` **named** volume. Named rather
+  than a bind mount because a bind mount arrives owned by the host user, which
+  reintroduces the ownership problem the image change just solved.
+* Docs in `configuration/udr.md`, including what is *not* covered.
+
+Enabling this is only safe because of #190: a corrupt snapshot is now refused
+rather than overwritten, so switching persistence on cannot silently destroy what
+it fails to read. Turning it on before that landed would have been the wrong order.
+
+## Verification, and its limit
+
+The criterion's own test is *"restart `udrd` in the E2E stack and assert
+previously provisioned `smf-registrations` and `amf-3gpp-access` registrations
+survive"*. **CI skips the Docker E2E jobs**, so that test would never run
+anywhere — writing it would produce coverage that only appears to exist.
+
+Instead:
+
+* `shipped_docker_config_enables_udr_persistence` reads `docker-compose.yml` from
+  `cargo test` and asserts the state file is set, non-empty, backed by a volume
+  mounted at its directory, and that the volume is the named one. **Revert-verified:**
+  removing the env line fails it.
+* `test_persistence_survives_restart` (pre-existing) already proves the
+  restore-across-restart mechanism at the store level.
+
+**Not verified:** no container was built or started. The image change in particular
+is unexecuted here — `Dockerfile.core` is only exercised by the Docker Build job,
+which is skipped. The ownership reasoning above is derived from the Dockerfiles,
+not observed. First real `docker compose up` should confirm the UDR logs a snapshot
+write rather than `EACCES`.
+
+## Deliberately not covered: Kubernetes and Helm
+
+The `udr` manifest is a `Deployment` with `replicas: 1` and no volume for this.
+Persistence there needs a `PersistentVolumeClaim` plus `strategy: Recreate` — a
+plain rolling update would have two pods contending for one `ReadWriteOnce`
+volume — or conversion to a `StatefulSet`, which is what MongoDB does here
+(`volumeClaimTemplates`). That is a storage-topology decision, not a config line,
+and criterion 3 asks specifically for the **Docker/E2E** configuration. Stated in
+the docs rather than left for someone to discover.
+
+## Definition of done
+
+- [x] UDR persistence enabled in the shipped Docker configuration, on a volume
+      that survives container recreation.
+- [x] The image provides a state directory the non-root NF user can write.
+- [x] Guarded by a test that runs where CI actually runs.
+- [x] Documented, including the k8s/Helm gap and the unexecuted image change.
+- [ ] k8s/Helm persistence — out of scope, documented.

--- a/src/bins/nextgcore-udrd/src/data_store.rs
+++ b/src/bins/nextgcore-udrd/src/data_store.rs
@@ -1336,6 +1336,62 @@ mod tests {
         std::env::temp_dir().join(format!("udrd-test-{tag}-{pid}-{nanos}.json"))
     }
 
+    /// **Issue #66 criterion 3.** The shipped Docker configuration must actually
+    /// enable UDR persistence, and must back it with a volume that survives the
+    /// container being recreated.
+    ///
+    /// The criterion's own test is "restart udrd in the E2E stack and assert the
+    /// registrations survive" — but CI skips the Docker E2E jobs, so that test
+    /// would never run anywhere. This reads the shipped compose file from
+    /// `cargo test` instead: it cannot prove the restart works, but it does prove
+    /// the configuration that makes it possible is present, which is the part a
+    /// future edit could silently drop.
+    ///
+    /// Same reasoning as the webui source-level guards: pin what you can where it
+    /// will actually execute, and say plainly what it does not cover.
+    #[test]
+    fn shipped_docker_config_enables_udr_persistence() {
+        let compose = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(3)
+            .expect("crate is at <root>/src/bins/nextgcore-udrd")
+            .join("docker/rust/docker-compose.yml");
+        let text = std::fs::read_to_string(&compose)
+            .unwrap_or_else(|e| panic!("read {}: {e}", compose.display()));
+
+        let state_file = text
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("NEXTGCORE_UDR_STATE_FILE:"))
+            .map(str::trim)
+            .expect(
+                "the shipped compose must set NEXTGCORE_UDR_STATE_FILE for the UDR: without \
+                 it a restart erases every subscriber's amf-3gpp-access and smf-registration \
+                 (issue #66 criterion 3)",
+            );
+        assert!(
+            !state_file.is_empty(),
+            "an empty NEXTGCORE_UDR_STATE_FILE is treated as unset, so persistence would be \
+             off while looking configured"
+        );
+
+        // The snapshot must live on a declared volume, or it dies with the
+        // container and the flag is theatre.
+        let dir = state_file
+            .rsplit_once('/')
+            .map(|(d, _)| d)
+            .expect("the state file path must be absolute");
+        assert!(
+            text.contains(&format!(":{dir}")),
+            "{state_file} is not backed by any volume mounted at {dir}, so the snapshot \
+             would not survive the container being recreated"
+        );
+        assert!(
+            text.contains("udr_state:"),
+            "the udr_state named volume must be declared; a bind mount would arrive owned \
+             by the host user and the non-root NF could not write it"
+        );
+    }
+
     /// **Issue #66.** A corrupt state file must not be overwritten by the empty
     /// store that failing to read it produced.
     ///


### PR DESCRIPTION
`Closes #66` — criterion 3, the last one tracked on that issue. Criteria 1/6/7 landed in #190; criterion 2 is #191, criterion 4 is #192, criterion 5 is #193.

## The defect

The UDR's durable store already existed — `--state-file` / `NEXTGCORE_UDR_STATE_FILE`, wired since before #66 — and **nothing anywhere switched it on**. `grep -rn NEXTGCORE_UDR_STATE_FILE docker/ k8s/ deploy/` returned nothing.

#66 calls the UDR its most severe member, and the reason is the *shape* of the failure rather than its size: a restart erases every subscriber's `amf-3gpp-access` and `smf-registration` at once, after which the UDR answers "not registered" — authoritatively, with a 404 — for subscribers that **are** registered. A consumer cannot tell that apart from a genuine deprovisioning.

## Why this needed an image change

This looked like a two-line change: set the env var, add a volume. It would have **silently failed**.

`Dockerfile.nf` ends `USER nextgcore`, and the core image creates only `/etc/nextgcore`, `/var/log/nextgcore` and `/var/run/nextgcore`. Docker initialises a named volume by copying the content *and ownership* of the container path it is mounted over — but only if that path exists in the image. Mounted over a path the image lacks, the volume is created **root-owned**, so the first snapshot write fails `EACCES`: persistence configured, and silently not working, which is worse than persistence off because the configuration claims otherwise.

A bind mount is not the escape either — that arrives owned by the *host* user instead.

So `Dockerfile.core` now creates `/var/lib/nextgcore` owned by `nextgcore`, and the volume inherits that ownership. This also prepares the ground for #191 and #192, whose NFs will want the same directory.

## Ordering mattered

Enabling this is only safe **because of #190**, where a corrupt snapshot became refused-rather-than-overwritten. Switching persistence on before that landed would have meant a truncated snapshot destroying itself on the next write — the exact failure #190 documents.

## The change

* `Dockerfile.core` — `/var/lib/nextgcore`, owned by `nextgcore`.
* `docker-compose.yml` — `NEXTGCORE_UDR_STATE_FILE=/var/lib/nextgcore/udr-state.json` on the `udr` service, backed by a new `udr_state` **named** volume, so the snapshot survives both `docker compose restart` and `up -d` recreating the container.
* `configuration/udr.md` — including what is *not* covered.

## Verification, and its limit

The criterion's own test is *"restart `udrd` in the E2E stack and assert previously provisioned `smf-registrations` and `amf-3gpp-access` registrations survive"*. **CI skips the Docker E2E jobs**, so that test would never run anywhere — writing it would manufacture coverage that only appears to exist.

Instead:

* `shipped_docker_config_enables_udr_persistence` reads `docker-compose.yml` from `cargo test` and asserts the state file is set, non-empty, backed by a volume mounted at its directory, and that the volume is the named one. **Revert-verified:** removing the env line fails it.
* `test_persistence_survives_restart` (pre-existing) already covers the restore-across-restart mechanism at the store level.

**Not verified — please weigh this in review:** no container was built or started. The image change is exercised only by the skipped Docker Build job, so the ownership reasoning above is derived from reading the Dockerfiles, **not observed**. A first real `docker compose up` should confirm the UDR logs a snapshot write rather than `EACCES`.

* Workspace **5662 passed / 0 failed** (baseline 5661), `cargo test` exit 0.
* `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets` 0 errors.

## Deliberately not covered: Kubernetes and Helm

The `udr` manifest is a `Deployment` with `replicas: 1` and no volume for this. Persistence there needs a `PersistentVolumeClaim` plus `strategy: Recreate` — a plain rolling update would have two pods contending for one `ReadWriteOnce` volume — or conversion to a `StatefulSet`, which is what MongoDB already does here (`volumeClaimTemplates`). That is a storage-topology decision rather than a config line, and criterion 3 asks specifically for the **Docker/E2E** configuration. Stated in the docs rather than left for someone to discover.

## Count arithmetic

Closing #66 while three honest follow-ups (#191, #192, #193) stand open moves the open-issue count the **wrong way** — net +2. Flagging it explicitly, per the convention that issues-closed is not the same as parts-closed.

Spec: `specs/fix-udr-persistence-on-by-default.md`
