### PR TITLE
fix(amfd,udrd): decode the full PEI and refuse a SUPI derived from a protected SUCI (Closes #73)

### DIFF
--- a/specs/fix-amf-n11-supi-and-serving-network.md
+++ b/specs/fix-amf-n11-supi-and-serving-network.md
@@ -3,8 +3,10 @@
 Verified against `main` @ `fa6ffff`. The issue's cites are from `76ea248`; all five defects
 re-verified and all five still hold.
 
-`Refs #73`, **not Closes**. Ships criteria 1, 2, 3 and 7 — the N11 identity chain, end to end.
-Criteria 4, 5 and 6 remain open; see "Scope" below. The open count deliberately does not move.
+**Two passes.** Pass 1 (`Refs #73`, commit `65cd2a3`, PR #203) shipped criteria 1, 2, 3 and 7 —
+the N11 identity chain, end to end — and is documented below. Pass 2 (`Closes #73`) ships
+criteria 4 and 5 and splits criterion 6 out to **#204** and the `gpsi` remainder to **#205**;
+see "Pass 2" at the end of this document.
 
 ## The defect shipped here
 
@@ -68,8 +70,16 @@ Split deliberately, stated up front rather than discovered late:
 * **6 (default DNN from subscription data)** is a larger question than the criterion implies.
   amfd retrieves only `am-data` from UDM SDM, never `sm-data`, where `dnnConfigurations` lives —
   so this needs a **new southbound interaction**. And per TS 23.501 the **SMF**, not the AMF, is
-  the NF that retrieves SM subscription data; the SMF already does. Implementing it in amfd
+  the NF that retrieves SM subscription data. Implementing it in amfd
   would put subscription retrieval in the wrong NF. Worth deciding before building.
+
+  > **Correction (pass 2).** This section claimed "the SMF already does" retrieve SM
+  > subscription data. **That is wrong**, and it is corrected here so the next reader does not
+  > build on it: `smfd` never issues a `nudm-sdm` request at all. Its only mention is a
+  > response-handling FSM arm (`gsm_sm.rs:302`) that nothing can reach. The *producer* chain
+  > does exist end to end (`udmd` serves `sm-data` at `app.rs:663` → `handle_get_sm_data`
+  > `:950`, proxying `udrd`'s `build_sm_data` `:589` with `dnnConfigurations` `:677`) — it is
+  > the SMF-side consumer that is missing. See #204.
 
 ## Verification
 
@@ -106,7 +116,111 @@ the context; the field is emitted when supplied and omitted otherwise.
 - [x] `servingNetwork` is the real serving PLMN, not a literal
 - [x] `smfd` rejects a non-emergency create with no `supi`; no `imsi-unknown` fabrication
 - [x] Workspace clippy + amfd/smfd suites pass
-- [ ] PEI/IMEISV decode (criterion 4) — **#73**
-- [ ] SUCI scheme guard (criterion 5) — **#73**
-- [ ] Default DNN from subscription data (criterion 6) — **#73**, and see the architectural note
-- [ ] `gpsi` — no field exists in amfd; follow-up
+- [x] PEI/IMEISV decode (criterion 4) — pass 2
+- [x] SUCI scheme guard (criterion 5) — pass 2
+- [-] Default DNN from subscription data (criterion 6) — split to **#204** (belongs in smfd)
+- [-] `gpsi` — no field exists in amfd; split to **#205**
+
+---
+
+# Pass 2 (`Closes #73`): PEI decode, SUCI scheme gate, and two carve-outs
+
+Verified against `main` @ `d9aea74`. Both remaining defects re-verified present.
+
+## Criterion 4: one PEI helper, and the prefix comes from the wire
+
+The defect is in **octet 4**. `content[0]` carries the type of identity in bits 1-3, the
+odd/even indicator in bit 4, and **identity digit 1 in bits 5-8** (TS 24.501 §9.11.3.4). Both
+sites decoded from `content[1..]`, so every PEI was one digit short. Independently confirmed:
+the IMEISV test vector decodes to `234567890123456` under the old slice — 15 digits, digit 1
+gone — against `1234567890123456` now.
+
+New `decode_pei(content) -> Option<(String, String)>` returns the `Pei` string and the bare
+digits. Three decisions:
+
+* **The prefix is read from the type-of-identity field, never assumed.** The old code emitted
+  `imeisv-` for both arms, so a 15-digit IMEI violated the TS 29.571 `Pei` pattern
+  (`imei-[0-9]{15}` vs `imeisv-[0-9]{16}`).
+* **The digit count must match the type, or nothing is emitted.** A malformed identity yields no
+  PEI rather than one that breaks the pattern downstream — the same omit-never-placehold rule as
+  Decision 2 above.
+* **`decode_bcd_digits` was left alone.** It has four callers, and two of them are the SUCI
+  parser (`parse_suci_identity`, routing digits and MSIN). Changing it to recover digit 1 would
+  have corrupted SUCI parsing. The two PEI sites route onto the new helper instead, which is
+  also what stops them diverging again — the divergence the issue explicitly asked to prevent.
+
+One thing the issue's cite got slightly wrong, in the safe direction: at the Security Mode
+Complete site the code **already** gated on `content[0] & 0x07 == IMEISV`, so its `imeisv-`
+prefix was correct and only the dropped digit was a defect there. The Identity Response site
+accepted `IMEI || IMEISV` and so had both defects.
+
+## Criterion 4, second half: the consumer that would have broken
+
+Emitting a correct `imei-` prefix for the first time **breaks two downstream sites** that assumed
+the other form: `udrd` did `pei.strip_prefix("imeisv-").unwrap_or(pei)` in two places
+(`main.rs:904`, `nudr_handler.rs:265`), which stores the literal `"imei-353…"` — prefix included
+— as the equipment identity. Found by grepping the consumers before shipping the producer
+change, not after.
+
+Fixed with one shared `data_store::imeisv_from_pei`, used by both sites, because they were two
+copies of the same three lines in two targets (the lib and the bin) — the same
+count-the-implementations shape recorded in LEARNINGS.
+
+## Criterion 5: the scheme id is the gate, not the digit check
+
+`supi_from_suci` concatenated `parts[2]`/`parts[3]`/`parts[7]` without inspecting `parts[5]`, the
+protection scheme id. For an ECIES SUCI `parts[7]` is hex-encoded **ciphertext**, so the result
+was a fabricated SUPI — which then seeded `nextgcore_kdf_kamf` and UECM registration.
+
+The signature became `-> Option<String>`, **mirroring `supi_from_suci` in nextgcore-udmd's
+`context.rs`, which already returned `Option` for exactly this reason** — the sibling stack had
+the right answer and the AMF had the wrong one.
+
+The load-bearing detail: **an all-digit MSIN check alone is not sufficient**, because a hex
+ciphertext can be all decimal digits by chance. So the scheme id is checked first and the tests
+prove the attribution — the profile-A and profile-B rejection vectors use all-digit scheme
+outputs, and a null-scheme SUCI of the *same shape* is asserted to still succeed.
+
+Both callers now **fail closed**: registration reject + UE release, mirroring the NIA-selection
+precedent already in the same function. Deriving KAMF under a fabricated identity would key the
+entire NAS security context to the wrong subscriber (TS 33.501 §6.1.3).
+
+## Verification
+
+Six new tests. Workspace **5728 passed / 0 failed** (was 5722), `cargo test --workspace` exit 0,
+checked for `^error` rather than only a `test result:` line. `cargo fmt --all --check` clean.
+`cargo clippy --workspace` (the CI gate) exit 0, zero warnings.
+
+**Revert-verified**, each one at a time, each failing on the value and not merely on a status:
+
+| revert | test that fails | wrong value it produced |
+|---|---|---|
+| decode from `content[1..]` again | `decode_pei_recovers_digit_one_and_selects_the_prefix_by_type` | 15 digits, digit 1 dropped |
+| hardcode the `imeisv-` prefix | same, plus `decode_pei_output_matches_the_pei_pattern` | `imeisv-123456789012345` |
+| drop the SUCI scheme gate | `supi_from_suci_refuses_a_protected_suci` | `imsi-99970<ciphertext>` |
+| strip only `imeisv-` in udrd | `imeisv_from_pei_strips_either_pei_prefix` | `imei-123456789012345` |
+
+**Not verified — the ceiling, stated plainly:**
+
+* The two **caller** rejection paths are *not* executed by any test. amfd has no harness that
+  drives `handle_authentication_confirm` or `complete_registration` (there are zero tests for
+  either today), and building one is disproportionate to this change. What holds them is
+  structural, not tested: `let Some(supi) = … else { … return }` cannot fall through, so the
+  compiler guarantees no path reaches key derivation with an unresolved SUPI. That is weaker
+  than a test and is recorded as such.
+* No real UE, gNB or AUSF was involved; PEI decoding is asserted on hand-built IE octets whose
+  encodings were verified independently before use, not observed off a live radio link.
+* `cargo clippy --workspace --all-targets` fails with 7 errors in `nextgcore-sbi` and
+  `nextgcore-hssd` — **pre-existing**, confirmed identical on clean `main` by stashing, and
+  outside every file touched here. CI gates on `cargo clippy --workspace`, which passes.
+* GitNexus impact analysis, which this repo's CLAUDE.md mandates before editing a symbol, was
+  **not run**: no GitNexus MCP server was connected in this session. Caller analysis was done
+  with grep instead (4 `decode_bcd_digits` callers, 2 `supi_from_suci` callers in amfd plus a
+  separate same-named function in udmd, 2 `Pei`-prefix consumers in udrd).
+
+**A dead site, verified and deliberately left:** `gmm_handler::handle_security_mode_complete`
+also formats `imeisv-{imeisv}` (`:504`). It has **no production caller** — only its own two
+tests — and its input is an already-decoded `Option<String>` carrying no type information, so it
+could not select a prefix even if wired. Its prefix is also *correct* for the path it models
+(the Security Mode Complete carries the IMEISV specifically). Left untouched rather than folded
+into the new helper, and noted here so it is not mistaken for a missed site.

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -2009,10 +2009,29 @@ impl NgapServer {
 
         // SUPI (from AUSF) and key hierarchy:
         // KSEAF -> KAMF (A.7) -> KNASint/KNASenc (A.8)
-        let supi = confirm
-            .supi
-            .clone()
-            .unwrap_or_else(|| supi_from_suci(&state.suci));
+        //
+        // Fail-closed SUPI resolution (TS 33.501 Section 6.1.3): when the AUSF
+        // omits the SUPI we may only fall back to the SUCI if that SUCI is
+        // null-scheme, i.e. actually carries the MSIN in cleartext. For an
+        // ECIES-protected SUCI there is no SUPI to recover here, and deriving
+        // KAMF under a fabricated identity would key the whole NAS security
+        // context to the wrong subscriber. Reject the registration instead --
+        // same reasoning as the NIA selection below.
+        let Some(supi) = confirm.supi.clone().or_else(|| supi_from_suci(&state.suci)) else {
+            log::error!(
+                "UE {amf_ue_ngap_id}: AUSF returned no SUPI and the SUCI is not null-scheme, \
+                 so no SUPI can be recovered; rejecting registration rather than deriving \
+                 KAMF under a fabricated identity (TS 33.501 Section 6.1.3 fail-closed)"
+            );
+            let reject =
+                gmm_build::build_registration_reject(GmmCause::SecurityModeRejectedUnspecified);
+            self.ue_auth_state.insert(amf_ue_ngap_id, state);
+            self.send_nas_pdu(association_id, amf_ue_ngap_id, ran_ue_ngap_id, &reject)
+                .await?;
+            self.release_ue(association_id, amf_ue_ngap_id, ran_ue_ngap_id, 1)
+                .await?;
+            return Ok(());
+        };
         state.amf_ue.supi = Some(supi.clone());
 
         let abba_len = state.amf_ue.abba_len as usize;
@@ -2258,10 +2277,22 @@ impl NgapServer {
                 }
             }
             t if t == mobile_identity_type::IMEISV || t == mobile_identity_type::IMEI => {
-                let pei = decode_bcd_digits(&content[1..]);
-                log::info!("Identity Response: PEI {pei}");
-                state.amf_ue.pei = Some(format!("imeisv-{pei}"));
-                state.amf_ue.imeisv = Some(pei);
+                match decode_pei(content) {
+                    Some((pei, digits)) => {
+                        log::info!("Identity Response: PEI {pei}");
+                        state.amf_ue.pei = Some(pei);
+                        state.amf_ue.imeisv = Some(digits);
+                    }
+                    None => {
+                        // Record no PEI rather than one that breaks the
+                        // TS 29.571 `Pei` pattern downstream.
+                        log::error!(
+                            "Identity Response: malformed IMEI/IMEISV (type {id_type}, {} octets); \
+                             no PEI recorded",
+                            content.len()
+                        );
+                    }
+                }
                 if state.pei_requested {
                     state.pei_requested = false;
                     self.complete_registration(association_id, amf_ue_ngap_id, ran_ue_ngap_id)
@@ -2404,10 +2435,20 @@ impl NgapServer {
                     if len > 0 && pos + 3 + len <= nas.len() {
                         let content = &nas[pos + 3..pos + 3 + len];
                         if content[0] & 0x07 == mobile_identity_type::IMEISV {
-                            let imeisv = decode_bcd_digits(&content[1..]);
-                            log::info!("IMEISV from Security Mode Complete: {imeisv}");
-                            state.amf_ue.imeisv = Some(imeisv.clone());
-                            state.amf_ue.pei = Some(format!("imeisv-{imeisv}"));
+                            match decode_pei(content) {
+                                Some((pei, digits)) => {
+                                    log::info!("IMEISV from Security Mode Complete: {digits}");
+                                    state.amf_ue.imeisv = Some(digits);
+                                    state.amf_ue.pei = Some(pei);
+                                }
+                                None => {
+                                    log::error!(
+                                        "Security Mode Complete: malformed IMEISV ({} octets); \
+                                         no PEI recorded",
+                                        content.len()
+                                    );
+                                }
+                            }
                         }
                     }
                     break;
@@ -2453,11 +2494,29 @@ impl NgapServer {
             return Ok(());
         };
 
-        let supi = state
+        // The authentication path always sets `supi`; this fallback only fires
+        // if registration completed without it. Same fail-closed rule as there:
+        // never register a UECM context or fetch subscription data under a SUPI
+        // derived from a protected SUCI (TS 33.501 Section 6.1.3).
+        let Some(supi) = state
             .amf_ue
             .supi
             .clone()
-            .unwrap_or_else(|| supi_from_suci(&state.suci));
+            .or_else(|| supi_from_suci(&state.suci))
+        else {
+            log::error!(
+                "UE {amf_ue_ngap_id}: no SUPI available and the SUCI is not null-scheme; \
+                 rejecting registration rather than registering a fabricated subscriber"
+            );
+            let reject =
+                gmm_build::build_registration_reject(GmmCause::SecurityModeRejectedUnspecified);
+            self.ue_auth_state.insert(amf_ue_ngap_id, state);
+            self.send_nas_pdu(association_id, amf_ue_ngap_id, ran_ue_ngap_id, &reject)
+                .await?;
+            self.release_ue(association_id, amf_ue_ngap_id, ran_ue_ngap_id, 1)
+                .await?;
+            return Ok(());
+        };
 
         let (serving_mcc, serving_mnc) = plmn_mcc_mnc_strings(&state.amf_ue.nr_tai.plmn_id);
 
@@ -5980,15 +6039,109 @@ fn encode_hex_lower(data: &[u8]) -> String {
     s
 }
 
-/// Derive a SUPI string from a null-scheme SUCI
-/// ("suci-0-mcc-mnc-routing-0-0-msin" -> "imsi-mccmncmsin")
-fn supi_from_suci(suci: &str) -> String {
-    let parts: Vec<&str> = suci.split('-').collect();
-    if parts.len() >= 8 && parts[0] == "suci" {
-        format!("imsi-{}{}{}", parts[2], parts[3], parts[7])
-    } else {
-        suci.to_string()
+/// Derive a SUPI string from a **null-scheme** SUCI
+/// ("suci-0-mcc-mnc-routing-0-hnkey-msin" -> "imsi-mccmncmsin"), or pass an
+/// already-plain `imsi-` SUPI through.
+///
+/// Returns `None` for anything from which a real SUPI cannot be recovered
+/// without the home network private key. That is the whole point of the
+/// function: only a null-scheme (scheme id 0) SUCI exposes the MSIN in
+/// cleartext (TS 23.003 Section 2.2A / Section 6.2.2). For an ECIES-protected
+/// SUCI the scheme output is ciphertext, so concatenating it would yield a
+/// FABRICATED SUPI -- and callers feed this value into `nextgcore_kdf_kamf`
+/// and UECM registration, so a fabricated identity silently derives the wrong
+/// keys and registers the wrong subscriber (TS 33.501 Section 6.1.3: the SUPI
+/// is recovered only after de-concealment).
+///
+/// The scheme id is checked FIRST and is the load-bearing gate: an all-digit
+/// check alone is not sufficient, because a hex-encoded ciphertext can be
+/// all decimal digits by chance.
+///
+/// Mirrors `supi_from_suci` in nextgcore-udmd's context.rs, which already
+/// returned `Option` for exactly this reason.
+fn supi_from_suci(suci: &str) -> Option<String> {
+    if let Some(rest) = suci.strip_prefix("imsi-") {
+        // Already de-concealed by the AUSF/UDM.
+        return if !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()) {
+            Some(suci.to_string())
+        } else {
+            None
+        };
     }
+
+    let parts: Vec<&str> = suci.split('-').collect();
+    if parts.len() < 8 || parts[0] != "suci" {
+        return None;
+    }
+    // parts: suci-<supi type>-<mcc>-<mnc>-<routing>-<scheme>-<hnkey>-<output>
+    if parts[1] != "0" {
+        // Only the IMSI SUPI type yields an imsi- SUPI.
+        return None;
+    }
+    let Ok(scheme) = parts[5].parse::<u8>() else {
+        return None;
+    };
+    if scheme != SUCI_PROTECTION_SCHEME_NULL {
+        log::error!(
+            "SUCI protection scheme {scheme} is not the null scheme: the scheme output is \
+             ciphertext, so no SUPI can be derived without de-concealment"
+        );
+        return None;
+    }
+    let msin = parts[7];
+    if msin.is_empty() || !msin.bytes().all(|b| b.is_ascii_digit()) {
+        log::error!("null-scheme SUCI carries a non-digit MSIN; refusing to derive a SUPI");
+        return None;
+    }
+    if parts[2].is_empty() || parts[3].is_empty() {
+        return None;
+    }
+    Some(format!("imsi-{}{}{}", parts[2], parts[3], msin))
+}
+
+/// Decode a PEI (IMEI or IMEISV) from the content of a 5GS mobile identity IE
+/// (TS 24.501 Section 9.11.3.4) and format it per the TS 29.571 `Pei` pattern.
+///
+/// The identity digits do NOT start at `content[1]`. Octet 4 of the IE -- which
+/// is `content[0]` here -- carries the type of identity in bits 1-3, the
+/// odd/even indicator in bit 4, and **identity digit 1 in bits 5-8**. Slicing
+/// from `content[1]` therefore drops the first digit and yields a value one
+/// digit short, which is the defect this helper exists to prevent.
+///
+/// Returns `(pei, digits)`, where `pei` is `imei-<15 digits>` or
+/// `imeisv-<16 digits>` -- the prefix is chosen from the type-of-identity
+/// field, never assumed -- and `digits` is the bare identity.
+///
+/// Returns `None` when the content is too short, the type is neither IMEI nor
+/// IMEISV, digit 1 is not a decimal digit, or the recovered digit count does
+/// not match the type. A malformed identity yields NO PEI rather than one that
+/// violates the `Pei` pattern: absent is checkable by a peer, wrong is not.
+///
+/// Both the Identity Response and the Security Mode Complete paths route
+/// through here so the two cannot diverge again.
+fn decode_pei(content: &[u8]) -> Option<(String, String)> {
+    if content.len() < 2 {
+        return None;
+    }
+    let (prefix, expected_digits) = match content[0] & 0x07 {
+        t if t == mobile_identity_type::IMEI => ("imei", 15),
+        t if t == mobile_identity_type::IMEISV => ("imeisv", 16),
+        _ => return None,
+    };
+
+    // Identity digit 1 shares octet 4 with the type-of-identity field.
+    let digit1 = (content[0] >> 4) & 0x0f;
+    if digit1 > 9 {
+        return None;
+    }
+    let mut digits = String::with_capacity(expected_digits);
+    digits.push((b'0' + digit1) as char);
+    digits.push_str(&decode_bcd_digits(&content[1..]));
+
+    if digits.len() != expected_digits {
+        return None;
+    }
+    Some((format!("{prefix}-{digits}"), digits))
 }
 
 /// Decode (nibble-swapped) BCD digits, skipping 0xF fillers
@@ -6634,14 +6787,132 @@ mod tests {
     #[test]
     fn test_supi_from_suci() {
         assert_eq!(
-            supi_from_suci("suci-0-999-70-0-0-0-0000000001"),
-            "imsi-999700000000001"
+            supi_from_suci("suci-0-999-70-0-0-0-0000000001").as_deref(),
+            Some("imsi-999700000000001")
         );
-        // Non-SUCI strings pass through
+        // Already-de-concealed SUPIs pass through
         assert_eq!(
-            supi_from_suci("imsi-001010000000001"),
-            "imsi-001010000000001"
+            supi_from_suci("imsi-001010000000001").as_deref(),
+            Some("imsi-001010000000001")
         );
+    }
+
+    /// A protected (ECIES) SUCI carries ciphertext, not the MSIN, so no SUPI
+    /// can be derived from it -- and the derived value would otherwise seed
+    /// `nextgcore_kdf_kamf` and UECM registration (#73 criterion 5).
+    ///
+    /// The scheme id is the load-bearing gate, which is why the profile-A and
+    /// profile-B cases below use an ALL-DIGIT scheme output: a digits-only
+    /// check would pass them, and only reading the scheme id rejects them.
+    #[test]
+    fn supi_from_suci_refuses_a_protected_suci() {
+        // ECIES profile A (scheme 1) with a scheme output that is all digits.
+        assert_eq!(
+            supi_from_suci("suci-0-999-70-0-1-1-0123456789012345678901234567890123456789"),
+            None
+        );
+        // ECIES profile B (scheme 2), likewise all digits.
+        assert_eq!(supi_from_suci("suci-0-999-70-0-2-1-9876543210"), None);
+        // An unknown or future scheme is refused rather than treated as null.
+        assert_eq!(supi_from_suci("suci-0-999-70-0-7-1-1234567890"), None);
+        // A non-numeric scheme id is not silently read as the null scheme.
+        assert_eq!(supi_from_suci("suci-0-999-70-0-x-1-1234567890"), None);
+
+        // The null scheme with the SAME shape is still accepted, so the
+        // rejections above are attributable to the scheme id and nothing else.
+        assert_eq!(
+            supi_from_suci("suci-0-999-70-0-0-1-9876543210").as_deref(),
+            Some("imsi-999709876543210")
+        );
+    }
+
+    #[test]
+    fn supi_from_suci_refuses_malformed_input() {
+        // Hex ciphertext that is not all digits (the common case).
+        assert_eq!(supi_from_suci("suci-0-999-70-0-0-0-deadbeef"), None);
+        // Empty MSIN.
+        assert_eq!(supi_from_suci("suci-0-999-70-0-0-0-"), None);
+        // Too few fields.
+        assert_eq!(supi_from_suci("suci-0-999-70-0-0"), None);
+        // Non-IMSI SUPI type (network-specific identifier).
+        assert_eq!(supi_from_suci("suci-1-999-70-0-0-0-1234567890"), None);
+        // Neither a SUCI nor an imsi- SUPI.
+        assert_eq!(supi_from_suci("nai-user@example.com"), None);
+        // An imsi- SUPI whose digits are not digits.
+        assert_eq!(supi_from_suci("imsi-unknown"), None);
+        assert_eq!(supi_from_suci("imsi-"), None);
+    }
+
+    /// Identity digit 1 lives in the HIGH NIBBLE of octet 4, alongside the
+    /// type-of-identity field, so the digits do not start at `content[1]`
+    /// (TS 24.501 Section 9.11.3.4). Decoding from `content[1..]` drops digit 1
+    /// and yields a value one digit short (#73 criterion 4).
+    ///
+    /// These vectors assert the FULL digit string, so reverting the fix makes
+    /// them fail on both the count and the value -- not merely on a prefix.
+    #[test]
+    fn decode_pei_recovers_digit_one_and_selects_the_prefix_by_type() {
+        // IMEISV 1234567890123456: 16 digits, so digit 1 in octet 4's high
+        // nibble plus 15 digits over 8 octets, the last high nibble a filler.
+        //   octet 4 = digit1(1) << 4 | even/odd(0) | type(IMEISV=5) = 0x15
+        let imeisv = [0x15, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0x54, 0xf6];
+        let (pei, digits) = decode_pei(&imeisv).expect("IMEISV decodes");
+        assert_eq!(digits, "1234567890123456");
+        assert_eq!(pei, "imeisv-1234567890123456");
+
+        // IMEI 123456789012345: 15 digits, digit 1 plus 14 over 7 octets.
+        //   octet 4 = digit1(1) << 4 | odd(1) << 3 | type(IMEI=3) = 0x1b
+        let imei = [0x1b, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0x54];
+        let (pei, digits) = decode_pei(&imei).expect("IMEI decodes");
+        assert_eq!(digits, "123456789012345");
+        assert_eq!(pei, "imei-123456789012345");
+    }
+
+    /// Both emitted forms must satisfy the TS 29.571 `Pei` pattern
+    /// (`imei-[0-9]{15}` / `imeisv-[0-9]{16}`), which is what the old
+    /// unconditional `imeisv-` prefix violated for a 15-digit IMEI.
+    #[test]
+    fn decode_pei_output_matches_the_pei_pattern() {
+        for (content, prefix, len) in [
+            (
+                vec![0x15, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0x54, 0xf6],
+                "imeisv-",
+                16,
+            ),
+            (
+                vec![0x1b, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0x54],
+                "imei-",
+                15,
+            ),
+        ] {
+            let (pei, _) = decode_pei(&content).expect("decodes");
+            let digits = pei.strip_prefix(prefix).expect("expected prefix");
+            assert_eq!(digits.len(), len, "{pei} has the wrong digit count");
+            assert!(
+                digits.bytes().all(|b| b.is_ascii_digit()),
+                "{pei} is not all digits"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_pei_refuses_malformed_identities() {
+        // Right type, wrong digit count (an IMEI's octets labelled IMEISV):
+        // emitting this would break the `Pei` pattern.
+        assert_eq!(
+            decode_pei(&[0x15, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0x54]),
+            None
+        );
+        // Digit 1 is a 0xF filler, not a digit.
+        assert_eq!(
+            decode_pei(&[0xf5, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0x54, 0xf6]),
+            None
+        );
+        // Not an equipment identity at all (SUCI type).
+        assert_eq!(decode_pei(&[0x11, 0x32, 0x54]), None);
+        // Too short to carry a type plus any digits.
+        assert_eq!(decode_pei(&[0x15]), None);
+        assert_eq!(decode_pei(&[]), None);
     }
 
     #[test]

--- a/src/bins/nextgcore-udrd/src/data_store.rs
+++ b/src/bins/nextgcore-udrd/src/data_store.rs
@@ -833,6 +833,21 @@ pub fn init_store(state_path: Option<PathBuf>) -> bool {
 // Helpers: URI handling, RFC 7396 merge-patch, notification dispatch
 // ---------------------------------------------------------------------------
 
+/// Strip the TS 29.571 `Pei` type prefix, returning the bare equipment-identity
+/// digits.
+///
+/// A `Pei` is `imei-<15 digits>` OR `imeisv-<16 digits>` -- both forms are
+/// valid and the AMF emits whichever the UE actually reported. Stripping only
+/// `imeisv-` leaves an `imei-` value stored with its prefix intact, so the
+/// persisted identity becomes the literal `"imei-35..."` rather than digits.
+/// Order matters: `imeisv-` must be tried first, since `imei` is a prefix of it
+/// only up to the `s`, and an unprefixed value is passed through unchanged.
+pub fn imeisv_from_pei(pei: &str) -> &str {
+    pei.strip_prefix("imeisv-")
+        .or_else(|| pei.strip_prefix("imei-"))
+        .unwrap_or(pei)
+}
+
 /// RFC 7396 JSON merge-patch applied in place.
 pub fn merge_patch(target: &mut Value, patch: &Value) {
     if let Value::Object(patch_obj) = patch {
@@ -1541,5 +1556,33 @@ mod tests {
             t.policy_ue_get("imsi-1"),
             Some(json!({"subscPolicySections": {}}))
         );
+    }
+
+    /// A `Pei` is `imei-<15>` OR `imeisv-<16>`. Stripping only `imeisv-`
+    /// persisted the literal `"imei-35..."` as the equipment identity once the
+    /// AMF started emitting the correct prefix for a 15-digit IMEI (#73
+    /// criterion 4).
+    #[test]
+    fn imeisv_from_pei_strips_either_pei_prefix() {
+        assert_eq!(
+            imeisv_from_pei("imeisv-1234567890123456"),
+            "1234567890123456"
+        );
+        assert_eq!(imeisv_from_pei("imei-123456789012345"), "123456789012345");
+        // Already-bare digits and unknown forms pass through unchanged.
+        assert_eq!(imeisv_from_pei("123456789012345"), "123456789012345");
+        assert_eq!(imeisv_from_pei(""), "");
+        // No output ever retains a prefix.
+        for pei in [
+            "imeisv-1234567890123456",
+            "imei-123456789012345",
+            "123456789012345",
+        ] {
+            let out = imeisv_from_pei(pei);
+            assert!(
+                out.bytes().all(|b| b.is_ascii_digit()),
+                "{pei} -> {out} kept a non-digit"
+            );
+        }
     }
 }

--- a/src/bins/nextgcore-udrd/src/main.rs
+++ b/src/bins/nextgcore-udrd/src/main.rs
@@ -901,7 +901,7 @@ async fn handle_amf_3gpp_access(supi: &str, method: &str, request: &SbiRequest) 
             // Persist the PEI (IMEISV) claim off-thread (last live
             // blocking Mongo call moved to the spawn_blocking wrapper).
             if let Some(pei) = reg_data.get("pei").and_then(|v| v.as_str()) {
-                let imeisv = pei.strip_prefix("imeisv-").unwrap_or(pei).to_string();
+                let imeisv = data_store::imeisv_from_pei(pei).to_string();
                 if let Err(e) = nextgcore_dbi::subscription::nextgcore_dbi_update_imeisv_async(
                     supi.to_string(),
                     imeisv,

--- a/src/bins/nextgcore-udrd/src/nudr_handler.rs
+++ b/src/bins/nextgcore-udrd/src/nudr_handler.rs
@@ -261,12 +261,9 @@ pub fn handle_subscription_context(event: &UdrEvent, stream_id: u64) {
                                 {
                                     if let Some(pei) = reg_data.get("pei").and_then(|v| v.as_str())
                                     {
-                                        // PEI format: "imeisv-XXXXXXXXXXXXXXXX"
-                                        let imeisv = if pei.starts_with("imeisv-") {
-                                            &pei[7..]
-                                        } else {
-                                            pei
-                                        };
+                                        // Pei is imei-<15> OR imeisv-<16>;
+                                        // strip whichever prefix is present.
+                                        let imeisv = crate::data_store::imeisv_from_pei(pei);
                                         if let Err(e) =
                                             nextgcore_dbi::subscription::nextgcore_dbi_update_imeisv(
                                                 supi, imeisv,


### PR DESCRIPTION
Closes #73 (criteria 4 and 5). Criterion 6 is split to #204 and the `gpsi` remainder to #205 — both because they belong in other NFs; see **Scope** below.

Spec: `specs/fix-amf-n11-supi-and-serving-network.md` (pass 2 section).

Two defects on the identity path, both verified present at `d9aea74`.

## Criterion 4 — the PEI was one digit short and every IMEI was mislabelled

The defect is in **octet 4**. `content[0]` carries the type of identity in bits 1-3, the odd/even indicator in bit 4, and **identity digit 1 in bits 5-8** (TS 24.501 §9.11.3.4). Both sites decoded from `content[1..]`, so every PEI dropped its first digit. Confirmed independently before fixing: the IMEISV vector decodes to `234567890123456` under the old slice — 15 digits, digit 1 gone — against `1234567890123456` now.

New `decode_pei` returns the `Pei` string and the bare digits, and:

* **reads the prefix from the type-of-identity field rather than assuming it.** The old code emitted `imeisv-` for both arms, so a 15-digit IMEI violated the TS 29.571 `Pei` pattern (`imei-[0-9]{15}` vs `imeisv-[0-9]{16}`);
* **requires the digit count to match the type, emitting no PEI when it does not.** A malformed identity must not become one that breaks the pattern downstream — the same omit-never-placehold rule as #203.

Two things worth calling out for review:

**`decode_bcd_digits` was deliberately left alone.** It has four callers and two of them are the SUCI parser (routing digits and MSIN), so teaching it to recover digit 1 — the obvious fix — would have corrupted SUCI parsing for every registration. The two PEI sites route onto the new helper instead, which is also what stops them diverging again.

**Emitting a correct `imei-` prefix would have broken udrd.** Two sites did `strip_prefix("imeisv-").unwrap_or(pei)` (`main.rs:904`, `nudr_handler.rs:265`), which stores the literal `"imei-353…"` — prefix included — as the equipment identity. So the producer becomes conformant and the stored data becomes garbage on the same commit. Found by grepping the consumers *before* shipping the producer change; fixed with one shared `data_store::imeisv_from_pei` used by both, since they were two copies of the same three lines across the lib and the bin.

One cite in the issue was slightly wrong, in the safe direction: the Security Mode Complete site **already** gated on `content[0] & 0x07 == IMEISV`, so its prefix was correct and only the dropped digit was a defect there. The Identity Response site accepted `IMEI || IMEISV` and had both.

## Criterion 5 — the scheme id is the gate, not the digit check

`supi_from_suci` concatenated `parts[2]`/`parts[3]`/`parts[7]` without inspecting `parts[5]`, the protection scheme id. For an ECIES SUCI `parts[7]` is hex-encoded **ciphertext**, so the result was a fabricated SUPI that then seeded `nextgcore_kdf_kamf` and UECM registration.

The load-bearing detail: **an all-digit MSIN check alone is not sufficient**, because a hex ciphertext can be all decimal digits by chance. The scheme id is checked first, and the tests prove the attribution — the profile-A and profile-B rejection vectors use all-digit scheme outputs, and a null-scheme SUCI of the *same shape* is asserted to still succeed.

The signature became `Option<String>`, **mirroring `supi_from_suci` in nextgcore-udmd's `context.rs`, which already returned `Option` for exactly this reason** — the sibling stack had the right answer and the AMF had the wrong one. Both callers now **fail closed** (registration reject + UE release), mirroring the NIA-selection precedent already in the same function. Deriving K_AMF under a fabricated identity is not a degraded outcome; it keys the whole NAS security context to the wrong subscriber (TS 33.501 §6.1.3).

## Scope

**Criterion 6 (default DNN) → #204.** amfd retrieves only `am-data`, never `sm-data` where `dnnConfigurations` lives, so implementing the criterion literally means adding a new southbound call to the AMF — and per TS 23.501 §6.2.2 the **SMF** is the NF that retrieves SM subscription data, so that call would sit in the wrong NF. This also corrects a claim in #203's spec note: smfd does **not** already retrieve it — it never issues a `nudm-sdm` request, and its only mention is an unreachable response arm at `gsm_sm.rs:302`. The producer chain does exist (udmd serves `sm-data` at `app.rs:663`, proxying udrd's `build_sm_data`), so #204 is a missing consumer, not a missing capability. **Sequencing is load-bearing and stated there:** amfd must keep its `internet` fallback until #204 lands, or DNN-less sessions would get no DNN at all.

**`gpsi` → #205.** The value sits in the `am-data` the AMF already fetches and is simply never parsed or stored.

Note the count arithmetic goes the **wrong** way, as CONVENTIONS warns: closing #73 while filing two honest follow-ups moves the open count 65 → 66.

## Verification

Six new tests. Workspace **5728 passed / 0 failed** (was 5722), `cargo test --workspace` exit 0 — checked for `^error` rather than only a `test result:` line. `cargo fmt --all --check` clean. `cargo clippy --workspace` (the CI gate) exit 0, zero warnings.

**Revert-verified**, one at a time, each failing on the *value* and not merely on a status:

| revert | test that fails | wrong value produced |
|---|---|---|
| decode from `content[1..]` again | `decode_pei_recovers_digit_one_and_selects_the_prefix_by_type` | 15 digits, digit 1 dropped |
| hardcode the `imeisv-` prefix | same, plus `decode_pei_output_matches_the_pei_pattern` | `imeisv-123456789012345` |
| drop the SUCI scheme gate | `supi_from_suci_refuses_a_protected_suci` | `imsi-99970<ciphertext>` |
| strip only `imeisv-` in udrd | `imeisv_from_pei_strips_either_pei_prefix` | `imei-123456789012345` |

## Not verified — the ceiling, stated plainly

* The two **caller** rejection paths are **not executed by any test**. amfd has no harness driving `handle_authentication_confirm` or `complete_registration` — there are zero tests for either today — and building one is disproportionate to this change. What holds them is structural: `let Some(supi) = … else { … return }` cannot fall through, so the compiler guarantees no path reaches key derivation with an unresolved SUPI. That is weaker than a test and is recorded as such.
* No real UE, gNB or AUSF was involved. PEI decoding is asserted on hand-built IE octets whose encodings were verified independently before use, not observed off a live radio link.
* `cargo clippy --workspace --all-targets` fails with 7 errors in `nextgcore-sbi` and `nextgcore-hssd` — **pre-existing**, confirmed identical on clean `main` by stashing, and outside every file touched here. CI gates on `cargo clippy --workspace`, which passes.
* **GitNexus impact analysis, which this repo's CLAUDE.md mandates before editing a symbol, was not run** — no GitNexus MCP server was connected in that session. Caller analysis was done with grep instead: 4 `decode_bcd_digits` callers, 2 `supi_from_suci` callers in amfd plus a separate same-named function in udmd, 2 `Pei`-prefix consumers in udrd.

**A dead site, verified and deliberately left:** `gmm_handler::handle_security_mode_complete` also formats `imeisv-{imeisv}` (`:504`). It has no production caller — only its own two tests — and its input is an already-decoded `Option<String>` carrying no type information, so it could not select a prefix even if wired; its prefix is also correct for the path it models. Noted so it is not mistaken for a missed site.
