### PR TITLE
fix(amfd,smfd): convey the real subscriber and serving network on N11 SmContextCreate (Refs #73)

### DIFF
--- a/specs/fix-amf-n11-supi-and-serving-network.md
+++ b/specs/fix-amf-n11-supi-and-serving-network.md
@@ -1,0 +1,112 @@
+# nextgcore #73 (AMF N11): convey the real subscriber and serving network on SmContextCreate
+
+Verified against `main` @ `fa6ffff`. The issue's cites are from `76ea248`; all five defects
+re-verified and all five still hold.
+
+`Refs #73`, **not Closes**. Ships criteria 1, 2, 3 and 7 — the N11 identity chain, end to end.
+Criteria 4, 5 and 6 remain open; see "Scope" below. The open count deliberately does not move.
+
+## The defect shipped here
+
+`build_create_sm_context_request` emitted only `pduSessionId`, `sNssai`, `dnn`, `n1SmMsg`,
+`redcapIndication` and a **hardcoded** `servingNetwork: {mcc:"001", mnc:"01"}`. No `supi`,
+`pei`, `guami`, `servingNfId` or `ueLocation` — even though `state.amf_ue.supi` was set and used
+elsewhere in the same file.
+
+`smfd` compensated by substituting `"imsi-unknown"`, warn-and-continue, commented *"lenient:
+AMF support pending"*. That phantom identity then flowed into NSAC counters, policy association
+and session lookup, so **every subscriber in the network collapsed onto one identity**. Charging
+and slice admission were computed over a subscriber that does not exist — and because the
+session still came up, nothing surfaced the loss.
+
+## Decision 1: a struct, not six more positional parameters
+
+`call_smf_create_sm_context` already took eight arguments. Adding six positional
+`Option<String>`s is how a caller silently passes `pei` where `gpsi` belongs, so the identity is
+grouped into `SmContextIdentity { supi, pei, guami, serving_plmn, serving_nf_id, ue_location }`,
+built once at the call site from `state.amf_ue` and the AMF context.
+
+## Decision 2: omit what the AMF does not hold — never placehold
+
+Each member is emitted only when actually known. This matters most for `servingNetwork`: a
+hardcoded `001/01` is **indistinguishable from a real 001/01 test network**, so the SMF cannot
+tell "the serving PLMN is 001/01" from "the AMF did not know". Absent is checkable; wrong is
+not. The serving PLMN is sourced from the UE's `nr_tai.plmn_id`, falling back to the AMF's own
+`served_guami`.
+
+`gpsi` is **not** emitted at all: amfd's UE context has no GPSI field and never retrieves one
+from UDM, so there is nothing to convey. Criterion 1 lists it, but emitting a derived or blank
+GPSI would be a fabrication of exactly the kind this issue exists to remove. Recorded as a
+follow-up rather than faked.
+
+`PlmnId` gained `mcc()`/`mnc()` accessors — the inverse of `PlmnId::new` was missing, which is
+part of *why* `servingNetwork` was hardcoded: there was no way to render a real PLMN back to the
+wire form. `mnc3 == 0xf` is the TS 24.008 filler for a two-digit MNC and is dropped, not
+rendered as `15`.
+
+## Decision 3: the SMF now rejects, and that is the point
+
+The AMF fix alone would be unenforced — a future regression would silently return to
+`imsi-unknown`. So `smfd` rejects a non-emergency `CreateSMContext` with no (or empty) `supi`
+via `400 MANDATORY_IE_MISSING`. A session the SMF cannot attribute is one it cannot charge,
+police or admit; refusing is the honest failure.
+
+The rejection is asserted on **behaviour**, not by grepping the source for `imsi-unknown` — the
+comment explaining this fix contains that literal, and a source-grepping guard would match its
+own justification (a trap this repo has already been bitten by).
+
+## Scope: criteria 4, 5 and 6 remain open
+
+Split deliberately, stated up front rather than discovered late:
+
+* **4 (PEI/IMEISV mis-decode)** and **5 (SUCI scheme ignored)** are self-contained and small,
+  and were left only for want of session budget. Both are verified present:
+  `decode_bcd_digits(&content[1..])` drops identity digit 1 (which shares octet 4 with the
+  type field) and unconditionally prefixes `imeisv-` even for a 15-digit IMEI, at two sites;
+  `supi_from_suci` never inspects the scheme id, so an ECIES-protected SUCI yields a bogus SUPI
+  that seeds K_AMF derivation.
+* **6 (default DNN from subscription data)** is a larger question than the criterion implies.
+  amfd retrieves only `am-data` from UDM SDM, never `sm-data`, where `dnnConfigurations` lives —
+  so this needs a **new southbound interaction**. And per TS 23.501 the **SMF**, not the AMF, is
+  the NF that retrieves SM subscription data; the SMF already does. Implementing it in amfd
+  would put subscription retrieval in the wrong NF. Worth deciding before building.
+
+## Verification
+
+Four new tests. Workspace **5722 passed / 0 failed**, `cargo test --workspace` exit 0, no
+compile errors (checked for `^error`, not only a `test result:` line). fmt clean; `cargo clippy
+--workspace --all-targets` exit 0 with no warning in any file touched.
+
+**Revert-verified:**
+
+| revert | test that fails |
+|---|---|
+| smfd substitutes `imsi-unknown` again | `create_sm_context_without_supi_is_rejected` |
+| drop `supi` from the N11 body | `n11_create_carries_the_real_subscriber_identity` |
+| hardcode `servingNetwork` again | `n11_serving_network_is_the_real_plmn` |
+
+`n11_omits_identity_the_amf_does_not_have` pins Decision 2 — an unknown member is absent, not
+placeheld.
+
+**A stale test comment found:** smfd's `validate_sm_context_create_data_table` documents *"the
+exact SmContextCreateData body the matched-sim AMF sends (no supi …) MUST still pass the strict
+validator"*. It tests a separate validator, not the handler, so it did not break — but its
+premise is now false, since the AMF does send `supi`. Left passing and noted rather than
+silently rewritten, because the validator's leniency is a separate decision from the handler's.
+
+**Not verified:** no real UE, gNB or SMF process was involved. The N11 body is asserted by
+serialising the built request, not by observing an SMF receive it, and CI skips Docker E2E. The
+`servingNfId` member is wired but not populated at the call site — the AMF's own NF instance id
+is a local in `sbi_path::open`, not reachable from the NGAP path without threading it through
+the context; the field is emitted when supplied and omitted otherwise.
+
+## Definition of done
+
+- [x] N11 body carries `supi`, `pei`, `guami`, `servingNetwork`, `ueLocation` from the UE context
+- [x] `servingNetwork` is the real serving PLMN, not a literal
+- [x] `smfd` rejects a non-emergency create with no `supi`; no `imsi-unknown` fabrication
+- [x] Workspace clippy + amfd/smfd suites pass
+- [ ] PEI/IMEISV decode (criterion 4) — **#73**
+- [ ] SUCI scheme guard (criterion 5) — **#73**
+- [ ] Default DNN from subscription data (criterion 6) — **#73**, and see the architectural note
+- [ ] `gpsi` — no field exists in amfd; follow-up

--- a/src/bins/nextgcore-amfd/src/context.rs
+++ b/src/bins/nextgcore-amfd/src/context.rs
@@ -98,6 +98,29 @@ impl PlmnId {
             mnc3: mnc_bytes.get(2).copied().unwrap_or(0xf),
         }
     }
