### PR TITLE
fix(scpd,sbi): mint the delegated Model D token for the consumer, not the SCP (Closes #101)

### DIFF
--- a/specs/fix-scp-model-d-token-and-discovery-confidentiality.md
+++ b/specs/fix-scp-model-d-token-and-discovery-confidentiality.md
@@ -3,9 +3,10 @@
 Verified against `main` @ `8c15bb6`. The issue's cites are from `76ea248`; all four were
 re-verified and all four still hold, at new line numbers.
 
-`Refs #101`, **not Closes** — see "Scope actually shipped" below. This ships criterion 1,
-the discovery-encoding hard breaker. Criteria 2–4 and defects 3–7 remain open on #101, with
-the design for 2–4 recorded here so it need not be re-derived.
+**Two passes.** Pass 1 (`Refs #101`) shipped criterion 1, the discovery-encoding hard breaker;
+it is documented below. Pass 2 (`Closes #101`) ships criteria 2, 3 and 4 — the delegated token
+identity, scope and per-consumer cache — and files defects 3–7 as #207–#211. See "Pass 2" at
+the end.
 
 ## Verified against current main
 
@@ -176,3 +177,118 @@ is the peer whose rejection motivated the issue. CI skips Docker E2E.
 * **#101 remains open** for criteria 2-4, with the design in Decisions 2 and 3 above. The
   open count deliberately does not move.
 * Defects 3-7 still to be filed as separate issues per the issue's own instruction.
+
+---
+
+# Pass 2 (`Closes #101`): criteria 2, 3 and 4
+
+Verified against `main` @ `562b4a1`. Decisions 2 and 3 above were implemented as written; two of
+their stated premises turned out to be wrong, and both corrections are recorded here rather than
+left for the next reader to trip over.
+
+## Correction 1: the blast radius was 2 direct callers, not ~15
+
+Decision 3 justified adding a method by "`OAuth2Client::get_token` is used by ~15 NFs". The real
+count is **2** direct callers outside `oauth.rs` (`scpd/proxy.rs` and `sbi/client.rs`); 13 crates
+reach it *indirectly* through `SbiClient::with_oauth2`. The decision still stands — a new method
+keeps the non-delegated path unchanged **by construction** rather than by review, which is worth
+more than the call-count argument it was justified with — but the number was wrong.
+
+## Correction 2: `forward()` was already acquiring the token, so this was not a restructure
+
+Pass 1 recorded the blocker as: `with_oauth2` "attaches the token automatically and has no
+per-request hook, so a consumer-scoped token requires the delegated path to acquire and attach
+the token itself, bypassing that integration. That is a restructure of `forward()`."
+
+`forward()` **already** acquired the token itself, to prime the cache so L1's attach step would
+not make a second NRF round-trip. And L1 attaches only when the request carries no
+`Authorization` (`client.rs:596`). So the seam already existed: `forward()` sets the
+`Authorization` header from the consumer-scoped token, and L1's attach becomes a no-op **by
+construction** rather than by ordering luck. No restructure — roughly thirty lines.
+
+This is worth noting as a pattern: the blocker recorded at the end of a long session was a
+plausible reading of the code that one more look disconfirmed. It cost a session's hesitation.
+
+## What shipped
+
+**Criterion 2 — identity, per Decision 2's three-way rule.** `TokenConsumer { nf_instance_id,
+nf_type, cca }` names who a token is for. `request_token_on_behalf_of` chooses the CCA by **who
+the body names**, which is the load-bearing detail: the consumer's own CCA when it supplied one;
+our key when the body names us; and **no assertion** when the body names a third party who gave
+us nothing — because `build_cca` mints `sub` = `self.nf_instance_id`, so signing there would emit
+a CCA whose subject contradicts the body. That is worse than sending none: it is a verifiable
+proof of the wrong claim.
+
+`ScpProxy::delegated_auth` resolves the three cases and logs case 3, so an operator can tell an
+SCP-attested token from a consumer-attested one. `trust_requester_identity` (default off) is the
+operator declaration for an NRF that does not require client authentication.
+
+One asymmetry found while implementing: `requester-nf-type` is mandatory for delegated discovery
+but `requester-nf-instance-id` is **optional**, so a consumer can be typed without being named. An
+unnamed consumer cannot be asserted at all and falls to case 3 regardless of any CCA.
+
+**Criterion 3 — scope and CCA.** `3gpp-Sbi-Access-Scope` now sets the token scope, winning over
+the URI-derived service name. Both constants already existed in `constants.rs` with **zero**
+readers — `CLIENT_CREDENTIALS` and `ACCESS_SCOPE` — the same dead-constant shape as
+`3gpp-Sbi-Callback` (now #210). The consumer's CCA is stripped from the forwarded request: it
+authenticates to the NRF's token endpoint and is not a producer-facing credential.
+
+**Criterion 4 — cache.** `CacheKey` becomes `(consumer, target_nf_type, scope)`. For an ordinary
+NF the consumer is always itself, so the key gains a constant component and caching is
+behaviour-identical. `invalidate` replaces the retry path's `clear_cache`, because one consumer's
+401 should not re-mint the whole fleet's tokens.
+
+## Verification
+
+Seven new tests. Workspace **5735 passed / 0 failed** (was 5728), `cargo test --workspace` exit 0,
+checked for `^error` rather than only a `test result:` line. `cargo fmt --all --check` clean;
+`cargo clippy --workspace` (the CI gate) exit 0.
+
+**Revert-verified**, one at a time. Revert A reproduces the original defect body verbatim:
+
+| revert | test that fails | observed wrong value |
+|---|---|---|
+| token names the SCP again | `delegated_token_asserts_the_consumer_identity_when_the_consumer_attests_it` | `nfInstanceId=scp-instance-1&nfType=SCP` |
+| treat a missing CCA as trusted | `delegated_token_stays_scp_attested_without_a_consumer_cca` | consumer asserted unattested |
+| mint our own CCA for a third party | (same as A) | consumer's CCA absent |
+| ignore `Access-Scope` | `access_scope_header_sets_the_delegated_token_scope` | `scope=nudm-uecm` |
+| consumer-agnostic cache key | `two_consumers_of_one_target_scope_each_get_their_own_token` (+ the `oauth` unit test) | 1 token request for 2 consumers |
+| relay the CCA onward | (same as A) | `cca_leaked: true` |
+| let L1 attach instead | (same as A) | a second, SCP-identity token request |
+
+The scope test is built so that only reading the header can pass it: the URI says `nudm-uecm`
+and the header says `nudm-sdm`. The protected-identity tests likewise assert on the **absence**
+of `scp-instance-1` *and* the presence of the consumer, so a change that emits both cannot pass.
+
+**Not verified:**
+
+* No conformant external NRF was involved. The token request body is asserted against a mock NRF
+  that records it — the same ceiling pass 1 recorded, and the reason #101 needed an external NRF
+  to surface at all. In particular **case 1 has never been exercised against an NRF that actually
+  verifies a consumer CCA**: the mock accepts any body, so what is proven is that the SCP *sends*
+  the consumer's identity and assertion, not that a real NRF accepts them.
+* `build_cca` returns `None` unless a signing key is configured, and the tests configure none, so
+  the "our key, our identity" arm is covered only by the third-party-identity path.
+* Docker E2E remains skipped by CI.
+* GitNexus impact analysis, mandated by this repo's CLAUDE.md, was **not run** — no GitNexus MCP
+  server was connected. Caller analysis was grep-based: 2 direct `get_token` callers, 13
+  `with_oauth2` crates, `TokenCache` only re-exported and never used outside `oauth.rs`.
+
+## Defects 3-7, now filed
+
+* **#207** — producer `NFService` selected without matching service name or API version; no `INVALID_API`.
+* **#208** — relay drops `nfSetId`/`nfGroupId` on a cache hit, overwrites `Producer-Id`, no `Target-apiRoot`/`Location` absolutisation.
+* **#209** — no alternate-producer reselection; connection-refused returns 502 not 504.
+* **#210** — `3gpp-Sbi-Callback` never inspected.
+* **#211** — NRF-unreachable / NRF-error / empty-`SearchResult` all collapse to 502, and an unreachable NRF reports `TARGET_NF_NOT_REACHABLE`.
+
+Count arithmetic, honestly: closing #101 while filing five follow-ups moves the open count the
+**wrong way**. Pass 1 predicted 61 → 65; the actual backlog is larger now, so quote both numbers
+when reporting rather than the issues-closed figure alone.
+
+## Definition of done (pass 2)
+
+- [x] Delegated token request carries the consumer's identity when attestable
+- [x] `3gpp-Sbi-Access-Scope` populated; consumer CCA forwarded to the NRF and stripped from the producer request
+- [x] `TokenCache` keyed by consumer; invalidation scoped to one consumer
+- [x] Defects 3-7 filed as #207-#211

--- a/src/bins/nextgcore-scpd/src/proxy.rs
+++ b/src/bins/nextgcore-scpd/src/proxy.rs
@@ -31,7 +31,7 @@ use nextgcore_sbi::constants::{custom_header, discovery_header};
 use nextgcore_sbi::message::{
     ProblemDetails, SbiHttpMessage, SbiRequest, SbiResponse, UriComponents,
 };
-use nextgcore_sbi::oauth::OAuth2Client;
+use nextgcore_sbi::oauth::{OAuth2Client, TokenConsumer};
 use nextgcore_sbi::types::{NfType, UriScheme};
 use nextgcore_sbi::SbiError;
 
@@ -133,6 +133,22 @@ pub struct ScpProxyConfig {
     pub circuit_failure_threshold: u32,
     /// Time a tripped circuit stays Open before admitting a probe.
     pub circuit_open_timeout: Duration,
+    /// Assert the requesting consumer's identity in a delegated (Model D) token
+    /// request **even when the consumer supplied no CCA of its own**
+    /// (nextgcore #101 criterion 2).
+    ///
+    /// Default `false`, and that default is not timidity. After #64 the NRF's
+    /// token endpoint authenticates the requester by a CCA keyed to
+    /// `nfInstanceId`; the SCP can only sign with its OWN key, so naming the
+    /// consumer in the body while signing as ourselves produces a request a
+    /// conformant NRF rejects. Asserting the consumer's identity is therefore
+    /// only safe when the consumer attests it (its own CCA — the conformant
+    /// Model D case, TS 33.501 §13.4.1.3.2) or when the operator declares the
+    /// NRF does not require client authentication, which is what this flag is.
+    ///
+    /// Set it only for such an NRF: with it on and no consumer CCA, the token
+    /// request carries an unattested identity.
+    pub trust_requester_identity: bool,
 }
 
 impl Default for ScpProxyConfig {
@@ -148,6 +164,7 @@ impl Default for ScpProxyConfig {
             cache_ttl: DEFAULT_CACHE_TTL,
             circuit_failure_threshold: DEFAULT_CIRCUIT_FAILURE_THRESHOLD,
             circuit_open_timeout: DEFAULT_CIRCUIT_OPEN_TIMEOUT,
+            trust_requester_identity: false,
         }
     }
 }
@@ -228,6 +245,25 @@ fn normalize_binding(value: &str) -> String {
         .filter(|c| !c.is_whitespace())
         .collect::<String>()
         .to_ascii_lowercase()
+}
+
+/// Everything the SCP needs to mint a delegated (Model D) access token for the
+/// NF Service Consumer that sent the request (TS 33.501 §13.4.1.3.2).
+#[derive(Debug, Clone)]
+struct DelegatedAuth {
+    /// NF type of the discovered producer — the token's `targetNfType`.
+    target_nf_type: NfType,
+    /// Whose token this is. Either the consumer (when its identity can be
+    /// attested) or the SCP itself; see [`ScpProxy::delegated_auth`].
+    consumer: TokenConsumer,
+    /// The scope the consumer explicitly asked for in `3gpp-Sbi-Access-Scope`,
+    /// if any. When absent the scope is derived from the request URI's service
+    /// name, as before.
+    requested_scope: Option<String>,
+    /// True when `consumer` is the requester rather than the SCP. Only used for
+    /// logging, so an operator can tell an SCP-attested token from a
+    /// consumer-attested one.
+    consumer_attested: bool,
 }
 
 /// Remove any `Authorization` header (case-insensitive) from a forwardable
@@ -911,6 +947,116 @@ impl ScpProxy {
         Some(client)
     }
 
+    /// Resolve whose identity a delegated token request should assert
+    /// (nextgcore #101 criterion 2, TS 33.501 §13.4.1.3.2).
+    ///
+    /// The governing rule is **never assert an identity you cannot attest**.
+    /// Sending the consumer's `nfInstanceId` unconditionally would break the
+    /// delegated path outright against our own NRF: after #64 that token
+    /// endpoint requires a CCA keyed to the `nfInstanceId` in the body, and the
+    /// SCP can only sign with its own key. Consumer identity and an
+    /// SCP-signed CCA are therefore mutually exclusive, which is why a bare
+    /// feature flag would just turn delegated discovery off.
+    ///
+    /// So, in order:
+    ///
+    /// 1. the consumer conveyed its own CCA in `3gpp-Sbi-Client-Credentials`
+    ///    → assert the consumer's identity and forward that CCA, which the NRF
+    ///    verifies against the consumer's registered key. This is the
+    ///    conformant Model D case;
+    /// 2. no consumer CCA, but the operator set `trust_requester_identity` for
+    ///    an NRF that does not require client authentication → assert the
+    ///    consumer's identity with no assertion attached;
+    /// 3. otherwise → keep the SCP's own identity and log, so the token is
+    ///    honestly SCP-attested rather than a forgery of the consumer's.
+    ///
+    /// Note the asymmetry with discovery: `requester-nf-type` is mandatory for
+    /// delegated discovery (rejected with 400 in [`ScpProxy::discover`]) but
+    /// `requester-nf-instance-id` is optional, so a consumer can be typed
+    /// without being named. An unnamed consumer cannot be asserted at all, and
+    /// falls to case 3 regardless of the other inputs.
+    fn delegated_auth(&self, request: &SbiRequest, target_nf_type: NfType) -> DelegatedAuth {
+        let requested_scope = request
+            .http
+            .get_header(custom_header::ACCESS_SCOPE)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        let scp_consumer = || {
+            self.oauth2
+                .as_ref()
+                .map(|o| o.self_consumer())
+                .unwrap_or_else(|| {
+                    TokenConsumer::new(
+                        self.config
+                            .nf_instance_id
+                            .clone()
+                            .unwrap_or_else(|| DEFAULT_SCP_NF_INSTANCE_ID.to_string()),
+                        NfType::Scp,
+                    )
+                })
+        };
+
+        // The consumer must be both named and typed before it can be asserted.
+        let requester = request
+            .http
+            .get_header(discovery_header::REQUESTER_NF_INSTANCE_ID)
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .and_then(|id| {
+                request
+                    .http
+                    .get_header(discovery_header::REQUESTER_NF_TYPE)
+                    .and_then(|t| nf_type_from_str(t))
+                    .map(|nf_type| (id.to_string(), nf_type))
+            });
+
+        let consumer_cca = request
+            .http
+            .get_header(custom_header::CLIENT_CREDENTIALS)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        match requester {
+            Some((id, nf_type)) => match consumer_cca {
+                // Case 1: attested by the consumer itself.
+                Some(cca) => DelegatedAuth {
+                    target_nf_type,
+                    consumer: TokenConsumer::new(id, nf_type).with_cca(cca),
+                    requested_scope,
+                    consumer_attested: true,
+                },
+                // Case 2: attested by operator declaration.
+                None if self.config.trust_requester_identity => DelegatedAuth {
+                    target_nf_type,
+                    consumer: TokenConsumer::new(id, nf_type),
+                    requested_scope,
+                    consumer_attested: true,
+                },
+                // Case 3: not attestable — stay honest about who we are.
+                None => {
+                    log::debug!(
+                        "SCP Model D: consumer {id} sent no 3gpp-Sbi-Client-Credentials and \
+                         trust_requester_identity is off; requesting an SCP-attested token \
+                         instead of asserting an identity we cannot attest"
+                    );
+                    DelegatedAuth {
+                        target_nf_type,
+                        consumer: scp_consumer(),
+                        requested_scope,
+                        consumer_attested: false,
+                    }
+                }
+            },
+            None => DelegatedAuth {
+                target_nf_type,
+                consumer: scp_consumer(),
+                requested_scope,
+                consumer_attested: false,
+            },
+        }
+    }
+
     /// Decide how to route an incoming request (TS 29.500 §6.10.2):
     /// Target-apiRoot wins; otherwise a Routing-Binding that matches a cached
     /// Binding; otherwise delegated discovery when Discovery headers are
@@ -1115,7 +1261,7 @@ impl ScpProxy {
         target: &ApiRoot,
         producer_id: Option<&str>,
         group_id: Option<&str>,
-        delegated_nf_type: Option<NfType>,
+        delegated: Option<DelegatedAuth>,
     ) -> SbiResponse {
         // scpd-#102: consult this producer's circuit breaker before forwarding.
         // An Open circuit short-circuits to 503 without contacting the producer,
@@ -1161,42 +1307,86 @@ impl ScpProxy {
 
         // Model D: if the SCP can mint a delegated token, drop whatever
         // Authorization the consumer sent (it was scoped to the consumer, not
-        // to this producer) so L1 attaches a fresh, correctly scoped Bearer
-        // token. If no OAuth2 client is configured, fall back to forwarding the
-        // request as-is (Authorization, if any, passes through).
-        let (client, delegated) =
-            match delegated_nf_type.and_then(|nf| self.oauth_client_for(target, nf)) {
-                Some(oauth_client) => {
-                    strip_authorization(&mut fwd.http.headers);
-                    (oauth_client, true)
-                }
-                None => (self.client_for(target), false),
-            };
+        // to this producer) so the delegated Bearer token replaces it. If no
+        // OAuth2 client is configured, fall back to forwarding the request
+        // as-is (Authorization, if any, passes through).
+        let (client, delegated) = match delegated
+            .as_ref()
+            .and_then(|d| self.oauth_client_for(target, d.target_nf_type))
+        {
+            Some(oauth_client) => {
+                strip_authorization(&mut fwd.http.headers);
+                (oauth_client, delegated)
+            }
+            None => (self.client_for(target), None),
+        };
+
+        // The consumer's CCA authenticates it to the NRF's token endpoint; it is
+        // not a producer-facing credential and must not travel onward
+        // (TS 29.500 §5.2.3.2: it is consumed by the token request we make on
+        // the consumer's behalf, below).
+        fwd.http
+            .headers
+            .retain(|k, _| !k.eq_ignore_ascii_case(custom_header::CLIENT_CREDENTIALS));
 
         // scpd: on the Model D delegated path the SCP must obtain a valid OAuth2
         // access token for the producer *before* forwarding (TS 33.501 §13). If
         // the token cannot be acquired — the NRF rejects the Access Token Request
         // or is unreachable — surface the mandated 400 MISSING_ACCESS_TOKEN_INFO /
         // 403 ACCESS_TOKEN_DENIED ProblemDetails instead of silently forwarding
-        // tokenless (TS 29.500 §6.10.11.2.2 / §6.10.11.2.2A). Acquiring here
-        // primes the token cache, so L1's attach step reuses it (no double NRF
-        // round-trip). A no-scope request (no service name) needs no token.
-        if delegated {
-            if let (Some(oauth2), Some(nf)) = (self.oauth2.as_ref(), delegated_nf_type) {
-                let scope = UriComponents::parse(&request.header.uri)
+        // tokenless (TS 29.500 §6.10.11.2.2 / §6.10.11.2.2A).
+        //
+        // #101 criterion 2: the token is minted for the CONSUMER, so this path
+        // attaches the Bearer header ITSELF rather than leaving it to L1.
+        // `SbiClient::with_oauth2` has no per-request hook — it would re-derive
+        // the token from the SCP's own identity — but it only attaches when the
+        // request carries no `Authorization`, so setting the header here makes
+        // its attach step a no-op by construction rather than by ordering luck.
+        //
+        // A no-scope request (no service name and no Access-Scope) needs no token.
+        let token_scope = delegated.as_ref().map(|d| {
+            d.requested_scope.clone().unwrap_or_else(|| {
+                UriComponents::parse(&request.header.uri)
                     .api_name
-                    .unwrap_or_default();
-                if !scope.is_empty() {
-                    if let Err(e) = oauth2.get_token(nf, &scope).await {
+                    .unwrap_or_default()
+            })
+        });
+
+        // scpd-07: keep a pristine (pre-token) copy for a single refresh-and-
+        // retry on a delegated 401/403 Bearer challenge. Cloned BEFORE the
+        // Bearer header is set, so the retry cannot replay the token the
+        // producer just refused.
+        let retry_fwd = if delegated.is_some() {
+            Some(fwd.clone())
+        } else {
+            None
+        };
+
+        if let (Some(oauth2), Some(d), Some(scope)) = (
+            self.oauth2.as_ref(),
+            delegated.as_ref(),
+            token_scope.as_ref(),
+        ) {
+            if !scope.is_empty() {
+                match oauth2
+                    .get_token_on_behalf_of(&d.consumer, d.target_nf_type, scope)
+                    .await
+                {
+                    Ok(token) => {
+                        fwd.http
+                            .set_header("Authorization", format!("Bearer {token}"));
+                        if !d.consumer_attested {
+                            log::debug!(
+                                "SCP Model D: forwarding an SCP-attested token for scope {scope}"
+                            );
+                        }
+                    }
+                    Err(e) => {
                         return self.stamp_server(token_acquisition_failure_response(&e));
                     }
                 }
             }
         }
-
-        // scpd-07: keep a pristine (pre-token) copy for a single refresh-and-
-        // retry on a delegated 401/403 Bearer challenge.
-        let retry_fwd = if delegated { Some(fwd.clone()) } else { None };
 
         let mut upstream = match client.send_request(fwd).await {
             Ok(response) => response,
@@ -1212,12 +1402,34 @@ impl ScpProxy {
         // 401/403 + a Bearer `WWW-Authenticate`, the cached token was refused —
         // invalidate it, mint a fresh one, and retry exactly once
         // (TS 29.500 §6.10.11.2.3). If it still fails, the response is relayed.
-        if delegated
+        if delegated.is_some()
             && matches!(upstream.status, 401 | 403)
             && www_authenticate_is_bearer(&upstream)
         {
-            if let (Some(oauth2), Some(retry)) = (self.oauth2.as_ref(), retry_fwd) {
-                oauth2.clear_cache().await;
+            if let (Some(oauth2), Some(d), Some(scope), Some(mut retry)) = (
+                self.oauth2.as_ref(),
+                delegated.as_ref(),
+                token_scope.as_ref(),
+                retry_fwd,
+            ) {
+                // #101 criterion 4: evict only THIS consumer's token. The
+                // producer refused a token minted for this consumer, which says
+                // nothing about any other consumer's — and clearing the whole
+                // cache would make one consumer's 401 re-mint the entire
+                // fleet's tokens.
+                oauth2
+                    .invalidate_token(&d.consumer, d.target_nf_type, scope)
+                    .await;
+                if !scope.is_empty() {
+                    if let Ok(token) = oauth2
+                        .get_token_on_behalf_of(&d.consumer, d.target_nf_type, scope)
+                        .await
+                    {
+                        retry
+                            .http
+                            .set_header("Authorization", format!("Bearer {token}"));
+                    }
+                }
                 if let Ok(retried) = client.send_request(retry).await {
                     upstream = retried;
                 }
@@ -1303,10 +1515,13 @@ impl ScpProxy {
                 Ok(producer) => {
                     // The producer NF type comes from the delegated-discovery
                     // header; used to scope the OAuth2 token the SCP attaches.
-                    let delegated_nf_type = request
+                    // #101 criterion 2: the token is minted for the requesting
+                    // consumer when its identity can be attested.
+                    let delegated_auth = request
                         .http
                         .get_header(discovery_header::TARGET_NF_TYPE)
-                        .and_then(|s| nf_type_from_str(s));
+                        .and_then(|s| nf_type_from_str(s))
+                        .map(|nf| self.delegated_auth(&request, nf));
                     let producer_id =
                         build_producer_id(&producer.nf_instance_id, producer.nf_set_id.as_deref());
                     log::debug!(
@@ -1321,7 +1536,7 @@ impl ScpProxy {
                         &producer.target,
                         producer_id.as_deref(),
                         producer.nf_group_id.as_deref(),
-                        delegated_nf_type,
+                        delegated_auth,
                     )
                     .await
                 }
@@ -2151,6 +2366,361 @@ mod tests {
         );
         // The SCP actually went to the NRF's token endpoint.
         assert_eq!(token_hits.load(Ordering::SeqCst), 1);
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        producer.stop().await.expect("producer stop");
+    }
+
+    // ------------------------------------------------------------------
+    // #101 criteria 2-4: delegated token identity, scope and per-consumer cache
+    // ------------------------------------------------------------------
+
+    /// A mock NRF that RECORDS each token-request body rather than asserting on
+    /// it, so each test states its own expectation about the identity the SCP
+    /// asserted.
+    async fn start_recording_nrf(
+        port: u16,
+        producer_port: u16,
+        token: &'static str,
+        token_bodies: Arc<tokio::sync::Mutex<Vec<String>>>,
+    ) -> nextgcore_sbi::server::SbiServer {
+        let server = nextgcore_sbi::server::SbiServer::new(
+            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        );
+        server
+            .start(move |request: SbiRequest| {
+                let token_bodies = token_bodies.clone();
+                async move {
+                    if request.header.uri == "/nnrf-oauth2/v1/access-token" {
+                        let body = request.http.content.clone().unwrap_or_default();
+                        token_bodies.lock().await.push(body);
+                        let resp = format!(
+                            r#"{{"access_token":"{token}","token_type":"Bearer","expires_in":3600}}"#
+                        );
+                        return SbiResponse::ok().with_body(resp, "application/json");
+                    }
+                    assert_eq!(request.header.uri, "/nnrf-disc/v1/nf-instances");
+                    let search_result = serde_json::json!({
+                        "validityPeriod": 3600,
+                        "nfInstances": [{
+                            "nfInstanceId": "udm-instance-1",
+                            "nfType": "UDM",
+                            "nfStatus": "REGISTERED",
+                            "ipv4Addresses": ["127.0.0.1"],
+                            "priority": 1,
+                            "capacity": 100,
+                            "load": 0,
+                            "nfServices": [{
+                                "serviceInstanceId": "nudm-uecm-1",
+                                "serviceName": "nudm-uecm",
+                                "ipEndPoints": [{"ipv4Address": "127.0.0.1", "port": producer_port}]
+                            }]
+                        }]
+                    });
+                    SbiResponse::ok().with_body(search_result.to_string(), "application/json")
+                }
+            })
+            .await
+            .expect("nrf start");
+        server
+    }
+
+    /// A producer that echoes the Authorization it received AND whether the
+    /// consumer's CCA header leaked through to it.
+    async fn start_header_echo_producer(port: u16) -> nextgcore_sbi::server::SbiServer {
+        let server = nextgcore_sbi::server::SbiServer::new(
+            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        );
+        server
+            .start(|request: SbiRequest| async move {
+                let echoed = serde_json::json!({
+                    "authorization": request
+                        .http
+                        .get_header("Authorization")
+                        .cloned()
+                        .unwrap_or_default(),
+                    "cca_leaked": request
+                        .http
+                        .get_header(custom_header::CLIENT_CREDENTIALS)
+                        .is_some(),
+                });
+                SbiResponse::ok().with_body(echoed.to_string(), "application/json")
+            })
+            .await
+            .expect("producer start");
+        server
+    }
+
+    /// A Model D request from consumer `amf-instance-7`, optionally attesting
+    /// itself with its own CCA and optionally naming an explicit access scope.
+    fn model_d_request(cca: Option<&str>, access_scope: Option<&str>) -> SbiRequest {
+        let mut request = SbiRequest::post("/nudm-uecm/v1/registrations")
+            .with_body(r#"{"amf":"reg"}"#, "application/json")
+            .with_header(discovery_header::TARGET_NF_TYPE, "UDM")
+            .with_header(discovery_header::REQUESTER_NF_TYPE, "AMF")
+            .with_header(discovery_header::REQUESTER_NF_INSTANCE_ID, "amf-instance-7")
+            .with_header(discovery_header::SERVICE_NAMES, "nudm-uecm");
+        if let Some(cca) = cca {
+            request = request.with_header(custom_header::CLIENT_CREDENTIALS, cca);
+        }
+        if let Some(scope) = access_scope {
+            request = request.with_header(custom_header::ACCESS_SCOPE, scope);
+        }
+        request
+    }
+
+    /// A CCA-shaped value. Only its opacity matters here: the SCP must forward
+    /// it verbatim to the NRF, not interpret it.
+    const CONSUMER_CCA: &str = "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJhbWYtaW5zdGFuY2UtNyJ9.c2lnbmF0dXJl";
+
+    /// #101 criterion 2: when the consumer attests itself with its own CCA, the
+    /// delegated token request must name the CONSUMER — not `nextgcore-scp` /
+    /// `NfType::Scp` — and must forward that CCA so the NRF can verify it
+    /// against the consumer's registered key (TS 33.501 §13.4.1.3.2).
+    #[tokio::test]
+    async fn delegated_token_asserts_the_consumer_identity_when_the_consumer_attests_it() {
+        let (producer_port, nrf_port, scp_port) =
+            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+        let producer = start_header_echo_producer(producer_port).await;
+        let nrf =
+            start_recording_nrf(nrf_port, producer_port, "consumer-token", bodies.clone()).await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                nf_instance_id: Some("scp-instance-1".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let response = fast_client(scp_port)
+            .send_request(model_d_request(Some(CONSUMER_CCA), None))
+            .await
+            .expect("model D roundtrip");
+        assert_eq!(response.status, 200);
+
+        let bodies = bodies.lock().await;
+        assert_eq!(bodies.len(), 1, "exactly one token request");
+        let body = &bodies[0];
+        assert!(
+            body.contains("nfInstanceId=amf-instance-7"),
+            "token must be minted for the consumer, got: {body}"
+        );
+        assert!(
+            body.contains("nfType=AMF"),
+            "token nfType must be the consumer's, got: {body}"
+        );
+        assert!(
+            !body.contains("scp-instance-1") && !body.contains("nfType=SCP"),
+            "the SCP must not name itself once the consumer is attested, got: {body}"
+        );
+        // The consumer's assertion is forwarded verbatim (percent-encoded).
+        assert!(
+            body.contains("cca=eyJhbGciOiJFUzI1NiJ9"),
+            "the consumer's CCA must be forwarded, got: {body}"
+        );
+
+        // The CCA authenticates to the NRF only; it must not reach the producer.
+        let echoed: serde_json::Value = response.json_body().unwrap();
+        assert_eq!(echoed["authorization"], "Bearer consumer-token");
+        assert_eq!(
+            echoed["cca_leaked"], false,
+            "3gpp-Sbi-Client-Credentials must not be relayed to the producer"
+        );
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        producer.stop().await.expect("producer stop");
+    }
+
+    /// The other half of the rule, and the reason a blind feature flag would be
+    /// wrong: with no consumer CCA the SCP cannot attest the consumer's
+    /// identity, so it must name ITSELF rather than assert an identity it
+    /// cannot prove. Naming the consumer here would be rejected by our own NRF
+    /// after #64, because the CCA we can sign has `sub` = the SCP.
+    #[tokio::test]
+    async fn delegated_token_stays_scp_attested_without_a_consumer_cca() {
+        let (producer_port, nrf_port, scp_port) =
+            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+        let producer = start_header_echo_producer(producer_port).await;
+        let nrf = start_recording_nrf(nrf_port, producer_port, "scp-token", bodies.clone()).await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                nf_instance_id: Some("scp-instance-1".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let response = fast_client(scp_port)
+            .send_request(model_d_request(None, None))
+            .await
+            .expect("model D roundtrip");
+        assert_eq!(response.status, 200);
+
+        let bodies = bodies.lock().await;
+        let body = &bodies[0];
+        assert!(
+            body.contains("nfInstanceId=scp-instance-1") && body.contains("nfType=SCP"),
+            "an unattestable consumer must leave the token SCP-attested, got: {body}"
+        );
+        assert!(
+            !body.contains("amf-instance-7"),
+            "the consumer's identity must not be asserted unattested, got: {body}"
+        );
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        producer.stop().await.expect("producer stop");
+    }
+
+    /// The operator escape hatch for an NRF that does not require client
+    /// authentication: assert the consumer's identity with no assertion.
+    #[tokio::test]
+    async fn trust_requester_identity_asserts_the_consumer_without_a_cca() {
+        let (producer_port, nrf_port, scp_port) =
+            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+        let producer = start_header_echo_producer(producer_port).await;
+        let nrf = start_recording_nrf(nrf_port, producer_port, "tok", bodies.clone()).await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                nf_instance_id: Some("scp-instance-1".into()),
+                trust_requester_identity: true,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let response = fast_client(scp_port)
+            .send_request(model_d_request(None, None))
+            .await
+            .expect("model D roundtrip");
+        assert_eq!(response.status, 200);
+
+        let bodies = bodies.lock().await;
+        let body = &bodies[0];
+        assert!(
+            body.contains("nfInstanceId=amf-instance-7") && body.contains("nfType=AMF"),
+            "the declared-trust path must assert the consumer, got: {body}"
+        );
+        assert!(
+            !body.contains("cca="),
+            "no assertion exists to send, so none must be fabricated, got: {body}"
+        );
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        producer.stop().await.expect("producer stop");
+    }
+
+    /// #101 criterion 3: `3gpp-Sbi-Access-Scope` names the scope the consumer
+    /// needs, and it must win over the scope derived from the request URI's
+    /// service name. Here the URI says `nudm-uecm` and the header says
+    /// `nudm-sdm`, so only reading the header can produce the right token.
+    #[tokio::test]
+    async fn access_scope_header_sets_the_delegated_token_scope() {
+        let (producer_port, nrf_port, scp_port) =
+            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+        let producer = start_header_echo_producer(producer_port).await;
+        let nrf = start_recording_nrf(nrf_port, producer_port, "tok", bodies.clone()).await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                nf_instance_id: Some("scp-instance-1".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let response = fast_client(scp_port)
+            .send_request(model_d_request(Some(CONSUMER_CCA), Some("nudm-sdm")))
+            .await
+            .expect("model D roundtrip");
+        assert_eq!(response.status, 200);
+
+        let bodies = bodies.lock().await;
+        let body = &bodies[0];
+        assert!(
+            body.contains("scope=nudm-sdm"),
+            "Access-Scope must set the token scope, got: {body}"
+        );
+        assert!(
+            !body.contains("scope=nudm-uecm"),
+            "the URI-derived scope must not win over an explicit Access-Scope, got: {body}"
+        );
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        producer.stop().await.expect("producer stop");
+    }
+
+    /// #101 criterion 4, end to end: two different consumers of the SAME
+    /// (target, scope) must each cause their OWN token request. Before the
+    /// cache key gained its consumer component the second consumer silently
+    /// reused the first's token — one consumer receiving another's
+    /// authorisation at the producer.
+    #[tokio::test]
+    async fn two_consumers_of_one_target_scope_each_get_their_own_token() {
+        let (producer_port, nrf_port, scp_port) =
+            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+        let producer = start_header_echo_producer(producer_port).await;
+        let nrf = start_recording_nrf(nrf_port, producer_port, "tok", bodies.clone()).await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                nf_instance_id: Some("scp-instance-1".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let client = fast_client(scp_port);
+        // Consumer A, attested.
+        let first = model_d_request(Some(CONSUMER_CCA), None);
+        assert_eq!(client.send_request(first).await.expect("A").status, 200);
+        // Consumer B: same target and scope, different identity and assertion.
+        let second = SbiRequest::post("/nudm-uecm/v1/registrations")
+            .with_body(r#"{"smf":"reg"}"#, "application/json")
+            .with_header(discovery_header::TARGET_NF_TYPE, "UDM")
+            .with_header(discovery_header::REQUESTER_NF_TYPE, "SMF")
+            .with_header(discovery_header::REQUESTER_NF_INSTANCE_ID, "smf-instance-9")
+            .with_header(discovery_header::SERVICE_NAMES, "nudm-uecm")
+            .with_header(
+                custom_header::CLIENT_CREDENTIALS,
+                "eyJhbGciOiJFUzI1NiJ9.c21m.c2ln",
+            );
+        assert_eq!(client.send_request(second).await.expect("B").status, 200);
+
+        let bodies = bodies.lock().await;
+        assert_eq!(
+            bodies.len(),
+            2,
+            "each consumer must trigger its own token request, got: {bodies:?}"
+        );
+        assert!(bodies
+            .iter()
+            .any(|b| b.contains("nfInstanceId=amf-instance-7")));
+        assert!(bodies
+            .iter()
+            .any(|b| b.contains("nfInstanceId=smf-instance-9")));
 
         scp.stop().await.expect("scp stop");
         nrf.stop().await.expect("nrf stop");

--- a/src/libs/nextgcore-sbi/src/oauth.rs
+++ b/src/libs/nextgcore-sbi/src/oauth.rs
@@ -473,13 +473,60 @@ impl CachedToken {
     }
 }
 
-/// Cache key for tokens: (target_nf_type_str, scope).
-type CacheKey = (String, String);
+/// The NF on whose behalf an access token is requested.
+///
+/// For an ordinary NF this is always itself, and [`OAuth2Client::get_token`]
+/// supplies it implicitly. It is a distinct concept only on the SCP's Model D
+/// delegated path (TS 33.501 §13.4.1.3.2), where the SCP requests a token *for
+/// the NF Service Consumer that sent the request* — so the token's subject and
+/// `nfType` must be the consumer's, not the SCP's.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenConsumer {
+    /// `nfInstanceId` asserted in the token request.
+    pub nf_instance_id: String,
+    /// `nfType` asserted in the token request.
+    pub nf_type: NfType,
+    /// The consumer's OWN Client Credentials Assertion, when it supplied one
+    /// (conveyed to the SCP in `3gpp-Sbi-Client-Credentials`).
+    ///
+    /// This field is what makes asserting somebody else's identity legitimate:
+    /// the NRF verifies the assertion against the **consumer's** registered
+    /// key, so the `nfInstanceId` in the body is attested by the party it names.
+    /// Signing that body with our own key instead would produce a CCA whose
+    /// `sub` disagrees with the body, which a conformant NRF rejects — see
+    /// [`OAuth2Client::request_token_on_behalf_of`].
+    pub cca: Option<String>,
+}
+
+impl TokenConsumer {
+    /// A consumer identified by instance id and type, with no assertion.
+    pub fn new(nf_instance_id: impl Into<String>, nf_type: NfType) -> Self {
+        Self {
+            nf_instance_id: nf_instance_id.into(),
+            nf_type,
+            cca: None,
+        }
+    }
+
+    /// Attach the consumer's own CCA (TS 29.500 `3gpp-Sbi-Client-Credentials`).
+    pub fn with_cca(mut self, cca: impl Into<String>) -> Self {
+        self.cca = Some(cca.into());
+        self
+    }
+}
+
+/// Cache key for tokens: (consumer_nf_instance_id, target_nf_type_str, scope).
+///
+/// The consumer component exists so a token minted for one consumer is never
+/// replayed for another (nextgcore #101 criterion 4). For an ordinary NF the
+/// consumer is always itself, so the key gains a constant component and caching
+/// behaves exactly as it did before — a behaviour-preserving generalisation.
+type CacheKey = (String, String, String);
 
 /// OAuth2 token cache with automatic expiry.
 ///
-/// Caches access tokens keyed by `(target_nf_type, scope)` so repeated
-/// requests to the same service reuse the token until it expires.
+/// Caches access tokens keyed by `(consumer, target_nf_type, scope)` so
+/// repeated requests to the same service reuse the token until it expires.
 pub struct TokenCache {
     tokens: RwLock<HashMap<CacheKey, CachedToken>>,
 }
@@ -491,9 +538,22 @@ impl TokenCache {
         }
     }
 
+    fn key(consumer_id: &str, target_nf_type: NfType, scope: &str) -> CacheKey {
+        (
+            consumer_id.to_string(),
+            target_nf_type.to_str().to_string(),
+            scope.to_string(),
+        )
+    }
+
     /// Retrieve a non-expired cached token for the given key.
-    pub async fn get(&self, target_nf_type: NfType, scope: &str) -> Option<AccessTokenResponse> {
-        let key = (target_nf_type.to_str().to_string(), scope.to_string());
+    pub async fn get(
+        &self,
+        consumer_id: &str,
+        target_nf_type: NfType,
+        scope: &str,
+    ) -> Option<AccessTokenResponse> {
+        let key = Self::key(consumer_id, target_nf_type, scope);
         let tokens = self.tokens.read().await;
         tokens.get(&key).and_then(|cached| {
             if cached.is_expired() {
@@ -505,14 +565,30 @@ impl TokenCache {
     }
 
     /// Store a token in the cache.
-    pub async fn put(&self, target_nf_type: NfType, scope: &str, response: AccessTokenResponse) {
-        let key = (target_nf_type.to_str().to_string(), scope.to_string());
+    pub async fn put(
+        &self,
+        consumer_id: &str,
+        target_nf_type: NfType,
+        scope: &str,
+        response: AccessTokenResponse,
+    ) {
+        let key = Self::key(consumer_id, target_nf_type, scope);
         let cached = CachedToken {
             response,
             obtained_at: Instant::now(),
         };
         let mut tokens = self.tokens.write().await;
         tokens.insert(key, cached);
+    }
+
+    /// Drop one consumer's token for one target/scope, leaving every other
+    /// consumer's tokens intact. Used when a producer refuses a token: the
+    /// refusal concerns that consumer, so evicting the whole cache would make
+    /// one consumer's rejection re-mint tokens for all of them.
+    pub async fn invalidate(&self, consumer_id: &str, target_nf_type: NfType, scope: &str) {
+        let key = Self::key(consumer_id, target_nf_type, scope);
+        let mut tokens = self.tokens.write().await;
+        tokens.remove(&key);
     }
 
     /// Remove expired entries from the cache.
@@ -978,19 +1054,65 @@ impl OAuth2Client {
     /// Returns a cached token if available and not expired, otherwise
     /// requests a new one from the NRF.
     pub async fn get_token(&self, target_nf_type: NfType, scope: &str) -> SbiResult<String> {
+        self.get_token_on_behalf_of(&self.self_consumer(), target_nf_type, scope)
+            .await
+    }
+
+    /// This client's own identity as a token consumer.
+    pub fn self_consumer(&self) -> TokenConsumer {
+        TokenConsumer::new(&self.nf_instance_id, self.nf_type)
+    }
+
+    /// Get a valid access token **for another NF**, as the SCP does on the
+    /// Model D delegated path (TS 33.501 §13.4.1.3.2).
+    ///
+    /// A separate method rather than a widened [`OAuth2Client::get_token`]: 13
+    /// NFs reach `get_token` indirectly through
+    /// [`crate::client::SbiClient::with_oauth2`], and this keeps the
+    /// non-delegated path unchanged by construction rather than by review.
+    ///
+    /// The token is cached per consumer, so one consumer's token is never
+    /// replayed for another.
+    pub async fn get_token_on_behalf_of(
+        &self,
+        consumer: &TokenConsumer,
+        target_nf_type: NfType,
+        scope: &str,
+    ) -> SbiResult<String> {
         // Check cache first
-        if let Some(cached) = self.cache.get(target_nf_type, scope).await {
+        if let Some(cached) = self
+            .cache
+            .get(&consumer.nf_instance_id, target_nf_type, scope)
+            .await
+        {
             return Ok(cached.access_token);
         }
 
         // Request new token from NRF
-        let response = self.request_token(target_nf_type, scope).await?;
+        let response = self
+            .request_token_on_behalf_of(consumer, target_nf_type, scope)
+            .await?;
         let token = response.access_token.clone();
 
         // Cache it
-        self.cache.put(target_nf_type, scope, response).await;
+        self.cache
+            .put(&consumer.nf_instance_id, target_nf_type, scope, response)
+            .await;
 
         Ok(token)
+    }
+
+    /// Drop one consumer's cached token for a target/scope. See
+    /// [`TokenCache::invalidate`].
+    pub async fn invalidate_token(
+        &self,
+        consumer: &TokenConsumer,
+        target_nf_type: NfType,
+        scope: &str,
+    ) {
+        self.cache
+            .invalidate(&consumer.nf_instance_id, target_nf_type, scope)
+            .await;
     }
 
     /// Request a new access token from the NRF.
@@ -999,12 +1121,45 @@ impl OAuth2Client {
         target_nf_type: NfType,
         scope: &str,
     ) -> SbiResult<AccessTokenResponse> {
-        let mut request =
-            AccessTokenRequest::new(&self.nf_instance_id, self.nf_type, target_nf_type, scope);
+        self.request_token_on_behalf_of(&self.self_consumer(), target_nf_type, scope)
+            .await
+    }
+
+    /// Request a new access token from the NRF naming `consumer` as the
+    /// requesting NF.
+    ///
+    /// **Never assert an identity you cannot attest.** The CCA is chosen by who
+    /// the body names, not by what key happens to be loaded:
+    ///
+    /// * the consumer supplied its own CCA → forward it, because the NRF can
+    ///   verify it against that consumer's registered key (TS 33.501
+    ///   §13.4.1.3.2 conveys the consumer's CCA in Model D);
+    /// * the body names *us* → sign with our own key, as before;
+    /// * the body names a third party and they gave us no assertion → send
+    ///   **no** assertion. [`OAuth2Client::build_cca`] mints `sub` =
+    ///   `self.nf_instance_id`, so signing here would emit a CCA whose subject
+    ///   contradicts the `nfInstanceId` in the body — worse than sending none,
+    ///   because it presents a verifiable proof of the wrong claim.
+    pub async fn request_token_on_behalf_of(
+        &self,
+        consumer: &TokenConsumer,
+        target_nf_type: NfType,
+        scope: &str,
+    ) -> SbiResult<AccessTokenResponse> {
+        let mut request = AccessTokenRequest::new(
+            &consumer.nf_instance_id,
+            consumer.nf_type,
+            target_nf_type,
+            scope,
+        );
         // Issue #64 gaps 1+2: authenticate this NF to the token endpoint. Absent
         // a CCA (and absent a client certificate the NRF can see) the NRF has
         // only the self-asserted nfInstanceId in the body to go on.
-        request.cca = self.build_cca();
+        request.cca = match consumer.cca.clone() {
+            Some(consumer_cca) => Some(consumer_cca),
+            None if consumer.nf_instance_id == self.nf_instance_id => self.build_cca(),
+            None => None,
+        };
 
         let body = request.to_form_body();
         // sbi-06/I4: the resource path is configurable; the process-wide
@@ -1670,48 +1825,139 @@ mod tests {
         assert!(decode_jwt_parts("a.b").is_err());
     }
 
+    /// A token response with the given access token, for cache tests.
+    fn token_response(access_token: &str, scope: Option<&str>) -> AccessTokenResponse {
+        AccessTokenResponse {
+            access_token: access_token.to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: Some(3600),
+            scope: scope.map(str::to_string),
+        }
+    }
+
     #[tokio::test]
     async fn test_token_cache_basic() {
         let cache = TokenCache::new();
+        let consumer = "amf-1";
 
         // Nothing cached yet
-        assert!(cache.get(NfType::Smf, "nsmf-pdusession").await.is_none());
+        assert!(cache
+            .get(consumer, NfType::Smf, "nsmf-pdusession")
+            .await
+            .is_none());
 
         // Store a token
-        let response = AccessTokenResponse {
-            access_token: "cached-token".to_string(),
-            token_type: "Bearer".to_string(),
-            expires_in: Some(3600),
-            scope: Some("nsmf-pdusession".to_string()),
-        };
+        let response = token_response("cached-token", Some("nsmf-pdusession"));
         cache
-            .put(NfType::Smf, "nsmf-pdusession", response.clone())
+            .put(consumer, NfType::Smf, "nsmf-pdusession", response.clone())
             .await;
 
         // Should be retrievable
-        let cached = cache.get(NfType::Smf, "nsmf-pdusession").await;
+        let cached = cache.get(consumer, NfType::Smf, "nsmf-pdusession").await;
         assert!(cached.is_some());
         assert_eq!(cached.unwrap().access_token, "cached-token");
 
-        // Different key should miss
-        assert!(cache.get(NfType::Amf, "nsmf-pdusession").await.is_none());
-        assert!(cache.get(NfType::Smf, "other-scope").await.is_none());
+        // Different key should miss — on any of the three components
+        assert!(cache
+            .get(consumer, NfType::Amf, "nsmf-pdusession")
+            .await
+            .is_none());
+        assert!(cache
+            .get(consumer, NfType::Smf, "other-scope")
+            .await
+            .is_none());
+        assert!(cache
+            .get("smf-9", NfType::Smf, "nsmf-pdusession")
+            .await
+            .is_none());
     }
 
     #[tokio::test]
     async fn test_token_cache_clear() {
         let cache = TokenCache::new();
-        let response = AccessTokenResponse {
-            access_token: "token".to_string(),
-            token_type: "Bearer".to_string(),
-            expires_in: Some(3600),
-            scope: None,
-        };
-        cache.put(NfType::Smf, "scope", response).await;
-        assert!(cache.get(NfType::Smf, "scope").await.is_some());
+        cache
+            .put("amf-1", NfType::Smf, "scope", token_response("token", None))
+            .await;
+        assert!(cache.get("amf-1", NfType::Smf, "scope").await.is_some());
 
         cache.clear().await;
-        assert!(cache.get(NfType::Smf, "scope").await.is_none());
+        assert!(cache.get("amf-1", NfType::Smf, "scope").await.is_none());
+    }
+
+    /// nextgcore #101 criterion 4: two distinct consumers of the SAME
+    /// (target, scope) must hold two distinct tokens, not share one. Before the
+    /// key gained its consumer component, the second `get` here returned the
+    /// FIRST consumer's token — which is how one consumer received another's
+    /// authorisation scope at the producer.
+    #[tokio::test]
+    async fn two_consumers_of_one_target_scope_do_not_share_a_token() {
+        let cache = TokenCache::new();
+        let (target, scope) = (NfType::Udm, "nudm-sdm");
+
+        cache
+            .put(
+                "amf-1",
+                target,
+                scope,
+                token_response("token-for-amf", None),
+            )
+            .await;
+        cache
+            .put(
+                "smf-2",
+                target,
+                scope,
+                token_response("token-for-smf", None),
+            )
+            .await;
+
+        assert_eq!(
+            cache
+                .get("amf-1", target, scope)
+                .await
+                .unwrap()
+                .access_token,
+            "token-for-amf"
+        );
+        assert_eq!(
+            cache
+                .get("smf-2", target, scope)
+                .await
+                .unwrap()
+                .access_token,
+            "token-for-smf"
+        );
+
+        // A third consumer gets nothing rather than inheriting either token.
+        assert!(cache.get("pcf-3", target, scope).await.is_none());
+    }
+
+    /// Invalidating one consumer's token must leave every other consumer's
+    /// intact: a producer refusing one consumer's token says nothing about the
+    /// others, and evicting all of them would re-mint the whole fleet's tokens
+    /// on a single 401.
+    #[tokio::test]
+    async fn invalidate_is_scoped_to_one_consumer() {
+        let cache = TokenCache::new();
+        let (target, scope) = (NfType::Udm, "nudm-sdm");
+        cache
+            .put("amf-1", target, scope, token_response("a", None))
+            .await;
+        cache
+            .put("smf-2", target, scope, token_response("b", None))
+            .await;
+
+        cache.invalidate("amf-1", target, scope).await;
+
+        assert!(cache.get("amf-1", target, scope).await.is_none());
+        assert_eq!(
+            cache
+                .get("smf-2", target, scope)
+                .await
+                .unwrap()
+                .access_token,
+            "b"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #101 (criteria 2, 3 and 4). Defects 3-7 filed as #207, #208, #209, #210, #211.

Spec: `specs/fix-scp-model-d-token-and-discovery-confidentiality.md` (pass 2 section).

The OAuth2 token the SCP minted on a consumer's behalf carried the SCP's own identity (`nfInstanceId=nextgcore-scp`, `nfType=SCP`) and was cached on `(target, scope)` alone — so it was replayed across every consumer of a given target. A producer enforcing OAuth2 either rejected the call or **granted one consumer's scope to another**.

## Criterion 2 — never assert an identity you cannot attest

Sending the consumer's `nfInstanceId` unconditionally would **break the delegated path outright** against our own NRF, and the issue's feature-gate advice doesn't explain why: after #64 the NRF's token endpoint requires a CCA keyed to the `nfInstanceId` in the body, and the SCP can only sign with its own key. **Consumer identity and an SCP-signed CCA are mutually exclusive**, so a blind flag would just turn delegated discovery off.

TS 33.501 §13.4.1.3.2 resolves it — in Model D the *consumer's* CCA is conveyed — so the rule is three-way and self-configuring rather than flag-driven:

1. the consumer sent its own CCA in `3gpp-Sbi-Client-Credentials` → assert the consumer and forward that assertion, which the NRF verifies against the **consumer's** registered key. The conformant case;
2. no CCA, but the operator set `trust_requester_identity` for an NRF that does not require client authentication → assert the consumer unattested;
3. otherwise → keep the SCP's identity and log that the token is SCP-attested.

**The load-bearing sub-decision is which CCA to attach, and it is chosen by who the body names.** `build_cca` mints `sub = self.nf_instance_id`, so signing for a third party would emit an assertion whose subject *contradicts* the body — worse than sending none, because it is a verifiable proof of the wrong claim. That arm sends no assertion at all.

An asymmetry found while implementing: `requester-nf-type` is mandatory for delegated discovery but `requester-nf-instance-id` is **optional**, so a consumer can be typed without being named. An unnamed consumer cannot be asserted at all and falls to case 3 regardless of any CCA it sends.

## Criterion 3 — scope and CCA plumbing

`3gpp-Sbi-Access-Scope` now sets the token scope, winning over the URI-derived service name. Both it and `3gpp-Sbi-Client-Credentials` already existed in `constants.rs` with **zero readers** — the same dead-constant shape as `3gpp-Sbi-Callback` (now #210). The consumer's CCA is stripped from the forwarded request: it authenticates to the NRF's token endpoint and is not a producer-facing credential.

## Criterion 4 — per-consumer cache

`CacheKey` becomes `(consumer, target_nf_type, scope)`. For an ordinary NF the consumer is always itself, so the key gains a constant component and caching is behaviour-identical — a generalisation, not a change. `invalidate` replaces the retry path's `clear_cache`, because one consumer's 401 says nothing about any other consumer's token and should not re-mint the fleet's.

## Two premises in the recorded design were wrong

Both corrected in the spec rather than left for the next reader.

**The recorded blocker was wrong, and it cost a session's hesitation.** Pass 1 recorded that `with_oauth2` "attaches the token automatically and has no per-request hook, so … That is a restructure of `forward()`." But `forward()` was **already** acquiring the token itself, deliberately, to prime the cache; and L1 attaches only when the request carries no `Authorization` (`client.rs:596`), which the delegated path had already stripped. So the seam the blocker said didn't exist was sitting in the code the blocker described: `forward()` sets the header from the consumer-scoped token, and L1's attach becomes a no-op **by construction** rather than by ordering luck. ~30 lines, not a restructure.

**The blast radius was 2 direct callers, not ~15.** `get_token` has two direct callers outside `oauth.rs`; 13 crates reach it *indirectly* via `with_oauth2`. The new-method decision still stands — it keeps the non-delegated path unchanged by construction rather than by review — but not for the reason recorded.

## Verification

Seven new tests. Workspace **5735 passed / 0 failed** (was 5728), `cargo test --workspace` exit 0 — checked for `^error`, not only a `test result:` line. `cargo fmt --all --check` clean; `cargo clippy --workspace` (the CI gate) exit 0.

**Revert-verified, one at a time.** The first reproduces the original defect body verbatim:

| revert | test that fails | observed wrong value |
|---|---|---|
| token names the SCP again | `delegated_token_asserts_the_consumer_identity_when_the_consumer_attests_it` | `nfInstanceId=scp-instance-1&nfType=SCP` |
| treat a missing CCA as trusted | `delegated_token_stays_scp_attested_without_a_consumer_cca` | consumer asserted unattested |
| mint our own CCA for a third party | (as above) | consumer's CCA absent |
| ignore `Access-Scope` | `access_scope_header_sets_the_delegated_token_scope` | `scope=nudm-uecm` |
| consumer-agnostic cache key | `two_consumers_of_one_target_scope_each_get_their_own_token` + the `oauth` unit test | 1 token request for 2 consumers |
| relay the CCA onward | (as above) | `cca_leaked: true` |
| let L1 attach instead | (as above) | a second, SCP-identity token request |

The scope test is built so that **only** reading the header can pass it: the URI says `nudm-uecm` and the header says `nudm-sdm`. The identity tests assert both the *absence* of `scp-instance-1` and the *presence* of the consumer, so code emitting both cannot pass.

## Not verified — the ceiling

* **No conformant external NRF was involved.** The token body is asserted against a mock that records it — the same ceiling pass 1 recorded, and the reason #101 needed an external NRF to surface at all. In particular **case 1 has never been exercised against an NRF that actually verifies a consumer CCA**: the mock accepts any body, so what is proven is that the SCP *sends* the consumer's identity and assertion, not that a real NRF accepts them.
* `build_cca` returns `None` unless a signing key is configured and the tests configure none, so the "our key, our identity" arm is covered only via the third-party path.
* Docker E2E remains skipped by CI.
* **GitNexus impact analysis, mandated by this repo's CLAUDE.md, was not run** — no GitNexus MCP server was connected. Caller analysis was grep-based: 2 direct `get_token` callers, 13 `with_oauth2` crates, `TokenCache` only re-exported and never used outside `oauth.rs`.

## Count arithmetic

Closing #101 while filing five honest follow-ups moves the open count the **wrong way** — the understatement the repo's issues-closed-vs-parts-closed learning warns about. Quote both numbers, not the issues-closed figure alone.
