### PR TITLE
fix(sbi): percent-encode SBI query parameters, so structured discovery factors survive Uri::parse (Refs #101)

### DIFF
--- a/specs/fix-scp-model-d-token-and-discovery-confidentiality.md
+++ b/specs/fix-scp-model-d-token-and-discovery-confidentiality.md
@@ -1,0 +1,178 @@
+# nextgcore #101 (SCP Model D): encode the discovery query, and mint tokens for the consumer
+
+Verified against `main` @ `8c15bb6`. The issue's cites are from `76ea248`; all four were
+re-verified and all four still hold, at new line numbers.
+
+`Refs #101`, **not Closes** — see "Scope actually shipped" below. This ships criterion 1,
+the discovery-encoding hard breaker. Criteria 2–4 and defects 3–7 remain open on #101, with
+the design for 2–4 recorded here so it need not be re-derived.
+
+## Verified against current main
+
+| # | defect | site |
+|---|---|---|
+| 1 | query params joined with no encoding, then `Uri::parse` | `libs/nextgcore-sbi/src/client.rs:806,811` |
+| 2 | token request built from the SCP's own ids | `oauth.rs:1003`, `proxy.rs:653` (`NfType::Scp`) |
+| 2 | consumer's `Authorization` stripped on the delegated path | `proxy.rs:1170` |
+| 3 | no `3gpp-Sbi-Access-Scope` anywhere | grep finds none |
+| 4 | `CacheKey = (String, String)` — no consumer identity | `oauth.rs:477` |
+
+## Decision 1: two encodings, not one — do NOT deduplicate them
+
+The repo already has **two** percent-encoders, and the reflex ("count the implementations
+before writing the abstraction") would be to merge them. That would introduce a bug. They
+differ, and both are right:
+
+| | space | correct for |
+|---|---|---|
+| `oauth.rs::url_encode` (private) | `+` | `application/x-www-form-urlencoded` **body** — the token request |
+| `pcfd::sbi_path::percent_encode` | `%20` | RFC 3986 **query component** |
+
+In a strict RFC 3986 query, `+` is a *literal plus*, not a space. So encoding a discovery
+factor with the form-style encoder would corrupt any value containing a space when a
+conformant NRF parses it.
+
+So: one shared module, **two clearly named functions**, and a test pinning that they differ
+on space so nobody unifies them later:
+
+* `encode_query_value` — RFC 3986 unreserved set, space → `%20`. Used by the SBI client's
+  query builder and by pcfd (whose local copy is deleted).
+* `encode_form_value` — same set but space → `+`. Used by the token request body.
+
+The client's query builder is the right home for the fix rather than the `with_param` call
+site in `proxy.rs`, exactly as the issue suggests: **every** SBI query benefits, and a
+future caller cannot forget.
+
+## Decision 2: use the consumer's identity only when it can be attested
+
+Criterion 2 wants the token request to carry the consumer's identity. Doing that
+unconditionally would **break the delegated path outright** against our own NRF, and the
+issue's feature-gate advice does not go far enough to explain why:
+
+After #64, the NRF's token endpoint requires client authentication — a **CCA keyed by
+`nfInstanceId`**. If the SCP sends the *consumer's* `nfInstanceId` while signing the CCA with
+the *SCP's* key, the NRF rejects the request. So "send the consumer's identity" and "sign with
+our own key" are mutually exclusive; a blind flag would just turn the delegated path off.
+
+TS 33.501 §13.4.1.3.2 resolves it: in Model D the **consumer's** CCA is conveyed. So the rule
+is *never assert an identity you cannot attest*:
+
+1. Consumer supplied its own CCA → use the consumer's `nfInstanceId`/`nfType` and forward
+   that CCA. Conformant, and the NRF can verify it.
+2. No consumer CCA, but the deployment has explicitly set
+   `scp.delegated.trust_requester_identity` → use the consumer's identity anyway, for an NRF
+   that does not require client authentication. Logged at startup.
+3. Otherwise → keep the SCP's identity and log, once per consumer, that the token is
+   SCP-attested rather than consumer-attested.
+
+This is self-configuring rather than flag-driven: correct by default, conformant when the
+inputs allow it, and it cannot regress a CCA-less deployment. The consumer identity comes
+from `3gpp-Sbi-Discovery-requester-nf-instance-id` (optional) and
+`-requester-nf-type` (already mandatory — `proxy.rs:961`, missing is a 400).
+
+## Decision 3: a new method, not a changed signature
+
+`OAuth2Client::get_token` is used by ~15 NFs. Rather than widen it, add
+`get_token_on_behalf_of(consumer, target_nf_type, scope)`; `get_token` delegates to it with
+the client's own identity as the consumer. Blast radius stays inside scpd, and the
+non-delegated path is unchanged by construction.
+
+`CacheKey` becomes `(consumer_id, target_nf_type, scope)`. For a normal NF the consumer is
+always itself, so the key gains a constant component and caching behaves exactly as before —
+a behaviour-preserving generalisation rather than a change.
+
+## Split to follow-ups (defects 3–7) — planned, not yet filed
+
+To be filed as separate issues, each named in the PR that closes #101 so the close is
+auditable: producer
+`NFService` selection by service name + API major version with `INVALID_API`; relay metadata
+(`nf_set_id`/`nf_group_id`, `Producer-Id` overwrite, `Target-apiRoot`, `Location`
+absolutisation); candidate reselection with connection-refused → 504; `3gpp-Sbi-Callback`
+pass-through; and NRF error-status splitting (504 `NRF_NOT_REACHABLE` vs discovery 4xx).
+
+Note the count arithmetic honestly: closing one issue while filing five follow-ups moves the
+open count the **wrong way** (61 → 65), which is the understatement the repo's
+issues-closed-vs-parts-closed learning warns about.
+
+## Scope actually shipped: criterion 1 only, as `Refs #101`
+
+**This PR ships the discovery-encoding breaker and nothing else.** #101 stays open.
+
+The repo convention permits this: *"a safety-critical defect inside an umbrella may ship
+alone, labelled `Refs #N`, with the PR stating why it did not wait and that the count
+deliberately does not move."* This qualifies — criterion 1 is the hard breaker (a 502 before
+the request leaves the process, so Model D discovery by slice/GUAMI/TAI/PLMN cannot work at
+all), and it turned out to be cross-cutting infrastructure every SBI query benefits from.
+
+Criteria 2-4 were deliberately NOT started, for a reason found while implementing:
+`SbiClient::with_oauth2(oauth2, target_nf_type)` attaches the token automatically and has
+**no per-request hook**, so a consumer-scoped token requires the delegated path in `proxy.rs`
+to acquire and attach the token itself, bypassing that integration. That is a restructure of
+`forward()`, not an incremental edit. The design is settled and recorded above (Decisions 2
+and 3) so the next session does not re-derive it.
+
+## What criterion 1 turned out to be
+
+Not a one-line encode. Three things had to move together:
+
+**1. Encode centrally in the client** (`client.rs`), so no call site can forget.
+
+**2. Two encodings, kept distinct** - the finding in Decision 1. New shared
+`nextgcore_sbi::uri_encode` with `encode_query_value` (space -> `%20`) and
+`encode_form_value` (space -> `+`), and a test pinning that they differ so a later tidy-up
+cannot merge them. pcfd's local copy now delegates to the shared one; it must still encode
+because it builds URI **strings** by hand rather than going through `with_param`.
+
+**3. The contract is asymmetric, and that trap is now documented on `with_param`.** A value
+passed to `with_param`/`set_param` is RAW and the client encodes it; a hand-built URI string
+bypasses the client and the caller must encode. Getting this wrong double-encodes
+(`{` -> `%7B` -> `%257B`), and the peer's single decode yields `%7B`.
+
+### Four tests were compensating for the defect
+
+Encoding centrally broke four tests, and every one broke because it had been **hand-encoding
+to work around a client that did not encode**:
+
+* `nextgcore-nrfd` `test_http_lifecycle_register_discover_patch_deregister` passed a
+  pre-encoded S-NSSAI with the comment *"percent-encoded"* - so it exercised a path no real
+  consumer takes. It now passes the raw JSON and asserts the true round trip
+  (client encodes -> nrfd's `percent_decode` reverses).
+* three `nextgcore-bsfd` MBS tests did the same via a local `pct_encode_query` test helper,
+  now deleted as unused.
+
+Server-side decoding was already correct in both NFs - the gap was only ever on the client.
+Worth recording: the defect was invisible in-repo precisely because the tests had been
+written around it, which is why #101 needed a conformant *external* NRF to surface it.
+
+## Verification (actual)
+
+Workspace **5710 passed / 0 failed**, `cargo test --workspace` exit 0, no compile errors
+(checked for `^error`, not only a `test result:` line). Four new tests in `uri_encode`.
+
+* `a_json_discovery_factor_is_fully_encoded` - the #101 breaker: asserts none of
+  `[ ] { } "` or space survives, against the exact expected encoding.
+* `query_and_form_encoders_differ_on_space` - the anti-deduplication guard, plus a loop
+  asserting the two agree on everything *except* space.
+* `unreserved_passes_through_and_plus_is_escaped` - a literal `+` must not decode back to a
+  space.
+* `multibyte_utf8_is_encoded_per_octet` - RFC 3986 5.2.5, uppercase hex per 2.1.
+
+**Not verified:** no conformant external NRF was involved - the encoding is asserted against
+the RFC and against nextgcore's own decoders, not against a third-party NRF's parser, which
+is the peer whose rejection motivated the issue. CI skips Docker E2E.
+
+## Definition of done
+
+- [x] Structured discovery factors survive `Uri::parse`, encoded centrally in the client
+- [x] One shared encoder module; pcfd's duplicate delegates; the two encodings kept distinct
+- [x] The raw-vs-pre-encoded contract documented where callers will read it
+- [ ] Delegated token request carries the consumer's identity when attestable - **#101**
+- [ ] `3gpp-Sbi-Access-Scope` populated; consumer CCA forwarded - **#101**
+- [ ] `TokenCache` keyed by consumer - **#101**
+- [ ] Defects 3-7 filed as separate issues - **#101**
+
+## Follow-ups
+
+* **#101 remains open** for criteria 2-4, with the design in Decisions 2 and 3 above. The
+  open count deliberately does not move.
+* Defects 3-7 still to be filed as separate issues per the issue's own instruction.

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -2584,23 +2584,6 @@ mod tests {
         server.stop().await.expect("stop");
     }
 
-    /// Percent-encode a JSON query-parameter value the way a conformant
-    /// consumer must: TS 29.521 declares `mbs-session-id` as
-    /// `content: application/json`, and raw `{`/`}`/`"` are not legal URI
-    /// characters, so the JSON has to be escaped before it goes on the wire.
-    fn pct_encode_query(s: &str) -> String {
-        let mut out = String::with_capacity(s.len() * 3);
-        for b in s.bytes() {
-            match b {
-                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                    out.push(b as char)
-                }
-                _ => out.push_str(&format!("%{b:02X}")),
-            }
-        }
-        out
-    }
-
     fn problem(resp: &SbiResponse) -> serde_json::Value {
         serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap()
     }
@@ -3671,8 +3654,7 @@ mod tests {
             "tmgi": {"plmnId": {"mnc": "01", "mcc": "001"}, "mbsServiceId": "AABBCC"}
         });
         let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
