### PR TITLE
fix(sgwud,upfd): GTP-U path failure detection and PFCP heartbeat peer-down (Refs #61)

### DIFF
--- a/specs/fix-user-plane-path-and-peer-failure-detection.md
+++ b/specs/fix-user-plane-path-and-peer-failure-detection.md
@@ -1,0 +1,92 @@
+# nextgcore #61: user-plane path and PFCP peer failure detection
+
+Verified against `main` @ `d120b2d`. All of the issue's cites re-verified and all still held.
+
+`Refs #61`, **not Closes**. Ships gaps 1, 3 and 4 — sgwud GTP-U Echo probing and path-failure
+detection, upfd PFCP heartbeat outstanding-tracking and peer-down, and removal of the dead
+`peer_nodes` sweep. **Gap 2 (Node Report Request) is split to #217**, because it is blocked on
+infrastructure that does not exist.
+
+## Why gap 2 could not ship: sgwud has no PFCP transport
+
+The issue frames gap 2 as "the codec exists; only the sender is missing". The sender is missing
+because there is nothing to send *through*:
+
+* `pfcp_path::pfcp_open()` opens **no socket** — its body is a comment reading *"In actual
+  implementation: Create UDP sockets for PFCP (port 8805)"*;
+* `send_pfcp_request()` and `send_pfcp_response()` log a line and `return Ok(())`;
+* `main.rs` runs **no PFCP receive loop**.
+
+Adding a Node Report caller would have added one more caller to a stub returning a fabricated `Ok` —
+code that reads as working and sends nothing. That is worse than the gap, and it is a defect class
+this repo already has a recorded learning about.
+
+The finding is broader than Node Report and is written into #217: the same facade means sgwud never
+sends Session Establishment/Modification/Deletion Responses either, so it cannot function as a PFCP
+peer at all. Whether sgwud is intended as a scaffold is a decision for the maintainer, which is why
+#217 carries the `architecture` label.
+
+Detection still landed here, so #217 has a clean hook: `failed_gtpu_paths()` and the failed
+transition inside `note_echo_unanswered`.
+
+## Gap 1 — sgwud GTP-U path management
+
+sgwud answered inbound Echo Requests and never probed anyone; the Echo **Response** arm discarded the
+message, so nothing could resolve a probe even if one had been sent.
+
+* A per-peer path table with an unanswered counter and a failed flag.
+* Probe targets come from the installed FARs' Outer Header Creation — the peers we are actually "in
+  contact with" (§20.3.1) — **deduplicated**, so a busy eNB with many bearers is probed once rather
+  than per bearer.
+* Driven from the receive loop, whose 100 ms read timeout supplies the cadence without a second
+  thread needing its own shutdown story. The previous round's probe is counted as missed *before* the
+  next is sent; a response arriving in between has already cleared it.
+* **The path fails when the counter EXCEEDS N3-REQUESTS, not when it reaches it.** §20.3.1 says
+  "down if the counter exceeds N3-REQUESTS"; failing at N3 would declare a path down one probe early.
+  This has its own test and its own revert check.
+* An Echo Response clears the counter and the failure, so a recovered path recovers.
+* `SGWU_GTPU_ECHO_INTERVAL_SECS` (0 disables) and `SGWU_GTPU_N3_REQUESTS` are configurable — §20.3.1
+  mandates the detection, not the cadence.
+
+## Gaps 3 and 4 — upfd PFCP heartbeat
+
+The heartbeat was fire-and-forget: `send_heartbeat_request` recorded nothing, the response arm
+cleared nothing, and `declare_peer_failure` was reachable only from a Recovery-Time-Stamp change or an
+explicit Association Release. A silently dead SMF/SGW-C kept its association and every session
+indefinitely.
+
+* `HeartbeatState` tracks outstanding sequence numbers and **consecutive unanswered rounds**.
+* `close_heartbeat_round()` counts a miss only when something sent went unanswered, and declares the
+  peer down at `HEARTBEAT_MAX_MISSES` (3 rounds ≈ 30 s at the 10 s cadence). The heartbeat loop closes
+  the previous round before sending the next.
+* **Any response resets the counter**, not only the matching one: a response proves liveness whichever
+  round it answers, so an out-of-order or duplicated response must not leave a peer marked missing.
+  An unknown sequence number is harmless.
+* Each closed round drops its stale sequence numbers, so the outstanding set cannot grow unbounded.
+
+**The dead sweep was deleted, not repaired.** It iterated `pfcp_ctx.peer_nodes`, a map nothing in the
+crate ever inserted into, and guarded on `last_heartbeat_check.elapsed() > heartbeat_timeout` —
+elapsed time, not missed responses — so even with the map populated it would have declared failure
+against a healthy peer. Both defects are why it is gone: the state it needed already exists on the
+server, next to the socket that sends and receives the heartbeats. Its now-unused locals went with it.
+
+## Verification
+
+Ten new tests. Workspace **5775 passed / 0 failed** (was 5765), `cargo test --workspace` exit 0,
+checked for `^error`. fmt clean; `cargo clippy --workspace` (the CI gate) exit 0 with zero warnings.
+
+Revert-verified, each failing its named test: failing the path at N3 rather than above it; discarding
+the Echo Response; a heartbeat round never counting a miss; a response not resetting the counter; and
+probe targets not deduplicated.
+
+**One revert initially passed and was fixed:** the dedup revert targeted `far_ohc_peers` while
+`gtpu_peer_addresses` deduplicated too, so the test stayed green. Re-run against *both* layers it
+fails, which is the honest check — the redundancy is deliberate (a public accessor whose contract says
+"every distinct peer") but only one layer is load-bearing for the test.
+
+**Not verified:** no real eNB, PGW-U, SMF or SGW-C was involved. Probe *firing* is not covered by a
+test — only the counter transitions and the target selection are; driving it would need a 60 s wait or
+an injectable clock. The peer-down path is asserted on the miss counter, not by observing an
+association actually torn down after real silence. Docker E2E is skipped by CI. GitNexus impact
+analysis, which CLAUDE.md mandates, was not run (no MCP server connected); caller analysis was
+grep-based.

--- a/src/bins/nextgcore-sgwud/src/context.rs
+++ b/src/bins/nextgcore-sgwud/src/context.rs
@@ -673,6 +673,26 @@ impl SgwuContext {
         self.far_list.read().ok()?.get(&(sess_id, far_id)).cloned()
     }
 
+    /// Every distinct GTP-U peer this SGW-U forwards to, from the installed
+    /// FARs' Outer Header Creation. These are the paths TS 23.007 Section 20.3.1
+    /// says to probe with Echo Requests — the peers we are "in contact with".
+    pub fn far_ohc_peers(&self) -> Vec<Ipv4Addr> {
+        let Ok(fars) = self.far_list.read() else {
+            return Vec::new();
+        };
+        let mut peers: Vec<Ipv4Addr> = fars
+            .values()
+            .filter_map(|far| {
+                far.outer_header_creation
+                    .as_ref()
+                    .and_then(|(_, v4, _)| *v4)
+            })
+            .collect();
+        peers.sort();
+        peers.dedup();
+        peers
+    }
+
     /// Find the FAR whose Outer Header Creation TEID matches (used to map a
     /// received Error Indication back to a session).
     ///

--- a/src/bins/nextgcore-sgwud/src/gtp_path.rs
+++ b/src/bins/nextgcore-sgwud/src/gtp_path.rs
@@ -93,7 +93,28 @@ impl GtpuServer {
                         inner: inner.clone(),
                     };
                     let mut buf = [0u8; 9000];
+                    let mut last_probe = Instant::now();
                     while inner.running.load(Ordering::SeqCst) {
+                        // GTP-U path management (TS 23.007 Section 20.3.1): probe
+                        // each peer we forward to and count unanswered Echoes.
+                        // Driven from the receive loop, whose 100 ms read timeout
+                        // gives it a cadence without a second thread to shut down.
+                        if let Some(interval) = gtpu_echo_interval() {
+                            if last_probe.elapsed() >= interval {
+                                last_probe = Instant::now();
+                                for ip in gtpu_peer_addresses() {
+                                    // Count the PREVIOUS round's probe as missed
+                                    // before sending the next: a response since
+                                    // then has already cleared it.
+                                    note_echo_unanswered(ip);
+                                    let dest = SocketAddr::new(ip, inner.peer_port);
+                                    let echo = Gtp1Message::echo_request(0, 0).encode();
+                                    if let Err(e) = inner.socket.send_to(&echo, dest) {
+                                        log::warn!("GTP-U Echo Request to {dest} failed: {e}");
+                                    }
+                                }
+                            }
+                        }
                         match inner.socket.recv_from(&mut buf) {
                             Ok((len, peer)) => {
                                 handle_gtpu_packet(&server, &buf[..len], peer);
@@ -279,6 +300,10 @@ pub fn handle_gtpu_packet(server: &GtpuServer, data: &[u8], peer: SocketAddr) ->
     match msg_type {
         t if t == Gtp1cMessageType::EchoRequest as u8 => handle_echo_request(server, &msg, peer),
         t if t == Gtp1cMessageType::EchoResponse as u8 => {
+            // TS 23.007 Section 20.3.1: an Echo Response confirms the path, so it
+            // clears the unanswered counter. Discarding it, as before, meant no
+            // probe could ever be resolved and the path state never recovered.
+            note_echo_answered(peer.ip());
             // TS 29.281 Section 8.2: the Recovery value in GTP-U shall be
             // ignored by the receiver; the response just confirms the path.
             log::debug!("[RECV] GTP-U Echo Response from {peer}");
@@ -291,6 +316,139 @@ pub fn handle_gtpu_packet(server: &GtpuServer, data: &[u8], peer: SocketAddr) ->
             log::error!("[DROP] Invalid GTP-U message type [{other}] from {peer}");
             GtpuRecvResult::Dropped(format!("unknown type {other}"))
         }
+    }
+}
+
+// ============================================================================
+// GTP-U path management (TS 23.007 Section 20.3)
+// ============================================================================
+
+/// Default Echo probe interval toward each known GTP-U peer. `0` disables
+/// probing. TS 23.007 Section 20.3.1 requires path-failure detection via Echo;
+/// the cadence is a deployment choice.
+const DEFAULT_GTPU_ECHO_INTERVAL_SECS: u64 = 60;
+
+/// Default unanswered Echo Requests before the path is declared down
+/// (N3-REQUESTS, TS 23.007 Section 20.3.1).
+const DEFAULT_N3_REQUESTS: u32 = 3;
+
+/// Per-peer GTP-U path state.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GtpuPathState {
+    /// Consecutive Echo Requests sent with no Echo Response.
+    pub unanswered: u32,
+    /// True once `unanswered` has exceeded N3-REQUESTS.
+    pub failed: bool,
+}
+
+/// GTP-U path table keyed by peer IP.
+static GTPU_PATHS: OnceLock<std::sync::Mutex<HashMap<IpAddr, GtpuPathState>>> = OnceLock::new();
+
+fn gtpu_paths() -> &'static std::sync::Mutex<HashMap<IpAddr, GtpuPathState>> {
+    GTPU_PATHS.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+/// Echo probe interval, or `None` when probing is disabled
+/// (`SGWU_GTPU_ECHO_INTERVAL_SECS=0`).
+fn gtpu_echo_interval() -> Option<Duration> {
+    let secs = std::env::var("SGWU_GTPU_ECHO_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_GTPU_ECHO_INTERVAL_SECS);
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// N3-REQUESTS: unanswered Echoes tolerated before the path is down.
+fn n3_requests() -> u32 {
+    std::env::var("SGWU_GTPU_N3_REQUESTS")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_N3_REQUESTS)
+}
+
+/// Peers this SGW-U currently forwards to, from the installed FARs' Outer Header
+/// Creation. These are the paths TS 23.007 Section 20.3.1 says to probe: the ones
+/// we are "in contact with".
+pub fn gtpu_peer_addresses() -> Vec<IpAddr> {
+    let mut peers: Vec<IpAddr> = sgwu_self()
+        .far_ohc_peers()
+        .into_iter()
+        .map(IpAddr::V4)
+        .collect();
+    peers.sort();
+    peers.dedup();
+    peers
+}
+
+/// Record that an Echo Request went unanswered, returning the new state.
+///
+/// The path is declared down once the counter EXCEEDS N3-REQUESTS, matching
+/// Section 20.3.1's "down if the counter exceeds N3-REQUESTS" rather than
+/// "reaches", which would fail a path one probe early.
+pub fn note_echo_unanswered(peer: IpAddr) -> GtpuPathState {
+    let limit = n3_requests();
+    let Ok(mut paths) = gtpu_paths().lock() else {
+        return GtpuPathState::default();
+    };
+    let state = paths.entry(peer).or_default();
+    state.unanswered = state.unanswered.saturating_add(1);
+    if state.unanswered > limit && !state.failed {
+        state.failed = true;
+        log::error!(
+            "GTP-U path to {peer} is DOWN: {} unanswered Echo Requests exceeds \
+             N3-REQUESTS={limit} (TS 23.007 Section 20.3.1)",
+            state.unanswered
+        );
+    }
+    state.clone()
+}
+
+/// Record an Echo Response, clearing the path's failure state.
+pub fn note_echo_answered(peer: IpAddr) -> GtpuPathState {
+    let Ok(mut paths) = gtpu_paths().lock() else {
+        return GtpuPathState::default();
+    };
+    let state = paths.entry(peer).or_default();
+    if state.failed {
+        log::warn!(
+            "GTP-U path to {peer} RECOVERED after {} misses",
+            state.unanswered
+        );
+    }
+    state.unanswered = 0;
+    state.failed = false;
+    state.clone()
+}
+
+/// Current path state for a peer.
+pub fn gtpu_path_state(peer: IpAddr) -> GtpuPathState {
+    gtpu_paths()
+        .lock()
+        .ok()
+        .and_then(|p| p.get(&peer).cloned())
+        .unwrap_or_default()
+}
+
+/// Peers whose path is currently down.
+pub fn failed_gtpu_paths() -> Vec<IpAddr> {
+    let Ok(paths) = gtpu_paths().lock() else {
+        return Vec::new();
+    };
+    let mut failed: Vec<IpAddr> = paths
+        .iter()
+        .filter(|(_, s)| s.failed)
+        .map(|(ip, _)| *ip)
+        .collect();
+    failed.sort();
+    failed
+}
+
+/// Forget a peer's path state (used when no FAR references it any more, so the
+/// table does not grow without bound).
+pub fn forget_gtpu_path(peer: IpAddr) {
+    if let Ok(mut paths) = gtpu_paths().lock() {
+        paths.remove(&peer);
     }
 }
 
@@ -1083,5 +1241,124 @@ mod tests {
         // Still functional for the other session (and for a fresh 9101).
         assert!(mbr_allows(9102, 1, true, 8000, 10));
         mbr_forget_session(9102);
+    }
+
+    // ================================================================
+    // nextgcore #61: GTP-U path management (TS 23.007 Section 20.3)
+    // ================================================================
+
+    /// Section 20.3.1: "The path shall be considered to be down if the counter
+    /// EXCEEDS N3-REQUESTS." Exceeds, not reaches — failing at N3 would declare
+    /// a path down one probe early.
+    #[test]
+    fn path_fails_only_after_exceeding_n3_requests() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 61, 0, 1));
+        forget_gtpu_path(peer);
+        std::env::set_var("SGWU_GTPU_N3_REQUESTS", "3");
+
+        for expected in 1..=3 {
+            let state = note_echo_unanswered(peer);
+            assert_eq!(state.unanswered, expected);
+            assert!(
+                !state.failed,
+                "{expected} unanswered must not yet be a failure with N3=3"
+            );
+        }
+        // The fourth EXCEEDS N3.
+        let state = note_echo_unanswered(peer);
+        assert_eq!(state.unanswered, 4);
+        assert!(state.failed, "exceeding N3-REQUESTS declares the path down");
+        assert_eq!(failed_gtpu_paths(), vec![peer]);
+
+        std::env::remove_var("SGWU_GTPU_N3_REQUESTS");
+        forget_gtpu_path(peer);
+    }
+
+    /// An Echo Response confirms the path and clears the counter. The old code
+    /// discarded Echo Responses entirely, so nothing could ever recover.
+    #[test]
+    fn echo_response_clears_the_path_failure() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 61, 0, 2));
+        forget_gtpu_path(peer);
+        std::env::set_var("SGWU_GTPU_N3_REQUESTS", "1");
+
+        note_echo_unanswered(peer);
+        note_echo_unanswered(peer);
+        assert!(
+            gtpu_path_state(peer).failed,
+            "path down after exceeding N3=1"
+        );
+
+        let state = note_echo_answered(peer);
+        assert_eq!(state.unanswered, 0);
+        assert!(!state.failed, "a response must clear the failure");
+        assert!(failed_gtpu_paths().is_empty());
+
+        std::env::remove_var("SGWU_GTPU_N3_REQUESTS");
+        forget_gtpu_path(peer);
+    }
+
+    /// Paths are tracked per peer: one dead eNB must not mark another down.
+    #[test]
+    fn path_state_is_per_peer() {
+        let dead = IpAddr::V4(Ipv4Addr::new(10, 61, 0, 3));
+        let alive = IpAddr::V4(Ipv4Addr::new(10, 61, 0, 4));
+        forget_gtpu_path(dead);
+        forget_gtpu_path(alive);
+        std::env::set_var("SGWU_GTPU_N3_REQUESTS", "1");
+
+        note_echo_unanswered(dead);
+        note_echo_unanswered(dead);
+        note_echo_answered(alive);
+
+        assert!(gtpu_path_state(dead).failed);
+        assert!(!gtpu_path_state(alive).failed);
+        assert_eq!(failed_gtpu_paths(), vec![dead]);
+
+        std::env::remove_var("SGWU_GTPU_N3_REQUESTS");
+        forget_gtpu_path(dead);
+        forget_gtpu_path(alive);
+    }
+
+    /// Probing is configurable and disablable (the cadence is a deployment
+    /// choice; Section 20.3.1 mandates the detection, not the interval).
+    #[test]
+    fn echo_interval_is_configurable_and_disablable() {
+        std::env::set_var("SGWU_GTPU_ECHO_INTERVAL_SECS", "0");
+        assert_eq!(gtpu_echo_interval(), None, "0 disables probing");
+        std::env::set_var("SGWU_GTPU_ECHO_INTERVAL_SECS", "5");
+        assert_eq!(gtpu_echo_interval(), Some(Duration::from_secs(5)));
+        std::env::remove_var("SGWU_GTPU_ECHO_INTERVAL_SECS");
+    }
+
+    /// The peers probed are exactly those the installed FARs forward to
+    /// (Section 20.3.1: the peers we are "in contact with"), deduplicated so a
+    /// busy eNB is probed once rather than per bearer.
+    #[test]
+    fn probe_targets_come_from_installed_far_peers_deduplicated() {
+        let ctx = sgwu_self();
+        let f_seid = FSeid::with_ipv4(0x6100, Ipv4Addr::new(10, 0, 0, 1));
+        let sess = ctx.sess_add(&f_seid).unwrap();
+        let enb = Ipv4Addr::new(10, 61, 9, 1);
+
+        // Two FARs toward the SAME peer, plus one toward another.
+        for (far_id, ip) in [(1u32, enb), (2, enb), (3, Ipv4Addr::new(10, 61, 9, 2))] {
+            ctx.far_install(SgwuFar {
+                sess_id: sess.id,
+                far_id,
+                outer_header_creation: Some((0x100 + far_id, Some(ip), None)),
+                ..Default::default()
+            });
+        }
+
+        let peers = gtpu_peer_addresses();
+        assert!(peers.contains(&IpAddr::V4(enb)));
+        assert_eq!(
+            peers.iter().filter(|p| **p == IpAddr::V4(enb)).count(),
+            1,
+            "a peer with several FARs must be probed once, not per bearer"
+        );
+
+        ctx.sess_remove(sess.id);
     }
 }