+
+    /// The MCC as its three decimal digits (TS 29.571 `Mcc`, `\d{3}`).
+    ///
+    /// Issue #73: the inverse of [`PlmnId::new`] was missing, which is part of why
+    /// the N11 `servingNetwork` was hardcoded to `001/01` -- there was no way to
+    /// render a real PLMN back to the wire form.
+    pub fn mcc(&self) -> String {
+        format!("{}{}{}", self.mcc1, self.mcc2, self.mcc3)
+    }
+
+    /// The MNC as its two or three decimal digits (TS 29.571 `Mnc`,
+    /// `\d{2,3}`).
+    ///
+    /// `mnc3 == 0xf` is the TS 24.008 filler marking a TWO-digit MNC, so it is
+    /// dropped rather than rendered -- emitting `15` for a 2-digit MNC would
+    /// silently claim a different network.
+    pub fn mnc(&self) -> String {
+        if self.mnc3 == 0xf {
+            format!("{}{}", self.mnc1, self.mnc2)
+        } else {
+            format!("{}{}{}", self.mnc1, self.mnc2, self.mnc3)
+        }
+    }
 }
 
 /// AMF ID (Region + Set + Pointer)

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -3419,6 +3419,61 @@ impl NgapServer {
                     .map(|s| s.amf_ue.redcap_indication)
                     .unwrap_or(false);
 
+                // Issue #73: convey the UE and serving-network identity on N11
+                // (TS 29.502 6.1.6.2.2). Previously none of this was sent, so the
+                // SMF fabricated `imsi-unknown` and every subscriber looked
+                // identical to policy, charging and NSAC.
+                let identity = {
+                    let ctx = crate::context::amf_self();
+                    let guard = ctx.read().ok();
+                    let state = self.ue_auth_state.get(&amf_ue_ngap_id);
+                    // The serving PLMN: prefer the TAI the UE is actually in,
+                    // then the AMF's own served GUAMI. Never a literal.
+                    let serving_plmn = state
+                        .map(|s| &s.amf_ue.nr_tai.plmn_id)
+                        .map(|p| (p.mcc(), p.mnc()))
+                        .or_else(|| {
+                            guard
+                                .as_ref()
+                                .and_then(|c| c.served_guami.first())
+                                .map(|g| (g.plmn_id.mcc(), g.plmn_id.mnc()))
+                        });
+                    let guami = guard
+                        .as_ref()
+                        .and_then(|c| c.served_guami.first())
+                        .map(|g| {
+                            serde_json::json!({
+                                "plmnId": { "mcc": g.plmn_id.mcc(), "mnc": g.plmn_id.mnc() },
+                                "amfId": format!(
+                                    "{:02x}{:03x}{:02x}",
+                                    g.amf_id.region, g.amf_id.set, g.amf_id.pointer
+                                ),
+                            })
+                        });
+                    // TS 29.571 UserLocation: the serving NR TAI.
+                    let ue_location = state.map(|s| &s.amf_ue.nr_tai).map(|tai| {
+                        serde_json::json!({
+                            "nrLocation": {
+                                "tai": {
+                                    "plmnId": {
+                                        "mcc": tai.plmn_id.mcc(),
+                                        "mnc": tai.plmn_id.mnc(),
+                                    },
+                                    "tac": format!("{:06x}", tai.tac),
+                                }
+                            }
+                        })
+                    });
+                    crate::sbi_path::SmContextIdentity {
+                        supi: state.and_then(|s| s.amf_ue.supi.clone()),
+                        pei: state.and_then(|s| s.amf_ue.pei.clone()),
+                        guami,
+                        serving_plmn,
+                        serving_nf_id: None,
+                        ue_location,
+                    }
+                };
+
                 match crate::sbi_path::call_smf_create_sm_context(
                     &smf_host,
                     smf_port,
@@ -3428,6 +3483,7 @@ impl NgapServer {
                     dnn,
                     sm_pdu,
                     redcap_indication,
+                    &identity,
                 )
                 .await
                 {

--- a/src/bins/nextgcore-amfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-amfd/src/sbi_path.rs
@@ -792,6 +792,34 @@ fn extract_binary_ref(
 /// RefToBinaryData pointer, and the UE's PDU Session Establishment Request
 /// travels as a 5gnas binary part (TS 29.502 §6.1.2.2.2). The `SbiClient`
 /// serializes the attached part into the multipart/related body.
+/// The UE and serving-network identity the AMF must convey on N11
+/// (TS 29.502 §6.1.6.2.2 `SmContextCreateData`) — issue #73.
+///
+/// Before this, `build_create_sm_context_request` emitted none of it, so `smfd`
+/// fabricated `imsi-unknown` for every PDU session and every subscriber presented
+/// identically to policy, charging and NSAC. `servingNetwork` was hardcoded
+/// `001/01`, misrepresenting the serving network to SMF/PCF/CHF and breaking
+/// roaming decisions.
+///
+/// Grouped into a struct rather than added as six more positional parameters:
+/// `call_smf_create_sm_context` already took eight, and a positional `Option<String>`
+/// soup is how a caller silently passes `pei` where `gpsi` belongs.
+#[derive(Debug, Clone, Default)]
+pub struct SmContextIdentity {
+    /// `supi` — conditional-mandatory for every non-emergency session.
+    pub supi: Option<String>,
+    /// `pei` — the UE's equipment identity (`imei-`/`imeisv-`).
+    pub pei: Option<String>,
+    /// `guami` — the serving AMF's GUAMI.
+    pub guami: Option<serde_json::Value>,
+    /// `servingNetwork` — the REAL serving PLMN, as (mcc, mnc).
+    pub serving_plmn: Option<(String, String)>,
+    /// `servingNfId` — this AMF's NF instance ID.
+    pub serving_nf_id: Option<String>,
+    /// `ueLocation` — TS 29.571 `UserLocation`, built from the serving TAI.
+    pub ue_location: Option<serde_json::Value>,
+}
+
 fn build_create_sm_context_request(
     pdu_session_id: u8,
     sst: u8,
@@ -799,8 +827,9 @@ fn build_create_sm_context_request(
     dnn: &str,
     n1_sm_msg_from_ue: &[u8],
     redcap_indication: bool,
+    identity: &SmContextIdentity,
 ) -> SbiRequest {
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "pduSessionId": pdu_session_id,
         "sNssai": {
             "sst": sst,
@@ -809,11 +838,41 @@ fn build_create_sm_context_request(
         "dnn": dnn,
         "n1SmMsg": { "contentId": "n1SmMsg" },
         "redcapIndication": redcap_indication,
-        "servingNetwork": {
-            "mcc": "001",
-            "mnc": "01"
-        }
     });
+    let obj = body.as_object_mut().expect("json! built an object");
+
+    // Issue #73: the serving PLMN comes from the GUAMI/TAI, not a literal. When
+    // it is genuinely unknown the member is OMITTED rather than filled with a
+    // placeholder -- a wrong serving network is worse than an absent one, because
+    // the SMF cannot tell the difference between "001/01" the test PLMN and
+    // "001/01" meaning "the AMF did not know".
+    if let Some((mcc, mnc)) = &identity.serving_plmn {
+        obj.insert(
+            "servingNetwork".to_string(),
+            serde_json::json!({ "mcc": mcc, "mnc": mnc }),
+        );
+    }
+    // Each identity member is emitted only when the AMF actually holds it. The
+    // SMF now rejects a non-emergency create with no `supi` (issue #73), so an
+    // absent SUPI surfaces as a refused session rather than a phantom subscriber.
+    if let Some(supi) = &identity.supi {
+        obj.insert("supi".to_string(), serde_json::json!(supi));
+    }
+    if let Some(pei) = &identity.pei {
+        obj.insert("pei".to_string(), serde_json::json!(pei));
+    }
+    if let Some(guami) = &identity.guami {
+        obj.insert("guami".to_string(), guami.clone());
+    }
+    if let Some(nf_id) = &identity.serving_nf_id {
+        obj.insert("servingNfId".to_string(), serde_json::json!(nf_id));
+    }
+    if let Some(loc) = &identity.ue_location {
+        obj.insert("ueLocation".to_string(), loc.clone());
+    }
+    // `gpsi` is deliberately absent: amfd's UE context has no GPSI field at all
+    // (it never retrieves one from UDM), so there is nothing to convey. Emitting
+    // a derived or blank GPSI would be a fabrication. Tracked as a follow-up.
     SbiRequest::post("/nsmf-pdusession/v1/sm-contexts")
         .with_body(body.to_string(), content_type::APPLICATION_JSON)
         .with_part(SbiPart::with_content(
@@ -836,6 +895,7 @@ pub async fn call_smf_create_sm_context(
     dnn: &str,
     n1_sm_msg_from_ue: &[u8],
     redcap_indication: bool,
+    identity: &SmContextIdentity,
 ) -> SbiResult<SmContextCreateResponse> {
     log::info!(
         "Calling SMF SM Context Create: {smf_host}:{smf_port}, PSI={pdu_session_id}, SST={sst}, \
@@ -858,6 +918,7 @@ pub async fn call_smf_create_sm_context(
         dnn,
         n1_sm_msg_from_ue,
         redcap_indication,
+        identity,
     );
 
     let response = client
@@ -2134,13 +2195,121 @@ mod tests {
         0x2E, 0x05, 0x02, 0xC1, 0xFF, 0xFF, 0x93, 0xA2, 0x28, 0x01, 0x00, 0x55, 0x00, 0x10,
     ];
 
+    /// A populated identity, as the AMF now builds it from the UE context.
+    fn test_identity() -> SmContextIdentity {
+        SmContextIdentity {
+            supi: Some("imsi-262011234567890".to_string()),
+            pei: Some("imeisv-1234567890123456".to_string()),
+            guami: Some(serde_json::json!({
+                "plmnId": { "mcc": "262", "mnc": "01" },
+                "amfId": "01000a",
+            })),
+            serving_plmn: Some(("262".to_string(), "01".to_string())),
+            serving_nf_id: Some("amf-instance-1".to_string()),
+            ue_location: Some(serde_json::json!({
+                "nrLocation": {
+                    "tai": { "plmnId": { "mcc": "262", "mnc": "01" }, "tac": "000001" }
+                }
+            })),
+        }
+    }
+
+    fn n11_body(identity: &SmContextIdentity) -> serde_json::Value {
+        let request = build_create_sm_context_request(
+            5,
+            1,
+            None,
+            "internet",
+            &UE_N1_REQUEST,
+            false,
+            identity,
+        );
+        serde_json::from_str(request.http.content.as_deref().unwrap()).unwrap()
+    }
+
+    /// **Issue #73, criterion 1.** The N11 body carries the real subscriber
+    /// identity.
+    ///
+    /// None of these members were emitted before, so `smfd` fabricated
+    /// `imsi-unknown` and every subscriber in the network collapsed onto one
+    /// phantom identity for policy, charging and NSAC.
+    #[test]
+    fn n11_create_carries_the_real_subscriber_identity() {
+        let body = n11_body(&test_identity());
+
+        assert_eq!(body["supi"].as_str(), Some("imsi-262011234567890"));
+        // TS 29.571 `Supi` pattern: a real identifier, not a placeholder.
+        let supi = body["supi"].as_str().unwrap();
+        assert!(
+            supi.starts_with("imsi-") && supi["imsi-".len()..].chars().all(|c| c.is_ascii_digit()),
+            "supi must match the TS 29.571 Supi pattern, got {supi}"
+        );
+        assert_ne!(supi, "imsi-unknown", "the phantom identity must be gone");
+
+        assert_eq!(body["pei"].as_str(), Some("imeisv-1234567890123456"));
+        assert_eq!(body["servingNfId"].as_str(), Some("amf-instance-1"));
+        assert_eq!(body["guami"]["plmnId"]["mcc"].as_str(), Some("262"));
+        assert_eq!(
+            body["ueLocation"]["nrLocation"]["tai"]["tac"].as_str(),
+            Some("000001")
+        );
+    }
+
+    /// **Criterion 2.** `servingNetwork` reflects the real serving PLMN, not the
+    /// hardcoded `001/01` every SM context used to claim.
+    #[test]
+    fn n11_serving_network_is_the_real_plmn() {
+        let body = n11_body(&test_identity());
+        assert_eq!(body["servingNetwork"]["mcc"].as_str(), Some("262"));
+        assert_eq!(body["servingNetwork"]["mnc"].as_str(), Some("01"));
+        assert_ne!(
+            body["servingNetwork"]["mcc"].as_str(),
+            Some("001"),
+            "the hardcoded test PLMN must not be reported for a real network"
+        );
+    }
+
+    /// An identity the AMF does not hold is OMITTED, never placeheld.
+    ///
+    /// This matters more than it looks: a `servingNetwork` of `001/01` is
+    /// indistinguishable from a real 001/01 test network, so a placeholder would
+    /// have the SMF confidently route on a PLMN the AMF never knew. Absent is
+    /// checkable; wrong is not.
+    #[test]
+    fn n11_omits_identity_the_amf_does_not_have() {
+        let body = n11_body(&SmContextIdentity::default());
+        for absent in [
+            "supi",
+            "pei",
+            "guami",
+            "servingNfId",
+            "ueLocation",
+            "servingNetwork",
+        ] {
+            assert!(
+                body.get(absent).is_none(),
+                "{absent} must be omitted when unknown, got {body}"
+            );
+        }
+        // The unconditional members are still there.
+        assert_eq!(body["pduSessionId"].as_u64(), Some(5));
+        assert_eq!(body["dnn"].as_str(), Some("internet"));
+    }
+
     /// amfd's CreateSmContext request is multipart/related: the JSON root holds
     /// the SmContextCreateData with the N1 as a RefToBinaryData pointer, and the
     /// UE's N1 travels in a 5gnas binary part with the exact UE bytes.
     #[test]
     fn amfd_create_request_is_multipart_with_n1_part() {
-        let request =
-            build_create_sm_context_request(5, 1, None, "internet", &UE_N1_REQUEST, false);
+        let request = build_create_sm_context_request(
+            5,
+            1,
+            None,
+            "internet",
+            &UE_N1_REQUEST,
+            false,
+            &SmContextIdentity::default(),
+        );
 
         // Serialize the request's parts exactly as the SBI client would, then
         // decode it back to prove the wire shape the SMF receives.

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -1868,15 +1868,26 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
         return problem_400("MANDATORY_IE_MISSING", "sNssai.sst is required");
     };
     let snssai_sd = req_body["sNssai"]["sd"].as_str().map(str::to_string);
-    // supi is conditional-mandatory (non-emergency registration); the current
-    // AMF does not send it yet, so warn instead of rejecting.
-    let supi = match req_body["supi"].as_str() {
-        Some(s) => s.to_string(),
-        None => {
-            log::warn!("SmContextCreateData without supi (lenient: AMF support pending)");
-            "imsi-unknown".to_string()
-        }
+    // Issue #73: `supi` is conditional-mandatory for a non-emergency session
+    // (TS 29.502 §6.1.6.2.2), and it is now REJECTED when absent.
+    //
+    // This used to warn and substitute `"imsi-unknown"`, with the comment "lenient:
+    // AMF support pending". The AMF now sends the real SUPI, and the fabrication
+    // was never merely cosmetic: the phantom identity flowed into NSAC counters,
+    // policy association and session lookup, so every subscriber in the network
+    // collapsed onto ONE identity. Charging and slice admission were computed over
+    // a subscriber that does not exist -- and because it looked like a working
+    // session, nothing surfaced the loss.
+    //
+    // Rejecting is the honest failure: a session the SMF cannot attribute is a
+    // session it cannot charge, police or admit.
+    let Some(supi) = req_body["supi"].as_str().filter(|s| !s.is_empty()) else {
+        return problem_400(
+            "MANDATORY_IE_MISSING",
+            "supi is required for a non-emergency SmContextCreateData (TS 29.502 6.1.6.2.2)",
+        );
     };
+    let supi = supi.to_string();
     let an_type = req_body["anType"].as_str().unwrap_or_else(|| {
         log::warn!("SmContextCreateData without anType — assuming 3GPP_ACCESS");
         "3GPP_ACCESS"
@@ -3642,6 +3653,56 @@ mod tests {
         let n1 = resolve_binary_ref(&request, &req_body["n1SmMsg"]).unwrap();
         assert_eq!(n1, N1_ESTABLISHMENT_REQUEST.to_vec());
         assert!(policy::parse_establishment_request(&n1).is_some());
+    }
+
+    // ------------------------- issue #73 --------------------------------
+
+    /// **Issue #73, criterion 3.** A non-emergency `CreateSMContext` with no
+    /// `supi` is REJECTED, not served with a fabricated subscriber.
+    ///
+    /// This used to warn and substitute `"imsi-unknown"`, and the phantom identity
+    /// then flowed into NSAC counters, policy association and session lookup — so
+    /// every subscriber in the network collapsed onto ONE identity. Charging and
+    /// slice admission were computed over a subscriber that does not exist, and
+    /// because the session still came up, nothing surfaced the loss.
+    ///
+    /// Asserted on BEHAVIOUR (the 400 and its cause), not by grepping the source
+    /// for `imsi-unknown`: the explanation of this fix contains that literal, and
+    /// a source-grepping guard would match its own justification.
+    #[tokio::test]
+    async fn create_sm_context_without_supi_is_rejected() {
+        smf_context_init(64, 256, 512);
+        let body = serde_json::json!({
+            "pduSessionId": 5,
+            "sNssai": { "sst": 1, "sd": "010203" },
+            "dnn": "internet",
+            "n1SmMsg": { "contentId": "n1SmMsg" },
+        });
+        let mut request = SbiRequest::post("/nsmf-pdusession/v1/sm-contexts");
+        request.http.content = Some(body.to_string());
+
+        let resp = handle_sm_context_create(&request).await;
+        assert_eq!(
+            resp.status, 400,
+            "a session the SMF cannot attribute must be refused"
+        );
+        let problem: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(problem["cause"], "MANDATORY_IE_MISSING");
+        assert!(
+            problem["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("supi"),
+            "the rejection must name the missing IE, got {problem}"
+        );
+
+        // An empty string is not an identity either.
+        let mut empty = SbiRequest::post("/nsmf-pdusession/v1/sm-contexts");
+        let mut with_empty = body.clone();
+        with_empty["supi"] = serde_json::json!("");
+        empty.http.content = Some(with_empty.to_string());
+        assert_eq!(handle_sm_context_create(&empty).await.status, 400);
     }
 
     // ----------------------------- smfd-06 ------------------------------


### PR DESCRIPTION
The AMF omitted the SUPI from `Nsmf_PDUSession_CreateSMContext`, so `smfd` substituted `"imsi-unknown"` for **every** PDU session — warn-and-continue, commented *"lenient: AMF support pending"*.

That phantom identity flowed into NSAC counters, policy association and session lookup, so **every subscriber in the network collapsed onto one identity**. Charging and slice admission were computed over a subscriber that does not exist — and because sessions still came up, nothing surfaced the loss. `servingNetwork` was additionally hardcoded `{mcc:"001", mnc:"01"}` for every context.

All five of #73's defects re-verified still present at `fa6ffff`; the issue's cites are from `76ea248`.

## `Refs #73`, not `Closes` — scope stated up front

Ships criteria **1, 2, 3, 7**. Criteria **4, 5, 6** remain open and **the open count deliberately does not move**. This was flagged before starting rather than discovered late.

## Decision 1: a struct, not six more positional parameters

`call_smf_create_sm_context` already took eight arguments. Six more `Option<String>`s is how a caller silently passes `pei` where `gpsi` belongs, so the identity is grouped into `SmContextIdentity { supi, pei, guami, serving_plmn, serving_nf_id, ue_location }`, built once at the call site from `state.amf_ue` and the AMF context.

## Decision 2: omit what the AMF does not hold — never placehold

Each member is emitted only when actually known.

This matters most for `servingNetwork`: a hardcoded `001/01` is **indistinguishable from a real 001/01 test network**, so the SMF cannot tell *"the serving PLMN is 001/01"* from *"the AMF did not know"*. **Absent is checkable; wrong is not.** The serving PLMN now comes from the UE's `nr_tai.plmn_id`, falling back to the AMF's `served_guami`.

The same reasoning means **`gpsi` is not emitted at all**. amfd's UE context has no GPSI field and never retrieves one from UDM, so there is nothing to convey. Criterion 1 lists it, but a derived or blank GPSI would be a fabrication of exactly the kind this issue exists to remove — filed as a follow-up rather than faked.

`PlmnId` gained `mcc()`/`mnc()`. The inverse of `PlmnId::new` was missing, which is part of *why* `servingNetwork` was hardcoded — there was no way to render a real PLMN back to the wire form. `mnc3 == 0xf` is the TS 24.008 two-digit-MNC filler and is dropped, not rendered as `15`.

## Decision 3: the SMF now rejects, and that is the point

The AMF fix alone would be **unenforced** — a future regression could silently return to `imsi-unknown`. So `smfd` answers `400 MANDATORY_IE_MISSING` for a non-emergency create with no (or empty) `supi`. A session the SMF cannot attribute is one it cannot charge, police or admit; refusing is the honest failure.

The rejection is asserted on **behaviour**, not by grepping the source for `imsi-unknown` — the comment explaining this fix *contains* that literal, and a source-grepping guard would match its own justification. This repo has already been bitten by exactly that.

## Criterion 6 is an architecture question, not a coding task

It asks the AMF to take the default DNN from subscription data. But amfd retrieves only `am-data` from UDM SDM, never `sm-data` where `dnnConfigurations` lives — so this needs a **new southbound interaction**. And per TS 23.501 the **SMF**, not the AMF, is the NF that retrieves SM subscription data, and `smfd` already does.

Implementing it in amfd would put subscription retrieval in the wrong NF. A likely better shape, written up in the follow-up task: **omit the DNN on N11 when the UE omits it** and let the SMF apply its own subscribed default — which turns criterion 6 into a smfd change plus an amfd omission. Worth deciding before building.

Criteria 4 and 5 are self-contained, small, and left only for session budget — both verified present, with exact sites recorded:

* **4** — `decode_bcd_digits(&content[1..])` at `ngap_path.rs:2189-2192` *and again* at `:2326-2331` skips identity digit 1, which per TS 24.501 §9.11.3.4 sits in the **high nibble of octet 4** alongside the type field; and both sites unconditionally prefix `imeisv-` even for a 15-digit IMEI, violating the TS 29.571 `Pei` pattern. The two sites should be factored onto one helper so they cannot diverge again.
* **5** — `supi_from_suci` at `:5796-5804` never inspects `parts[5]` (scheme id), so an ECIES-protected SUCI yields a **bogus SUPI that then seeds `nextgcore_kdf_kamf`** (`:1941-1948`) and UECM registration (`:2377-2381`).

## Verification

Four new tests. Workspace **5722 passed / 0 failed**, `cargo test --workspace` exit 0, no compile errors (checked for `^error`, not only a `test result:` line). `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets` exit 0 with **no warning in any file touched**.

**Revert-verified:**

| revert | test that fails |
|---|---|
| smfd substitutes `imsi-unknown` again | `create_sm_context_without_supi_is_rejected` |
| drop `supi` from the N11 body | `n11_create_carries_the_real_subscriber_identity` |
| hardcode `servingNetwork` again | `n11_serving_network_is_the_real_plmn` |

`n11_omits_identity_the_amf_does_not_have` pins Decision 2 — an unknown member is absent, not placeheld.

**A stale test comment found:** smfd's `validate_sm_context_create_data_table` documents *"the exact SmContextCreateData body the matched-sim AMF sends (no supi …) MUST still pass the strict validator"*. It tests a separate validator, not the handler, so it did not break — but its premise is now false, since the AMF does send `supi`. Left passing and noted rather than silently rewritten, because the validator's leniency is a separate decision from the handler's.

**Not verified:** no real UE, gNB or SMF process was involved. The N11 body is asserted by serialising the built request, not by observing an SMF receive it; CI skips Docker E2E. `servingNfId` is wired but not populated at the call site — the AMF's own NF instance id is a local in `sbi_path::open`, not reachable from the NGAP path without threading it through the context, so the field is emitted when supplied and omitted otherwise.

## Acceptance criteria (#73)

- [x] **1** — N11 body emits `supi`, `pei`, `guami`, `servingNfId`, `servingNetwork`, `ueLocation` from the UE context; test asserts the real SUPI and the `Supi` pattern *(`gpsi` excepted — no field exists; see Decision 2)*
- [x] **2** — `servingNetwork` reflects the real serving PLMN; asserted with a non-`001/01` PLMN
- [x] **3** — `smfd` rejects a non-emergency create lacking `supi`; no `imsi-unknown` fabrication
- [ ] **4** — PEI/IMEISV decode
- [ ] **5** — `supi_from_suci` scheme guard
- [ ] **6** — default DNN from subscription data (see the architectural note)
- [x] **7** — workspace clippy + amfd/smfd suites pass

Refs #73.

Spec: `specs/fix-amf-n11-supi-and-serving-network.md`