-        req.http
-            .set_param("mbs-session-id", &pct_encode_query(&upper.to_string()));
+        req.http.set_param("mbs-session-id", upper.to_string());
         let resp = client
             .send_request(req)
             .await
@@ -3729,8 +3711,7 @@ mod tests {
             "tmgi": {"mbsServiceId": "975002", "plmnId": {"mcc": "001", "mnc": "01"}}
         });
         let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
-        req.http
-            .set_param("mbs-session-id", &pct_encode_query(&id.to_string()));
+        req.http.set_param("mbs-session-id", id.to_string());
         let resp = client.send_request(req).await.expect("mbs discover empty");
         assert_eq!(resp.status, 200);
         let body: serde_json::Value =
@@ -3748,8 +3729,7 @@ mod tests {
             .expect("POST mbs");
         assert_eq!(resp.status, 201);
         let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
-        req.http
-            .set_param("mbs-session-id", &pct_encode_query(&id.to_string()));
+        req.http.set_param("mbs-session-id", id.to_string());
         let resp = client.send_request(req).await.expect("mbs discover one");
         assert_eq!(resp.status, 200);
         let body: serde_json::Value =
@@ -4003,8 +3983,7 @@ mod tests {
 
         // Discovery by mbsSessionId → 200 single result.
         let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
-        req.http
-            .set_param("mbs-session-id", &pct_encode_query(&mbs_id_obj.to_string()));
+        req.http.set_param("mbs-session-id", mbs_id_obj.to_string());
         let resp = client.send_request(req).await.expect("discover mbs");
         assert_eq!(resp.status, 200);
 
@@ -4019,10 +3998,8 @@ mod tests {
 
         // Unknown mbsSessionId → 204.
         let mut req = SbiRequest::get("/nbsf-management/v1/pcf-mbs-bindings");
-        req.http.set_param(
-            "mbs-session-id",
-            &pct_encode_query(&mbs_id_other.to_string()),
-        );
+        req.http
+            .set_param("mbs-session-id", mbs_id_other.to_string());
         let resp = client.send_request(req).await.expect("discover mbs miss");
         // 200 with an empty array, not 204 (see the UE site above).
         assert_eq!(resp.status, 200);

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -3346,11 +3346,13 @@ mod tests {
             req.http.set_param("requester-nf-type", "AMF");
             req.http.set_param("service-names", "nsmf-pdusession");
             req.http.set_param("dnn", "internet");
-            // [{"sst":1,"sd":"010203"}] percent-encoded
-            req.http.set_param(
-                "snssais",
-                "%5B%7B%22sst%22%3A1%2C%22sd%22%3A%22010203%22%7D%5D",
-            );
+            // Issue #101: the RAW JSON. This used to be hand-percent-encoded
+            // here, compensating for a client that did not encode -- so the test
+            // exercised a path no real consumer takes. The client encodes now, and
+            // nrfd's `percent_decode` reverses it, so this asserts the real
+            // round trip.
+            req.http
+                .set_param("snssais", r#"[{"sst":1,"sd":"010203"}]"#);
             let resp = client.send_request(req).await.expect("discover");
             assert_eq!(resp.status, 200);
             let result: serde_json::Value =

--- a/src/bins/nextgcore-pcfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-pcfd/src/sbi_path.rs
@@ -530,18 +530,15 @@ pub struct DiscoveredEndpoint {
     pub scheme: String,
 }
 
-/// Minimal RFC 3986 percent-encoding for a query-string value (no external dep).
+/// RFC 3986 percent-encoding for a query-string value.
+///
+/// Issue #101: was a local copy. It now delegates to nextgcore-sbi's shared
+/// encoder, which is byte-identical in behaviour (same unreserved set, space ->
+/// `%20`). These call sites build the URI **string** by hand rather than through
+/// `SbiRequest::with_param`, so the client's central encoding does not reach them
+/// and they must still encode here -- see `with_param`'s contract note.
 fn percent_encode(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for b in s.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(b as char)
-            }
-            _ => out.push_str(&format!("%{b:02X}")),
-        }
-    }
-    out
+    nextgcore_sbi::uri_encode::encode_query_value(s)
 }
 
 /// Parse the first matching service endpoint from an NRF SearchResult body.

--- a/src/libs/nextgcore-sbi/src/client.rs
+++ b/src/libs/nextgcore-sbi/src/client.rs
@@ -803,7 +803,22 @@ impl SbiClient {
                 .http
                 .params
                 .iter()
-                .map(|(k, v)| format!("{k}={v}"))
+                // Issue #101: percent-encode BOTH key and value. Joining them raw
+                // meant any structured SBI query factor -- an S-NSSAI list, a
+                // GUAMI, a TAI, a PLMN list -- contained `[`, `{`, `"` or `:`,
+                // which made the `Uri::parse` below reject the whole URI. The SCP's
+                // delegated discovery therefore died with 502 before the request
+                // ever left the process (TS 29.500 6.10.3.2).
+                //
+                // Encoded here, in the one place every SBI query passes through,
+                // rather than at each call site -- a caller cannot forget.
+                .map(|(k, v)| {
+                    format!(
+                        "{}={}",
+                        crate::uri_encode::encode_query_value(k),
+                        crate::uri_encode::encode_query_value(v)
+                    )
+                })
                 .collect();
             format!("{}?{}", uri_str, params.join("&"))
         };

--- a/src/libs/nextgcore-sbi/src/lib.rs
+++ b/src/libs/nextgcore-sbi/src/lib.rs
@@ -59,6 +59,7 @@ pub mod security;
 pub mod test_support; // Shared test helpers (NOT cfg(test): other crates' tests use it)
 pub mod tls;
 pub mod types; // Event-driven pub-sub (B6.1)
+pub mod uri_encode; // Percent-encoding for URI queries and form bodies (issue #101)
 
 pub mod client;
 pub mod server;

--- a/src/libs/nextgcore-sbi/src/message.rs
+++ b/src/libs/nextgcore-sbi/src/message.rs
@@ -493,7 +493,18 @@ impl SbiRequest {
         self
     }
 
-    /// Add a query parameter
+    /// Add a query parameter.
+    ///
+    /// **The value is RAW.** `SbiClient` percent-encodes both key and value when
+    /// it assembles the URI (issue #101), so a caller must NOT pre-encode --
+    /// doing so double-encodes (`{` -> `%7B` -> `%257B`) and the peer decodes it
+    /// once, back to `%7B`.
+    ///
+    /// This contract is asymmetric with hand-built URI strings: a caller that
+    /// formats a path itself and passes it to `SbiClient::get` bypasses the
+    /// client's encoder and MUST encode with
+    /// [`crate::uri_encode::encode_query_value`] (pcfd's nudr-dr queries do
+    /// exactly that).
     pub fn with_param(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.http.set_param(key, value);
         self

--- a/src/libs/nextgcore-sbi/src/oauth.rs
+++ b/src/libs/nextgcore-sbi/src/oauth.rs
@@ -1163,24 +1163,15 @@ async fn http2_connect(
     }
 }
 
-/// Minimal percent-encoding for form values.
+/// Percent-encoding for `application/x-www-form-urlencoded` values.
+///
+/// Issue #101: was a local copy. It now delegates to the shared encoder, which
+/// keeps the form encoding (space -> `+`) DISTINCT from the RFC 3986 query
+/// encoding (space -> `%20`) rather than merging them -- the two are not
+/// interchangeable, and this is the form-body surface. See
+/// [`crate::uri_encode`].
 fn url_encode(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => result.push(c),
-            ' ' => result.push('+'),
-            _ => {
-                let mut buf = [0u8; 4];
-                let encoded = c.encode_utf8(&mut buf);
-                for &b in encoded.as_bytes() {
-                    result.push('%');
-                    result.push_str(&format!("{b:02X}"));
-                }
-            }
-        }
-    }
-    result
+    crate::uri_encode::encode_form_value(s)
 }
 
 // ============================================================================