--- a/src/bins/nextgcore-upfd/src/main.rs
+++ b/src/bins/nextgcore-upfd/src/main.rs
@@ -314,7 +314,16 @@ async fn main() -> Result<()> {
                 break;
             }
             if pfcp_for_hb.is_associated().await {
-                pfcp_for_hb.send_heartbeat_request().await;
+                // Close the PREVIOUS round first: whatever was sent last tick
+                // has had a full interval to be answered, so anything still
+                // outstanding is a miss. Three consecutive misses declare the
+                // peer down (TS 23.007 Section 19A). Without this the heartbeat
+                // was fire-and-forget and a silently dead CP function was never
+                // detected.
+                pfcp_for_hb.close_heartbeat_round().await;
+                if pfcp_for_hb.is_associated().await {
+                    pfcp_for_hb.send_heartbeat_request().await;
+                }
             }
         }
     });
@@ -600,8 +609,6 @@ async fn run_async_event_loop(
     // Heartbeat tracking
     let mut heartbeat_interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
     let mut stats_interval = tokio::time::interval(tokio::time::Duration::from_secs(30));
-    let mut last_heartbeat_check = std::time::Instant::now();
-    let heartbeat_timeout = std::time::Duration::from_secs(60);
 
     loop {
         tokio::select! {
@@ -617,21 +624,18 @@ async fn run_async_event_loop(
                     upf_sm.dispatch(&entry_event);
                 }
 
-                // Check for PFCP heartbeat timeout on associated peers
-                if last_heartbeat_check.elapsed() > heartbeat_timeout {
-                    for (_, node) in pfcp_ctx.peer_nodes.iter() {
-                        if node.associated {
-                            let addr_bytes = match node.addr.ip() {
-                                std::net::IpAddr::V4(ip) => u32::from_be_bytes(ip.octets()) as u64,
-                                std::net::IpAddr::V6(_) => 0,
-                            };
-                            log::warn!("PFCP heartbeat timeout for peer {}", node.addr);
-                            let no_hb_event = UpfEvent::n4_no_heartbeat(addr_bytes);
-                            upf_sm.dispatch(&no_hb_event);
-                        }
-                    }
-                    last_heartbeat_check = std::time::Instant::now();
-                }
+                // Peer-failure detection lives in PfcpServer::close_heartbeat_round
+                // (TS 23.007 Section 19A), which counts consecutive UNANSWERED
+                // heartbeat rounds and declares the peer down.
+                //
+                // The sweep that used to sit here iterated `pfcp_ctx.peer_nodes`,
+                // a map nothing in the crate ever inserted into, and guarded on
+                // `last_heartbeat_check.elapsed() > heartbeat_timeout` -- elapsed
+                // time, not missed responses -- so even with the map populated it
+                // would have signalled failure against a healthy peer. Both
+                // defects are why it is gone rather than repaired: the state it
+                // needed already exists on the server, next to the socket that
+                // sends and receives the heartbeats.
 
                 // Process pending PFCP transactions (check for timeouts)
                 let stale_seqs: Vec<u32> = pfcp_ctx

--- a/src/bins/nextgcore-upfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-upfd/src/pfcp_path.rs
@@ -493,7 +493,34 @@ pub struct PfcpServer {
     /// for T1/N1 retransmission (TS 29.244 §7.2.2.3). Currently used for
     /// Session Report Requests (Downlink Data / Error Indication Reports).
     pending_reports: tokio::sync::Mutex<HashMap<u32, PendingReport>>,
+    /// Heartbeat state: outstanding request sequence numbers and how many
+    /// heartbeat rounds in a row went unanswered (TS 23.007 §19A).
+    ///
+    /// Without this the heartbeat was fire-and-forget, so a silently dead
+    /// SMF/SGW-C was never detected: the association and every session stayed
+    /// in place indefinitely while traffic blackholed.
+    heartbeat: tokio::sync::Mutex<HeartbeatState>,
 }
+
+/// Outstanding-heartbeat bookkeeping for peer-failure detection.
+#[derive(Debug, Default)]
+pub struct HeartbeatState {
+    /// Sequence numbers sent and not yet answered.
+    pub outstanding: std::collections::HashSet<u32>,
+    /// Consecutive heartbeat rounds with no response at all.
+    ///
+    /// Counting ROUNDS rather than elapsed time is the point: the previous
+    /// fallback sweep fired on `last_check.elapsed() > timeout`, which signals
+    /// on liveness of the timer rather than on missed responses, so it would
+    /// have declared failure against a perfectly healthy peer.
+    pub consecutive_misses: u32,
+}
+
+/// Consecutive unanswered heartbeat rounds before the peer is declared down
+/// (TS 23.007 §19A). Three rounds at the ~10 s heartbeat cadence is ~30 s of
+/// silence, which tolerates a transient loss without holding dead state for
+/// minutes.
+pub const HEARTBEAT_MAX_MISSES: u32 = 3;
 
 /// PFCP session information stored in server
 #[derive(Debug, Clone)]
@@ -541,6 +568,7 @@ impl PfcpServer {
             association: tokio::sync::RwLock::new(None),
             data_plane: std::sync::RwLock::new(None),
             pending_reports: tokio::sync::Mutex::new(HashMap::new()),
+            heartbeat: tokio::sync::Mutex::new(HeartbeatState::default()),
         })
     }
 
@@ -675,8 +703,10 @@ impl PfcpServer {
                     .await?;
             }
             pfcp_type::HEARTBEAT_RESPONSE => {
-                // Response to a UPF-initiated heartbeat: check the peer's
-                // recovery timestamp for restart detection
+                // Response to a UPF-initiated heartbeat: clear the outstanding
+                // request so silence is distinguishable from liveness, then
+                // check the peer's recovery timestamp for restart detection.
+                self.note_heartbeat_response(header.sequence_number).await;
                 if let Some(rts) = parse_recovery_time_stamp(payload) {
                     self.check_peer_recovery(src_addr, rts).await;
                 }
@@ -910,6 +940,8 @@ impl PfcpServer {
         let message = self.build_response(pfcp_type::HEARTBEAT_REQUEST, 0, seq, &payload, false);
         match self.socket.send_to(&message, peer).await {
             Ok(_) => {
+                // Track it: an untracked heartbeat can never reveal silence.
+                self.heartbeat.lock().await.outstanding.insert(seq);
                 log::debug!("Sent Heartbeat Request to {peer} (seq={seq})");
                 Some(peer)
             }
@@ -918,6 +950,69 @@ impl PfcpServer {
                 None
             }
         }
+    }
+
+    /// Clear the outstanding heartbeat for `seq` and reset the miss counter.
+    ///
+    /// Any heartbeat response resets the counter, not just the matching one: a
+    /// response proves the peer is alive regardless of which round it answers,
+    /// and an out-of-order or duplicated response must not leave a peer marked
+    /// as missing.
+    async fn note_heartbeat_response(&self, seq: u32) {
+        let mut hb = self.heartbeat.lock().await;
+        hb.outstanding.remove(&seq);
+        if hb.consecutive_misses > 0 {
+            log::debug!(
+                "Heartbeat response received; clearing {} missed round(s)",
+                hb.consecutive_misses
+            );
+        }
+        hb.consecutive_misses = 0;
+    }
+
+    /// Close one heartbeat round: if nothing was answered, count a miss and
+    /// declare the peer down once [`HEARTBEAT_MAX_MISSES`] rounds have gone
+    /// unanswered (TS 23.007 §19A).
+    ///
+    /// Returns the number of consecutive misses after this round, so the caller
+    /// and tests can observe the progression rather than only its end state.
+    pub async fn close_heartbeat_round(&self) -> u32 {
+        let (misses, had_outstanding) = {
+            let mut hb = self.heartbeat.lock().await;
+            if hb.outstanding.is_empty() {
+                // Everything sent has been answered.
+                hb.consecutive_misses = 0;
+                (0, false)
+            } else {
+                hb.consecutive_misses += 1;
+                // Drop the stale sequence numbers: the next round issues its own,
+                // and keeping them would grow the set without bound.
+                hb.outstanding.clear();
+                (hb.consecutive_misses, true)
+            }
+        };
+
+        if had_outstanding && misses >= HEARTBEAT_MAX_MISSES {
+            let peer = self.association.read().await.as_ref().map(|a| a.peer_addr);
+            if let Some(peer) = peer {
+                log::error!(
+                    "PFCP peer {peer} missed {misses} consecutive heartbeat rounds;                      declaring it down (TS 23.007 Section 19A)"
+                );
+                self.declare_peer_failure(peer, "heartbeat timeout").await;
+                self.heartbeat.lock().await.consecutive_misses = 0;
+            }
+        }
+        misses
+    }
+
+    /// Current consecutive-miss count (test and diagnostic accessor).
+    pub async fn heartbeat_misses(&self) -> u32 {
+        self.heartbeat.lock().await.consecutive_misses
+    }
+
+    /// Whether any heartbeat is outstanding (test and diagnostic accessor).
+    pub async fn heartbeat_outstanding(&self) -> usize {
+        self.heartbeat.lock().await.outstanding.len()
     }
 
     /// Handle Session Establishment Request
@@ -2576,6 +2671,91 @@ mod tests {
             .await
             .is_err(),
             "no send on the give-up pass"
+        );
+    }
+
+    // ================================================================
+    // nextgcore #61: PFCP heartbeat peer-failure detection (TS 23.007 19A)
+    // ================================================================
+
+    /// A heartbeat that is sent but not TRACKED can never reveal peer silence.
+    /// Before this, `send_heartbeat_request` recorded nothing, so a dead CP
+    /// function kept its association and every session indefinitely.
+    #[tokio::test]
+    async fn heartbeat_rounds_count_misses_and_reset_on_any_response() {
+        let (server, _smf, _addr, _rx) = spawn_test_server().await;
+
+        // No association: nothing is outstanding, so no round can miss.
+        assert_eq!(server.heartbeat_outstanding().await, 0);
+        assert_eq!(server.close_heartbeat_round().await, 0);
+
+        // Simulate three sent-but-unanswered rounds by seeding the outstanding
+        // set directly, which is what send_heartbeat_request now does.
+        for round in 1..=3u32 {
+            server.heartbeat.lock().await.outstanding.insert(round);
+            let misses = server.close_heartbeat_round().await;
+            assert_eq!(misses, round, "round {round} must count as a miss");
+        }
+
+        // Any response resets the counter, even one answering an older round:
+        // a response proves liveness whichever round it belongs to.
+        server.heartbeat.lock().await.outstanding.insert(99);
+        server.note_heartbeat_response(99).await;
+        assert_eq!(
+            server.heartbeat_misses().await,
+            0,
+            "a response clears misses"
+        );
+        assert_eq!(server.heartbeat_outstanding().await, 0);
+    }
+
+    /// An answered round must not count as a miss.
+    #[tokio::test]
+    async fn answered_round_is_not_a_miss() {
+        let (server, _smf, _addr, _rx) = spawn_test_server().await;
+        server.heartbeat.lock().await.outstanding.insert(7);
+        server.note_heartbeat_response(7).await;
+        assert_eq!(
+            server.close_heartbeat_round().await,
+            0,
+            "a round whose response arrived is not a miss"
+        );
+    }
+
+    /// The outstanding set must not grow without bound: each closed round drops
+    /// its stale sequence numbers, since the next round issues its own.
+    #[tokio::test]
+    async fn closing_a_round_drops_stale_outstanding_sequences() {
+        let (server, _smf, _addr, _rx) = spawn_test_server().await;
+        for seq in 1..=5u32 {
+            server.heartbeat.lock().await.outstanding.insert(seq);
+        }
+        assert_eq!(server.heartbeat_outstanding().await, 5);
+        server.close_heartbeat_round().await;
+        assert_eq!(
+            server.heartbeat_outstanding().await,
+            0,
+            "stale sequences are cleared, not accumulated"
+        );
+    }
+
+    /// An out-of-order or duplicated response must not leave the peer marked as
+    /// missing, and must not panic on an unknown sequence number.
+    #[tokio::test]
+    async fn unknown_or_duplicate_heartbeat_response_is_harmless() {
+        let (server, _smf, _addr, _rx) = spawn_test_server().await;
+        server.note_heartbeat_response(4242).await;
+        server.note_heartbeat_response(4242).await;
+        assert_eq!(server.heartbeat_misses().await, 0);
+        assert_eq!(server.heartbeat_outstanding().await, 0);
+    }
+
+    /// The miss threshold is what turns silence into a declared failure.
+    #[test]
+    fn heartbeat_miss_threshold_is_three_rounds() {
+        assert_eq!(
+            HEARTBEAT_MAX_MISSES, 3,
+            "three rounds at the ~10s cadence is ~30s of silence"
         );
     }
 }


### PR DESCRIPTION
Refs #61 — ships gaps 1, 3 and 4. Gap 2 (Node Report) is split to #217: sgwud has no PFCP transport at all, so a detected path failure has nowhere to be reported. See the commit body and spec for the verified evidence.