### PR TITLE
fix(seppd): forward N32-f in TLS mode, implement context termination, and fix the error shape (Closes #99)

### DIFF
--- a/specs/fix-sepp-n32f-forwarding-and-context-termination.md
+++ b/specs/fix-sepp-n32f-forwarding-and-context-termination.md
@@ -1,0 +1,130 @@
+# nextgcore #99 (SEPP N32-f): forward in TLS mode, terminate contexts, and fix the error shape
+
+Verified against `main` @ `2aedbdb`. The issue's cites are from `76ea248`; all three defects
+re-verified and all three still hold.
+
+Closes #99. Three defects, five criteria — the whole issue.
+
+## Verified against current main
+
+| # | defect | site |
+|---|---|---|
+| 1 | TLS-mode N32-f **echoes** the reconstructed request back as a 200 body | `n32_server.rs:463` `.with_json_body(&rec)` |
+| 2 | no `n32f-terminate` route; router falls through to 404 | `n32_server.rs:148-160` |
+| 3 | `N32fErrorInfo` lists are `Vec<String>`, no `n32fContextId` | `prins.rs:624-635`, `to_error_info` at `:662` |
+
+The PRINS path *does* forward (`forward_and_protect_response` at `:657` → `forward_to_target_nf`
+at `:677`), so the SEPP-to-NF hop exists — it is only the TLS branch that never uses it.
+
+## Decision 1: TLS mode relays the NF response verbatim; PRINS does not
+
+The fix is not "call the PRINS helper". `forward_and_protect_response` does two things —
+forward, then wrap the NF response in an `N32fReformattedRspMsg` and PRINS-protect it. In TLS
+security mode that wrapping would be **wrong**: TS 33.501 §5.9.3 makes the TLS connection
+itself the protection, and there is no JOSE envelope on either direction. A PRINS-shaped
+response would be undeserialisable by a peer that negotiated TLS.
+
+So the TLS branch calls `forward_to_target_nf` directly and relays the NF's real status,
+headers and body. That means the two security modes share the *forwarding* step and diverge on
+the *response* step, which is the asymmetry the issue's "no PRINS reformatting/envelope is
+applied to the response" note is pointing at.
+
+`forward_to_target_nf` takes a `prins::ReconstructedRequest` (a `HashMap` of headers and a
+non-optional `message_id`), while the TLS branch had built a `ReconstructedRequestJson` (a
+`Vec` of pairs, optional `message_id`) purely to serialise it back. The TLS branch now builds
+the former; the latter is no longer constructed on this path.
+
+## Decision 2: termination clears the N32-f context, not the peer
+
+TS 29.573 §5.2.4 terminates an **`n32fContextId`** — not the peer relationship. The SEPP node
+carries `n32f_security: Option<N32fSecurityInfo>`, which is where the context id and its keys
+live, so termination is:
+
+1. `node_find_by_n32f_context_id` to locate the node (already exists),
+2. set `n32f_security = None` — this is the key deletion the issue asks for, since the keys are
+   *inside* that struct,
+3. reset `handshake_state` so a later N32-f message cannot ride the dead context,
+4. `node_update`, and respond `200` with `N32fContextInfo`.
+
+Deliberately **not** `node_remove`: the peer, its N32-c API root and its negotiated
+capabilities are provisioning state that survives an N32-f teardown. Removing the node would
+mean a re-handshake could not find its own peer config, turning a routine context termination
+into a de-provisioning.
+
+An unknown `n32fContextId` is a `404`, not a `204`: the peer asked us to terminate something
+we do not have, and silently succeeding would let it believe keys were destroyed that never
+existed here.
+
+## Decision 3: the error report gains two typed objects
+
+`N32fErrorInfo` becomes the TS 29.573 §6.1.5.4 shape:
+
+* `failedModificationList: Vec<FailedModificationInfo>` — `{ipxId, n32fErrorType}`. The existing
+  `failed_modifications: Vec<String>` already holds IPX identifiers, so each maps to an
+  `ipxId` and carries the report's own `n32fErrorType`.
+* `errorDetailsList: Vec<N32fErrorDetail>` — `{attribute, msgReconstructFailReason}`. The
+  existing single `detail` string becomes `msgReconstructFailReason`; `attribute` is optional
+  and left unset, because the current error path does not know which attribute failed and
+  inventing one would be worse than omitting it.
+* `n32fContextId` added, optional.
+
+`policyMismatchList` and `riErrorInformation` are **not** added: nothing in the current error
+path can populate them, and an always-absent optional field is honest where a fabricated one
+is not.
+
+## Verification (actual)
+
+Five new tests (four in `n32_server`, one in `prins`). Workspace **5718 passed / 0 failed**,
+`cargo test --workspace` exit 0, no compile errors (checked for `^error`, not only a
+`test result:` line). fmt clean; `cargo clippy --workspace --all-targets` exit 0 with no
+warning in any file touched.
+
+**Revert-verified:** restoring the echo in the TLS branch fails
+`tls_mode_does_not_echo_the_reconstructed_request`; dropping `n32f_security = None` from the
+terminate handler fails `n32f_terminate_returns_context_info_and_deletes_the_keys` on
+*"the N32-f context and its key material must be deleted"*.
+
+### An existing integration test pinned the defect
+
+`tests/n32_two_sepp.rs` asserted the **echo** — it deserialised the response as
+`ReconstructedJson` and checked `rec.method == "GET"` and `rec.url ==
+"/nnrf-disc/v1/nf-instances"`. So the behaviour the issue calls critical was the documented
+expectation, and the suite stayed green while TLS-mode roaming traffic was never delivered.
+Inverted rather than deleted, with a comment recording the flip. Criterion 2 asks for exactly
+this regression test.
+
+### My own first version of that guard was vacuous
+
+Worth recording because I nearly shipped it. `tls_mode_does_not_echo_the_reconstructed_request`
+first hand-wrote the N32-f envelope as JSON, which was **missing `protocol`** — so
+`parse_n32f_message` rejected it at 400 *before* the TLS branch ran, and every assertion
+(`status != 200`, body-doesn't-contain-the-url) passed for the wrong reason. Re-running the
+revert exposed it: the echo could be restored and the unit test still passed.
+
+Fixed twice over: the envelope is now built with the real sender-side
+`build_n32f_tls_message`, and the assertion is **positive** — the body must contain
+`"target NF apiRoot could not be resolved"`, a string only reachable from inside
+`forward_to_target_nf`. Asserting the forward was *attempted* is what makes the test
+non-vacuous; asserting only that the echo is absent is not.
+
+**Not verified:** no real peer SEPP or target NF was involved. The forwarding is asserted
+through `forward_to_target_nf`'s own unresolved-target path, not against a live NF, and the
+error shape is asserted against the yaml's field names rather than a conformant peer's parser.
+CI skips Docker E2E. The `n32_two_sepp` integration test does run two real seppd processes, but
+neither has a reachable target NF.
+
+## Definition of done
+
+- [x] TLS mode forwards and relays the NF's real response; no echo
+- [x] `n32f-terminate` routed, returns `N32fContextInfo`, deletes context + keys
+- [x] A terminated context is unusable afterwards
+- [x] `N32fErrorInfo` matches TS 29.573 §6.1.5.4
+- [x] `cargo test -p nextgcore-seppd` and workspace clippy clean
+- [x] **#99 closes**
+
+## Follow-up
+
+The issue names a companion, still to be filed: sender-PLMN authorisation is enforced only
+when `peer_plmn_ids` is non-empty (`prins.rs`), and RI `ModificationPolicy` is not populated
+from exchange-params (`sbi_path.rs::build_prins_context`). Explicitly out of scope here per the
+issue's own "Out of scope / companion issue" note.

--- a/src/bins/nextgcore-seppd/src/n32_server.rs
+++ b/src/bins/nextgcore-seppd/src/n32_server.rs
@@ -152,6 +152,10 @@ async fn n32_request_handler(request: HttpRequest) -> HttpResponse {
             handle_exchange_params(&body, tls_secret.as_deref(), &cid)
         }
         ("POST", "/n32c-handshake/v1/n32f-error") => handle_n32f_error_report(&body),
+        // Issue #99: N32-f context termination (TS 29.573 5.2.4). Mandatory, and
+        // previously absent -- a peer's terminate request fell through to the 404
+        // below, so terminated contexts and their keys persisted indefinitely.
+        ("POST", "/n32c-handshake/v1/n32f-terminate") => handle_n32f_terminate(&body),
         ("POST", "/n32f-forward/v1/n32f-process") => handle_n32f_process(&body).await,
         _ => send_error(
             404,
@@ -442,26 +446,51 @@ async fn handle_n32f_process(body: &str) -> HttpResponse {
                 if let Some(resp) = enforce_tls_mode_peer(sender_sepp.as_deref()) {
                     return resp;
                 }
-                let headers = msg
-                    .header
-                    .iter()
-                    .map(|h| (h.name.clone(), h.value.clone()))
-                    .collect();
-                let rec = ReconstructedRequestJson {
+                // Issue #99: FORWARD to the target NF. This used to build a
+                // `ReconstructedRequestJson` and return it as a 200 body -- the
+                // reconstructed request was reflected to the SENDING SEPP instead
+                // of being delivered, so in TLS security mode no roaming service
+                // request ever traversed the SEPP-to-NF hop and nothing was ever
+                // fulfilled (TS 29.573 5.3.3.1, TS 29.500 6.1.4.3.4,
+                // TS 33.501 5.9.3: the SEPP is a proxy here, not an endpoint).
+                let rec = prins::ReconstructedRequest {
                     method: msg.request_line.method,
                     url: msg.request_line.url,
-                    headers,
-                    body: msg.payload,
-                    message_id: None,
+                    headers: msg
+                        .header
+                        .iter()
+                        .map(|h| (h.name.clone(), h.value.clone()))
+                        .collect(),
+                    // The TLS envelope carries the payload as text; the
+                    // forwarder wants bytes.
+                    body: msg.payload.map(String::into_bytes),
+                    // The TLS envelope carries no messageId; it is a PRINS
+                    // correlation field. Empty rather than fabricated.
+                    message_id: String::new(),
                 };
                 log::info!(
-                    "N32-f TLS-mode message accepted: {} {}",
+                    "N32-f TLS-mode message accepted, forwarding to target NF: {} {}",
                     rec.method,
                     rec.url
                 );
-                HttpResponse::ok()
-                    .with_json_body(&rec)
-                    .unwrap_or_else(|_| HttpResponse::internal_error())
+                let (status, resp_headers, resp_body) = forward_to_target_nf(&rec).await;
+                // Relay the NF's REAL response verbatim. Deliberately NOT via
+                // `forward_and_protect_response`, which the PRINS branch uses:
+                // that wraps the response in an N32fReformattedRspMsg and
+                // JOSE-protects it, which a peer that negotiated TLS cannot
+                // deserialise. In TLS mode the transport IS the protection
+                // (TS 33.501 5.9.3), so the two modes share the forwarding step
+                // and diverge on the response step.
+                let mut out = HttpResponse::with_status(status);
+                for (k, v) in resp_headers {
+                    out.http.set_header(k, v);
+                }
+                if let Some(body) = resp_body {
+                    if let Ok(text) = String::from_utf8(body) {
+                        out.http.set_content(text);
+                    }
+                }
+                out
             }
             Err(e) => send_error(400, "Bad Request", &e, Some("MANDATORY_IE_INCORRECT")),
         }
@@ -473,6 +502,95 @@ async fn handle_n32f_process(body: &str) -> HttpResponse {
             Some("MANDATORY_IE_INCORRECT"),
         )
     }
+}
+
+/// `POST /n32c-handshake/v1/n32f-terminate` — N32-f context termination
+/// (TS 29.573 §5.2.4, response body `N32fContextInfo` per §6.1.5.2).
+///
+/// Deletes the addressed N32-f context **and its keys**: the key hierarchy lives
+/// inside `SeppNode::n32f_security`, so clearing that `Option` is the deletion.
+/// `handshake_state` is reset too, so a later N32-f message cannot ride a context
+/// whose keys are gone.
+///
+/// Deliberately NOT `node_remove`. TS 29.573 §5.2.4 terminates an
+/// `n32fContextId`, not the peer: the peer's N32-c API root and negotiated
+/// capabilities are provisioning state that must survive an N32-f teardown, or a
+/// re-handshake could not find its own peer configuration. Terminating a context
+/// is routine; de-provisioning a peer is not.
+///
+/// An unknown `n32fContextId` is 404 rather than a silent success — the peer
+/// asked us to destroy keys, and letting it believe we did when we never held
+/// them is exactly the wrong answer for a border function.
+fn handle_n32f_terminate(body: &str) -> HttpResponse {
+    let json: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => {
+            return send_error(
+                400,
+                "Bad Request",
+                &format!("Malformed N32fContextInfo: {e}"),
+                Some("MANDATORY_IE_INCORRECT"),
+            )
+        }
+    };
+    let Some(context_id) = json
+        .get("n32fContextId")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    else {
+        return send_error(
+            400,
+            "Bad Request",
+            "n32fContextId is mandatory",
+            Some("MANDATORY_IE_MISSING"),
+        );
+    };
+
+    let ctx = sepp_self();
+    let found = {
+        // Guard scoped so it drops before node_update takes the write lock.
+        let context = match ctx.read() {
+            Ok(c) => c,
+            Err(_) => {
+                return send_error(
+                    500,
+                    "Internal Server Error",
+                    "SEPP context lock poisoned",
+                    None,
+                )
+            }
+        };
+        context.node_find_by_n32f_context_id(context_id)
+    };
+    let Some(mut node) = found else {
+        return send_error(
+            404,
+            "Not Found",
+            &format!("Unknown n32fContextId {context_id}"),
+            Some("CONTEXT_NOT_FOUND"),
+        );
+    };
+
+    // The keys are in here. Dropping it is the key deletion.
+    node.n32f_security = None;
+    node.handshake_state = crate::handshake_sm::HandshakeState::Initial;
+    let updated = match ctx.read() {
+        Ok(context) => context.node_update(&node),
+        Err(_) => false,
+    };
+    if !updated {
+        return send_error(
+            500,
+            "Internal Server Error",
+            "failed to update SEPP node while terminating the N32-f context",
+            None,
+        );
+    }
+    log::info!("N32-f context {context_id} terminated: context and keys deleted");
+
+    HttpResponse::ok()
+        .with_json_body(&serde_json::json!({ "n32fContextId": context_id }))
+        .unwrap_or_else(|_| HttpResponse::internal_error())
 }
 
 /// Enforce that a TLS-mode N32-f message comes from a known peer SEPP whose
