### PR TITLE
fix(amfd,crypt): seed the {NH, NCC} chain from KgNB and advance it on both mobility paths (Refs #70)

### DIFF
--- a/specs/fix-amf-n2-xn-forward-security.md
+++ b/specs/fix-amf-n2-xn-forward-security.md
@@ -1,0 +1,166 @@
+# nextgcore #70 (AMF mobility): seed and advance the {NH, NCC} forward-security chain
+
+Verified against `main` @ `6e02d63`. The issue's cites are from `76ea248`; **all eight were
+re-verified and all eight still hold**, at new line numbers.
+
+`Refs #70`, **not Closes**. Ships gaps 1, 2 and 3 — the forward-security break and the missing
+KAMF′ derivation. Gaps 4 and 5 (mobility control-plane completion) remain open; see "Scope" below.
+The open count deliberately does not move.
+
+## Why this ships alone
+
+CONVENTIONS requires one PR per issue covering all its parts, with one stated exception: *a
+safety-critical defect inside an umbrella may ship alone, labelled `Refs #N`, with the PR stating
+why it did not wait.* This qualifies, and the enumeration was done before starting rather than
+discovered late:
+
+* gaps 1–3 are a **key forward-security break** with no new spec machinery required — `nh_gnb`
+  (Annex A.10) already exists and KgNB is already derived and stored;
+* gap 4 (N2 control plane) is wiring: `build_ue_context_release_command_asn1` and
+  `call_smf_update_sm_context` both already exist;
+* gap 5 (Xn → SMF) needs a **`PathSwitchRequestAcknowledgeTransfer` encoder that does not exist
+  anywhere in the tree** — a new APER type plus SMF wiring, which wants its own review.
+
+Holding a forward-security break behind that encoder is the failure mode the exception exists to
+prevent.
+
+## The defect
+
+Two sites, one chain, three ways of getting it wrong.
+
+`AmfUe::nh` is zero-initialised (`context.rs`) and `kgnb` — derived and stored at AS-security-context
+establishment — was **never copied into it**. The only NH derivation chained `nh` from *itself*:
+`nh_gnb(kamf, nh)` with `nh` still all-zeros.
+
+* **N2 (`HandoverRequired`)** copied `{nhcc, nh}` into the HandoverRequest `SecurityContext`
+  verbatim — no increment, no derivation. A UE that had performed no prior Xn handover shipped
+  **32 zero bytes with NCC = 0**.
+* **Xn (`PathSwitchRequest`)** did increment NCC and chain the NH, but from that zero seed.
+
+Either way the target gNB derives an AS root key the source gNB — and anyone who logged KgNB — can
+reproduce. That is exactly the property the NH chain exists to provide (TS 33.501 §6.9.2.3.3).
+
+## The fix
+
+**Seed once, advance everywhere, through one helper.**
+
+`AmfUe::init_next_hop_chain()` is called immediately after `kgnb` is stored: `NH = KDF(KAMF, KgNB)`
+with `NCC = 1`, per Annex A.10 — KgNB itself is the NCC = 0 pair.
+
+`AmfUe::advance_next_hop() -> (u8, [u8; 32])` chains `NH = KDF(KAMF, NH)` and increments
+`NCC = (NCC + 1) mod 8`, returning the pair **in the order the NGAP `SecurityContext` fields are
+written** so a caller cannot transpose them. Both mobility paths call it, which is what stops them
+diverging again — they had diverged in the worst way, one advancing and one not.
+
+The advance-then-send ordering follows the issue's own criterion (*"NCC = previous + 1 (mod 8) for a
+UE that has performed no prior handover"*) and matches what the Xn path already did, so the Xn wire
+behaviour changes only in the seed.
+
+### A defect the issue does not mention
+
+`save_memento`/`restore_memento` persisted **`nh` but not `nhcc`** — `nhcc` was not even a field on
+`AmfUeMemento`. `nh` and `nhcc` are one value: the NCC names the position of that NH in the chain.
+Restoring the key while leaving the counter advanced makes the AMF convey a pair that does not
+describe itself, and the target derives a key the UE cannot match. Found by reading the memento
+while making the pair coherent; fixed by carrying `nhcc` with it.
+
+### Gap 3: KAMF′ (FC 0x72)
+
+`nextgcore_kdf_kamf_prime(kamf, direction, nas_count)` added to `nextgcore-crypt`, with the `S`
+construction spelled out in the doc comment so a reviewer holding Annex A.13 can check it by eye:
+
+```text
+S = FC(0x72) || P0(direction) || L0(0x0001) || P1(NAS COUNT, 4 octets BE) || L1(0x0004)
+```
+
+`KAMF_PRIME_DIRECTION_UPLINK` (0x00) binds to the uplink NAS COUNT as at idle-mode mobility;
+`KAMF_PRIME_DIRECTION_DOWNLINK` (0x01) binds to the downlink COUNT as at connected-mode handover.
+The COUNT is big-endian, matching the other 5G derivations — note the **EPS-era helpers in the same
+file deliberately use native byte order** to stay bit-compatible with the C original, which is a
+live trap for anyone copying a neighbour.
+
+It is **not yet called**: gaps 4 and 5 are where mobility re-keying is invoked. Shipping the
+primitive with the security fix keeps that follow-up from having to touch the crypto library.
+
+## Verification
+
+Eight new tests. Workspace **5743 passed / 0 failed** (was 5735), `cargo test --workspace` exit 0,
+checked for `^error` rather than only a `test result:` line. `cargo fmt --all --check` clean;
+`cargo clippy --workspace` (the CI gate) exit 0.
+
+**Revert-verified, one at a time — and the first pass found two of my own tests wanting:**
+
+| revert | test that fails |
+|---|---|
+| seed the chain from zeros again | `next_hop_chain_is_seeded_from_kgnb_never_from_zero` |
+| stop incrementing NCC | `first_handover_conveys_a_non_zero_nh_and_an_incremented_ncc` |
+| drop `nhcc` from the memento | `memento_restores_the_nh_and_ncc_together` |
+| N2 copies the stored pair | `both_mobility_paths_route_through_the_shared_next_hop_helper` |
+| drop the KAMF′ direction parameter | `kamf_prime_uses_every_input` |
+| native byte order for the KAMF′ COUNT | `kamf_prime_matches_its_golden_vectors` |
+
+The last two rows are the interesting ones, because on the **first** revert pass neither failed:
+
+* **The N2 wiring was uncovered.** The derivation is unit-tested, but nothing drove the emission
+  site — amfd has no harness for `handle_handover_required` — so reverting N2 to copy the stored
+  pair compiled and passed everything. Fixed with a source guard that positively asserts the two
+  mobility sites and the single seed site, plus a negative on the defective expression. It lives in
+  `context.rs` and reads `ngap_path.rs` **deliberately**: a guard grepping the file it lives in
+  matches its own needle, including inside the comment explaining it — a trap this repo has already
+  been bitten by.
+* **My endianness test proved nothing.** It asserted only that two different COUNTs give different
+  outputs, which is true under either byte order — a negative assertion satisfied by the very defect
+  it was meant to catch. Replaced with golden vectors generated from the implementation and pasted,
+  not typed.
+
+**Not verified:**
+
+* **No 3GPP test vector exists for FC 0x72 KAMF′**, in this tree or available to this session. The
+  golden vectors pin *our* construction, so any change to the FC, parameter order, a length or the
+  byte order fails the test — but agreement with 3GPP rests on the doc-commented `S` layout being
+  read against Annex A.13 by a reviewer. **Interop against a real peer AMF is the outstanding
+  validation, and this is the single highest-value review item in the change.**
+* No real gNB, UE or handover was exercised. The chain is asserted at the `AmfUe` level; the emission
+  sites are covered by a source guard, which proves the call is present, not that the encoded NGAP
+  `SecurityContext` is correct on the wire.
+* Docker E2E remains skipped by CI.
+* GitNexus impact analysis, mandated by this repo's CLAUDE.md, was **not run** — no GitNexus MCP
+  server was connected. Caller analysis was grep-based: every `.nh`/`.nhcc`/`.kgnb` use in amfd
+  (12 sites, 2 of them the memento) and both `nextgcore_kdf_nh_gnb` callers.
+
+## Scope: gaps 4 and 5 remain open, with the plan recorded
+
+Stated up front rather than discovered late, so the next session does not re-derive it.
+
+**Gap 4 — N2 handover control plane.** `HandoverNotify` mutates only in-memory serving state. It
+must additionally (a) tell the SMF the target DL tunnel via `Nsmf_PDUSession_UpdateSMContext` —
+`call_smf_update_sm_context` exists at `sbi_path.rs:986` — and (b) send a `UEContextReleaseCommand`
+to the **source** gNB and drop its RAN-UE context;
+`build_ue_context_release_command_asn1` exists at `ngap_asn1.rs:837`. The blocker is not machinery
+but bookkeeping: the source association and RAN-UE-NGAP-ID are **overwritten** on the Xn path
+(`state.ran_ue_ngap_id = req.ran_ue_ngap_id; state.association_id = association_id;`), so the source
+identity must be captured before the switch or the release cannot be addressed. Cross-gNB relocation
+(target RAN-UE-NGAP-ID allocation, T304, `HandoverRequestAcknowledge`→`HandoverCommand` stitching) is
+marked "future work" at `ngap_path.rs:4522` and is the larger part.
+
+**Gap 5 — Xn path switch → SMF.** `handle_path_switch_request` echoes the inbound
+`PathSwitchRequestTransfer` back as the acknowledge transfer (`p.transfer.clone()`), and never calls
+the SMF. The SMF's `PATH_SWITCH_REQ` branch returns only
+`{upCnxState: "ACTIVATED", n2SmInfoType: "PATH_SWITCH_REQ_ACK"}` with no `n2SmInfo` binary part
+(`smfd/main.rs:2607-2609`), and is unreachable because the AMF never invokes it — so both halves are
+broken and neither can be tested against the other today. **`PathSwitchRequestAcknowledgeTransfer`
+does not exist anywhere in the tree**, so this needs a new APER encoder first; that is the reason
+gap 5 is not in this PR. Note the SMF *does* already perform a PFCP DL-FAR modify from the decoded
+endpoint just above (`main.rs:2558`), so the user-plane DL is partially updated — which is why the
+missing acknowledge transfer has not shown up as an outage.
+
+## Definition of done
+
+- [x] N2 `HandoverRequest` carries an NH derived from KgNB (never all-zero) with NCC incremented
+- [x] N2 and Xn share one NCC-increment/NH-derive helper; a test drives both for equal inputs
+- [x] `nextgcore-crypt` exposes FC 0x72 KAMF′ derivation with vectors (ours, not 3GPP's — see above)
+- [x] `nh` and `nhcc` survive a memento round trip as a pair (not in the issue; found while fixing)
+- [ ] `handle_path_switch_request` calls the SMF and uses the SMF-supplied acknowledge transfer — **#70 gap 5**
+- [ ] SMF `PATH_SWITCH_REQ` response includes a non-empty `n2SmInfo` transfer — **#70 gap 5**
+- [ ] `HandoverNotify` updates the SMF's DL tunnel and releases the source gNB — **#70 gap 4**
+- [x] Full workspace lint and test suites pass

--- a/src/bins/nextgcore-amfd/src/context.rs
+++ b/src/bins/nextgcore-amfd/src/context.rs
@@ -1983,6 +1983,14 @@ pub struct AmfUeMemento {
     pub kgnb: [u8; NEXTGCORE_SHA256_DIGEST_SIZE],
     /// Next hop key
     pub nh: [u8; NEXTGCORE_SHA256_DIGEST_SIZE],
+    /// Next Hop Chaining Count.
+    ///
+    /// `nh` and `nhcc` are ONE VALUE: the NCC names the position of that NH in
+    /// the chain, and the target gNB derives KgNB* from the pair. Saving `nh`
+    /// without `nhcc` (as this memento did) rolls the key back while leaving the
+    /// counter advanced, so the AMF then conveys an NCC that does not describe
+    /// the NH beside it and the target derives a key the UE cannot match.
+    pub nhcc: u8,
     /// Selected encryption algorithm
     pub selected_enc_algorithm: u8,
     /// Selected integrity algorithm
@@ -2608,6 +2616,42 @@ pub struct AmfSessRef {
 }
 
 impl AmfUe {
+    /// Seed the {NH, NCC} forward-security chain from KgNB when the AS security
+    /// context is established (TS 33.501 Annex A.10, Section 6.9.2.3.3).
+    ///
+    /// KgNB, derived straight from KAMF, is the pair with **NCC = 0**. The
+    /// initial NH is `KDF(KAMF, KgNB)` and is the pair with **NCC = 1**. Call
+    /// this immediately after storing `kgnb`.
+    ///
+    /// Skipping this step is the defect behind nextgcore #70: `nh` is
+    /// zero-initialised and the only derivation chained it from ITSELF, so a UE
+    /// that had never performed an Xn handover shipped 32 ZERO BYTES with
+    /// NCC = 0 to the target gNB, and one that had chained from a zero seed.
+    /// Either way the target derives an AS root key the source gNB — and anyone
+    /// who logged KgNB — can reproduce, which is precisely the forward security
+    /// the NH chain exists to provide.
+    pub fn init_next_hop_chain(&mut self) {
+        self.nh = nextgcore_crypt::kdf::nextgcore_kdf_nh_gnb(&self.kamf, &self.kgnb);
+        self.nhcc = 1;
+    }
+
+    /// Advance the {NH, NCC} chain one step and return the pair to convey to the
+    /// target gNB (TS 33.501 Section 6.9.2.3.3).
+    ///
+    /// `NH_next = KDF(KAMF, NH_current)` and `NCC_next = (NCC + 1) mod 8`. Both
+    /// the N2 (HandoverRequest) and Xn (PathSwitchRequestAcknowledge) paths go
+    /// through here, so the two cannot derive keys differently — they did
+    /// before: N2 copied the stored pair without advancing it at all, while Xn
+    /// advanced correctly from the wrong seed.
+    ///
+    /// Returns `(ncc, nh)` in the order the NGAP `SecurityContext` fields are
+    /// written, so a caller cannot transpose them.
+    pub fn advance_next_hop(&mut self) -> (u8, [u8; NEXTGCORE_SHA256_DIGEST_SIZE]) {
+        self.nh = nextgcore_crypt::kdf::nextgcore_kdf_nh_gnb(&self.kamf, &self.nh);
+        self.nhcc = self.nhcc.wrapping_add(1) & 0x07;
+        (self.nhcc, self.nh)
+    }
+
     /// Create a new AMF UE context
     pub fn new(id: u64, ran_ue_id: u64) -> Self {
         Self {
@@ -2796,6 +2840,7 @@ impl AmfUe {
         self.memento.ul_count_established = self.ul_count_established;
         self.memento.kgnb = self.kgnb;
         self.memento.nh = self.nh;
+        self.memento.nhcc = self.nhcc;
         self.memento.selected_enc_algorithm = self.selected_enc_algorithm;
         self.memento.selected_int_algorithm = self.selected_int_algorithm;
     }
@@ -2818,6 +2863,7 @@ impl AmfUe {
         self.ul_count_established = self.memento.ul_count_established;
         self.kgnb = self.memento.kgnb;
         self.nh = self.memento.nh;
+        self.nhcc = self.memento.nhcc;
         self.selected_enc_algorithm = self.memento.selected_enc_algorithm;
         self.selected_int_algorithm = self.memento.selected_int_algorithm;
     }
@@ -3415,6 +3461,169 @@ mod tests {
         assert_eq!(plmn.mnc1, 0);
         assert_eq!(plmn.mnc2, 1);
         assert_eq!(plmn.mnc3, 0xf);
+    }
+
+    /// A UE with an established AS security context: KAMF and KgNB set, chain
+    /// seeded, no handover yet performed.
+    fn ue_with_as_context() -> AmfUe {
+        let mut ue = AmfUe::new(1, 1);
+        ue.kamf = [0x11; NEXTGCORE_SHA256_DIGEST_SIZE];
+        ue.kgnb = [0x22; NEXTGCORE_SHA256_DIGEST_SIZE];
+        ue.init_next_hop_chain();
+        ue
+    }
+
+    /// nextgcore #70, the dominant defect: before this, `nh` was zero-initialised
+    /// and the only derivation chained it from ITSELF, so a UE that had performed
+    /// no prior handover shipped 32 ZERO BYTES with NCC=0 to the target gNB.
+    #[test]
+    fn next_hop_chain_is_seeded_from_kgnb_never_from_zero() {
+        let mut ue = AmfUe::new(1, 1);
+        // The pre-fix starting state.
+        assert_eq!(ue.nh, [0u8; NEXTGCORE_SHA256_DIGEST_SIZE]);
+        assert_eq!(ue.nhcc, 0);
+
+        ue.kamf = [0x11; NEXTGCORE_SHA256_DIGEST_SIZE];
+        ue.kgnb = [0x22; NEXTGCORE_SHA256_DIGEST_SIZE];
+        ue.init_next_hop_chain();
+
+        // Annex A.10: the initial NH is KDF(KAMF, KgNB) and is the NCC=1 pair.
+        assert_eq!(ue.nhcc, 1);
+        assert_ne!(ue.nh, [0u8; NEXTGCORE_SHA256_DIGEST_SIZE]);
+        assert_eq!(
+            ue.nh,
+            nextgcore_crypt::kdf::nextgcore_kdf_nh_gnb(&ue.kamf, &ue.kgnb),
+            "the initial NH must be bound to KgNB"
+        );
+        // It must NOT be the degenerate self-chained value the defect produced.
+        assert_ne!(
+            ue.nh,
+            nextgcore_crypt::kdf::nextgcore_kdf_nh_gnb(
+                &ue.kamf,
+                &[0u8; NEXTGCORE_SHA256_DIGEST_SIZE]
+            ),
+            "the NH must not be derived from a zero seed"
+        );
+    }
+
+    /// The pair a first handover conveys: NH non-zero, NCC = previous + 1.
+    #[test]
+    fn first_handover_conveys_a_non_zero_nh_and_an_incremented_ncc() {
+        let mut ue = ue_with_as_context();
+        let ncc_before = ue.nhcc;
+
+        let (ncc, nh) = ue.advance_next_hop();
+
+        assert_ne!(nh, [0u8; NEXTGCORE_SHA256_DIGEST_SIZE]);
+        assert_eq!(ncc, ncc_before + 1);
+        // The conveyed NH is one the SOURCE gNB has never held — that is the
+        // forward-security property the chain exists for.
+        assert_ne!(nh, ue.kgnb);
+        // And the returned pair is the stored pair, so the AMF's view and the
+        // target's agree.
+        assert_eq!((ncc, nh), (ue.nhcc, ue.nh));
+    }
+
+    /// The N2 and Xn paths now share one helper, so equal inputs must give
+    /// identical key derivation. Before, N2 copied the stored pair without
+    /// advancing it while Xn advanced from a zero seed.
+    #[test]
+    fn n2_and_xn_derive_identically_for_equal_inputs() {
+        let mut n2 = ue_with_as_context();
+        let mut xn = ue_with_as_context();
+
+        for _ in 0..3 {
+            assert_eq!(
+                n2.advance_next_hop(),
+                xn.advance_next_hop(),
+                "the two mobility paths must not diverge"
+            );
+        }
+    }
+
+    /// NCC is a 3-bit field, so the chain wraps mod 8 while the NH keeps
+    /// advancing — the counter repeating must not mean the key repeats.
+    #[test]
+    fn ncc_wraps_mod_8_while_the_nh_keeps_advancing() {
+        let mut ue = ue_with_as_context();
+        let mut seen = Vec::new();
+        for _ in 0..8 {
+            let (ncc, nh) = ue.advance_next_hop();
+            assert!(ncc < 8, "NCC must stay within 3 bits, got {ncc}");
+            seen.push(nh);
+        }
+        // Back to the starting NCC after eight steps...
+        assert_eq!(ue.nhcc, 1);
+        // ...but no NH repeated.
+        for (i, a) in seen.iter().enumerate() {
+            for b in seen.iter().skip(i + 1) {
+                assert_ne!(a, b, "an NH repeated within one NCC cycle");
+            }
+        }
+    }
+
+    /// `nh` and `nhcc` are one value. The memento saved the key without the
+    /// counter, so a restore rolled the key back while leaving the counter
+    /// advanced and the AMF then conveyed a pair that did not describe itself.
+    #[test]
+    fn memento_restores_the_nh_and_ncc_together() {
+        let mut ue = ue_with_as_context();
+        ue.save_memento();
+        let saved = (ue.nhcc, ue.nh);
+
+        ue.advance_next_hop();
+        ue.advance_next_hop();
+        assert_ne!((ue.nhcc, ue.nh), saved, "the chain moved");
+
+        ue.restore_memento();
+        assert_eq!(
+            (ue.nhcc, ue.nh),
+            saved,
+            "a restore must recover the NH and its NCC as a pair"
+        );
+    }
+
+    /// Both mobility paths must route through the shared chain helper, and the
+    /// chain must be seeded where the AS context is established.
+    ///
+    /// The unit tests above cover the DERIVATION; nothing covers the WIRING,
+    /// because amfd has no harness that drives `handle_handover_required` or
+    /// `handle_path_switch_request` (both are async NGAP handlers needing live
+    /// associations). Reverting the N2 site to copy the stored pair therefore
+    /// compiled and passed every test — which is what this guard exists to
+    /// catch.
+    ///
+    /// It lives in `context.rs` and reads `ngap_path.rs` deliberately: a guard
+    /// that greps the file it lives in matches its own needle, including inside
+    /// the comment explaining it. Keeping the two apart makes that impossible
+    /// rather than merely avoided. Do not move this test into `ngap_path.rs`.
+    #[test]
+    fn both_mobility_paths_route_through_the_shared_next_hop_helper() {
+        let src = include_str!("ngap_path.rs");
+
+        // Positive: the N2 HandoverRequest site and the Xn
+        // PathSwitchRequestAcknowledge site, and nothing else.
+        assert_eq!(
+            src.matches("advance_next_hop()").count(),
+            2,
+            "expected exactly the N2 and Xn mobility sites to advance the chain; \
+             a new site must either use the helper or this count must be raised \
+             deliberately"
+        );
+        // Positive: the chain is seeded once, where KgNB is derived.
+        assert_eq!(
+            src.matches("init_next_hop_chain()").count(),
+            1,
+            "the forward-security chain must be seeded exactly once, at \
+             AS-security-context establishment"
+        );
+        // Negative, and the reason the positives above are not enough on their
+        // own: the defective form conveyed the stored pair unchanged.
+        assert!(
+            !src.contains("next_hop_chaining_count: state.amf_ue.nhcc"),
+            "a mobility path is conveying the stored NCC verbatim instead of \
+             advancing the chain (nextgcore #70)"
+        );
     }
 
     #[test]

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -2873,6 +2873,11 @@ impl NgapServer {
             access_type_distinguisher,
         );
         state.amf_ue.kgnb = kgnb;
+        // Seed the {NH, NCC} forward-security chain from KgNB (TS 33.501 Annex
+        // A.10): KgNB is the NCC=0 pair, NH = KDF(KAMF, KgNB) is NCC=1. Without
+        // this the chain starts from a zero NH and every handover hands the
+        // target a key the source can reproduce (#70).
+        state.amf_ue.init_next_hop_chain();
 
         let tmsi = state.amf_ue.next_guti.tmsi;
         let allowed_nssai = state.amf_ue.allowed_nssai.clone();
@@ -4522,7 +4527,9 @@ impl NgapServer {
         // future work; we emit the HandoverRequest with the source container so
         // the target can begin admission.
         let target_assoc = target_assoc.expect("checked is_some");
-        let Some(state) = self.ue_auth_state.get(&required.amf_ue_ngap_id) else {
+        // Mutable: advancing the {NH, NCC} chain for the target gNB mutates the
+        // stored pair (TS 33.501 Section 6.9.2.3.3).
+        let Some(state) = self.ue_auth_state.get_mut(&required.amf_ue_ngap_id) else {
             log::warn!(
                 "HandoverRequired for unknown UE {}; rejecting",
                 required.amf_ue_ngap_id
@@ -4555,6 +4562,12 @@ impl NgapServer {
             }
         };
 
+        // Advance the forward-security chain for the target gNB (TS 33.501
+        // Section 6.9.2.3.3). This MUST NOT copy the stored pair: the target
+        // needs an NH the source gNB has never held, which is the whole point
+        // of the chain. Shared with the Xn path so the two cannot diverge.
+        let (ho_ncc, ho_nh) = state.amf_ue.advance_next_hop();
+
         let ho_request = nextgcore_ngap::types::HandoverRequest {
             amf_ue_ngap_id: required.amf_ue_ngap_id,
             handover_type: required.handover_type,
@@ -4565,8 +4578,8 @@ impl NgapServer {
             },
             ue_security_capabilities: ue_caps_to_ngap(&state.amf_ue.ue_security_capability),
             security_context: nextgcore_ngap::types::SecurityContext {
-                next_hop_chaining_count: state.amf_ue.nhcc,
-                next_hop: state.amf_ue.nh,
+                next_hop_chaining_count: ho_ncc,
+                next_hop: ho_nh,
             },
             pdu_session_list: required
                 .pdu_session_list
@@ -4906,10 +4919,10 @@ impl NgapServer {
                 .ue_auth_state
                 .get_mut(&amf_ue_ngap_id)
                 .expect("checked");
-            let new_nh =
-                nextgcore_crypt::kdf::nextgcore_kdf_nh_gnb(&state.amf_ue.kamf, &state.amf_ue.nh);
-            state.amf_ue.nh = new_nh;
-            state.amf_ue.nhcc = state.amf_ue.nhcc.wrapping_add(1) & 0x07;
+            // Shared with the N2 path (see AmfUe::advance_next_hop) so the two
+            // cannot derive keys differently. The chain is seeded from KgNB at
+            // AS-context establishment, so this no longer chains from zeros.
+            let (_ncc, _nh) = state.amf_ue.advance_next_hop();
             // Move the UE's serving RAN association and RAN-UE-NGAP-ID to the
             // target gNB; this is the N3 tunnel/RAN identity update.
             state.ran_ue_ngap_id = req.ran_ue_ngap_id;

--- a/src/libs/nextgcore-crypt/src/kdf.rs
+++ b/src/libs/nextgcore-crypt/src/kdf.rs
@@ -32,6 +32,7 @@ const FC_FOR_KSEAF_DERIVATION: u8 = 0x6C;
 const FC_FOR_KAMF_DERIVATION: u8 = 0x6D;
 const FC_FOR_KGNB_KN3IWF_DERIVATION: u8 = 0x6E;
 const FC_FOR_NH_GNB_DERIVATION: u8 = 0x6F;
+const FC_FOR_KAMF_PRIME_DERIVATION: u8 = 0x72;
 const FC_FOR_SOR_MAC_IAUSF_DERIVATION: u8 = 0x77;
 const FC_FOR_SOR_MAC_IUE_DERIVATION: u8 = 0x78;
 const FC_FOR_UPU_MAC_IAUSF_DERIVATION: u8 = 0x7B;
@@ -299,6 +300,58 @@ pub fn nextgcore_kdf_nh_gnb(
 
     nextgcore_kdf_common(kamf, FC_FOR_NH_GNB_DERIVATION, &params)
 }
+
+/// TS 33.501 Annex A.13: KAMF' derivation for 5GS mobility (FC 0x72)
+///
+/// Re-keys KAMF when the UE moves, so the new AMF (or the same AMF after a
+/// mobility event) holds a key the previous one cannot compute — horizontal
+/// re-keying at N2/Xn handover and vertical re-keying at idle-mode mobility.
+///
+/// The derived key is `KDF(KAMF, S)` per TS 33.220 B.2.0 with
+///
+/// ```text
+/// S = FC(0x72) || P0(direction) || L0(0x0001) || P1(NAS COUNT, 4 octets BE) || L1(0x0004)
+/// ```
+///
+/// * `direction` — [`KAMF_PRIME_DIRECTION_UPLINK`] (0x00) when the derivation is
+///   bound to the **uplink** NAS COUNT, as at idle-mode mobility, and
+///   [`KAMF_PRIME_DIRECTION_DOWNLINK`] (0x01) when bound to the **downlink**
+///   NAS COUNT, as at connected-mode handover. The direction is what keeps the
+///   two derivations distinct even when the COUNT values coincide.
+/// * `nas_count` — the NAS COUNT for that direction, big-endian, matching how
+///   [`nextgcore_kdf_kgnb_and_kn3iwf`] encodes its COUNT (note the EPS-era
+///   helpers in this file deliberately use NATIVE byte order to stay
+///   bit-compatible with the C original; the 5G derivations do not).
+///
+/// # Verification ceiling
+///
+/// **No published 3GPP test vector was available when this was written**, and
+/// none exists in this tree. The unit tests therefore pin THIS construction —
+/// that the two directions differ, that the COUNT is load-bearing, and that the
+/// output is stable — rather than agreement with a 3GPP vector. The `S` layout
+/// is spelled out above precisely so a reviewer holding Annex A.13 can check it
+/// by eye rather than by reading the code. Treat interop against a real peer AMF
+/// as the outstanding validation.
+pub fn nextgcore_kdf_kamf_prime(
+    kamf: &[u8; SHA256_DIGEST_SIZE],
+    direction: u8,
+    nas_count: u32,
+) -> [u8; SHA256_DIGEST_SIZE] {
+    let count_be = nas_count.to_be_bytes();
+
+    let mut params = [KdfParam::default(), KdfParam::default()];
+    params[0].buf = Some(vec![direction]);
+    params[0].len = 1;
+    params[1].buf = Some(count_be.to_vec());
+    params[1].len = 4;
+
+    nextgcore_kdf_common(kamf, FC_FOR_KAMF_PRIME_DERIVATION, &params)
+}
+
+/// KAMF' bound to the uplink NAS COUNT (idle-mode mobility).
+pub const KAMF_PRIME_DIRECTION_UPLINK: u8 = 0x00;
+/// KAMF' bound to the downlink NAS COUNT (connected-mode handover).
+pub const KAMF_PRIME_DIRECTION_DOWNLINK: u8 = 0x01;
 
 /// TS 33.501 Annex A.17: SoR-MAC-I_AUSF generation function
 ///
@@ -1054,5 +1107,87 @@ mod tests {
         let (c3, _) =
             nextgcore_kdf_ck_ik_prime(&ck, &ik, "5G:mnc002.mcc002.3gppnetwork.org", &sqn_xor_ak);
         assert_ne!(c1, c3);
+    }
+
+    /// nextgcore #70 criterion 3: FC 0x72 KAMF' derivation.
+    ///
+    /// No published 3GPP vector was available, so these pin the CONSTRUCTION,
+    /// not agreement with a 3GPP vector — see the doc comment on
+    /// `nextgcore_kdf_kamf_prime`. What they do establish is that every input is
+    /// load-bearing, which is what catches a parameter dropped or transposed.
+    #[test]
+    fn kamf_prime_uses_every_input() {
+        let kamf = [0x33u8; SHA256_DIGEST_SIZE];
+        let other_kamf = [0x44u8; SHA256_DIGEST_SIZE];
+
+        let base = nextgcore_kdf_kamf_prime(&kamf, KAMF_PRIME_DIRECTION_UPLINK, 7);
+
+        // Deterministic for equal inputs.
+        assert_eq!(
+            base,
+            nextgcore_kdf_kamf_prime(&kamf, KAMF_PRIME_DIRECTION_UPLINK, 7)
+        );
+        // The direction distinguishes horizontal (handover) from vertical (idle)
+        // re-keying even when the COUNT coincides -- if P0 were dropped these
+        // would collide.
+        assert_ne!(
+            base,
+            nextgcore_kdf_kamf_prime(&kamf, KAMF_PRIME_DIRECTION_DOWNLINK, 7)
+        );
+        // The COUNT is load-bearing.
+        assert_ne!(
+            base,
+            nextgcore_kdf_kamf_prime(&kamf, KAMF_PRIME_DIRECTION_UPLINK, 8)
+        );
+        // The key is load-bearing.
+        assert_ne!(
+            base,
+            nextgcore_kdf_kamf_prime(&other_kamf, KAMF_PRIME_DIRECTION_UPLINK, 7)
+        );
+        // A re-key must not be the identity: the point is that the previous
+        // holder of KAMF cannot compute KAMF'.
+        assert_ne!(base, kamf);
+        assert_ne!(base, [0u8; SHA256_DIGEST_SIZE]);
+    }
+
+    /// Golden vectors pinning the exact `S` construction, including the COUNT's
+    /// big-endian encoding.
+    ///
+    /// These are a snapshot of OUR construction, generated from the
+    /// implementation and pasted (not typed), not a 3GPP vector — see the
+    /// function's doc comment. That still makes them load-bearing: any change to
+    /// the FC, the parameter order, a parameter length, or the COUNT's byte
+    /// order changes these bytes and fails this test.
+    ///
+    /// A first attempt asserted only that two different COUNTs produce different
+    /// outputs. That passed identically with `to_ne_bytes()`, because two
+    /// distinct COUNTs differ under either byte order — a negative assertion
+    /// satisfied by the very defect it was meant to catch. Hence the positive
+    /// form here.
+    #[test]
+    fn kamf_prime_matches_its_golden_vectors() {
+        fn hex(bytes: &[u8; SHA256_DIGEST_SIZE]) -> String {
+            bytes.iter().map(|b| format!("{b:02x}")).collect()
+        }
+        let kamf = [0x55u8; SHA256_DIGEST_SIZE];
+
+        assert_eq!(
+            hex(&nextgcore_kdf_kamf_prime(
+                &kamf,
+                KAMF_PRIME_DIRECTION_UPLINK,
+                1
+            )),
+            "b792e19a7ac57570820338756bd70b221b16e33f1d3e2d5f020a7e279961b952",
+            "uplink/COUNT=1 vector changed: the S construction moved"
+        );
+        assert_eq!(
+            hex(&nextgcore_kdf_kamf_prime(
+                &kamf,
+                KAMF_PRIME_DIRECTION_DOWNLINK,
+                1
+            )),
+            "3e3a6dae19cc9f91d5d9171a66749df5c71e77effdcc27d2c73fd98b567d1ded",
+            "downlink/COUNT=1 vector changed: the S construction moved"
+        );
     }
 }


### PR DESCRIPTION
`Refs #70`, **not Closes** — ships gaps 1, 2 and 3. Gaps 4 and 5 (mobility control-plane completion) remain open and the count deliberately does not move.

Spec: `specs/fix-amf-n2-xn-forward-security.md`.

All eight of the issue's cites were re-verified at `6e02d63` and **all eight still hold**, at new line numbers.

## The defect

`AmfUe::nh` is zero-initialised, `kgnb` was derived and stored at AS-security-context establishment but **never copied into it**, and the only NH derivation chained `nh` from *itself* — `nh_gnb(kamf, nh)` with `nh` still all-zeros.

* **N2 (`HandoverRequired`)** copied `{nhcc, nh}` into the HandoverRequest `SecurityContext` verbatim — no increment, no derivation. A UE that had performed no prior Xn handover shipped **32 zero bytes with NCC = 0**.
* **Xn (`PathSwitchRequest`)** did increment NCC and chain the NH, but from that zero seed.

Either way the target gNB derives an AS root key the source gNB — and anyone who logged KgNB — can reproduce. That is exactly the property the NH chain exists to provide (TS 33.501 §6.9.2.3.3).

## The fix — seed once, advance everywhere, through one helper

`init_next_hop_chain()` runs immediately after `kgnb` is stored: `NH = KDF(KAMF, KgNB)` with `NCC = 1`, per Annex A.10 (KgNB itself is the NCC = 0 pair).

`advance_next_hop() -> (u8, [u8; 32])` chains `NH = KDF(KAMF, NH)` and increments `NCC = (NCC + 1) mod 8`, returning the pair **in the order the NGAP `SecurityContext` fields are written** so a caller cannot transpose them. Both mobility paths call it — which is what stops them diverging again, and they had diverged in the worst way: one advancing, one not advancing at all.

Advance-then-send follows the issue's own criterion (*"NCC = previous + 1 (mod 8) for a UE that has performed no prior handover"*) and matches what Xn already did, so Xn's wire behaviour changes only in the seed.

### A defect the issue does not mention

`save_memento`/`restore_memento` persisted **`nh` but not `nhcc`** — `nhcc` was not even a field on `AmfUeMemento`. `nh` and `nhcc` are one value: the NCC names the position of that NH in the chain. Restoring the key while leaving the counter advanced makes the AMF convey a pair that does not describe itself, and the target derives a key the UE cannot match. Found by reading the memento while making the pair coherent.

### Gap 3 — KAMF′ (FC 0x72)

`nextgcore_kdf_kamf_prime(kamf, direction, nas_count)`, with the `S` construction spelled out in the doc comment so a reviewer holding Annex A.13 can check it by eye:

```text
S = FC(0x72) || P0(direction) || L0(0x0001) || P1(NAS COUNT, 4 octets BE) || L1(0x0004)
```

The COUNT is big-endian, matching the other 5G derivations — note the **EPS-era helpers in the same file deliberately use native byte order** for bit-compatibility with the C original, which is a live trap for anyone copying a neighbour. It is not yet called: gaps 4 and 5 are where mobility re-keying is invoked, and shipping the primitive now keeps that follow-up out of the crypto library.

## Why this ships alone

CONVENTIONS allows a safety-critical defect inside an umbrella to ship as `Refs #N`. Enumerated before starting rather than discovered late:

* gaps 1–3 need **no new machinery** — `nh_gnb` (Annex A.10) exists and KgNB is already derived;
* gap 4 is wiring — `build_ue_context_release_command_asn1` and `call_smf_update_sm_context` both exist;
* gap 5 needs a **`PathSwitchRequestAcknowledgeTransfer` encoder that does not exist anywhere in the tree**.

Holding a forward-security break behind that encoder is the failure mode the exception exists to prevent.

## Verification

Eight new tests. Workspace **5743 passed / 0 failed** (was 5735), `cargo test --workspace` exit 0 — checked for `^error`, not only a `test result:` line. `cargo fmt --all --check` clean; `cargo clippy --workspace` (the CI gate) exit 0.

**Revert-verified one at a time — and the first pass found two of my own tests wanting, which is the whole reason for doing it:**

| revert | test that fails |
|---|---|
| seed the chain from zeros again | `next_hop_chain_is_seeded_from_kgnb_never_from_zero` |
| stop incrementing NCC | `first_handover_conveys_a_non_zero_nh_and_an_incremented_ncc` |
| drop `nhcc` from the memento | `memento_restores_the_nh_and_ncc_together` |
| N2 copies the stored pair | `both_mobility_paths_route_through_the_shared_next_hop_helper` |
| drop the KAMF′ direction parameter | `kamf_prime_uses_every_input` |
| native byte order for the KAMF′ COUNT | `kamf_prime_matches_its_golden_vectors` |

The last two rows were **green on the first revert pass**:

* **The N2 wiring was uncovered.** The derivation is unit-tested, but nothing drove the emission site — amfd has no harness for `handle_handover_required` — so reverting N2 to copy the stored pair compiled and passed everything. Extracting logic into a tested helper does not test that the helper is *called*. Fixed with a source guard asserting positively that the two mobility sites and the single seed site are present, plus a negative on the defective expression. It lives in `context.rs` and reads `ngap_path.rs` **deliberately**: a guard grepping the file it lives in matches its own needle, including inside the comment explaining it — a trap this repo has already been bitten by.
* **My endianness test proved nothing.** It asserted only that two different COUNTs give different outputs, which is true under *either* byte order. Replaced with golden vectors generated from the implementation and pasted, not typed.

## Not verified

* **No 3GPP test vector exists for FC 0x72 KAMF′**, in this tree or available to the session that wrote it. The golden vectors pin *our* construction, so any change to the FC, parameter order, a length or the byte order fails the test — but agreement with 3GPP rests on the doc-commented `S` layout being read against Annex A.13. **Interop against a real peer AMF is the outstanding validation, and this is the single highest-value review item in the change.**
* No real gNB, UE or handover was exercised. The chain is asserted at the `AmfUe` level; the emission sites are covered by a source guard, which proves the call is present, not that the encoded NGAP `SecurityContext` is correct on the wire.
* Docker E2E remains skipped by CI.
* **GitNexus impact analysis, mandated by this repo's CLAUDE.md, was not run** — no GitNexus MCP server was connected. Caller analysis was grep-based: every `.nh`/`.nhcc`/`.kgnb` use in amfd (12 sites, 2 of them the memento) and both `nextgcore_kdf_nh_gnb` callers.

## Gaps 4 and 5 — plan recorded, not re-derived

**Gap 4 (N2 control plane).** `HandoverNotify` must tell the SMF the target DL tunnel and send a `UEContextReleaseCommand` to the source gNB. Both helpers exist; the trap is bookkeeping — the Xn path **overwrites** `state.ran_ue_ngap_id` and `state.association_id` with the target's, so the source identity must be captured before the switch or the release cannot be addressed. Cross-gNB relocation is still marked "future work" at `ngap_path.rs:4522` and is the larger part.

**Gap 5 (Xn → SMF).** Blocked on the missing encoder above. Today the AMF echoes the inbound transfer and the SMF returns no `n2SmInfo` part, so both halves are broken and neither can be tested against the other. Note the SMF *does* already perform a PFCP DL-FAR modify (`main.rs:2558`), which is why the missing acknowledge transfer has not surfaced as an outage.