--- a/src/libs/nextgcore-sbi/src/uri_encode.rs
+++ b/src/libs/nextgcore-sbi/src/uri_encode.rs
@@ -1,0 +1,148 @@
+//! Percent-encoding for SBI URIs and form bodies (issue #101).
+//!
+//! # Why there are two functions and not one
+//!
+//! Before this module the repo carried two hand-rolled encoders:
+//!
+//! | | space | used for |
+//! |---|---|---|
+//! | `oauth::url_encode` (private) | `+` | the `application/x-www-form-urlencoded` token-request body |
+//! | `pcfd::sbi_path::percent_encode` | `%20` | an RFC 3986 query component |
+//!
+//! They look redundant, and the obvious cleanup — pick one, share it, delete the
+//! other — **would introduce a bug**. The `+`-for-space convention belongs to
+//! `application/x-www-form-urlencoded`; in a strict RFC 3986 query component `+`
+//! is a **literal plus**, not a space. So encoding a discovery factor with the
+//! form encoder corrupts every value containing a space the moment a conformant
+//! NRF parses it, and encoding a form body with the query encoder sends `%20`
+//! where a form parser expects `+`.
+//!
+//! The two copies were therefore not duplication — they were two different
+//! encodings that resembled each other. This module keeps both, names them for
+//! the surface they belong to, and [`tests::query_and_form_encoders_differ_on_space`]
+//! pins the difference so a later tidy-up cannot merge them.
+//!
+//! Both share the RFC 3986 *unreserved* set (`ALPHA / DIGIT / "-" / "." / "_" /
+//! "~"`) and encode everything else, which is deliberately conservative: a
+//! sub-delimiter that would be legal unencoded in some position is still safe
+//! encoded, whereas the reverse is not true.
+
+/// Percent-encode a value for use in an RFC 3986 **query component**.
+///
+/// Space becomes `%20`. Use this for anything going into a URI — query
+/// parameters, path segments, `Location` values.
+///
+/// This is what makes a structured SBI discovery factor survive: an
+/// `3gpp-Sbi-Discovery-snssais` header carrying a JSON list
+/// (`[{"sst":1,"sd":"000001"}]`) contains `[`, `{`, `"` and `:`, every one of
+/// which makes `Uri::parse` reject the assembled URI. Before #101 the SCP's
+/// delegated discovery died with 502 before the query ever left the process.
+pub fn encode_query_value(s: &str) -> String {
+    encode_with(s, SpaceAs::Percent20)
+}
+
+/// Percent-encode a value for an `application/x-www-form-urlencoded` **body**.
+///
+/// Space becomes `+`. Use this only for form bodies — notably the NRF
+/// access-token request, whose media type mandates this encoding.
+pub fn encode_form_value(s: &str) -> String {
+    encode_with(s, SpaceAs::Plus)
+}
+
+/// How a space is represented — the single point on which the two encodings
+/// differ, kept as an explicit choice rather than a duplicated loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpaceAs {
+    /// RFC 3986 query component.
+    Percent20,
+    /// `application/x-www-form-urlencoded`.
+    Plus,
+}
+
+fn encode_with(s: &str, space: SpaceAs) -> String {
+    let mut out = String::with_capacity(s.len());
+    // Iterate BYTES, not chars: a multi-byte UTF-8 scalar must be encoded one
+    // octet at a time (RFC 3986 §2.5), and `for b in s.bytes()` gives exactly
+    // that without a per-char re-encode buffer.
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            b' ' if space == SpaceAs::Plus => out.push('+'),
+            _ => {
+                out.push('%');
+                // Uppercase hex: RFC 3986 §2.1 says producers should use it.
+                const HEX: &[u8; 16] = b"0123456789ABCDEF";
+                out.push(HEX[(b >> 4) as usize] as char);
+                out.push(HEX[(b & 0x0f) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The anti-deduplication guard.** These two functions exist because they
+    /// disagree on exactly one input, and merging them would silently corrupt one
+    /// of the two surfaces. If this test is failing because someone unified them,
+    /// read the module docs before "fixing" it.
+    #[test]
+    fn query_and_form_encoders_differ_on_space() {
+        assert_eq!(encode_query_value("a b"), "a%20b");
+        assert_eq!(encode_form_value("a b"), "a+b");
+        // ...and agree on everything else.
+        for input in ["", "plain", "a=b&c", "[{\"sst\":1}]", "café", "a+b", "~-._"] {
+            assert_eq!(
+                encode_query_value(input).replace("%20", "+"),
+                encode_form_value(input),
+                "the encoders must differ ONLY on space, input {input:?}"
+            );
+        }
+    }
+
+    /// The unreserved set passes through untouched; a literal `+` is encoded by
+    /// both, so a form value cannot be confused with a space on decode.
+    #[test]
+    fn unreserved_passes_through_and_plus_is_escaped() {
+        let unreserved = "abcXYZ019-._~";
+        assert_eq!(encode_query_value(unreserved), unreserved);
+        assert_eq!(encode_form_value(unreserved), unreserved);
+        assert_eq!(encode_query_value("a+b"), "a%2Bb");
+        assert_eq!(
+            encode_form_value("a+b"),
+            "a%2Bb",
+            "a literal plus must not decode back to a space"
+        );
+    }
+
+    /// The #101 breaker: a JSON discovery factor. Every one of `[ { \" : , } ]`
+    /// is encoded, so the assembled URI parses.
+    #[test]
+    fn a_json_discovery_factor_is_fully_encoded() {
+        let snssais = r#"[{"sst":1,"sd":"000001"}]"#;
+        let encoded = encode_query_value(snssais);
+        for illegal in ['[', ']', '{', '}', '"', ' '] {
+            assert!(
+                !encoded.contains(illegal),
+                "{illegal:?} must not survive encoding, got {encoded}"
+            );
+        }
+        assert_eq!(
+            encoded,
+            "%5B%7B%22sst%22%3A1%2C%22sd%22%3A%22000001%22%7D%5D"
+        );
+    }
+
+    /// Multi-byte UTF-8 is encoded per octet, uppercase hex (RFC 3986 §2.1/§2.5).
+    #[test]
+    fn multibyte_utf8_is_encoded_per_octet() {
+        assert_eq!(encode_query_value("é"), "%C3%A9");
+        assert_eq!(encode_query_value("日"), "%E6%97%A5");
+        // Uppercase, not lowercase.
+        assert_eq!(encode_query_value("\u{7f}"), "%7F");
+    }
+}


### PR DESCRIPTION
#101's first hard breaker. `SbiClient` joined query params with `format!("{k}={v}")` and then called `Uri::parse`. Any structured SBI discovery factor — an S-NSSAI list, GUAMI, TAI or PLMN list — contains `[`, `{`, `"` or `:`, so `Uri::parse` rejected the whole URI and the SCP's delegated discovery died with **502 before the request left the process**. An operator could not use Model D discovery for slice- or region-scoped producer selection, which is the common deployment case.

## `Refs #101`, not `Closes` — read this bit

**This ships criterion 1 only.** Criteria 2–4 (delegated token identity, `3gpp-Sbi-Access-Scope`, CCA, consumer-keyed token cache) remain open on #101, and **the open count deliberately does not move**.

The convention's carve-out applies — *"a safety-critical defect inside an umbrella may ship alone, labelled `Refs #N`, with the PR stating why it did not wait"* — and the reason it did not wait is that this is the hard breaker, and it turned out to be cross-cutting infrastructure that every SBI query benefits from.

The reason the rest did **not** ship is a blocker found while implementing: `SbiClient::with_oauth2(oauth2, target_nf_type)` attaches the token automatically and has **no per-request hook**, so a consumer-scoped token cannot be threaded through it — `proxy.rs`'s `forward()` must acquire and attach the token itself. That is a restructure, not an incremental edit. The design for it is fully written up in the spec (Decisions 2 and 3) so it need not be re-derived, including the non-obvious part: sending the consumer's `nfInstanceId` unconditionally would **break the delegated path against our own NRF**, because after #64 the token endpoint requires a CCA keyed by `nfInstanceId` — so consumer identity and an SCP-signed CCA are mutually exclusive, and the issue's suggested feature flag would just turn delegated discovery off.

## The fix is not a one-line encode

Three things had to move together, and one of them nearly went the wrong way.

**1. Encode centrally**, in the client's query builder rather than at the `with_param` call site the issue points at — so every SBI query benefits and no future caller can forget.

**2. Two encodings, kept distinct.** The repo already had two hand-rolled encoders, and the recorded lesson *"count the implementations before writing the abstraction"* pointed straight at merging them. **Merging them would have been a bug:**

| | space | correct for |
|---|---|---|
| `oauth.rs::url_encode` | `+` | `application/x-www-form-urlencoded` **body** — the token request |
| `pcfd::percent_encode` | `%20` | RFC 3986 **query component** |

In a strict query component `+` is a **literal plus**, not a space. A single merged encoder would corrupt every value containing a space on one of the two surfaces. They were never duplication — they were two encodings that resembled each other closely enough to look redundant, and the resemblance is the trap.

So: one shared `nextgcore_sbi::uri_encode` with `encode_query_value` and `encode_form_value`, both former copies now delegating to it, and `query_and_form_encoders_differ_on_space` pinning the difference so a later tidy-up cannot unify them.

**3. The contract is asymmetric, and that trap is now documented on `with_param`/`set_param`.** A value passed to `with_param` is **raw** and the client encodes it; a caller that formats a URI *string* by hand bypasses the client and must encode itself (pcfd's nudr-dr queries do exactly that). Getting it wrong double-encodes — `{` → `%7B` → `%257B` — and the peer's single decode yields `%7B`, which is how the test failures below presented.

## Four tests were compensating for the defect

Encoding centrally broke four tests, and **every one broke because it had been hand-encoding to work around a client that did not encode**:

* `nextgcore-nrfd` `test_http_lifecycle_register_discover_patch_deregister` passed a pre-encoded S-NSSAI with the comment *"percent-encoded"* — so it exercised a path no real consumer takes. It now passes the raw JSON and asserts the true round trip (client encodes → nrfd's `percent_decode` reverses).
* three `nextgcore-bsfd` MBS tests did the same via a local `pct_encode_query` test helper, now deleted as unused.

Server-side decoding was already correct in both NFs — the gap was only ever on the client. **That is why #101 needed a conformant external NRF to surface it:** in-repo, the tests had been written around the defect, so the suite was green over a URI no real peer would accept.

## Verification

Four new tests in `uri_encode`:

* `a_json_discovery_factor_is_fully_encoded` — the #101 breaker, asserted against the exact expected encoding with none of `[ ] { } "` or space surviving.
* `query_and_form_encoders_differ_on_space` — the anti-deduplication guard, plus a loop asserting the two agree on everything *except* space.
* `unreserved_passes_through_and_plus_is_escaped` — a literal `+` must not decode back to a space.
* `multibyte_utf8_is_encoded_per_octet` — RFC 3986 §2.5, uppercase hex per §2.1.

Workspace **5710 passed / 0 failed**, `cargo test --workspace` exit 0, no compile errors (checked for `^error`, not only a `test result:` line). `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets` exit 0 with **no warning in any file touched**.

**Not verified:** no conformant external NRF was involved. The encoding is asserted against the RFC and against nextgcore's own decoders — not against a third-party NRF's parser, which is the peer whose rejection motivated the issue. CI skips Docker E2E.

## Acceptance criteria (#101)

- [x] **1** — a JSON S-NSSAI discovery factor produces a percent-encoded nnrf-disc query that parses; no `SbiError::InvalidUri`/502
- [ ] **2** — delegated `AccessTokenReq` carries the consumer's identity
- [ ] **3** — `3gpp-Sbi-Access-Scope` populated, CCA attached when configured
- [ ] **4** — `TokenCache` keyed by consumer identity
- [ ] **5** (already marked *(Follow-up)* by the issue) — NRF error-status splitting

Criteria 2–4 plus defects 3–7 are tracked with the verified design; #101 stays open.

Refs #101.

Spec: `specs/fix-scp-model-d-token-and-discovery-confidentiality.md`