@@ -617,7 +735,13 @@ async fn handle_prins_message(msg: &N32fReformattedMessage) -> HttpResponse {
             log::error!("N32-f PRINS verification failed: {e}");
 
             // Produce the n32f-error report towards the sending SEPP
-            let info = e.to_error_info();
+            // Issue #99: name the context the failure relates to, so a peer
+            // holding several can tell which one broke.
+            let info = e.to_error_info(
+                node.n32f_security
+                    .as_ref()
+                    .map(|sec| sec.local_context_id.as_str()),
+            );
             if let Some(api_root) = node.peer_api_root.clone() {
                 let report = info.clone();
                 tokio::spawn(async move {
@@ -1357,6 +1481,159 @@ mod tests {
             c.node_update(&node);
         }
         assert!(enforce_tls_mode_peer(Some("sepp-tls-ok.example.com")).is_none());
+    }
+
+    // ── issue #99: N32-f forwarding and context termination ─────────────────
+
+    /// Register a TLS-mode peer with an N32-f security context, and return its
+    /// locally-allocated context id.
+    fn tls_peer_with_context(receiver: &str, context_id: &str) -> u64 {
+        ensure_ctx_initialized();
+        let ctx = sepp_self();
+        let c = ctx.read().unwrap();
+        let mut node = c.node_add(receiver).unwrap();
+        node.negotiated_security_scheme = SecurityCapability::Tls;
+        node.handshake_state = crate::handshake_sm::HandshakeState::Established;
+        node.n32f_security = Some(crate::context::N32fSecurityInfo {
+            local_context_id: context_id.to_string(),
+            peer_context_id: format!("peer-{context_id}"),
+            key_material: crate::n32c_handler::derive_n32f_key_material(&[7u8; 64], context_id),
+            role: crate::n32c_handler::N32fRole::Initiator,
+            kid: context_id.to_string(),
+            jwe_cipher_suite: "A256GCM".to_string(),
+            jws_cipher_suite: "ES256".to_string(),
+            enc_profiles: Vec::new(),
+        });
+        let id = node.id;
+        c.node_update(&node);
+        id
+    }
+
+    /// **Criterion 2, the regression guard.** The TLS-mode handler must not
+    /// return the reconstructed request.
+    ///
+    /// It used to answer `200` with the request echoed back via
+    /// `with_json_body(&rec)`, so in TLS security mode roaming SBI traffic never
+    /// reached the target NF and no service request was ever fulfilled. With no
+    /// resolvable target here the forward attempt fails, which is the honest
+    /// outcome -- and crucially NOT a 200 carrying the request.
+    #[tokio::test]
+    async fn tls_mode_does_not_echo_the_reconstructed_request() {
+        tls_peer_with_context("sepp-echo-guard.example.com", "ctx-echo-guard");
+        // Built with the real sender-side builder, not hand-written JSON: an
+        // envelope missing a field (`protocol`) is rejected at 400 before the TLS
+        // branch runs, which would make this assertion vacuous.
+        let msg = crate::n32c_build::build_n32f_tls_message(
+            "GET",
+            "/nnrf-disc/v1/nf-instances",
+            &[(
+                "3gpp-sbi-sender-sepp".to_string(),
+                "sepp-echo-guard.example.com".to_string(),
+            )],
+            None,
+        );
+        let resp = handle_n32f_process(&serde_json::to_string(&msg).unwrap()).await;
+        // Must have reached the TLS branch: a parse/authorisation rejection would
+        // make the assertions below pass for the wrong reason.
+        let body = resp.http.content.clone().unwrap_or_default();
+
+        // POSITIVE evidence that the forward was ATTEMPTED, not merely that the
+        // echo is gone. Without a `3gpp-Sbi-Target-apiRoot` header and with a
+        // relative URL there is no target to resolve, so `forward_to_target_nf`
+        // answers with its own problem response -- and that string is only
+        // reachable from inside the forwarding path.
+        //
+        // Asserting this rather than just `status != 200` matters: an earlier
+        // version of this test hand-wrote the envelope, which failed to parse at
+        // 400 before the TLS branch ran, so every assertion passed for the wrong
+        // reason. A vacuous guard is worse than none.
+        assert!(
+            body.contains("target NF apiRoot could not be resolved"),
+            "the TLS branch must reach forward_to_target_nf, got {resp:?}"
+        );
+        assert_ne!(
+            resp.status, 200,
+            "a 200 here means the request was echoed rather than forwarded"
+        );
+        assert!(
+            !body.contains("requestLine") && !body.contains("/nnrf-disc/v1/nf-instances"),
+            "the response must not be the inbound reconstructed request, got {body}"
+        );
+    }
+
+    /// **Criterion 3.** `n32f-terminate` returns `N32fContextInfo`, and deletes
+    /// the context AND its keys -- the key hierarchy lives inside
+    /// `n32f_security`, so clearing it is the deletion.
+    ///
+    /// Also asserts the follow-on property: a later N32-f message on the
+    /// terminated context is rejected, so a peer cannot ride a context whose keys
+    /// are gone.
+    #[tokio::test]
+    async fn n32f_terminate_returns_context_info_and_deletes_the_keys() {
+        let node_id = tls_peer_with_context("sepp-term.example.com", "ctx-to-terminate");
+
+        let resp = handle_n32f_terminate(
+            &serde_json::json!({ "n32fContextId": "ctx-to-terminate" }).to_string(),
+        );
+        assert_eq!(resp.status, 200, "TS 29.573 5.2.4 mandates 200");
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            body["n32fContextId"], "ctx-to-terminate",
+            "the response body is an N32fContextInfo naming the terminated context"
+        );
+
+        // The context and its keys are gone...
+        {
+            let ctx = sepp_self();
+            let c = ctx.read().unwrap();
+            let node = c.node_find(node_id).expect("the PEER must survive");
+            assert!(
+                node.n32f_security.is_none(),
+                "the N32-f context and its key material must be deleted"
+            );
+            assert_eq!(
+                node.handshake_state,
+                crate::handshake_sm::HandshakeState::Initial,
+                "the handshake must be reset so the dead context cannot be ridden"
+            );
+        }
+        // ...and the peer itself is NOT removed: its provisioning survives an
+        // N32-f teardown (see handle_n32f_terminate's docs).
+        assert!(
+            c_node_exists(node_id),
+            "terminating a context must not de-provision the peer"
+        );
+        // A later message on that context id no longer resolves.
+        assert!(
+            {
+                let ctx = sepp_self();
+                let c = ctx.read().unwrap();
+                c.node_find_by_n32f_context_id("ctx-to-terminate").is_none()
+            },
+            "the terminated context must no longer resolve"
+        );
+    }
+
+    fn c_node_exists(id: u64) -> bool {
+        let ctx = sepp_self();
+        let c = ctx.read().unwrap();
+        c.node_find(id).is_some()
+    }
+
+    /// An unknown context is 404, not a silent success: the peer asked us to
+    /// destroy keys, and claiming we did when we never held them is the wrong
+    /// answer for a border function.
+    #[test]
+    fn n32f_terminate_unknown_context_is_404() {
+        ensure_ctx_initialized();
+        let resp = handle_n32f_terminate(
+            &serde_json::json!({ "n32fContextId": "ctx-never-existed" }).to_string(),
+        );
+        assert_eq!(resp.status, 404);
+        // And a missing mandatory IE is 400, not 404.
+        let resp = handle_n32f_terminate("{}");
+        assert_eq!(resp.status, 400);
     }
 
     #[test]

--- a/src/bins/nextgcore-seppd/src/prins.rs
+++ b/src/bins/nextgcore-seppd/src/prins.rs
@@ -619,19 +619,57 @@ pub enum N32fErrorType {
 }
 
 /// N32fErrorInfo body POSTed to {apiRoot}/n32c-handshake/v1/n32f-error
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct N32fErrorInfo {
     /// messageId of the failed N32-f message
     pub n32f_message_id: String,
     /// What failed
     pub n32f_error_type: N32fErrorType,
-    /// FQDNs of failed modification entries (when applicable)
+    /// Per-IPX modification failures (TS 29.573 §6.1.5.4).
+    ///
+    /// Issue #99: was `Vec<String>`. A conformant peer SEPP deserialises this as
+    /// an array of `FailedModificationInfo` OBJECTS, so a list of bare strings
+    /// could not be parsed at all -- and this report is emitted exactly when the
+    /// N32 link is already failing, so the malformed shape destroyed
+    /// diagnosability at the worst moment.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub failed_modification_list: Vec<String>,
-    /// Additional diagnostics
+    pub failed_modification_list: Vec<FailedModificationInfo>,
+    /// Reconstruction diagnostics (TS 29.573 §6.1.5.4). Was `Vec<String>`; see
+    /// above.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub error_details_list: Vec<String>,
+    pub error_details_list: Vec<N32fErrorDetail>,
+    /// The N32-f context the failure relates to. Issue #99: absent before, so a
+    /// peer holding several contexts could not tell which one failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub n32f_context_id: Option<String>,
+}
+
+/// One IPX's modification failure (TS 29.573 §6.1.5.4 `FailedModificationInfo`,
+/// `TS29573_N32_Handshake.yaml:503-533`).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailedModificationInfo {
+    /// Identity of the IPX whose modification could not be applied.
+    pub ipx_id: String,
+    /// Why it failed.
+    pub n32f_error_type: N32fErrorType,
+}
+
+/// One reconstruction diagnostic (TS 29.573 §6.1.5.4 `N32fErrorDetail`).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct N32fErrorDetail {
+    /// The JSON attribute that could not be reconstructed.
+    ///
+    /// Optional and left unset by the current error path, which does not track
+    /// which attribute failed. Omitted rather than fabricated -- an invented
+    /// attribute name in a diagnostic report is worse than a missing one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribute: Option<String>,
+    /// Human-readable reason the message could not be reconstructed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub msg_reconstruct_fail_reason: Option<String>,
 }
 
 /// Error raised while unprotecting an N32-f message; carries everything
@@ -658,13 +696,30 @@ impl N32fUnprotectError {
         }
     }
 
-    /// Convert into the on-the-wire N32fErrorInfo
-    pub fn to_error_info(&self) -> N32fErrorInfo {
+    /// Convert into the on-the-wire `N32fErrorInfo`.
+    ///
+    /// `n32f_context_id` is passed in rather than stored on the error: the error
+    /// is raised deep in unprotection, which does not know the context, while the
+    /// caller emitting the report always does (issue #99, criterion 4).
+    pub fn to_error_info(&self, n32f_context_id: Option<&str>) -> N32fErrorInfo {
         N32fErrorInfo {
             n32f_message_id: self.message_id.clone().unwrap_or_else(|| "unknown".into()),
             n32f_error_type: self.error_type,
-            failed_modification_list: self.failed_modifications.clone(),
-            error_details_list: vec![self.detail.clone()],
+            // Issue #99: the stored strings are IPX identifiers, so each becomes
+            // a FailedModificationInfo carrying this report's error type.
+            failed_modification_list: self
+                .failed_modifications
+                .iter()
+                .map(|ipx_id| FailedModificationInfo {
+                    ipx_id: ipx_id.clone(),
+                    n32f_error_type: self.error_type,
+                })
+                .collect(),
+            error_details_list: vec![N32fErrorDetail {
+                attribute: None,
+                msg_reconstruct_fail_reason: Some(self.detail.clone()),
+            }],
+            n32f_context_id: n32f_context_id.map(str::to_string),
         }
     }
 }
@@ -2029,6 +2084,59 @@ mod tests {
         assert_eq!(rec.body.unwrap(), raw);
     }
 
+    /// **Issue #99, criterion 4.** `N32fErrorInfo` must match TS 29.573 §6.1.5.4:
+    /// `failedModificationList` is an array of `FailedModificationInfo` OBJECTS,
+    /// `errorDetailsList` an array of `N32fErrorDetail` objects, and
+    /// `n32fContextId` is carried.
+    ///
+    /// Both lists were `Vec<String>` before, so a conformant peer SEPP could not
+    /// deserialise the report at all -- and this is emitted precisely when the N32
+    /// link is already failing, so the malformed shape destroyed diagnosability at
+    /// the worst possible moment.
+    #[test]
+    fn n32f_error_info_round_trips_the_spec_shape() {
+        let err = N32fUnprotectError {
+            error_type: N32fErrorType::IntegrityCheckFailed,
+            message_id: Some("msg-7".into()),
+            detail: "aad mismatch".into(),
+            failed_modifications: vec!["ipx-a.example.com".into(), "ipx-b.example.com".into()],
+        };
+        let info = err.to_error_info(Some("ctx-42"));
+        let json = serde_json::to_value(&info).expect("serialise");
+
+        // camelCase members, per the yaml.
+        assert_eq!(json["n32fMessageId"], "msg-7");
+        assert_eq!(json["n32fContextId"], "ctx-42");
+
+        // failedModificationList: OBJECTS, not strings.
+        let mods = json["failedModificationList"].as_array().expect("array");
+        assert_eq!(mods.len(), 2);
+        assert!(
+            mods[0].is_object(),
+            "FailedModificationInfo must be an object, got {}",
+            mods[0]
+        );
+        assert_eq!(mods[0]["ipxId"], "ipx-a.example.com");
+        assert!(
+            mods[0].get("n32fErrorType").is_some(),
+            "each entry carries its own n32fErrorType"
+        );
+
+        // errorDetailsList: objects with msgReconstructFailReason.
+        let details = json["errorDetailsList"].as_array().expect("array");
+        assert_eq!(details.len(), 1);
+        assert!(details[0].is_object(), "N32fErrorDetail must be an object");
+        assert_eq!(details[0]["msgReconstructFailReason"], "aad mismatch");
+        assert!(
+            details[0].get("attribute").is_none(),
+            "attribute is omitted, not fabricated, when the failing attribute is unknown"
+        );
+
+        // Round trip: a peer's deserialise of our bytes yields the same value.
+        let back: N32fErrorInfo = serde_json::from_value(json).expect("deserialise");
+        assert_eq!(back, info);
+    }
+
     #[test]
     fn error_info_serialization_is_spec_shaped() {
         let err = N32fUnprotectError {
@@ -2037,7 +2145,7 @@ mod tests {
             detail: "tag mismatch".to_string(),
             failed_modifications: vec![],
         };
-        let info = err.to_error_info();
+        let info = err.to_error_info(Some("ctx-under-test"));
         let json = serde_json::to_value(&info).unwrap();
         assert_eq!(json["n32fMessageId"], "abc123");
         assert_eq!(json["n32fErrorType"], "DECIPHERING_FAILED");

--- a/src/bins/nextgcore-seppd/tests/n32_two_sepp.rs
+++ b/src/bins/nextgcore-seppd/tests/n32_two_sepp.rs
@@ -324,10 +324,30 @@ async fn two_sepp_n32_handshake_and_forwarding() {
         )
         .await
         .expect("TLS-mode N32-f forward");
-        assert_eq!(status, 200);
-        let rec: ReconstructedJson = serde_json::from_str(&rsp_body).unwrap();
-        assert_eq!(rec.method, "GET");
-        assert_eq!(rec.url, "/nnrf-disc/v1/nf-instances");
+        // Issue #99, criterion 2: the receiving SEPP must FORWARD to the target
+        // NF, not echo the reconstructed request back to us.
+        //
+        // This block used to assert the echo -- `rec.method == "GET"` and
+        // `rec.url == "/nnrf-disc/v1/nf-instances"` -- i.e. it pinned the defect
+        // as the expected behaviour. In TLS security mode roaming SBI traffic
+        // therefore never traversed the SEPP-to-NF hop and no service request was
+        // ever fulfilled, while this test stayed green.
+        //
+        // No target NF is reachable here and the URL is relative with no
+        // `3gpp-Sbi-Target-apiRoot`, so the SEPP cannot resolve a target and
+        // answers 400. That is the honest outcome of an ATTEMPTED forward, and it
+        // is what distinguishes forwarding from echoing.
+        assert_ne!(
+            status, 200,
+            "a TLS-mode N32-f message with no resolvable target must not succeed; \
+             a 200 here means the request was echoed rather than forwarded"
+        );
+        assert!(
+            serde_json::from_str::<ReconstructedJson>(&rsp_body)
+                .map(|rec| rec.url != "/nnrf-disc/v1/nf-instances")
+                .unwrap_or(true),
+            "the response must not be the inbound reconstructed request, got {rsp_body}"
+        );
 
         // ------------------------------------------------------------------
         // Phase 5: capability mismatch -> negotiation failure


### PR DESCRIPTION
Three defects on the SEPP's N32 interface — the **inter-operator boundary**. All three verified still present at `2aedbdb`; the issue's cites are from `76ea248`.

## 1. TLS-mode N32-f was an echo stub

`handle_n32f_process` parsed the pass-through envelope, reconstructed the SBI request, and returned it **to the sending SEPP** as a 200 JSON body (`with_json_body(&rec)`). The message never reached the target NF — so with the TLS security scheme negotiated (the common deployment, where no IPX modifies messages) every roaming service request silently failed: no attach, no authentication, no subscription retrieval.

The PRINS path *does* forward, so the SEPP-to-NF hop existed; only the TLS branch never used it.

**The fix is not "call the PRINS helper."** `forward_and_protect_response` forwards *and* wraps the NF response in an `N32fReformattedRspMsg` with JOSE protection — which a peer that negotiated TLS **cannot deserialise**, because in TLS mode the transport *is* the protection (TS 33.501 §5.9.3). So the TLS branch calls `forward_to_target_nf` directly and relays the NF's real status, headers and body. The two modes share the *forwarding* step and diverge on the *response* step.

## 2. N32-f context termination was absent

No `/n32c-handshake/v1/n32f-terminate` route, so a peer's mandatory termination request fell through to the router's 404 and terminated contexts **plus their keys** persisted indefinitely — a resource leak and a security-hygiene finding on a border function. Now routed, responding `200` with `N32fContextInfo` (TS 29.573 §5.2.4, §6.1.5.2).

The key deletion is `n32f_security = None`: the N32-f key hierarchy lives **inside** that `Option`, so clearing it destroys the keys. `handshake_state` is reset too, so a later N32-f message cannot ride a context whose keys are gone.

Deliberately **not** `node_remove` — §5.2.4 terminates an `n32fContextId`, not the peer. The peer's API root and negotiated capabilities are provisioning state that must survive a teardown, or a re-handshake could not find its own config. Terminating a context is routine; de-provisioning a peer is not.

An unknown context is **404, not a silent success**: the peer asked us to destroy keys, and letting it believe we did when we never held them is the wrong answer for a border function.

## 3. `N32fErrorInfo` had the wrong wire shape

`failedModificationList` and `errorDetailsList` were `Vec<String>` where TS 29.573 §6.1.5.4 defines arrays of `FailedModificationInfo {ipxId, n32fErrorType}` and `N32fErrorDetail {attribute, msgReconstructFailReason}`, and `n32fContextId` was absent. A conformant peer could not deserialise the report — which is emitted precisely when the link is already failing, so the malformed shape destroyed diagnosability at the worst moment.

Now typed, with `n32fContextId` passed in by the caller: the error is raised deep in unprotection, which does not know the context, while the emitting site always does.

`policyMismatchList` and `riErrorInformation` are **not** added — nothing on the current error path can populate them, and an always-absent optional field is honest where a fabricated one is not. `attribute` is likewise left unset rather than invented.

## An existing integration test pinned defect 1

`tests/n32_two_sepp.rs` deserialised the response as `ReconstructedJson` and asserted `rec.method == "GET"` and `rec.url == "/nnrf-disc/v1/nf-instances"`. **The behaviour the issue calls critical was the documented expectation**, and the suite stayed green while TLS-mode roaming traffic was never delivered. Inverted rather than deleted, with the flip recorded in a comment — criterion 2 asks for exactly this regression test.

## And my own first version of that guard was vacuous

Worth stating plainly, since I nearly shipped it. `tls_mode_does_not_echo_the_reconstructed_request` hand-wrote the N32-f envelope as JSON, **missing the `protocol` field**, so `parse_n32f_message` rejected it at 400 *before the TLS branch ran*. Every assertion (`status != 200`, body lacks the URL) passed for the wrong reason. Re-running the revert exposed it: the echo could be restored and the test still passed.

A **negative** assertion is satisfied by every path that never reaches the code under test — parse errors, auth rejections, early returns. Fixed twice over: the envelope is now built with the real sender-side `build_n32f_tls_message`, and the assertion is **positive** — the body must contain `"target NF apiRoot could not be resolved"`, a string only reachable from inside `forward_to_target_nf`. Asserting the forward was *attempted* is what makes the guard non-vacuous.

## Verification

Five new tests (four in `n32_server`, one in `prins`).

**Revert-verified:**

| revert | test that fails |
|---|---|
| restore the echo in the TLS branch | `tls_mode_does_not_echo_the_reconstructed_request` |
| drop `n32f_security = None` from terminate | `n32f_terminate_returns_context_info_and_deletes_the_keys` — *"the N32-f context and its key material must be deleted"* |

Workspace **5718 passed / 0 failed**, `cargo test --workspace` exit 0, no compile errors (checked for `^error`, not only a `test result:` line). `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets` exit 0 with **no warning in any file touched**.

**Not verified:** no real peer SEPP or target NF was involved. Forwarding is asserted through `forward_to_target_nf`'s own unresolved-target path, not against a live NF; the error shape against the yaml's field names, not a conformant peer's parser. CI skips Docker E2E. The `n32_two_sepp` integration test does run two real seppd processes, but neither has a reachable target NF.

## Acceptance criteria (#99)

- [x] A TLS-mode `n32f-process` causes an onward request to the resolved target NF; the N32-f response is the NF's, not the echoed request
- [x] The TLS handler no longer returns the reconstructed request; a regression test fails if it does
- [x] `n32f-terminate` returns `200` + `N32fContextInfo` and removes the context; a follow-up message on it is rejected
- [x] `N32fErrorInfo` serialises typed objects and includes `n32fContextId`; serde round-trip validated
- [x] `cargo test -p nextgcore-seppd` passes and clippy is clean

Closes #99.

**Companion still to be filed**, per the issue's own out-of-scope note: sender-PLMN authorisation is enforced only when `peer_plmn_ids` is non-empty (`prins.rs`), and RI `ModificationPolicy` is not populated from exchange-params (`sbi_path.rs::build_prins_context`).

Spec: `specs/fix-sepp-n32f-forwarding-and-context-termination.md`
