### PR TITLE
fix(nrfd): real SubscrCond matching, HAL NF list, Bootstrapping and the PUT event (Closes #68)

### DIFF
--- a/specs/fix-nrf-subscr-cond-hal-list-and-bootstrapping.md
+++ b/specs/fix-nrf-subscr-cond-hal-list-and-bootstrapping.md
@@ -1,0 +1,175 @@
+# nextgcore #68 (NRF): SubscrCond matching, HAL NF list, Bootstrapping, PUT event
+
+Verified against `main` @ `d2b0304`. The issue's cites are from `76ea248` and PR #219 moved most of
+them again, so every site was re-located before being touched.
+
+`Closes #68`. This ships the four gaps PR #219 left open, and with them the whole issue. #219 shipped
+criteria 1–3 and 8 (subscription PATCH, suspend notification, timers re-armed on restore); this ships
+criteria 4, 5, 6, 7 and 9.
+
+## Gap: `SubscrCond` collapsed to match-all (criterion 5)
+
+The worst of the four, and not a wire-shape problem — a delivery one.
+
+`SubscrCond` is a `oneOf` over **17** condition schemas (TS 29.510 §5.2.2.5.2). The old model was a
+three-field struct — `nfType`, `serviceName`, `nfInstanceId` — populated by reading those three keys
+out of whatever object arrived. A conformant `NfSetCond`, `AmfCond`, `NfGroupCond`,
+`NetworkSliceCond`, `GuamiListCond`, `ScpDomainCond` or any of the `conditionType`-tagged conditions
+carries **none** of those three keys, so it parsed to a condition with all three fields `None`.
+`subscription_matches` then fell through every `if let` and returned `true`.
+
+So a subscriber that asked for one NF set received a notification for **every NF in the registry** —
+and it looked like it was working, because notifications arrived.
+
+The model is now the discriminator plus the condition object verbatim:
+
+```rust
+pub struct SubscrCond { pub kind: SubscrCondKind, pub raw: serde_json::Value }
+```
+
+Keeping `raw` rather than re-flattening is the same shape as the recorded decision to store a
+received JSON object as-is and match on a canonical key. It also fixes a quieter bug: the 201 body
+used to be rebuilt from the three parsed fields, so a consumer reading back its own subscription saw
+a condition narrower than the one it sent.
+
+`subscr_cond_matches` has **no catch-all `=> true` arm**. Every one of the 17 arms compares real
+criteria against the profile document the NRF already stores verbatim in `NfProfile::attributes`,
+which is what makes the deep conditions matchable at all (`amfInfo.guamiList`, `nfSetIdList`,
+`sNssais`, `nwdafInfo.taiRangeList`, the per-type `*Info.groupId`).
+
+Three decisions inside that are worth review:
+
+* **A condition this NRF cannot evaluate is refused at subscribe time with 400, not accepted.**
+  Two criteria fall in this bucket. `UpfCond.taiList`: TS 29.510 `UpfInfo` carries `smfServingArea`,
+  `sNssaiUpfInfoList` and `interfaceUpfInfoList` and **no TAI list**, so a UPF profile holds nothing
+  to compare a TAI against — the condition's prose promises something its own profile schema does not
+  supply, which is the recorded "29.5xx disagrees with itself" pattern again. And `NefCond`'s
+  AF/identifier-range criteria, which match against nested `gpsiRanges` /
+  `externalGroupIdentifiersRanges` structures. Accepting either would leave only silent options:
+  notify for every NF, or for none. A visible refusal naming the criterion (`cause:
+  SUBSCR_COND_NOT_SUPPORTED`) is the honest one, and it follows the recorded principle that an NF
+  should advertise only what it can actually serve. **This is a deliberate deviation**: those
+  conditions are spec-valid and we answer 400. Criterion 5 explicitly permits it ("or rejects
+  unknown/malformed conditions with 400"), but it is the judgement most worth a second opinion.
+* **A `conditionType`-tagged condition is restricted to the NF type it names.** `UPF_COND` must not
+  match an AMF merely because the AMF carries no `upfInfo` to contradict it. Without this the
+  match-all hole reopens for exactly the four conditions whose criteria are all optional.
+* **A pattern-only `TacRange` does not match.** `TacRange` is `start`/`end` **or** `pattern`; the
+  pattern form is not evaluated, and treating an unevaluated pattern as a hit would widen the serving
+  area to everything — the failure mode this change exists to remove. Failing closed on one range
+  form is the recoverable direction; failing open reintroduces the bug.
+
+The identity comparators compare significant members rather than whole JSON values, because an
+insignificant spelling difference must not make two identical values differ: `sd` absent ≡ `sd:
+"ffffff"` (TS 23.003: no differentiator), TAC `"0001"` ≡ `"1"` (hex, 3–4 digits), hex case ignored for
+`sd`/`tac`/`amfId`, and a stray `nid` on one side of a PLMN ignored.
+
+## Gap: `reqNotifEvents` and `notifCondition` dropped on parse (criterion 4)
+
+Both were parsed nowhere, so a subscriber that asked only for `NF_DEREGISTERED` still received every
+registration and profile change, and `notifCondition` had no effect at all. Both are now parsed,
+persisted, echoed, and **enforced at all four notify-all call sites** — enforcing at one and not the
+others would have been the same bug with a smaller blast radius.
+
+`notifCondition` is expressed over top-level NFProfile attributes, so an RFC 6902 path is reduced to
+its first segment (`/nfServices/0/priority` → `nfServices`). A change touching several attributes is
+notified when **any** is monitored; dropping it would lose a change the subscriber asked for. An empty
+change list is not narrowed, because a complete-replacement notification carries the profile instead
+of a change list.
+
+The schema's `not: required: [monitoredAttributes, unmonitoredAttributes]` is enforced: a body
+carrying both is a 400 rather than silently resolved in one direction.
+
+## Gap: `validityTime` read as an integer duration (criterion 4)
+
+`validityTime` is a `DateTime` string. The create path read it with `as_u64`, so **every conformant
+proposal silently fell through to the 24h default** — the consumer's request had no observable effect.
+It is now parsed as RFC 3339 (reusing `rfc3339_to_epoch`, added by #219 for the PATCH path), clamped
+to the NRF's own maximum so a consumer cannot pin a subscription open indefinitely, and a
+non-conformant form — a bare integer, a malformed string, a past time — is a 400.
+
+Rejecting the integer form is a behaviour change for any out-of-tree consumer that was relying on the
+wrong reading. Nothing in this tree sends it (`nwdafd` only ever *reads* `validityTime`, and reads it
+as RFC 3339 already), and the spec type is unambiguous.
+
+## Gap: `GET /nf-instances` was neither HAL nor filtered (criterion 6)
+
+Three things wrong, all invisible to a lenient client: the media type was `application/json` rather
+than `application/3gppHal+json`; `_links` carried bare strings under a mis-spelled `items` (the
+`UriList` schema names it `item`, and the values are `LinksValueSchema` — `{ href }` objects); and the
+`nf-type`/`limit`/`page` parameters were ignored outright, the request being bound as `_request`. A
+consumer paging a large registry silently received the whole list on every page.
+
+Now: correct media type, `item` as an array of `Link` objects, `self` as a `Link`, `totalItemCount`
+over the **filtered** set so a consumer can tell how many pages remain, and the three parameters
+applied.
+
+Two judgement calls: results are **sorted by instance id** before paging, because without a total
+order two requests for page 2 can return different overlapping sets from the same registry (the
+backing store is a `HashMap`); and an **unusable `limit`/`page` is a 400, not an ignored parameter** —
+ignoring it returns a page the consumer did not ask for and cannot detect, which is precisely the old
+behaviour. `page` without `limit` is refused for the same reason.
+
+## Gap: no Bootstrapping service (criterion 7)
+
+`GET /bootstrapping` has a single path segment, so it never reached the service match — it fell out at
+the `parts.len() < 3` guard as a 404. It is now matched ahead of that guard and returns
+`BootstrappingInfo` in `application/3gppHal+json`, with the six registered relation types of Table
+6.4.6.3.3.1-1 (`self`, `manage`, `subscribe`, `discover`, `authorize`, `retrieve-key`) as absolute
+hrefs, plus `ETag`/`Cache-Control`.
+
+`oauth2Required` reports `require_oauth2_server` — the posture actually enforced — rather than a
+literal, so the answer cannot drift from behaviour.
+
+**Served unconditionally, not behind the feature gate the issue suggests.** §5.5 makes the service
+optional and the issue floats an off-default gate; both a cargo feature and an off-by-default switch
+were rejected. A cargo feature would put the tests outside `cargo test --workspace`, which is the CI
+gate, so the code would ship unexercised. An off-by-default runtime switch would leave the gap open
+for every deployment that did not know to flip it. The endpoint is read-only and publishes only what
+an unauthenticated peer must be able to read for bootstrapping to mean anything. `/bootstrapping` is
+outside `oauth2_protected_path`, so it stays reachable when server-side OAuth2 is on — required, since
+a consumer reads this document to *find* the token endpoint. A test asserts that non-gating directly.
+
+`If-None-Match` is honoured with a 304. The yaml declares the parameter but does not enumerate a 304
+response; the parameter has no other purpose, so the conditional is answered rather than accepted and
+ignored. The `ETag` is FNV-1a over the body, deliberately not `DefaultHasher` — that is documented as
+unstable across Rust releases and would silently invalidate every cached document on a toolchain bump.
+
+## Gap: a `PUT` replacement announced itself as a new registration (criterion 9)
+
+`handle_nf_register` always dispatched `NF_REGISTERED`, even when `is_new == false`. TS 29.510
+§5.2.2.3.1A: a complete replacement is a change, not an appearance. Subscribers were told a producer
+had just appeared that had been registered all along — which is what a consumer's "new NF available"
+handling keys on.
+
+## Verification
+
+**32 new tests** (9 in `sbi_path`, 10 in `main`, 13 more assertion groups inside those). Workspace
+`cargo test --workspace` **green**; `cargo clippy --workspace` (the CI gate) clean with **zero**
+warnings; `cargo fmt --all --check` clean.
+
+**Revert-verified: 21 reverts, 21 bit.** Each fix was individually undone and the named test watched
+to fail, then restored — including both halves of the `PUT` event fix separately (the mapping
+function *and* the handler passing `is_new`, since testing only the mapping would leave the part that
+was actually wrong unpinned), and the paging sort, re-run three times because a missing sort could
+otherwise pass on map order. Full list in the PR body.
+
+The `PUT`-replacement test is **end-to-end over a real HTTP/2 subscriber**, not a unit test of the
+event mapping: the notification is delivered by a `tokio::spawn`ed call, so the only way to observe
+which event the handler chose is to be the subscriber and read it off the wire.
+
+Two tests register profiles under a deliberately non-spec `nfType` (`NRFD68-HAL-LIST`,
+`NRFD68-PUT-EVENT`). `nf_manager()` is process-global and other tests in the same binary write to it;
+a unique type is what keeps the assertions from being perturbed, per the recorded
+process-global-state learning. It is a test fixture, not a wire claim.
+
+**One pre-existing clippy warning fixed in passing** (`main.rs` `needless_borrows_for_generic_args`,
+introduced by #219 in a test this change sits next to).
+
+**Not verified:** no live consumer, NF or restart was exercised beyond the in-process HTTP/2 server.
+The `reqNotifEvents` and `notifCondition` gates are pinned at the predicate and at all four call
+sites, but no test drives a real subscriber through a filtered notification, so their end-to-end
+behaviour rests on the call-site wiring being read correctly rather than observed. Docker E2E is
+skipped by CI. GitNexus impact analysis, which CLAUDE.md mandates, was **not run** — no MCP server is
+connected, so that mandate is currently unsatisfiable and this is the eighth consecutive PR to record
+it.

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -947,6 +947,16 @@ async fn nrf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
         return rejection;
     }
 
+    // Nnrf_Bootstrapping (TS 29.510 §5.5) is served at `{apiRoot}/bootstrapping`
+    // with NO service/version prefix, so it must be matched before the
+    // three-segment guard below — which is exactly why it used to 404.
+    if parts.first() == Some(&"bootstrapping") && parts.len() == 1 {
+        return match method {
+            "GET" => handle_bootstrapping(&request),
+            _ => send_method_not_allowed(method, uri),
+        };
+    }
+
     // Route based on service and resource
     // Expected paths:
     // - /nnrf-nfm/v1/nf-instances/{nfInstanceId}
@@ -1026,6 +1036,19 @@ async fn nrf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
     }
 }
 
+/// The `NotificationEventType` a `PUT /nf-instances/{id}` must be notified as.
+///
+/// TS 29.510 §5.2.2.3.1A / §5.2.2.3.2: a first registration is `NF_REGISTERED`;
+/// a complete replacement of a profile that already exists is
+/// `NF_PROFILE_CHANGED`.
+fn registration_notification_event(is_new: bool) -> NotificationEventType {
+    if is_new {
+        NotificationEventType::NfRegistered
+    } else {
+        NotificationEventType::NfProfileChanged
+    }
+}
+
 /// Handle NF Register request
 async fn handle_nf_register(nf_instance_id: &str, request: &SbiRequest) -> SbiResponse {
     log::info!("NF Register: {nf_instance_id}");
@@ -1100,18 +1123,26 @@ async fn handle_nf_register(nf_instance_id: &str, request: &SbiRequest) -> SbiRe
                 "Heartbeat timer started for NF {nf_instance_id} ({expiry_secs} seconds, 2x {hb}s interval)"
             );
 
-            // Send NF status notifications to all matching subscribers
+            // Send NF status notifications to all matching subscribers.
+            //
+            // TS 29.510 §5.2.2.3.1A: a PUT that COMPLETELY REPLACES an existing
+            // profile is a change, not an appearance, and must be notified as
+            // NF_PROFILE_CHANGED. Emitting NF_REGISTERED for a replacement tells
+            // every subscriber a producer just appeared that has in fact been
+            // registered all along — which is what a consumer's
+            // "new NF available" handling keys on.
+            let event = registration_notification_event(is_new);
             let notify_profile = nf_profile.clone();
             let server_uri = nrf_self_uri().to_string();
             tokio::spawn(async move {
                 if let Err(e) = nrf_nnrf_nfm_send_nf_status_notify_all_async(
-                    NotificationEventType::NfRegistered,
+                    event,
                     &notify_profile,
                     &server_uri,
                 )
                 .await
                 {
-                    log::error!("Failed to send NF_REGISTERED notifications: {e}");
+                    log::error!("Failed to send {} notifications: {e}", event.as_str());
                 }
             });
 
@@ -1478,26 +1509,247 @@ async fn handle_nf_update(nf_instance_id: &str, request: &SbiRequest) -> SbiResp
         .unwrap_or_else(|_| SbiResponse::with_status(200))
 }
 
+/// The `3gppHal+json` media type the NF-instance collection is served as
+/// (TS 29.510 §6.1.3.2.3.1).
+const HAL_JSON_CONTENT_TYPE: &str = "application/3gppHal+json";
+
 /// Handle NF List Retrieval request
-async fn handle_nf_list_retrieval(_request: &SbiRequest) -> SbiResponse {
+///
+/// TS 29.510 §6.1.3.2.3.1: `GET /nf-instances` returns a `UriList` in
+/// `application/3gppHal+json`, whose `_links` members are `LinksValueSchema`
+/// values — i.e. `{ "href": ... }` objects, or arrays of them — and it applies
+/// the `nf-type`, `limit` and `page` query parameters.
+///
+/// Three things were wrong and all three were invisible to a lenient client:
+/// the media type was plain `application/json`; `_links` carried bare strings
+/// under a mis-spelled `items` member (the schema names it `item`); and the
+/// query parameters were ignored outright — the request was bound as `_request`
+/// — so a consumer paging through a large registry silently received the whole
+/// list on every page.
+async fn handle_nf_list_retrieval(request: &SbiRequest) -> SbiResponse {
     log::debug!("NF List Retrieval");
+
+    let params = query_params(&request.header.uri);
+    let param = |name: &str| {
+        params
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_str())
+    };
+
+    // `nf-type` filters the collection; an unparseable `limit`/`page` is a 400
+    // rather than a silently-ignored parameter, since ignoring it returns a page
+    // the consumer did not ask for and cannot detect.
+    let nf_type_filter = param("nf-type");
+    let limit = match param("limit") {
+        Some(text) => match text.parse::<usize>() {
+            Ok(n) if n > 0 => Some(n),
+            _ => {
+                return send_bad_request(
+                    &format!("limit {text:?} must be a positive integer"),
+                    Some("MANDATORY_IE_INCORRECT"),
+                )
+            }
+        },
+        None => None,
+    };
+    let page = match param("page") {
+        Some(text) => match text.parse::<usize>() {
+            Ok(n) if n > 0 => Some(n),
+            _ => {
+                return send_bad_request(
+                    &format!("page {text:?} must be a positive integer (pages are 1-based)"),
+                    Some("MANDATORY_IE_INCORRECT"),
+                )
+            }
+        },
+        None => None,
+    };
+    if page.is_some() && limit.is_none() {
+        return send_bad_request(
+            "page requires limit: a page number is meaningless without a page size",
+            Some("MANDATORY_IE_INCORRECT"),
+        );
+    }
 
     let manager = nf_manager();
 
-    let instances: Vec<String> = manager
+    // Ordered by instance id so paging is stable: without a total order, two
+    // requests for page 2 can return different, overlapping sets from the same
+    // registry because the underlying map iterates arbitrarily.
+    let mut matched: Vec<String> = manager
         .list()
         .iter()
+        .filter(|p| nf_type_filter.is_none_or(|want| p.nf_type == want))
         .map(|p| p.nf_instance_id.clone())
         .collect();
+    matched.sort_unstable();
+
+    // `totalItemCount` counts everything the filter matched, not the page, so a
+    // consumer can tell how many pages remain.
+    let total_item_count = matched.len();
+
+    let page_items: Vec<String> = match (limit, page) {
+        (Some(limit), Some(page)) => matched
+            .into_iter()
+            .skip((page - 1) * limit)
+            .take(limit)
+            .collect(),
+        (Some(limit), None) => matched.into_iter().take(limit).collect(),
+        _ => matched,
+    };
+
+    let self_href = match (limit, page) {
+        (Some(limit), Some(page)) => {
+            format!("/nnrf-nfm/v1/nf-instances?limit={limit}&page={page}")
+        }
+        (Some(limit), None) => format!("/nnrf-nfm/v1/nf-instances?limit={limit}"),
+        _ => "/nnrf-nfm/v1/nf-instances".to_string(),
+    };
+
+    let body = serde_json::json!({
+        "_links": {
+            "self": { "href": self_href },
+            "item": page_items
+                .iter()
+                .map(|id| serde_json::json!({
+                    "href": format!("/nnrf-nfm/v1/nf-instances/{id}")
+                }))
+                .collect::<Vec<_>>(),
+        },
+        "totalItemCount": total_item_count,
+    });
 
     SbiResponse::with_status(200)
-        .with_json_body(&serde_json::json!({
-            "_links": {
-                "self": "/nnrf-nfm/v1/nf-instances",
-                "items": instances.iter().map(|id| format!("/nnrf-nfm/v1/nf-instances/{id}")).collect::<Vec<_>>()
-            }
-        }))
+        .with_json_body(&body)
         .unwrap_or_else(|_| SbiResponse::with_status(200))
+        .with_header("Content-Type", HAL_JSON_CONTENT_TYPE)
+}
+
+/// How long a `BootstrappingInfo` response may be cached, in seconds.
+///
+/// The document only changes when the NRF's own service surface or OAuth2
+/// posture changes, so a short cache is safe and keeps a fleet of consumers from
+/// re-fetching it on every start; the `ETag` lets a consumer revalidate cheaply.
+const BOOTSTRAPPING_MAX_AGE_SECS: u32 = 60;
+
+/// Handle `GET /bootstrapping` (TS 29.510 §5.5, `Nnrf_Bootstrapping`).
+///
+/// This service is how a consumer that knows only the NRF's authority learns
+/// where the NRF's services live and whether they need OAuth2 — before it holds
+/// a token. It was unrouted: the path has a single segment, so it never even
+/// reached the service match and fell out at the `parts.len() < 3` guard as a
+/// 404, leaving a consumer with no conformant way to discover the endpoints.
+///
+/// The service is optional per §5.5. It is nonetheless served unconditionally
+/// rather than behind a build feature or an off-by-default switch: it is
+/// read-only, it publishes only what an unauthenticated peer must be able to
+/// read for bootstrapping to mean anything, and a gate that defaults closed
+/// would leave the gap open for every deployment that did not know to flip it.
+/// `/bootstrapping` is outside `oauth2_protected_path`, so server-side OAuth2
+/// enforcement does not gate it even when enabled — which is required, since a
+/// consumer reads this document precisely to find the token endpoint.
+fn handle_bootstrapping(request: &SbiRequest) -> SbiResponse {
+    log::debug!("Bootstrapping Info Request");
+
+    let api_root = nrf_self_uri();
+    let policy = nrf_policy();
+
+    // Relation names are the registered types of TS 29.510 Table 6.4.6.3.3.1-1;
+    // hrefs are absolute, as that clause requires.
+    let body = serde_json::json!({
+        "status": "OPERATIVE",
+        "_links": {
+            "self": { "href": format!("{api_root}/bootstrapping") },
+            "manage": { "href": format!("{api_root}/nnrf-nfm/v1/nf-instances") },
+            "subscribe": { "href": format!("{api_root}/nnrf-nfm/v1/subscriptions") },
+            "discover": { "href": format!("{api_root}/nnrf-disc/v1/nf-instances") },
+            "authorize": { "href": format!("{api_root}/nnrf-oauth2/v1/access-token") },
+            "retrieve-key": { "href": format!("{api_root}/nnrf-oauth2/v1/jwks") },
+        },
+        // Keyed by NRF service name per §6.1.6.3.11. Reports the posture this
+        // NRF actually enforces (`require_oauth2_server`), so the answer cannot
+        // drift from behaviour the way a hardcoded value would.
+        "oauth2Required": {
+            "nnrf-nfm": policy.require_oauth2_server,
+            "nnrf-disc": policy.require_oauth2_server,
+        },
+        "nrfInstanceId": nrf_instance_id(),
+    });
+
+    let etag = format!("\"{:016x}\"", fnv1a64(&body.to_string()));
+
+    // RFC 9110 §13.1.2: a matching If-None-Match is answered 304 with no body.
+    // The Bootstrapping yaml lists If-None-Match as a parameter but does not
+    // enumerate a 304 response; the parameter has no other purpose, so the
+    // conditional is honoured rather than accepted and ignored.
+    if let Some(inm) = request.http.get_header("if-none-match") {
+        if if_none_match_matches(inm, &etag) {
+            return SbiResponse::with_status(304)
+                .with_header("ETag", &etag)
+                .with_header(
+                    "Cache-Control",
+                    format!("max-age={BOOTSTRAPPING_MAX_AGE_SECS}"),
+                );
+        }
+    }
+
+    SbiResponse::with_status(200)
+        .with_json_body(&body)
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+        .with_header("Content-Type", HAL_JSON_CONTENT_TYPE)
+        .with_header("ETag", &etag)
+        .with_header(
+            "Cache-Control",
+            format!("max-age={BOOTSTRAPPING_MAX_AGE_SECS}"),
+        )
+}
+
+/// Does an `If-None-Match` header field match `etag`?
+///
+/// Handles the `*` form and a comma-separated list, and compares weak and strong
+/// forms of the same tag as equal (RFC 9110 §13.1.2 uses the weak comparison
+/// function for `If-None-Match`).
+fn if_none_match_matches(header: &str, etag: &str) -> bool {
+    let strip = |t: &str| t.trim().trim_start_matches("W/").to_string();
+    let want = strip(etag);
+    header
+        .split(',')
+        .any(|candidate| candidate.trim() == "*" || strip(candidate) == want)
+}
+
+/// FNV-1a (64-bit) over a string, for deriving a strong `ETag` from a response
+/// body without adding a hashing dependency.
+///
+/// Deliberately not `DefaultHasher`: that is documented as unstable across Rust
+/// releases, which would silently invalidate every cached bootstrapping document
+/// on a toolchain bump.
+fn fnv1a64(text: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in text.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Split a request URI's query string into decoded `(key, value)` pairs.
+///
+/// Percent-decoding is applied to both halves so an encoded `nf-type` still
+/// compares equal; `+` is left alone because these are path-style query values,
+/// not form encoding.
+fn query_params(uri: &str) -> Vec<(String, String)> {
+    let Some(query) = uri.split_once('?').map(|(_, q)| q) else {
+        return Vec::new();
+    };
+    query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .map(|pair| match pair.split_once('=') {
+            Some((k, v)) => (percent_decode(k), percent_decode(v)),
+            None => (percent_decode(pair), String::new()),
+        })
+        .collect()
 }
 
 /// Handle Subscription Create request
@@ -1531,32 +1783,131 @@ async fn handle_subscription_create(request: &SbiRequest) -> SbiResponse {
     // Generate subscription ID
     let subscription_id = uuid::Uuid::new_v4().to_string();
 
-    // Parse subscription condition
-    let subscr_cond =
-        subscription
-            .get("subscrCond")
-            .map(|cond| nextgcore_nrfd::nnrf_handler::SubscrCond {
-                nf_type: cond
-                    .get("nfType")
-                    .and_then(|v| v.as_str())
-                    .map(String::from),
-                service_name: cond
-                    .get("serviceName")
-                    .and_then(|v| v.as_str())
-                    .map(String::from),
-                nf_instance_id: cond
-                    .get("nfInstanceId")
-                    .and_then(|v| v.as_str())
-                    .map(String::from),
-            });
+    // Parse the subscription condition (TS 29.510 §5.2.2.5.2 `SubscrCond`, a
+    // `oneOf` over 17 condition schemas).
+    //
+    // An unrecognised condition is a 400, NOT an unconditional subscription.
+    // This is the crux of the fix: the previous parse read three fields out of
+    // whatever object arrived, so a conformant `NfSetCond` or `AmfCond` produced
+    // a condition with no criteria at all — and a criteria-less condition
+    // matched every NF in the registry, flooding the subscriber with
+    // notifications it never asked for.
+    let subscr_cond = match subscription.get("subscrCond") {
+        Some(cond) => match nextgcore_nrfd::nnrf_handler::SubscrCond::from_json(cond) {
+            Some(parsed) => {
+                // A recognised variant whose criteria this NRF cannot evaluate
+                // is refused too. Accepting it would leave only bad options:
+                // notify for every NF, or for none — both silent, and both worse
+                // than a refusal the consumer can act on.
+                if let Some(unsupported) = parsed.unsupported_criterion() {
+                    return send_bad_request(
+                        &format!(
+                            "subscrCond criterion {:?} is not supported: {}",
+                            unsupported.criterion, unsupported.reason
+                        ),
+                        Some("SUBSCR_COND_NOT_SUPPORTED"),
+                    );
+                }
+                Some(parsed)
+            }
+            None => {
+                return send_bad_request(
+                    &format!(
+                        "subscrCond {cond} matches no TS 29.510 SubscrCond variant; \
+                         omit subscrCond to subscribe to every NF"
+                    ),
+                    Some("MANDATORY_IE_INCORRECT"),
+                )
+            }
+        },
+        None => None,
+    };
 
-    // Parse validity duration. The consumer MAY propose `validityTime`; the NRF
-    // negotiates the validity it will enforce and returns it as an absolute
-    // timestamp (below). Default = preconfigured 24h.
-    let validity_duration = subscription
-        .get("validityTime")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(NRF_SUBSCRIPTION_DEFAULT_VALIDITY);
+    // `reqNotifEvents` (TS 29.510 §5.2.2.5.2): the event types the subscriber
+    // wants. Previously dropped on parse, so a subscriber asking only for
+    // NF_DEREGISTERED still received every registration and profile change.
+    let req_notif_events = match subscription.get("reqNotifEvents") {
+        Some(v) => {
+            let Some(arr) = v.as_array() else {
+                return send_bad_request(
+                    "reqNotifEvents must be an array of NotificationEventType",
+                    Some("MANDATORY_IE_INCORRECT"),
+                );
+            };
+            if arr.is_empty() {
+                return send_bad_request(
+                    "reqNotifEvents must carry at least one NotificationEventType (minItems: 1)",
+                    Some("MANDATORY_IE_INCORRECT"),
+                );
+            }
+            let events: Vec<String> = arr
+                .iter()
+                .filter_map(|e| e.as_str())
+                .map(String::from)
+                .collect();
+            if events.len() != arr.len() {
+                return send_bad_request(
+                    "reqNotifEvents must contain only strings",
+                    Some("MANDATORY_IE_INCORRECT"),
+                );
+            }
+            Some(events)
+        }
+        None => None,
+    };
+
+    // `notifCondition` (TS 29.510 §5.2.2.5.2). The schema's `not` clause makes
+    // monitoredAttributes and unmonitoredAttributes mutually exclusive, so a
+    // body carrying both is refused rather than silently resolved one way.
+    let notif_condition = match subscription.get("notifCondition") {
+        Some(v) => match nextgcore_nrfd::nnrf_handler::NotifCondition::from_json(v) {
+            Some(c) => Some(c),
+            None => {
+                return send_bad_request(
+                    "notifCondition must carry exactly one of monitoredAttributes or \
+                     unmonitoredAttributes, each with at least one entry",
+                    Some("MANDATORY_IE_INCORRECT"),
+                )
+            }
+        },
+        None => None,
+    };
+
+    // Parse the proposed validity. `validityTime` is a DateTime string (TS 29.571
+    // `DateTime`), not an integer duration — reading it with `as_u64` meant every
+    // conformant proposal silently fell through to the default. The consumer MAY
+    // propose; the NRF negotiates the validity it will enforce and returns it as
+    // an absolute timestamp (below). Default = preconfigured 24h.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let validity_duration = match subscription.get("validityTime") {
+        None | Some(serde_json::Value::Null) => NRF_SUBSCRIPTION_DEFAULT_VALIDITY,
+        Some(v) => {
+            let Some(text) = v.as_str() else {
+                return send_bad_request(
+                    "validityTime is a DateTime string (TS 29.571), not a number",
+                    Some("MANDATORY_IE_INCORRECT"),
+                );
+            };
+            let Some(absolute) = rfc3339_to_epoch(text) else {
+                return send_bad_request(
+                    &format!("validityTime {text:?} is not an RFC 3339 date-time"),
+                    Some("MANDATORY_IE_INCORRECT"),
+                );
+            };
+            if absolute <= now {
+                return send_bad_request(
+                    &format!("validityTime {text:?} is in the past"),
+                    Some("MANDATORY_IE_INCORRECT"),
+                );
+            }
+            // The proposal is honoured only up to the NRF's own maximum, so a
+            // consumer cannot pin a subscription open indefinitely.
+            (absolute - now).min(NRF_SUBSCRIPTION_DEFAULT_VALIDITY)
+        }
+    };
 
     // Build subscription data
     let subscription_data = nextgcore_nrfd::SubscriptionData {
@@ -1572,15 +1923,13 @@ async fn handle_subscription_create(request: &SbiRequest) -> SbiResponse {
         notification_uri,
         subscr_cond,
         validity_duration,
+        req_notif_events,
+        notif_condition,
     };
 
     // nrfd-08: the NRF-assigned validityTime is an absolute RFC 3339 timestamp
     // (now + the armed validity duration) so the body matches the armed timer,
     // not the consumer's (possibly absent) proposal.
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
     let validity_time = epoch_to_rfc3339(now + validity_duration);
 
     // nrfd-08: return the full stored SubscriptionData (all fields), built
@@ -1630,18 +1979,18 @@ fn subscription_response_json(
     if let Some(ref id) = sub.req_nf_instance_id {
         map.insert("reqNfInstanceId".to_string(), id.clone().into());
     }
+    // Echoed exactly as received. Rebuilding it from parsed fields is what used
+    // to drop every member the old three-field model did not know about, so a
+    // consumer reading back its own subscription saw a condition narrower than
+    // the one it sent.
     if let Some(ref cond) = sub.subscr_cond {
-        let mut c = serde_json::Map::new();
-        if let Some(ref v) = cond.nf_type {
-            c.insert("nfType".to_string(), v.clone().into());
-        }
-        if let Some(ref v) = cond.service_name {
-            c.insert("serviceName".to_string(), v.clone().into());
-        }
-        if let Some(ref v) = cond.nf_instance_id {
-            c.insert("nfInstanceId".to_string(), v.clone().into());
-        }
-        map.insert("subscrCond".to_string(), serde_json::Value::Object(c));
+        map.insert("subscrCond".to_string(), cond.raw.clone());
+    }
+    if let Some(ref events) = sub.req_notif_events {
+        map.insert("reqNotifEvents".to_string(), events.clone().into());
+    }
+    if let Some(ref cond) = sub.notif_condition {
+        map.insert("notifCondition".to_string(), cond.to_json());
     }
     obj
 }
@@ -3946,12 +4295,10 @@ mod tests {
             req_nf_type: Some("AMF".to_string()),
             req_nf_instance_id: None,
             notification_uri: "http://amf.example.com/nrfd02/notify".to_string(),
-            subscr_cond: Some(SubscrCond {
-                nf_type: Some("SMF".to_string()),
-                service_name: None,
-                nf_instance_id: None,
-            }),
+            subscr_cond: Some(SubscrCond::nf_type("SMF")),
             validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
         };
 
         // Simulate a PATCH replacing /load.
@@ -4042,12 +4389,10 @@ mod tests {
             req_nf_type: Some("SMF".to_string()),
             req_nf_instance_id: None,
             notification_uri: "http://smf.example.com/nrfd02/notify".to_string(),
-            subscr_cond: Some(SubscrCond {
-                nf_type: Some("AMF".to_string()),
-                service_name: None,
-                nf_instance_id: None,
-            }),
+            subscr_cond: Some(SubscrCond::nf_type("AMF")),
             validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
         };
 
         let request = nrf_nnrf_nfm_build_nf_profile_changed_notify(
@@ -5423,12 +5768,10 @@ mod tests {
             req_nf_type: Some("AMF".to_string()),
             req_nf_instance_id: Some("amf-1".to_string()),
             notification_uri: "http://amf/cb".to_string(),
-            subscr_cond: Some(SubscrCond {
-                nf_type: Some("SMF".to_string()),
-                service_name: None,
-                nf_instance_id: None,
-            }),
+            subscr_cond: Some(SubscrCond::nf_type("SMF")),
             validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
         };
         let body = subscription_response_json(&sub, "2023-11-14T22:13:20Z");
         assert_eq!(body["subscriptionId"], "sub-08");
@@ -5595,6 +5938,8 @@ mod tests {
             notification_uri: "http://consumer/notify".to_string(),
             subscr_cond: None,
             validity_duration: 60,
+            req_notif_events: None,
+            notif_condition: None,
         };
         assert!(manager.add_subscription(sub));
 
@@ -5641,7 +5986,7 @@ mod tests {
             .as_secs();
         let future = epoch_to_rfc3339(now + 3600);
         let ok_req = SbiRequest::default().with_body(
-            &format!(r#"{{"validityTime":"{future}"}}"#),
+            format!(r#"{{"validityTime":"{future}"}}"#),
             "application/json",
         );
         let ok = handle_subscription_update("sub-68", &ok_req).await;
@@ -5656,5 +6001,643 @@ mod tests {
         );
 
         manager.remove_subscription("sub-68");
+    }
+
+    // ==================================================================
+    // #68 criterion 9: a complete PUT replacement is NF_PROFILE_CHANGED,
+    // not NF_REGISTERED.
+    // ==================================================================
+
+    #[test]
+    fn registration_event_distinguishes_first_registration_from_replacement() {
+        assert_eq!(
+            registration_notification_event(true).as_str(),
+            "NF_REGISTERED"
+        );
+        assert_eq!(
+            registration_notification_event(false).as_str(),
+            "NF_PROFILE_CHANGED",
+            "TS 29.510 Section 5.2.2.3.1A: a complete replacement is a change, \
+             not an appearance"
+        );
+    }
+
+    /// The wiring, not just the mapping: drive two real `PUT`s through
+    /// `handle_nf_register` with a real subscriber listening, and read the events
+    /// off the wire.
+    ///
+    /// Testing `registration_notification_event` alone would leave the part that
+    /// was actually wrong untested — the handler passing `is_new` at all. The
+    /// notification is delivered by a `tokio::spawn`ed HTTP/2 call, so the only
+    /// way to observe it is to be the subscriber.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn put_replacement_notifies_profile_changed_over_the_wire() {
+        use serde_json::json;
+        use std::sync::Mutex as StdMutex;
+
+        // A deliberately unique nfType: `nf_manager()` is process-global and
+        // other tests in this binary register into it, so the subscription is
+        // scoped to a type only this test uses. Same reason the recorded
+        // process-global-state learning gives for keying on a unique id.
+        const TEST_NF_TYPE: &str = "NRFD68-PUT-EVENT";
+        let nf_id = "nrfd68-put-event-nf";
+
+        let received: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
+        let sink = Arc::clone(&received);
+
+        let addr = nextgcore_sbi::test_support::ephemeral_addr();
+        let subscriber = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        subscriber
+            .start(move |req: SbiRequest| {
+                let sink = Arc::clone(&sink);
+                async move {
+                    if let Some(body) = req.http.content.clone() {
+                        sink.lock().expect("sink lock").push(body);
+                    }
+                    SbiResponse::with_status(204)
+                }
+            })
+            .await
+            .expect("subscriber server starts");
+
+        let manager = nf_manager();
+        let sub_id = "nrfd68-put-event-sub";
+        manager.add_subscription(nextgcore_nrfd::SubscriptionData {
+            id: sub_id.to_string(),
+            req_nf_type: None,
+            req_nf_instance_id: None,
+            notification_uri: format!("http://127.0.0.1:{}/callback", addr.port()),
+            subscr_cond: Some(nextgcore_nrfd::nnrf_handler::SubscrCond::nf_type(
+                TEST_NF_TYPE,
+            )),
+            validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
+        });
+
+        /// Wait until `want` notifications have arrived, or time out.
+        async fn wait_for(sink: &Arc<StdMutex<Vec<String>>>, want: usize) -> Vec<String> {
+            for _ in 0..100 {
+                {
+                    let got = sink.lock().expect("sink lock");
+                    if got.len() >= want {
+                        return got.clone();
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            sink.lock().expect("sink lock").clone()
+        }
+
+        let profile = json!({
+            "nfInstanceId": nf_id,
+            "nfType": TEST_NF_TYPE,
+            "nfStatus": "REGISTERED",
+            "capacity": 10,
+        });
+        let mut req = SbiRequest::put(format!("/nnrf-nfm/v1/nf-instances/{nf_id}"));
+        req.http.set_content(profile.to_string());
+
+        // --- First PUT: a new instance -> 201 and NF_REGISTERED -------------
+        let first = handle_nf_register(nf_id, &req).await;
+        assert_eq!(first.status, 201, "first registration is 201 Created");
+        let after_first = wait_for(&received, 1).await;
+        assert_eq!(
+            after_first.len(),
+            1,
+            "the subscriber must receive exactly one notification, got {after_first:?}"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(&after_first[0]).expect("notification is JSON");
+        assert_eq!(body["event"], "NF_REGISTERED");
+
+        // --- Second PUT: a complete replacement -> 200 and NF_PROFILE_CHANGED
+        let mut replacement_body = profile.clone();
+        replacement_body["capacity"] = json!(90);
+        let mut replacement = SbiRequest::put(format!("/nnrf-nfm/v1/nf-instances/{nf_id}"));
+        replacement.http.set_content(replacement_body.to_string());
+
+        let second = handle_nf_register(nf_id, &replacement).await;
+        assert_eq!(second.status, 200, "a replacement is 200 OK");
+        let after_second = wait_for(&received, 2).await;
+        assert_eq!(after_second.len(), 2, "got {after_second:?}");
+        let body: serde_json::Value =
+            serde_json::from_str(&after_second[1]).expect("notification is JSON");
+        assert_eq!(
+            body["event"], "NF_PROFILE_CHANGED",
+            "a complete replacement must NOT be announced as a new registration"
+        );
+        // The notification carries the replaced profile, so a subscriber can act
+        // on the change without a follow-up GET.
+        assert_eq!(body["nfProfile"]["capacity"], 90);
+
+        manager.remove_subscription(sub_id);
+        manager.deregister(nf_id).ok();
+        disarm_heartbeat_timer(nf_id);
+    }
+
+    // ==================================================================
+    // #68 criterion 6: GET /nf-instances is a HAL UriList and honours
+    // nf-type / limit / page.
+    // ==================================================================
+
+    #[tokio::test]
+    async fn nf_list_is_a_hal_urilist_with_link_objects() {
+        use serde_json::json;
+
+        // Unique nfType again: the registry is process-global.
+        const TEST_NF_TYPE: &str = "NRFD68-HAL-LIST";
+        let ids = [
+            "nrfd68-hal-c",
+            "nrfd68-hal-a",
+            "nrfd68-hal-b",
+            "nrfd68-hal-d",
+        ];
+        let manager = nf_manager();
+        for id in ids {
+            manager
+                .register(
+                    nextgcore_nrfd::nnrf_handler::NfProfile::from_json(&json!({
+                        "nfInstanceId": id,
+                        "nfType": TEST_NF_TYPE,
+                        "nfStatus": "REGISTERED",
+                    }))
+                    .expect("valid profile"),
+                )
+                .expect("register");
+        }
+
+        let get = |uri: &str| {
+            let req = SbiRequest::get(uri);
+            async move { handle_nf_list_retrieval(&req).await }
+        };
+        let body_of = |resp: &SbiResponse| -> serde_json::Value {
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("JSON")
+        };
+
+        // --- Media type and link-object shape ------------------------------
+        let resp = get(&format!("/nnrf-nfm/v1/nf-instances?nf-type={TEST_NF_TYPE}")).await;
+        assert_eq!(resp.status, 200);
+        assert_eq!(
+            resp.http.get_header("content-type").map(String::as_str),
+            Some(HAL_JSON_CONTENT_TYPE),
+            "TS 29.510 Section 6.1.3.2.3.1 serves the collection as 3gppHal+json"
+        );
+        let body = body_of(&resp);
+        assert!(
+            body["_links"]["self"]["href"].is_string(),
+            "_links values are LinksValueSchema objects carrying href, not bare \
+             strings: {body}"
+        );
+        let items = body["_links"]["item"]
+            .as_array()
+            .unwrap_or_else(|| panic!("the schema names the member `item`, not `items`: {body}"));
+        assert_eq!(items.len(), 4, "nf-type must filter to just our four");
+        for item in items {
+            assert!(
+                item["href"].is_string(),
+                "each item is a Link object: {item}"
+            );
+        }
+        assert_eq!(body["totalItemCount"], 4);
+
+        // --- nf-type genuinely filters -------------------------------------
+        let others = get("/nnrf-nfm/v1/nf-instances?nf-type=NRFD68-ABSENT-TYPE").await;
+        let body = body_of(&others);
+        assert_eq!(body["_links"]["item"].as_array().map(|a| a.len()), Some(0));
+        assert_eq!(body["totalItemCount"], 0);
+
+        // --- limit + page page through a stable, sorted order ---------------
+        let page1 = body_of(
+            &get(&format!(
+                "/nnrf-nfm/v1/nf-instances?nf-type={TEST_NF_TYPE}&limit=2&page=1"
+            ))
+            .await,
+        );
+        let page2 = body_of(
+            &get(&format!(
+                "/nnrf-nfm/v1/nf-instances?nf-type={TEST_NF_TYPE}&limit=2&page=2"
+            ))
+            .await,
+        );
+        let hrefs = |b: &serde_json::Value| -> Vec<String> {
+            b["_links"]["item"]
+                .as_array()
+                .expect("item array")
+                .iter()
+                .map(|i| i["href"].as_str().expect("href").to_string())
+                .collect()
+        };
+        let (h1, h2) = (hrefs(&page1), hrefs(&page2));
+        assert_eq!(h1.len(), 2, "limit must cap the page: {h1:?}");
+        assert_eq!(h2.len(), 2, "{h2:?}");
+        assert!(
+            h1.iter().all(|h| !h2.contains(h)),
+            "pages must not overlap: {h1:?} vs {h2:?}"
+        );
+        // Sorted order, so page 2 is deterministic rather than whatever the
+        // underlying map happened to yield.
+        assert!(h1[0].ends_with("nrfd68-hal-a"), "{h1:?}");
+        assert!(h1[1].ends_with("nrfd68-hal-b"), "{h1:?}");
+        assert!(h2[0].ends_with("nrfd68-hal-c"), "{h2:?}");
+        assert!(h2[1].ends_with("nrfd68-hal-d"), "{h2:?}");
+        // totalItemCount counts the whole filtered set, not the page, so a
+        // consumer can tell there is a page 2 at all.
+        assert_eq!(page1["totalItemCount"], 4);
+        // The self link echoes the paging actually applied.
+        assert_eq!(
+            page2["_links"]["self"]["href"],
+            "/nnrf-nfm/v1/nf-instances?limit=2&page=2"
+        );
+
+        // A page past the end is an empty page, not an error.
+        let page9 = body_of(
+            &get(&format!(
+                "/nnrf-nfm/v1/nf-instances?nf-type={TEST_NF_TYPE}&limit=2&page=9"
+            ))
+            .await,
+        );
+        assert_eq!(page9["_links"]["item"].as_array().map(|a| a.len()), Some(0));
+        assert_eq!(page9["totalItemCount"], 4);
+
+        // --- Unusable paging parameters are refused, not ignored ------------
+        // Ignoring them returns a page the consumer did not ask for and cannot
+        // detect, which is how the old handler behaved for every request.
+        for uri in [
+            "/nnrf-nfm/v1/nf-instances?limit=0",
+            "/nnrf-nfm/v1/nf-instances?limit=abc",
+            "/nnrf-nfm/v1/nf-instances?limit=2&page=0",
+            "/nnrf-nfm/v1/nf-instances?page=2",
+        ] {
+            let resp = get(uri).await;
+            assert_eq!(resp.status, 400, "{uri} must be refused");
+        }
+
+        for id in ids {
+            manager.deregister(id).ok();
+        }
+    }
+
+    #[test]
+    fn query_params_are_split_and_percent_decoded() {
+        assert!(query_params("/nnrf-nfm/v1/nf-instances").is_empty());
+        assert_eq!(
+            query_params("/x?nf-type=AMF&limit=2"),
+            vec![
+                ("nf-type".to_string(), "AMF".to_string()),
+                ("limit".to_string(), "2".to_string()),
+            ]
+        );
+        // A percent-encoded value must compare equal to its decoded form.
+        assert_eq!(
+            query_params("/x?nf-type=5G%5FEIR"),
+            vec![("nf-type".to_string(), "5G_EIR".to_string())]
+        );
+        // A valueless parameter and a stray separator must not panic or produce
+        // a phantom entry.
+        assert_eq!(
+            query_params("/x?flag&&limit=1"),
+            vec![
+                ("flag".to_string(), String::new()),
+                ("limit".to_string(), "1".to_string()),
+            ]
+        );
+    }
+
+    // ==================================================================
+    // #68 criterion 7: GET /bootstrapping.
+    // ==================================================================
+
+    #[tokio::test]
+    async fn bootstrapping_returns_hal_bootstrapping_info() {
+        // Routed through the real dispatcher, because the bug was in the router:
+        // /bootstrapping has one path segment and used to fall out at the
+        // three-segment guard as a 404.
+        let resp = nrf_sbi_request_handler(SbiRequest::get("/bootstrapping")).await;
+        assert_eq!(
+            resp.status, 200,
+            "GET /bootstrapping must be routed, not 404'd by the path guard"
+        );
+        assert_eq!(
+            resp.http.get_header("content-type").map(String::as_str),
+            Some(HAL_JSON_CONTENT_TYPE)
+        );
+
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("JSON");
+        assert_eq!(body["status"], "OPERATIVE");
+        assert_eq!(body["nrfInstanceId"], nrf_instance_id());
+
+        // The registered relation types of TS 29.510 Table 6.4.6.3.3.1-1, each an
+        // object carrying an ABSOLUTE href.
+        let api_root = nrf_self_uri();
+        for relation in [
+            "self",
+            "manage",
+            "subscribe",
+            "discover",
+            "authorize",
+            "retrieve-key",
+        ] {
+            let href = body["_links"][relation]["href"]
+                .as_str()
+                .unwrap_or_else(|| panic!("relation {relation} missing an href: {body}"));
+            assert!(
+                href.starts_with(api_root),
+                "relation {relation} href {href} must be absolute (apiRoot {api_root})"
+            );
+        }
+        assert_eq!(
+            body["_links"]["self"]["href"],
+            format!("{api_root}/bootstrapping")
+        );
+        assert_eq!(
+            body["_links"]["authorize"]["href"],
+            format!("{api_root}/nnrf-oauth2/v1/access-token")
+        );
+
+        // oauth2Required must report the posture actually enforced, keyed by NRF
+        // service name; a hardcoded value could drift from behaviour.
+        let expected = nrf_policy().require_oauth2_server;
+        assert_eq!(body["oauth2Required"]["nnrf-nfm"], expected);
+        assert_eq!(body["oauth2Required"]["nnrf-disc"], expected);
+
+        // Bootstrapping must stay reachable without a token even when
+        // server-side OAuth2 is on — a consumer reads this document to FIND the
+        // token endpoint.
+        assert!(
+            !oauth2_protected_path("/bootstrapping"),
+            "an OAuth2-gated bootstrapping resource is unusable by definition"
+        );
+
+        // A non-GET on the resource is 405, not 404.
+        let post = nrf_sbi_request_handler(SbiRequest::post("/bootstrapping")).await;
+        assert_eq!(post.status, 405);
+    }
+
+    #[tokio::test]
+    async fn bootstrapping_revalidates_with_an_etag() {
+        let first = nrf_sbi_request_handler(SbiRequest::get("/bootstrapping")).await;
+        let etag = first.http.get_header("etag").expect("ETag present").clone();
+        assert!(
+            first.http.get_header("cache-control").is_some(),
+            "Cache-Control is required alongside the ETag"
+        );
+
+        // The document is stable, so a second request yields the same tag.
+        let second = nrf_sbi_request_handler(SbiRequest::get("/bootstrapping")).await;
+        assert_eq!(second.http.get_header("etag"), Some(&etag));
+
+        // A matching If-None-Match is answered 304 with no body.
+        let conditional =
+            SbiRequest::get("/bootstrapping").with_header("If-None-Match", etag.as_str());
+        let resp = nrf_sbi_request_handler(conditional).await;
+        assert_eq!(resp.status, 304);
+        assert!(resp.http.content.is_none() || resp.http.content.as_deref() == Some(""));
+
+        // A non-matching tag still returns the document.
+        let stale =
+            SbiRequest::get("/bootstrapping").with_header("If-None-Match", "\"0000000000000000\"");
+        assert_eq!(nrf_sbi_request_handler(stale).await.status, 200);
+
+        // `*` matches any existing representation (RFC 9110 Section 13.1.2).
+        let star = SbiRequest::get("/bootstrapping").with_header("If-None-Match", "*");
+        assert_eq!(nrf_sbi_request_handler(star).await.status, 304);
+    }
+
+    #[test]
+    fn if_none_match_compares_weak_and_strong_forms_and_lists() {
+        assert!(if_none_match_matches("\"abc\"", "\"abc\""));
+        assert!(if_none_match_matches("W/\"abc\"", "\"abc\""));
+        assert!(if_none_match_matches("\"xyz\", \"abc\"", "\"abc\""));
+        assert!(if_none_match_matches("*", "\"abc\""));
+        assert!(!if_none_match_matches("\"xyz\"", "\"abc\""));
+        assert!(!if_none_match_matches("", "\"abc\""));
+    }
+
+    #[test]
+    fn fnv1a64_is_deterministic_and_content_sensitive() {
+        // Determinism across runs is the point: an ETag derived from a hash that
+        // changes between builds silently invalidates every cached document.
+        assert_eq!(fnv1a64("bootstrapping"), fnv1a64("bootstrapping"));
+        assert_eq!(fnv1a64(""), 0xcbf2_9ce4_8422_2325);
+        assert_ne!(fnv1a64("a"), fnv1a64("b"));
+        // A one-character difference deep in a long string must still change it.
+        assert_ne!(
+            fnv1a64("http://nrf:7777/nnrf-nfm/v1/nf-instances"),
+            fnv1a64("http://nrf:7778/nnrf-nfm/v1/nf-instances")
+        );
+    }
+
+    // ==================================================================
+    // #68 criterion 4/5 at the handler boundary: subscribe refuses a
+    // condition it cannot honour, and parses validityTime as a DateTime.
+    // ==================================================================
+
+    async fn subscribe(body: serde_json::Value) -> SbiResponse {
+        let mut req = SbiRequest::post("/nnrf-nfm/v1/subscriptions");
+        req.http.set_content(body.to_string());
+        handle_subscription_create(&req).await
+    }
+
+    fn problem_of(resp: &SbiResponse) -> serde_json::Value {
+        serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("JSON")
+    }
+
+    #[tokio::test]
+    async fn subscribe_refuses_a_condition_it_cannot_honour() {
+        use serde_json::json;
+
+        // An unrecognised condition is a 400. Accepting it is the match-all
+        // defect: the old parse produced a criteria-less condition that matched
+        // every NF in the registry.
+        for cond in [
+            json!({}),
+            json!({"conditionType": "NOT_A_REAL_COND"}),
+            json!({"somethingElse": "x"}),
+            // A tagged condition missing its own mandatory member is malformed,
+            // not match-all.
+            json!({"conditionType": "SERVICE_NAME_LIST_COND"}),
+            json!({"conditionType": "NF_GROUP_LIST_COND", "nfGroupIdList": ["g"]}),
+        ] {
+            let resp = subscribe(json!({
+                "nfStatusNotificationUri": "http://consumer.example.com/cb",
+                "subscrCond": cond,
+            }))
+            .await;
+            assert_eq!(resp.status, 400, "subscrCond {cond} must be refused");
+            assert_eq!(problem_of(&resp)["cause"], "MANDATORY_IE_INCORRECT");
+        }
+
+        // A recognised variant whose criterion this NRF cannot evaluate is also
+        // refused, and says which criterion and why.
+        let resp = subscribe(json!({
+            "nfStatusNotificationUri": "http://consumer.example.com/cb",
+            "subscrCond": {
+                "conditionType": "UPF_COND",
+                "taiList": [{"plmnId": {"mcc": "001", "mnc": "01"}, "tac": "0001"}],
+            },
+        }))
+        .await;
+        assert_eq!(resp.status, 400);
+        let problem = problem_of(&resp);
+        assert_eq!(problem["cause"], "SUBSCR_COND_NOT_SUPPORTED");
+        assert!(
+            problem["detail"]
+                .as_str()
+                .expect("detail")
+                .contains("taiList"),
+            "the refusal must name the criterion: {problem}"
+        );
+
+        // And an omitted condition is still accepted as "every NF" — refusing
+        // that would break the existing NF-status feeds.
+        let resp = subscribe(json!({
+            "nfStatusNotificationUri": "http://consumer.example.com/cb",
+        }))
+        .await;
+        assert_eq!(resp.status, 201);
+        let id = problem_of(&resp)["subscriptionId"]
+            .as_str()
+            .expect("subscriptionId")
+            .to_string();
+        assert!(nf_manager()
+            .find_subscription(&id)
+            .expect("stored")
+            .subscr_cond
+            .is_none());
+        nf_manager().remove_subscription(&id);
+    }
+
+    #[tokio::test]
+    async fn subscribe_parses_validity_time_as_a_datetime_and_echoes_the_full_body() {
+        use serde_json::json;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_secs();
+
+        // A conformant DateTime proposal is honoured. Read with `as_u64` — the
+        // old behaviour — this silently fell through to the 24h default, so the
+        // consumer's request had no effect it could observe.
+        let resp = subscribe(json!({
+            "nfStatusNotificationUri": "http://consumer.example.com/cb",
+            "validityTime": epoch_to_rfc3339(now + 600),
+            "reqNotifEvents": ["NF_DEREGISTERED", "NF_PROFILE_CHANGED"],
+            "notifCondition": {"monitoredAttributes": ["load"]},
+            "subscrCond": {"nfSetId": "set-68"},
+        }))
+        .await;
+        assert_eq!(resp.status, 201);
+        let body = problem_of(&resp);
+        let id = body["subscriptionId"].as_str().expect("id").to_string();
+
+        let stored = nf_manager().find_subscription(&id).expect("stored");
+        assert!(
+            (595..=600).contains(&stored.validity_duration),
+            "the proposed DateTime must set the enforced validity, got {}",
+            stored.validity_duration
+        );
+        assert_ne!(
+            stored.validity_duration, NRF_SUBSCRIPTION_DEFAULT_VALIDITY,
+            "falling back to the default means the proposal was ignored"
+        );
+
+        // reqNotifEvents / notifCondition are retained, not dropped on parse...
+        assert_eq!(
+            stored.req_notif_events.as_deref(),
+            Some(
+                &[
+                    "NF_DEREGISTERED".to_string(),
+                    "NF_PROFILE_CHANGED".to_string()
+                ][..]
+            )
+        );
+        assert_eq!(
+            stored
+                .notif_condition
+                .as_ref()
+                .and_then(|c| c.monitored_attributes.clone()),
+            Some(vec!["load".to_string()])
+        );
+        // ... and are echoed back, along with the condition VERBATIM: rebuilding
+        // it from parsed fields is what used to drop every member the old
+        // three-field model did not know about.
+        assert_eq!(body["reqNotifEvents"][0], "NF_DEREGISTERED");
+        assert_eq!(body["notifCondition"]["monitoredAttributes"][0], "load");
+        assert_eq!(body["subscrCond"]["nfSetId"], "set-68");
+        nf_manager().remove_subscription(&id);
+
+        // An absent validityTime still gets the NRF default.
+        let resp = subscribe(json!({
+            "nfStatusNotificationUri": "http://consumer.example.com/cb",
+        }))
+        .await;
+        let id = problem_of(&resp)["subscriptionId"]
+            .as_str()
+            .expect("id")
+            .to_string();
+        assert_eq!(
+            nf_manager()
+                .find_subscription(&id)
+                .expect("stored")
+                .validity_duration,
+            NRF_SUBSCRIPTION_DEFAULT_VALIDITY
+        );
+        nf_manager().remove_subscription(&id);
+
+        // A proposal beyond the NRF's maximum is clamped, not honoured, so a
+        // consumer cannot pin a subscription open indefinitely.
+        let resp = subscribe(json!({
+            "nfStatusNotificationUri": "http://consumer.example.com/cb",
+            "validityTime": epoch_to_rfc3339(now + NRF_SUBSCRIPTION_DEFAULT_VALIDITY * 10),
+        }))
+        .await;
+        let id = problem_of(&resp)["subscriptionId"]
+            .as_str()
+            .expect("id")
+            .to_string();
+        assert_eq!(
+            nf_manager()
+                .find_subscription(&id)
+                .expect("stored")
+                .validity_duration,
+            NRF_SUBSCRIPTION_DEFAULT_VALIDITY
+        );
+        nf_manager().remove_subscription(&id);
+
+        // Non-conformant validityTime forms are refused rather than coerced.
+        for bad in [
+            json!(3600),
+            json!("not-a-timestamp"),
+            json!(epoch_to_rfc3339(now.saturating_sub(600))),
+        ] {
+            let resp = subscribe(json!({
+                "nfStatusNotificationUri": "http://consumer.example.com/cb",
+                "validityTime": bad,
+            }))
+            .await;
+            assert_eq!(resp.status, 400, "validityTime {bad} must be refused");
+        }
+
+        // Malformed reqNotifEvents / notifCondition are refused too. Both forms
+        // of notifCondition at once violates the schema's `not` clause, and
+        // silently picking one would apply a filter the consumer did not ask for.
+        for bad in [
+            json!({"reqNotifEvents": "NF_REGISTERED"}),
+            json!({"reqNotifEvents": []}),
+            json!({"reqNotifEvents": [1, 2]}),
+            json!({"notifCondition": {}}),
+            json!({"notifCondition": {"monitoredAttributes": ["load"],
+                                      "unmonitoredAttributes": ["capacity"]}}),
+        ] {
+            let mut body = json!({"nfStatusNotificationUri": "http://consumer.example.com/cb"});
+            for (k, v) in bad.as_object().expect("object") {
+                body[k] = v.clone();
+            }
+            let resp = subscribe(body.clone()).await;
+            assert_eq!(resp.status, 400, "{body} must be refused");
+        }
     }
 }

--- a/src/bins/nextgcore-nrfd/src/nnrf_build.rs
+++ b/src/bins/nextgcore-nrfd/src/nnrf_build.rs
@@ -284,6 +284,8 @@ mod tests {
             notification_uri: "http://smf.example.com/notify".to_string(),
             subscr_cond: None,
             validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
         }
     }
 

--- a/src/bins/nextgcore-nrfd/src/nnrf_handler.rs
+++ b/src/bins/nextgcore-nrfd/src/nnrf_handler.rs
@@ -370,17 +370,363 @@ pub struct SubscriptionData {
     pub subscr_cond: Option<SubscrCond>,
     /// Validity duration (seconds)
     pub validity_duration: u64,
+    /// `reqNotifEvents` (TS 29.510 §5.2.2.5.2): the event types the subscriber
+    /// asked for, as the wire strings (`NF_REGISTERED`, `NF_DEREGISTERED`,
+    /// `NF_PROFILE_CHANGED`). `None` => the subscriber did not restrict the
+    /// event set, so every event is delivered.
+    pub req_notif_events: Option<Vec<String>>,
+    /// `notifCondition` (TS 29.510 §5.2.2.5.2): which NFProfile attributes the
+    /// subscriber wants `NF_PROFILE_CHANGED` for. `None` => no restriction.
+    pub notif_condition: Option<NotifCondition>,
 }
 
-/// Subscription condition
+/// `NotifCondition` (TS 29.510 §5.2.2.5.2 / `NotifCondition` schema): the list
+/// of NFProfile attributes whose change does — or does not — warrant an
+/// `NF_PROFILE_CHANGED` notification.
+///
+/// The schema is `not: required: [monitoredAttributes, unmonitoredAttributes]`,
+/// i.e. the two forms are mutually exclusive; a body carrying both is refused at
+/// parse time rather than silently resolved in one direction.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NotifCondition {
+    /// Only a change to one of these attributes is notified.
+    pub monitored_attributes: Option<Vec<String>>,
+    /// A change to one of these attributes is *not* notified.
+    pub unmonitored_attributes: Option<Vec<String>>,
+}
+
+impl NotifCondition {
+    /// Parse a `NotifCondition` object. `None` when the object carries both
+    /// `monitoredAttributes` and `unmonitoredAttributes` (the schema's `not`
+    /// clause) or neither, so the caller can answer 400 rather than guess.
+    pub fn from_json(v: &serde_json::Value) -> Option<Self> {
+        let list = |k: &str| -> Option<Vec<String>> {
+            let arr = v.get(k)?.as_array()?;
+            if arr.is_empty() {
+                return None; // minItems: 1
+            }
+            Some(
+                arr.iter()
+                    .filter_map(|x| x.as_str())
+                    .map(String::from)
+                    .collect(),
+            )
+        };
+        let monitored = list("monitoredAttributes");
+        let unmonitored = list("unmonitoredAttributes");
+        match (&monitored, &unmonitored) {
+            (Some(_), Some(_)) | (None, None) => None,
+            _ => Some(Self {
+                monitored_attributes: monitored,
+                unmonitored_attributes: unmonitored,
+            }),
+        }
+    }
+
+    /// Serialize back to the wire/snapshot shape.
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+        if let Some(ref a) = self.monitored_attributes {
+            map.insert("monitoredAttributes".into(), a.clone().into());
+        }
+        if let Some(ref a) = self.unmonitored_attributes {
+            map.insert("unmonitoredAttributes".into(), a.clone().into());
+        }
+        serde_json::Value::Object(map)
+    }
+
+    /// Does a change to `attribute` (a top-level NFProfile attribute name)
+    /// warrant a notification under this condition?
+    ///
+    /// `monitoredAttributes` is an allowlist, `unmonitoredAttributes` a
+    /// denylist; exactly one of the two is populated (see [`Self::from_json`]).
+    pub fn notifies_attribute(&self, attribute: &str) -> bool {
+        if let Some(ref monitored) = self.monitored_attributes {
+            return monitored.iter().any(|a| a == attribute);
+        }
+        if let Some(ref unmonitored) = self.unmonitored_attributes {
+            return !unmonitored.iter().any(|a| a == attribute);
+        }
+        true
+    }
+}
+
+/// The `SubscrCond` discriminator a subscription's condition was recognised as.
+///
+/// TS 29.510 §5.2.2.5.2 makes `SubscrCond` a `oneOf` over 17 condition schemas.
+/// Modelling the tag separately from the payload — rather than flattening a few
+/// fields into one struct — is what stops an unmodelled variant from parsing to
+/// "no criteria" and therefore matching every NF (the match-all defect this
+/// replaces). Same shape as the recorded decision to keep a received JSON object
+/// verbatim and match on a canonical key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscrCondKind {
+    /// `NfInstanceIdCond`
+    NfInstanceId,
+    /// `NfInstanceIdListCond`
+    NfInstanceIdList,
+    /// `NfTypeCond`
+    NfType,
+    /// `ServiceNameCond`
+    ServiceName,
+    /// `ServiceNameListCond` (`conditionType: SERVICE_NAME_LIST_COND`)
+    ServiceNameList,
+    /// `AmfCond`
+    Amf,
+    /// `GuamiListCond`
+    GuamiList,
+    /// `NetworkSliceCond`
+    NetworkSlice,
+    /// `NfGroupCond`
+    NfGroup,
+    /// `NfGroupListCond` (`conditionType: NF_GROUP_LIST_COND`)
+    NfGroupList,
+    /// `NfSetCond`
+    NfSet,
+    /// `NfServiceSetCond`
+    NfServiceSet,
+    /// `UpfCond` (`conditionType: UPF_COND`)
+    Upf,
+    /// `ScpDomainCond`
+    ScpDomain,
+    /// `NwdafCond` (`conditionType: NWDAF_COND`)
+    Nwdaf,
+    /// `NefCond` (`conditionType: NEF_COND`)
+    Nef,
+    /// `DccfCond` (`conditionType: DCCF_COND`)
+    Dccf,
+}
+
+impl SubscrCondKind {
+    /// The NF type a `conditionType`-tagged condition implicitly restricts to,
+    /// or `None` when the condition is not NF-type-specific.
+    ///
+    /// `UPF_COND`/`NWDAF_COND`/`NEF_COND`/`DCCF_COND` name the produced NF type
+    /// in the condition itself (TS 29.510 §5.2.2.5.2), so a UPF condition must
+    /// never match, say, an AMF whose profile happens to carry no criteria.
+    pub fn implied_nf_type(&self) -> Option<&'static str> {
+        match self {
+            SubscrCondKind::Upf => Some("UPF"),
+            SubscrCondKind::Nwdaf => Some("NWDAF"),
+            SubscrCondKind::Nef => Some("NEF"),
+            SubscrCondKind::Dccf => Some("DCCF"),
+            _ => None,
+        }
+    }
+
+    /// The `*Info` container in an NFProfile that carries this condition's
+    /// serving-area criteria, if any.
+    pub fn info_container(&self) -> Option<&'static str> {
+        match self {
+            SubscrCondKind::Upf => Some("upfInfo"),
+            SubscrCondKind::Nwdaf => Some("nwdafInfo"),
+            SubscrCondKind::Nef => Some("nefInfo"),
+            SubscrCondKind::Dccf => Some("dccfInfo"),
+            _ => None,
+        }
+    }
+}
+
+/// Subscription condition: the recognised discriminator plus the condition
+/// object exactly as received.
+///
+/// Keeping `raw` verbatim means a criterion this NRF does not yet evaluate is
+/// still persisted and still visible in the subscription resource, instead of
+/// being silently dropped on parse.
 #[derive(Debug, Clone)]
 pub struct SubscrCond {
-    /// NF type condition
-    pub nf_type: Option<String>,
-    /// Service name condition
-    pub service_name: Option<String>,
-    /// NF instance ID condition
-    pub nf_instance_id: Option<String>,
+    /// Which `oneOf` variant this condition was recognised as.
+    pub kind: SubscrCondKind,
+    /// The `subscrCond` object exactly as received.
+    pub raw: serde_json::Value,
+}
+
+/// A `subscrCond` that parsed to a known variant but whose criteria this NRF
+/// cannot evaluate against an NFProfile.
+///
+/// Returned so the caller can answer 400 naming the criterion, rather than
+/// accept a subscription it would then either over-serve (notify for every NF)
+/// or under-serve (notify for none). Both silent options are worse than a
+/// refusal the consumer can see; see the recorded principle that an NF should
+/// advertise only what it can actually serve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedCriterion {
+    /// The `subscrCond` member that cannot be evaluated.
+    pub criterion: &'static str,
+    /// Why it cannot be evaluated, for the ProblemDetails detail string.
+    pub reason: &'static str,
+}
+
+impl SubscrCond {
+    /// Recognise a `subscrCond` object as one of the TS 29.510 §5.2.2.5.2
+    /// `oneOf` variants.
+    ///
+    /// `None` means no discriminator matched — an unknown or malformed
+    /// condition, which the caller answers 400 for. That is the whole point of
+    /// this function: the previous model parsed *any* object into a struct whose
+    /// three fields were all `None`, and an all-`None` condition matched every
+    /// NF in the registry.
+    ///
+    /// `conditionType` is checked first because it is the explicit
+    /// discriminator; the untagged variants are then distinguished by their
+    /// required members, in an order that respects the schemas' `not` clauses
+    /// (`NfTypeCond` forbids `nfGroupId`, so `NfGroupCond` is tried first).
+    pub fn from_json(v: &serde_json::Value) -> Option<Self> {
+        let has = |k: &str| v.get(k).is_some_and(|x| !x.is_null());
+        let non_empty_array = |k: &str| {
+            v.get(k)
+                .and_then(|x| x.as_array())
+                .is_some_and(|a| !a.is_empty())
+        };
+
+        let kind = if let Some(ct) = v.get("conditionType").and_then(|x| x.as_str()) {
+            match ct {
+                "SERVICE_NAME_LIST_COND" if non_empty_array("serviceNameList") => {
+                    SubscrCondKind::ServiceNameList
+                }
+                "NF_GROUP_LIST_COND" if non_empty_array("nfGroupIdList") && has("nfType") => {
+                    SubscrCondKind::NfGroupList
+                }
+                "UPF_COND" => SubscrCondKind::Upf,
+                "NWDAF_COND" => SubscrCondKind::Nwdaf,
+                "NEF_COND" => SubscrCondKind::Nef,
+                "DCCF_COND" => SubscrCondKind::Dccf,
+                // A conditionType we do not know, or one whose mandatory
+                // members are missing, is malformed rather than match-all.
+                _ => return None,
+            }
+        } else if has("nfInstanceId") {
+            SubscrCondKind::NfInstanceId
+        } else if non_empty_array("nfInstanceIdList") {
+            SubscrCondKind::NfInstanceIdList
+        } else if has("nfGroupId") && has("nfType") {
+            SubscrCondKind::NfGroup
+        } else if has("nfType") {
+            SubscrCondKind::NfType
+        } else if has("serviceName") {
+            SubscrCondKind::ServiceName
+        } else if has("nfServiceSetId") {
+            SubscrCondKind::NfServiceSet
+        } else if has("nfSetId") {
+            SubscrCondKind::NfSet
+        } else if non_empty_array("guamiList") {
+            SubscrCondKind::GuamiList
+        } else if non_empty_array("snssaiList") {
+            SubscrCondKind::NetworkSlice
+        } else if has("amfSetId") || has("amfRegionId") {
+            SubscrCondKind::Amf
+        } else if non_empty_array("scpDomains") {
+            SubscrCondKind::ScpDomain
+        } else {
+            return None;
+        };
+
+        Some(Self {
+            kind,
+            raw: v.clone(),
+        })
+    }
+
+    /// The criterion this NRF cannot evaluate against an NFProfile, if any.
+    ///
+    /// Two cases, both grounded in the TS 29.510 NFProfile schema rather than in
+    /// implementation convenience:
+    ///
+    /// * `UpfCond.taiList` — `UpfInfo` (§6.1.6.2.13) carries `smfServingArea`,
+    ///   `sNssaiUpfInfoList` and `interfaceUpfInfoList`, but **no TAI list**, so
+    ///   there is nothing in a UPF's profile to compare a TAI against. The
+    ///   condition's own description mentions a TAI list; the profile schema
+    ///   does not provide one. Another instance of the recorded pattern where
+    ///   the 29.5xx schemas disagree with their prose.
+    /// * `NefCond` AF/identifier-range criteria — these match against
+    ///   `NefInfo.afEeData`, `gpsiRanges` and `externalGroupIdentifiersRanges`,
+    ///   which are nested range structures rather than directly comparable
+    ///   values.
+    pub fn unsupported_criterion(&self) -> Option<UnsupportedCriterion> {
+        let present = |k: &str| self.raw.get(k).is_some_and(|x| !x.is_null());
+        match self.kind {
+            SubscrCondKind::Upf if present("taiList") => Some(UnsupportedCriterion {
+                criterion: "taiList",
+                reason: "TS 29.510 UpfInfo carries no TAI list, so a UPF profile holds \
+                         nothing to match a TAI against; use smfServingArea instead",
+            }),
+            SubscrCondKind::Nef => {
+                for k in [
+                    "afEvents",
+                    "afInstanceId",
+                    "applicationIds",
+                    "externalIdentifiers",
+                    "externalGroupIdentifiers",
+                    "domainNames",
+                ] {
+                    if present(k) {
+                        return Some(UnsupportedCriterion {
+                            criterion: match k {
+                                "afEvents" => "afEvents",
+                                "afInstanceId" => "afInstanceId",
+                                "applicationIds" => "applicationIds",
+                                "externalIdentifiers" => "externalIdentifiers",
+                                "externalGroupIdentifiers" => "externalGroupIdentifiers",
+                                _ => "domainNames",
+                            },
+                            reason: "matching this criterion needs NefInfo afEeData / \
+                                     gpsiRanges / externalGroupIdentifiersRanges, which are \
+                                     nested range structures this NRF does not evaluate; \
+                                     use snssaiList or taiList",
+                        });
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Convenience constructor for an `NfTypeCond`.
+    pub fn nf_type(nf_type: &str) -> Self {
+        Self {
+            kind: SubscrCondKind::NfType,
+            raw: serde_json::json!({ "nfType": nf_type }),
+        }
+    }
+
+    /// Convenience constructor for a `ServiceNameCond`.
+    pub fn service_name(service_name: &str) -> Self {
+        Self {
+            kind: SubscrCondKind::ServiceName,
+            raw: serde_json::json!({ "serviceName": service_name }),
+        }
+    }
+
+    /// Convenience constructor for an `NfInstanceIdCond`.
+    pub fn nf_instance_id(nf_instance_id: &str) -> Self {
+        Self {
+            kind: SubscrCondKind::NfInstanceId,
+            raw: serde_json::json!({ "nfInstanceId": nf_instance_id }),
+        }
+    }
+
+    /// Read a string member of the condition.
+    pub fn str_at(&self, key: &str) -> Option<&str> {
+        self.raw.get(key).and_then(|v| v.as_str())
+    }
+
+    /// Read an array-of-strings member of the condition.
+    pub fn str_list_at(&self, key: &str) -> Option<Vec<&str>> {
+        Some(
+            self.raw
+                .get(key)?
+                .as_array()?
+                .iter()
+                .filter_map(|v| v.as_str())
+                .collect(),
+        )
+    }
+
+    /// Read an array-of-objects member of the condition.
+    pub fn obj_list_at(&self, key: &str) -> Option<&Vec<serde_json::Value>> {
+        self.raw.get(key)?.as_array()
+    }
 }
 
 /// Search result for NF discovery
@@ -836,18 +1182,18 @@ fn subscription_to_json(sub: &SubscriptionData) -> serde_json::Value {
     if let Some(ref iid) = sub.req_nf_instance_id {
         map.insert("reqNfInstanceId".into(), iid.clone().into());
     }
+    // The condition is snapshotted verbatim; the discriminator is re-derived on
+    // load by the same `from_json` the wire path uses, so a restored
+    // subscription cannot end up recognised differently from the one that was
+    // accepted.
     if let Some(ref cond) = sub.subscr_cond {
-        let mut c = serde_json::Map::new();
-        if let Some(ref v) = cond.nf_type {
-            c.insert("nfType".into(), v.clone().into());
-        }
-        if let Some(ref v) = cond.service_name {
-            c.insert("serviceName".into(), v.clone().into());
-        }
-        if let Some(ref v) = cond.nf_instance_id {
-            c.insert("nfInstanceId".into(), v.clone().into());
-        }
-        map.insert("subscrCond".into(), serde_json::Value::Object(c));
+        map.insert("subscrCond".into(), cond.raw.clone());
+    }
+    if let Some(ref events) = sub.req_notif_events {
+        map.insert("reqNotifEvents".into(), events.clone().into());
+    }
+    if let Some(ref cond) = sub.notif_condition {
+        map.insert("notifCondition".into(), cond.to_json());
     }
     obj
 }
@@ -861,17 +1207,34 @@ fn subscription_from_json(v: &serde_json::Value) -> Option<SubscriptionData> {
         .and_then(|d| d.as_u64())
         .unwrap_or(0);
     let str_at = |k: &str| v.get(k).and_then(|x| x.as_str()).map(|s| s.to_string());
-    let subscr_cond = v.get("subscrCond").map(|c| SubscrCond {
-        nf_type: c.get("nfType").and_then(|x| x.as_str()).map(String::from),
-        service_name: c
-            .get("serviceName")
-            .and_then(|x| x.as_str())
-            .map(String::from),
-        nf_instance_id: c
-            .get("nfInstanceId")
-            .and_then(|x| x.as_str())
-            .map(String::from),
-    });
+    // A persisted condition that no longer recognises (e.g. written by an older
+    // build) is dropped to `None` rather than kept as an unrecognised object,
+    // because `None` means "all NFs" and is at least a defined behaviour. Logged
+    // so the narrowing is visible instead of silent.
+    let subscr_cond = match v.get("subscrCond") {
+        Some(c) => match SubscrCond::from_json(c) {
+            Some(cond) => Some(cond),
+            None => {
+                log::warn!(
+                    "Restored subscription {id} carries an unrecognised subscrCond {c}; \
+                     treating it as unconditional"
+                );
+                None
+            }
+        },
+        None => None,
+    };
+    let req_notif_events = v
+        .get("reqNotifEvents")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| e.as_str())
+                .map(String::from)
+                .collect::<Vec<_>>()
+        })
+        .filter(|a: &Vec<String>| !a.is_empty());
+    let notif_condition = v.get("notifCondition").and_then(NotifCondition::from_json);
     Some(SubscriptionData {
         id,
         req_nf_type: str_at("reqNfType"),
@@ -879,6 +1242,8 @@ fn subscription_from_json(v: &serde_json::Value) -> Option<SubscriptionData> {
         notification_uri,
         subscr_cond,
         validity_duration,
+        req_notif_events,
+        notif_condition,
     })
 }
 
@@ -1780,12 +2145,10 @@ mod tests {
             req_nf_type: Some("AMF".to_string()),
             req_nf_instance_id: None,
             notification_uri: "http://example.com/notify".to_string(),
-            subscr_cond: Some(SubscrCond {
-                nf_type: Some("SMF".to_string()),
-                service_name: None,
-                nf_instance_id: None,
-            }),
+            subscr_cond: Some(SubscrCond::nf_type("SMF")),
             validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
         };
 
         assert!(manager.add_subscription(subscription));
@@ -1903,6 +2266,8 @@ mod tests {
             notification_uri: "".to_string(),
             subscr_cond: None,
             validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
         };
 
         let result = nrf_nnrf_handle_nf_status_subscribe(subscription);
@@ -2513,12 +2878,10 @@ mod tests {
                 req_nf_type: Some("AMF".to_string()),
                 req_nf_instance_id: Some("amf-1".to_string()),
                 notification_uri: "http://amf:8080/cb".to_string(),
-                subscr_cond: Some(SubscrCond {
-                    nf_type: Some("SMF".to_string()),
-                    service_name: Some("nsmf-pdusession".to_string()),
-                    nf_instance_id: None,
-                }),
+                subscr_cond: Some(SubscrCond::nf_type("SMF")),
                 validity_duration: 3600,
+                req_notif_events: None,
+                notif_condition: None,
             }));
         }
 
@@ -2550,12 +2913,12 @@ mod tests {
                 .expect("subscription retained across restart");
             assert_eq!(sub.notification_uri, "http://amf:8080/cb");
             assert_eq!(sub.req_nf_type.as_deref(), Some("AMF"));
-            assert_eq!(
-                sub.subscr_cond
-                    .as_ref()
-                    .and_then(|c| c.service_name.as_deref()),
-                Some("nsmf-pdusession")
-            );
+            // The condition survives the snapshot verbatim AND is recognised as
+            // the same variant it was accepted as; a restored subscription must
+            // not silently widen (an unrecognised condition would mean "all NFs").
+            let cond = sub.subscr_cond.as_ref().expect("condition retained");
+            assert_eq!(cond.kind, SubscrCondKind::NfType);
+            assert_eq!(cond.str_at("nfType"), Some("SMF"));
             assert_eq!(sub.validity_duration, 3600);
         }
 

--- a/src/bins/nextgcore-nrfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-nrfd/src/sbi_path.rs
@@ -6,7 +6,7 @@ use crate::nnrf_build::{
     nrf_nnrf_nfm_build_nf_profile_changed_notify, nrf_nnrf_nfm_build_nf_status_notify, ChangeItem,
     NotificationEventType,
 };
-use crate::nnrf_handler::{nf_manager, NfProfile, SubscriptionData};
+use crate::nnrf_handler::{nf_manager, NfProfile, SubscrCond, SubscrCondKind, SubscriptionData};
 use nextgcore_sbi::client::{SbiClient, SbiClientConfig};
 use nextgcore_sbi::message::SbiRequest;
 use nextgcore_sbi::oauth::OAuth2Client;
@@ -448,6 +448,9 @@ pub async fn nrf_nnrf_nfm_send_nf_status_notify_all_async(
         if !subscription_matches(subscription, nf_instance) {
             continue;
         }
+        if !subscription_accepts_event(subscription, event) {
+            continue;
+        }
 
         // Send notification asynchronously
         match nrf_nnrf_nfm_send_nf_status_notify_async(subscription, event, nf_instance, server_uri)
@@ -493,8 +496,16 @@ pub async fn nrf_nnrf_nfm_send_nf_profile_changed_notify_all_async(
     let subscriptions = manager.list_subscriptions();
     let mut sent_count = 0u32;
 
+    let changed_attributes = changed_attribute_names(&profile_changes);
+
     for subscription in &subscriptions {
         if !subscription_matches(subscription, nf_instance) {
+            continue;
+        }
+        if !subscription_accepts_event(subscription, NotificationEventType::NfProfileChanged) {
+            continue;
+        }
+        if !subscription_accepts_profile_changes(subscription, &changed_attributes) {
             continue;
         }
 
@@ -541,9 +552,16 @@ pub fn nrf_nnrf_nfm_send_nf_profile_changed_notify_all(
     profile_changes: Vec<ChangeItem>,
 ) -> Result<u32, String> {
     let mut sent_count = 0u32;
+    let changed_attributes = changed_attribute_names(&profile_changes);
 
     for subscription in subscriptions {
         if !subscription_matches(subscription, nf_instance) {
+            continue;
+        }
+        if !subscription_accepts_event(subscription, NotificationEventType::NfProfileChanged) {
+            continue;
+        }
+        if !subscription_accepts_profile_changes(subscription, &changed_attributes) {
             continue;
         }
 
@@ -593,6 +611,9 @@ pub fn nrf_nnrf_nfm_send_nf_status_notify_all(
         if !subscription_matches(subscription, nf_instance) {
             continue;
         }
+        if !subscription_accepts_event(subscription, event) {
+            continue;
+        }
 
         // Send notification
         match nrf_nnrf_nfm_send_nf_status_notify(subscription, event, nf_instance, server_uri) {
@@ -632,33 +653,558 @@ fn subscription_matches(subscription: &SubscriptionData, nf_instance: &NfProfile
         }
     }
 
-    // Check subscription condition
-    if let Some(ref subscr_cond) = subscription.subscr_cond {
-        // Check NF type condition
-        if let Some(ref cond_nf_type) = subscr_cond.nf_type {
-            if cond_nf_type != &nf_instance.nf_type {
-                return false;
+    // An absent condition means "every NF", which is the spec's reading of an
+    // omitted filter and the one nwdafd's NF-status feed relies on.
+    match subscription.subscr_cond {
+        Some(ref cond) => subscr_cond_matches(cond, nf_instance),
+        None => true,
+    }
+}
+
+/// Does `event` fall inside the subscriber's requested event set?
+///
+/// TS 29.510 §5.2.2.5.2: `reqNotifEvents` is the list of `NotificationEventType`
+/// the subscriber asked for. An absent list is "no restriction" — the filter's
+/// absence conventionally means unconstrained, per the project's recorded
+/// fail-open rule for filters (as distinct from credentials).
+pub fn subscription_accepts_event(
+    subscription: &SubscriptionData,
+    event: NotificationEventType,
+) -> bool {
+    match subscription.req_notif_events {
+        Some(ref events) => events.iter().any(|e| e == event.as_str()),
+        None => true,
+    }
+}
+
+/// Does at least one of `changed_attributes` warrant an `NF_PROFILE_CHANGED`
+/// notification under the subscriber's `notifCondition`?
+///
+/// TS 29.510 §5.2.2.5.2. An absent condition, or an empty change list (a
+/// complete-replacement notification carries the profile rather than a change
+/// list), is "no restriction".
+pub fn subscription_accepts_profile_changes(
+    subscription: &SubscriptionData,
+    changed_attributes: &[String],
+) -> bool {
+    let Some(ref cond) = subscription.notif_condition else {
+        return true;
+    };
+    if changed_attributes.is_empty() {
+        return true;
+    }
+    changed_attributes
+        .iter()
+        .any(|attr| cond.notifies_attribute(attr))
+}
+
+/// The top-level NFProfile attribute each `ChangeItem` touches, e.g. `/load` and
+/// `/nfServices/0/priority` both reduce to the first path segment (`load`,
+/// `nfServices`), which is the granularity `notifCondition` is expressed at.
+fn changed_attribute_names(changes: &[ChangeItem]) -> Vec<String> {
+    changes
+        .iter()
+        .filter_map(|c| {
+            c.path
+                .trim_start_matches('/')
+                .split('/')
+                .next()
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+        })
+        .collect()
+}
+
+/// Evaluate a recognised `SubscrCond` against an NF profile.
+///
+/// Every arm reads its criteria from the condition as received and compares them
+/// against the profile document the NRF stored verbatim on registration, so a
+/// criterion is either compared against real profile data or the condition was
+/// refused at subscribe time (see `SubscrCond::unsupported_criterion`). There is
+/// deliberately **no** catch-all `=> true` arm: a variant that reached here
+/// without criteria to compare would silently become match-all, which is the
+/// defect this replaces.
+fn subscr_cond_matches(cond: &SubscrCond, nf: &NfProfile) -> bool {
+    // A conditionType-tagged condition names its produced NF type; a UPF
+    // condition must not match an AMF just because the AMF has no upfInfo.
+    if let Some(implied) = cond.kind.implied_nf_type() {
+        if nf.nf_type != implied {
+            return false;
+        }
+    }
+
+    let doc = &nf.attributes;
+    let info = cond
+        .kind
+        .info_container()
+        .and_then(|name| doc.get(name))
+        .unwrap_or(&serde_json::Value::Null);
+
+    match cond.kind {
+        SubscrCondKind::NfInstanceId => cond.str_at("nfInstanceId") == Some(&nf.nf_instance_id),
+
+        SubscrCondKind::NfInstanceIdList => cond
+            .str_list_at("nfInstanceIdList")
+            .is_some_and(|ids| ids.iter().any(|id| *id == nf.nf_instance_id)),
+
+        SubscrCondKind::NfType => cond.str_at("nfType") == Some(&nf.nf_type),
+
+        SubscrCondKind::ServiceName => cond
+            .str_at("serviceName")
+            .is_some_and(|name| nf.nf_services.iter().any(|s| s.service_name == name)),
+
+        SubscrCondKind::ServiceNameList => {
+            cond.str_list_at("serviceNameList").is_some_and(|names| {
+                nf.nf_services
+                    .iter()
+                    .any(|s| names.iter().any(|n| *n == s.service_name))
+            })
+        }
+
+        // AmfCond: anyOf [amfSetId, amfRegionId]. Both present => both must
+        // match ("Set Id and/or Region Id" in the schema description).
+        SubscrCondKind::Amf => {
+            let amf_info = doc.get("amfInfo").unwrap_or(&serde_json::Value::Null);
+            let matches_member = |key: &str| match cond.str_at(key) {
+                Some(want) => amf_info.get(key).and_then(|v| v.as_str()) == Some(want),
+                None => true,
+            };
+            matches_member("amfSetId") && matches_member("amfRegionId")
+        }
+
+        SubscrCondKind::GuamiList => {
+            let profile_guamis = doc
+                .get("amfInfo")
+                .and_then(|i| i.get("guamiList"))
+                .and_then(|v| v.as_array());
+            match (cond.obj_list_at("guamiList"), profile_guamis) {
+                (Some(wanted), Some(held)) => {
+                    wanted.iter().any(|w| held.iter().any(|h| guami_eq(w, h)))
+                }
+                _ => false,
             }
         }
-        // Check service name condition
-        else if let Some(ref cond_service_name) = subscr_cond.service_name {
-            let has_service = nf_instance
-                .nf_services
-                .iter()
-                .any(|s| &s.service_name == cond_service_name);
-            if !has_service {
+
+        // NetworkSliceCond: snssaiList is mandatory; nsiList, when present, is
+        // an additional constraint rather than an alternative.
+        SubscrCondKind::NetworkSlice => {
+            let snssai_ok = match (
+                cond.obj_list_at("snssaiList"),
+                doc.get("sNssais").and_then(|v| v.as_array()),
+            ) {
+                (Some(wanted), Some(held)) => {
+                    wanted.iter().any(|w| held.iter().any(|h| snssai_eq(w, h)))
+                }
+                _ => false,
+            };
+            if !snssai_ok {
                 return false;
             }
+            match cond.str_list_at("nsiList") {
+                Some(wanted) if !wanted.is_empty() => {
+                    let held = doc
+                        .get("nsiList")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+                        .unwrap_or_default();
+                    wanted.iter().any(|w| held.contains(w))
+                }
+                _ => true,
+            }
         }
-        // Check NF instance ID condition
-        else if let Some(ref cond_nf_instance_id) = subscr_cond.nf_instance_id {
-            if cond_nf_instance_id != &nf_instance.nf_instance_id {
+
+        SubscrCondKind::NfGroup => {
+            if cond.str_at("nfType") != Some(&nf.nf_type) {
+                return false;
+            }
+            match cond.str_at("nfGroupId") {
+                Some(want) => profile_group_ids(doc).iter().any(|g| g == want),
+                None => false,
+            }
+        }
+
+        SubscrCondKind::NfGroupList => {
+            if cond.str_at("nfType") != Some(&nf.nf_type) {
+                return false;
+            }
+            let held = profile_group_ids(doc);
+            cond.str_list_at("nfGroupIdList")
+                .is_some_and(|wanted| wanted.iter().any(|w| held.iter().any(|g| g == w)))
+        }
+
+        SubscrCondKind::NfSet => cond
+            .str_at("nfSetId")
+            .is_some_and(|want| profile_nf_set_ids(doc).iter().any(|s| s == want)),
+
+        // NfServiceSetCond: nfServiceSetId is mandatory, nfSetId an optional
+        // additional constraint.
+        SubscrCondKind::NfServiceSet => {
+            let service_set_ok = cond.str_at("nfServiceSetId").is_some_and(|want| {
+                doc.get("nfServices")
+                    .and_then(|v| v.as_array())
+                    .is_some_and(|services| {
+                        services.iter().any(|s| {
+                            s.get("nfServiceSetIdList")
+                                .and_then(|v| v.as_array())
+                                .is_some_and(|ids| ids.iter().any(|id| id.as_str() == Some(want)))
+                        })
+                    })
+            });
+            if !service_set_ok {
+                return false;
+            }
+            match cond.str_at("nfSetId") {
+                Some(want) => profile_nf_set_ids(doc).iter().any(|s| s == want),
+                None => true,
+            }
+        }
+
+        SubscrCondKind::ScpDomain => {
+            let held = doc
+                .get("scpDomains")
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+                .unwrap_or_default();
+            let domain_ok = cond
+                .str_list_at("scpDomains")
+                .is_some_and(|wanted| wanted.iter().any(|w| held.contains(w)));
+            if !domain_ok {
+                return false;
+            }
+            match cond.str_list_at("nfTypeList") {
+                Some(wanted) if !wanted.is_empty() => wanted.iter().any(|t| *t == nf.nf_type),
+                _ => true,
+            }
+        }
+
+        // UpfCond: conditionType is the only mandatory member, so a bare
+        // {conditionType: UPF_COND} legitimately means "every UPF" — the NF-type
+        // narrowing above has already been applied. taiList is refused at
+        // subscribe time (UpfInfo carries no TAI list).
+        SubscrCondKind::Upf => match cond.str_list_at("smfServingArea") {
+            Some(wanted) if !wanted.is_empty() => {
+                let held = info
+                    .get("smfServingArea")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+                    .unwrap_or_default();
+                wanted.iter().any(|w| held.contains(w))
+            }
+            _ => true,
+        },
+
+        SubscrCondKind::Nwdaf => {
+            // analyticsIds are carried by NwdafInfo as eventIds / nwdafEvents.
+            if let Some(wanted) = cond.str_list_at("analyticsIds") {
+                if !wanted.is_empty() {
+                    let mut held: Vec<&str> = Vec::new();
+                    for key in ["eventIds", "nwdafEvents", "analyticsIds"] {
+                        if let Some(a) = info.get(key).and_then(|v| v.as_array()) {
+                            held.extend(a.iter().filter_map(|v| v.as_str()));
+                        }
+                    }
+                    if !wanted.iter().any(|w| held.contains(w)) {
+                        return false;
+                    }
+                }
+            }
+            if let Some(wanted) = cond.obj_list_at("snssaiList") {
+                if !wanted.is_empty() {
+                    let held = doc
+                        .get("sNssais")
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    if !wanted.iter().any(|w| held.iter().any(|h| snssai_eq(w, h))) {
+                        return false;
+                    }
+                }
+            }
+            serving_area_matches(cond, info)
+        }
+
+        // NefCond: the AF/identifier-range criteria are refused at subscribe
+        // time, so only snssaiList and the serving area reach here.
+        SubscrCondKind::Nef => {
+            if let Some(wanted) = cond.obj_list_at("snssaiList") {
+                if !wanted.is_empty() {
+                    let held = doc
+                        .get("sNssais")
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    if !wanted.iter().any(|w| held.iter().any(|h| snssai_eq(w, h))) {
+                        return false;
+                    }
+                }
+            }
+            serving_area_matches(cond, info)
+        }
+
+        SubscrCondKind::Dccf => {
+            for (cond_key, info_key) in [
+                ("nfTypeList", "servingNfTypeList"),
+                ("nfSetIdList", "servingNfSetIdList"),
+            ] {
+                if let Some(wanted) = cond.str_list_at(cond_key) {
+                    if !wanted.is_empty() {
+                        let held = info
+                            .get(info_key)
+                            .and_then(|v| v.as_array())
+                            .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+                            .unwrap_or_default();
+                        if !wanted.iter().any(|w| held.contains(w)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            serving_area_matches(cond, info)
+        }
+    }
+}
+
+/// `taiList` / `taiRangeList` narrowing against an `*Info` container's own
+/// `taiList` / `taiRangeList` (TS 29.510 NwdafInfo / NefInfo / DccfInfo).
+///
+/// Absent criteria do not narrow. A present criterion must find a counterpart:
+/// a wanted TAI matches when the profile lists it explicitly **or** when it
+/// falls inside one of the profile's TAI ranges, which is how a serving area is
+/// expressed for a large deployment.
+fn serving_area_matches(cond: &SubscrCond, info: &serde_json::Value) -> bool {
+    if let Some(wanted) = cond.obj_list_at("taiList") {
+        if !wanted.is_empty() {
+            let held = info
+                .get("taiList")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let held_ranges = info
+                .get("taiRangeList")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let hit = wanted.iter().any(|w| {
+                held.iter().any(|h| tai_eq(w, h))
+                    || held_ranges.iter().any(|r| tai_range_contains(r, w))
+            });
+            if !hit {
                 return false;
             }
         }
     }
-
+    if let Some(wanted) = cond.obj_list_at("taiRangeList") {
+        if !wanted.is_empty() {
+            let held_ranges = info
+                .get("taiRangeList")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let hit = wanted
+                .iter()
+                .any(|w| held_ranges.iter().any(|h| tai_range_overlaps(w, h)));
+            if !hit {
+                return false;
+            }
+        }
+    }
     true
+}
+
+/// Every `groupId` the profile carries, across its `*Info` containers.
+///
+/// TS 29.510 puts the NF Group Id inside the per-type info container
+/// (`udrInfo.groupId`, `udmInfo.groupId`, `ausfInfo.groupId`, ...), and the
+/// `*InfoList` forms hold a map of the same objects. Collecting from every
+/// container rather than switching on `nfType` keeps `NfGroupCond` working for
+/// any group-bearing NF type without enumerating them, and the condition's own
+/// mandatory `nfType` already restricts which profiles get here.
+fn profile_group_ids(doc: &serde_json::Value) -> Vec<String> {
+    let mut ids = Vec::new();
+    let Some(obj) = doc.as_object() else {
+        return ids;
+    };
+    let mut push = |v: &serde_json::Value| {
+        if let Some(id) = v.get("groupId").and_then(|g| g.as_str()) {
+            ids.push(id.to_string());
+        }
+    };
+    for (key, value) in obj {
+        if !key.ends_with("Info") && !key.ends_with("InfoList") {
+            continue;
+        }
+        if key.ends_with("InfoList") {
+            // Map of info objects keyed by an operator-chosen id.
+            if let Some(map) = value.as_object() {
+                for entry in map.values() {
+                    push(entry);
+                }
+            }
+        } else {
+            push(value);
+        }
+    }
+    ids
+}
+
+/// The profile's `nfSetIdList`, as owned strings.
+fn profile_nf_set_ids(doc: &serde_json::Value) -> Vec<String> {
+    doc.get("nfSetIdList")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// PLMN equality on the significant members (TS 29.571 `PlmnId`: mcc + mnc).
+///
+/// Compared member-by-member rather than by whole-value equality so an
+/// insignificant difference — a `nid` on one side, a differing key order, an
+/// explicit `null` — cannot make two identical PLMNs compare unequal.
+fn plmn_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+    let member = |v: &serde_json::Value, k: &str| {
+        v.get(k)
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_default()
+    };
+    !member(a, "mcc").is_empty()
+        && member(a, "mcc") == member(b, "mcc")
+        && member(a, "mnc") == member(b, "mnc")
+}
+
+/// GUAMI equality (TS 29.571 `Guami`: plmnId + amfId).
+fn guami_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+    fn amf_id(v: &serde_json::Value) -> &str {
+        v.get("amfId").and_then(|x| x.as_str()).unwrap_or_default()
+    }
+    match (a.get("plmnId"), b.get("plmnId")) {
+        (Some(pa), Some(pb)) => {
+            plmn_eq(pa, pb) && !amf_id(a).is_empty() && amf_id(a).eq_ignore_ascii_case(amf_id(b))
+        }
+        _ => false,
+    }
+}
+
+/// S-NSSAI equality (TS 29.571 `Snssai`: sst + optional sd).
+///
+/// An absent `sd` and an `sd` of `"ffffff"` both mean "no slice differentiator"
+/// per TS 23.003, so they compare equal — otherwise a conformant subscriber
+/// spelling the default explicitly would never match a profile that omits it.
+fn snssai_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+    let sst = |v: &serde_json::Value| v.get("sst").and_then(|x| x.as_u64());
+    let sd = |v: &serde_json::Value| match v.get("sd").and_then(|x| x.as_str()) {
+        Some(s) if !s.eq_ignore_ascii_case("ffffff") => Some(s.to_ascii_lowercase()),
+        _ => None,
+    };
+    match (sst(a), sst(b)) {
+        (Some(x), Some(y)) => x == y && sd(a) == sd(b),
+        _ => false,
+    }
+}
+
+/// TAI equality (TS 29.571 `Tai`: plmnId + tac, optional nid).
+///
+/// TAC is compared as a parsed number where both sides parse as hex, so `"0001"`
+/// and `"1"` are the same TAC — the schema's pattern permits 3 or 4 hex digits.
+fn tai_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+    let plmn_ok = match (a.get("plmnId"), b.get("plmnId")) {
+        (Some(pa), Some(pb)) => plmn_eq(pa, pb),
+        _ => false,
+    };
+    if !plmn_ok {
+        return false;
+    }
+    fn tac(v: &serde_json::Value) -> Option<&str> {
+        v.get("tac").and_then(|x| x.as_str())
+    }
+    match (tac(a), tac(b)) {
+        (Some(x), Some(y)) => match (tac_to_u32(x), tac_to_u32(y)) {
+            (Some(nx), Some(ny)) => nx == ny,
+            _ => x.eq_ignore_ascii_case(y),
+        },
+        _ => false,
+    }
+}
+
+/// Parse a TAC (3 or 4 hex digits per TS 29.571 `Tac`) to its numeric value.
+fn tac_to_u32(tac: &str) -> Option<u32> {
+    u32::from_str_radix(tac.trim(), 16).ok()
+}
+
+/// Does `tai` fall inside `range` (TS 29.510 `TaiRange`: plmnId + tacRangeList)?
+///
+/// A `TacRange` carries either a `start`/`end` pair or a `pattern`. Only the
+/// explicit range is evaluated; a pattern-only range does not match, because
+/// treating an unevaluated pattern as a hit would widen the serving area to
+/// everything, which is the failure mode this whole change removes.
+fn tai_range_contains(range: &serde_json::Value, tai: &serde_json::Value) -> bool {
+    let plmn_ok = match (range.get("plmnId"), tai.get("plmnId")) {
+        (Some(pr), Some(pt)) => plmn_eq(pr, pt),
+        _ => false,
+    };
+    if !plmn_ok {
+        return false;
+    }
+    let Some(tac) = tai.get("tac").and_then(|v| v.as_str()).and_then(tac_to_u32) else {
+        return false;
+    };
+    range
+        .get("tacRangeList")
+        .and_then(|v| v.as_array())
+        .is_some_and(|ranges| {
+            ranges.iter().any(|r| match tac_range_bounds(r) {
+                Some((start, end)) => tac >= start && tac <= end,
+                None => false,
+            })
+        })
+}
+
+/// Do two `TaiRange`s overlap? Same PLMN and at least one overlapping TAC range.
+fn tai_range_overlaps(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+    let plmn_ok = match (a.get("plmnId"), b.get("plmnId")) {
+        (Some(pa), Some(pb)) => plmn_eq(pa, pb),
+        _ => false,
+    };
+    if !plmn_ok {
+        return false;
+    }
+    let bounds = |v: &serde_json::Value| {
+        v.get("tacRangeList")
+            .and_then(|x| x.as_array())
+            .map(|ranges| {
+                ranges
+                    .iter()
+                    .filter_map(tac_range_bounds)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    };
+    let (ra, rb) = (bounds(a), bounds(b));
+    ra.iter()
+        .any(|(sa, ea)| rb.iter().any(|(sb, eb)| sa <= eb && sb <= ea))
+}
+
+/// The numeric `start`..=`end` bounds of a `TacRange`, or `None` for the
+/// pattern-only form.
+fn tac_range_bounds(range: &serde_json::Value) -> Option<(u32, u32)> {
+    let start = range
+        .get("start")
+        .and_then(|v| v.as_str())
+        .and_then(tac_to_u32)?;
+    let end = range
+        .get("end")
+        .and_then(|v| v.as_str())
+        .and_then(tac_to_u32)?;
+    if start <= end {
+        Some((start, end))
+    } else {
+        Some((end, start))
+    }
 }
 
 /// Client notification callback result
@@ -730,12 +1276,34 @@ mod tests {
             req_nf_type: Some("SMF".to_string()),
             req_nf_instance_id: None,
             notification_uri: "http://smf.example.com/notify".to_string(),
-            subscr_cond: nf_type_cond.map(|t| SubscrCond {
-                nf_type: Some(t.to_string()),
-                service_name: None,
-                nf_instance_id: None,
-            }),
+            subscr_cond: nf_type_cond.map(SubscrCond::nf_type),
             validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
+        }
+    }
+
+    /// A profile built from a full NFProfile document, so the conditions that
+    /// match against `attributes` (nfSetIdList, amfInfo, sNssais, ...) have real
+    /// data to read.
+    fn profile_from(doc: serde_json::Value) -> NfProfile {
+        NfProfile::from_json(&doc).expect("valid NFProfile")
+    }
+
+    fn cond(raw: serde_json::Value) -> SubscrCond {
+        SubscrCond::from_json(&raw).expect("recognised subscrCond")
+    }
+
+    fn sub_with_cond(raw: serde_json::Value) -> SubscriptionData {
+        SubscriptionData {
+            id: "cond-sub".to_string(),
+            req_nf_type: None,
+            req_nf_instance_id: None,
+            notification_uri: "http://consumer.example.com/notify".to_string(),
+            subscr_cond: Some(cond(raw)),
+            validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
         }
     }
 
@@ -924,5 +1492,518 @@ mod tests {
                 "{raw} must not be scoped as AMF"
             );
         }
+    }
+
+    // ------------------------------------------------------------------
+    // #68 criterion 5: SubscrCond matching honours the discriminator
+    // variants instead of collapsing to match-all.
+    // ------------------------------------------------------------------
+
+    /// The defect this replaces, stated as a test.
+    ///
+    /// The old model read `nfType`/`serviceName`/`nfInstanceId` out of whatever
+    /// object arrived. A conformant `NfSetCond`, `AmfCond`, `NfGroupCond` or
+    /// `NetworkSliceCond` carries none of those three, so it parsed to a
+    /// condition with all three fields `None` — and `subscription_matches` then
+    /// fell through every `if let` and returned `true`. Every such subscriber
+    /// received a notification for every NF in the registry.
+    #[test]
+    fn narrow_conditions_do_not_match_an_unrelated_nf() {
+        // A plain AMF: no nfSetIdList, no amfInfo, no sNssais, no group id.
+        let amf = profile_from(serde_json::json!({
+            "nfInstanceId": "amf-unrelated",
+            "nfType": "AMF",
+            "nfStatus": "REGISTERED",
+        }));
+
+        for raw in [
+            serde_json::json!({ "nfSetId": "set-1" }),
+            serde_json::json!({ "amfSetId": "set-1" }),
+            serde_json::json!({ "amfRegionId": "01" }),
+            serde_json::json!({ "guamiList": [{ "plmnId": {"mcc": "001", "mnc": "01"},
+                                                "amfId": "cafe00" }] }),
+            serde_json::json!({ "snssaiList": [{ "sst": 1 }] }),
+            serde_json::json!({ "nfType": "UDM", "nfGroupId": "group-1" }),
+            serde_json::json!({ "nfServiceSetId": "svcset-1" }),
+            serde_json::json!({ "scpDomains": ["dom-1"] }),
+            serde_json::json!({ "nfInstanceIdList": ["someone-else"] }),
+            serde_json::json!({ "conditionType": "SERVICE_NAME_LIST_COND",
+                                "serviceNameList": ["nsmf-pdusession"] }),
+            serde_json::json!({ "conditionType": "UPF_COND" }),
+            serde_json::json!({ "conditionType": "NWDAF_COND" }),
+            serde_json::json!({ "conditionType": "NEF_COND" }),
+            serde_json::json!({ "conditionType": "DCCF_COND" }),
+        ] {
+            let sub = sub_with_cond(raw.clone());
+            assert!(
+                !subscription_matches(&sub, &amf),
+                "condition {raw} must not match an unrelated AMF; matching it is \
+                 the match-all defect"
+            );
+        }
+    }
+
+    /// The positive half: each variant matches the profile it names. Asserting
+    /// only the negative above would pass for an implementation that matches
+    /// nothing at all.
+    #[test]
+    fn each_condition_variant_matches_its_own_profile() {
+        let amf = profile_from(serde_json::json!({
+            "nfInstanceId": "amf-1",
+            "nfType": "AMF",
+            "nfStatus": "REGISTERED",
+            "nfSetIdList": ["set-1", "set-2"],
+            "sNssais": [{"sst": 1, "sd": "0000ab"}, {"sst": 2}],
+            "nsiList": ["nsi-7"],
+            "scpDomains": ["dom-1"],
+            "amfInfo": {
+                "amfSetId": "set-a",
+                "amfRegionId": "01",
+                "guamiList": [{"plmnId": {"mcc": "001", "mnc": "01"}, "amfId": "cafe00"}],
+            },
+            "nfServices": [{
+                "serviceInstanceId": "s1",
+                "serviceName": "namf-comm",
+                "versions": [],
+                "scheme": "http",
+                "nfServiceSetIdList": ["svcset-1"],
+            }],
+        }));
+
+        let cases = [
+            (
+                "NfInstanceIdCond",
+                serde_json::json!({ "nfInstanceId": "amf-1" }),
+            ),
+            (
+                "NfInstanceIdListCond",
+                serde_json::json!({ "nfInstanceIdList": ["other", "amf-1"] }),
+            ),
+            ("NfTypeCond", serde_json::json!({ "nfType": "AMF" })),
+            (
+                "ServiceNameCond",
+                serde_json::json!({ "serviceName": "namf-comm" }),
+            ),
+            (
+                "ServiceNameListCond",
+                serde_json::json!({ "conditionType": "SERVICE_NAME_LIST_COND",
+                                 "serviceNameList": ["nsmf-pdusession", "namf-comm"] }),
+            ),
+            (
+                "AmfCond (set only)",
+                serde_json::json!({ "amfSetId": "set-a" }),
+            ),
+            (
+                "AmfCond (set + region)",
+                serde_json::json!({ "amfSetId": "set-a", "amfRegionId": "01" }),
+            ),
+            (
+                "GuamiListCond",
+                serde_json::json!({ "guamiList": [{"plmnId": {"mcc": "001", "mnc": "01"},
+                                                "amfId": "cafe00"}] }),
+            ),
+            (
+                "NetworkSliceCond",
+                serde_json::json!({ "snssaiList": [{"sst": 2}] }),
+            ),
+            (
+                "NetworkSliceCond + nsiList",
+                serde_json::json!({ "snssaiList": [{"sst": 2}], "nsiList": ["nsi-7"] }),
+            ),
+            ("NfSetCond", serde_json::json!({ "nfSetId": "set-2" })),
+            (
+                "NfServiceSetCond",
+                serde_json::json!({ "nfServiceSetId": "svcset-1" }),
+            ),
+            (
+                "NfServiceSetCond + nfSetId",
+                serde_json::json!({ "nfServiceSetId": "svcset-1", "nfSetId": "set-1" }),
+            ),
+            (
+                "ScpDomainCond",
+                serde_json::json!({ "scpDomains": ["dom-0", "dom-1"] }),
+            ),
+            (
+                "ScpDomainCond + nfTypeList",
+                serde_json::json!({ "scpDomains": ["dom-1"], "nfTypeList": ["AMF"] }),
+            ),
+        ];
+        for (name, raw) in cases {
+            let sub = sub_with_cond(raw.clone());
+            assert!(
+                subscription_matches(&sub, &amf),
+                "{name} ({raw}) must match the profile it names"
+            );
+        }
+
+        // And each optional extra criterion genuinely narrows: flip only the
+        // extra and the same condition must stop matching.
+        for raw in [
+            serde_json::json!({ "amfSetId": "set-a", "amfRegionId": "02" }),
+            serde_json::json!({ "snssaiList": [{"sst": 2}], "nsiList": ["nsi-other"] }),
+            serde_json::json!({ "nfServiceSetId": "svcset-1", "nfSetId": "set-absent" }),
+            serde_json::json!({ "scpDomains": ["dom-1"], "nfTypeList": ["SMF"] }),
+        ] {
+            let sub = sub_with_cond(raw.clone());
+            assert!(
+                !subscription_matches(&sub, &amf),
+                "the extra criterion in {raw} must narrow the match"
+            );
+        }
+    }
+
+    /// A group id lives inside the per-type `*Info` container, and the
+    /// `*InfoList` map form holds the same objects.
+    #[test]
+    fn nf_group_conditions_read_the_group_id_out_of_the_info_container() {
+        let udm = profile_from(serde_json::json!({
+            "nfInstanceId": "udm-1",
+            "nfType": "UDM",
+            "nfStatus": "REGISTERED",
+            "udmInfo": { "groupId": "udm-group-7" },
+        }));
+        let udr = profile_from(serde_json::json!({
+            "nfInstanceId": "udr-1",
+            "nfType": "UDR",
+            "nfStatus": "REGISTERED",
+            "udrInfoList": { "a": { "groupId": "udr-group-9" } },
+        }));
+
+        assert!(subscription_matches(
+            &sub_with_cond(serde_json::json!({"nfType": "UDM", "nfGroupId": "udm-group-7"})),
+            &udm
+        ));
+        assert!(subscription_matches(
+            &sub_with_cond(serde_json::json!({
+                "conditionType": "NF_GROUP_LIST_COND",
+                "nfType": "UDR",
+                "nfGroupIdList": ["udr-group-0", "udr-group-9"],
+            })),
+            &udr
+        ));
+
+        // The condition's mandatory nfType still restricts: the right group id
+        // on the wrong NF type must not match.
+        assert!(!subscription_matches(
+            &sub_with_cond(serde_json::json!({"nfType": "UDR", "nfGroupId": "udm-group-7"})),
+            &udm
+        ));
+        // ... and so does the group id: right type, wrong group.
+        assert!(!subscription_matches(
+            &sub_with_cond(serde_json::json!({"nfType": "UDM", "nfGroupId": "udm-group-other"})),
+            &udm
+        ));
+    }
+
+    /// A `conditionType`-tagged condition names the NF type it is about, so it
+    /// must not match another type's profile even when that profile happens to
+    /// carry nothing to compare against.
+    #[test]
+    fn conditiontype_conditions_are_restricted_to_their_own_nf_type() {
+        let upf = profile_from(serde_json::json!({
+            "nfInstanceId": "upf-1",
+            "nfType": "UPF",
+            "nfStatus": "REGISTERED",
+            "upfInfo": { "smfServingArea": ["area-1"] },
+        }));
+        let smf = profile_from(serde_json::json!({
+            "nfInstanceId": "smf-1",
+            "nfType": "SMF",
+            "nfStatus": "REGISTERED",
+        }));
+
+        let bare_upf_cond = sub_with_cond(serde_json::json!({"conditionType": "UPF_COND"}));
+        assert!(
+            subscription_matches(&bare_upf_cond, &upf),
+            "conditionType alone is the only mandatory member, so a bare \
+             UPF_COND legitimately means every UPF"
+        );
+        assert!(
+            !subscription_matches(&bare_upf_cond, &smf),
+            "a UPF condition must never match an SMF"
+        );
+
+        // smfServingArea narrows within the type.
+        assert!(subscription_matches(
+            &sub_with_cond(serde_json::json!({
+                "conditionType": "UPF_COND", "smfServingArea": ["area-1"]
+            })),
+            &upf
+        ));
+        assert!(!subscription_matches(
+            &sub_with_cond(serde_json::json!({
+                "conditionType": "UPF_COND", "smfServingArea": ["area-absent"]
+            })),
+            &upf
+        ));
+    }
+
+    /// Serving-area narrowing for the NWDAF/NEF/DCCF conditions: an explicit TAI
+    /// list and a TAI range both count as a hit, and a TAI outside both does not.
+    #[test]
+    fn serving_area_conditions_match_a_tai_list_or_a_tai_range() {
+        let nwdaf = profile_from(serde_json::json!({
+            "nfInstanceId": "nwdaf-1",
+            "nfType": "NWDAF",
+            "nfStatus": "REGISTERED",
+            "sNssais": [{"sst": 1}],
+            "nwdafInfo": {
+                "eventIds": ["NF_LOAD"],
+                "taiList": [{"plmnId": {"mcc": "001", "mnc": "01"}, "tac": "0001"}],
+                "taiRangeList": [{
+                    "plmnId": {"mcc": "001", "mnc": "01"},
+                    "tacRangeList": [{"start": "0100", "end": "0200"}],
+                }],
+            },
+        }));
+
+        let tai = |tac: &str| {
+            serde_json::json!({"taiList": [{"plmnId": {"mcc": "001", "mnc": "01"}, "tac": tac}],
+                               "conditionType": "NWDAF_COND"})
+        };
+        assert!(
+            subscription_matches(&sub_with_cond(tai("0001")), &nwdaf),
+            "an explicitly listed TAI must match"
+        );
+        assert!(
+            subscription_matches(&sub_with_cond(tai("0150")), &nwdaf),
+            "a TAI inside the profile's TAC range must match"
+        );
+        assert!(
+            !subscription_matches(&sub_with_cond(tai("0300")), &nwdaf),
+            "a TAI outside both the list and the range must not match"
+        );
+
+        // analyticsIds narrow against NwdafInfo eventIds / nwdafEvents.
+        assert!(subscription_matches(
+            &sub_with_cond(serde_json::json!({
+                "conditionType": "NWDAF_COND", "analyticsIds": ["NF_LOAD"]
+            })),
+            &nwdaf
+        ));
+        assert!(!subscription_matches(
+            &sub_with_cond(serde_json::json!({
+                "conditionType": "NWDAF_COND", "analyticsIds": ["UE_MOBILITY"]
+            })),
+            &nwdaf
+        ));
+
+        // A pattern-only TacRange is not evaluated, and must therefore NOT be
+        // read as a match — treating it as one would widen the serving area to
+        // everything, which is the failure mode being removed.
+        let pattern_only = profile_from(serde_json::json!({
+            "nfInstanceId": "nwdaf-2",
+            "nfType": "NWDAF",
+            "nfStatus": "REGISTERED",
+            "nwdafInfo": {
+                "taiRangeList": [{
+                    "plmnId": {"mcc": "001", "mnc": "01"},
+                    "tacRangeList": [{"pattern": "^01.*$"}],
+                }],
+            },
+        }));
+        assert!(!subscription_matches(
+            &sub_with_cond(tai("0150")),
+            &pattern_only
+        ));
+    }
+
+    /// The identity comparators compare significant members only, so an
+    /// insignificant spelling difference cannot make two identical values differ.
+    #[test]
+    fn identity_comparators_ignore_insignificant_differences() {
+        // sd absent == sd "ffffff" (TS 23.003: no slice differentiator).
+        assert!(snssai_eq(
+            &serde_json::json!({"sst": 1}),
+            &serde_json::json!({"sst": 1, "sd": "FFFFFF"})
+        ));
+        assert!(!snssai_eq(
+            &serde_json::json!({"sst": 1, "sd": "0000ab"}),
+            &serde_json::json!({"sst": 1})
+        ));
+        // sd is hex, so case must not distinguish two identical S-NSSAIs.
+        assert!(snssai_eq(
+            &serde_json::json!({"sst": 1, "sd": "0000AB"}),
+            &serde_json::json!({"sst": 1, "sd": "0000ab"})
+        ));
+        // A differing sst is a different slice even with the same sd.
+        assert!(!snssai_eq(
+            &serde_json::json!({"sst": 1, "sd": "0000ab"}),
+            &serde_json::json!({"sst": 2, "sd": "0000ab"})
+        ));
+
+        // TAC is hex, so "0001" and "1" are the same TAC.
+        let tai =
+            |tac: &str| serde_json::json!({"plmnId": {"mcc": "001", "mnc": "01"}, "tac": tac});
+        assert!(tai_eq(&tai("0001"), &tai("1")));
+        assert!(!tai_eq(&tai("0001"), &tai("0002")));
+        // A different PLMN is a different TAI even with the same TAC.
+        assert!(!tai_eq(
+            &tai("0001"),
+            &serde_json::json!({"plmnId": {"mcc": "002", "mnc": "01"}, "tac": "0001"})
+        ));
+
+        // A GUAMI needs both PLMN and amfId; amfId is hex, so case must not
+        // distinguish. An extra nid on one side must not either.
+        let guami = serde_json::json!({"plmnId": {"mcc": "001", "mnc": "01"}, "amfId": "CAFE00"});
+        assert!(guami_eq(
+            &guami,
+            &serde_json::json!({"plmnId": {"mcc": "001", "mnc": "01", "nid": "00000000000"},
+                                "amfId": "cafe00"})
+        ));
+        assert!(!guami_eq(
+            &guami,
+            &serde_json::json!({"plmnId": {"mcc": "001", "mnc": "01"}, "amfId": "cafe01"})
+        ));
+        // A GUAMI with no amfId at all must not match anything.
+        assert!(!guami_eq(
+            &serde_json::json!({"plmnId": {"mcc": "001", "mnc": "01"}}),
+            &guami
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // #68 criterion 4: reqNotifEvents and notifCondition are honoured.
+    // ------------------------------------------------------------------
+
+    /// `reqNotifEvents` was dropped on parse, so a subscriber asking only for
+    /// NF_DEREGISTERED still received every registration and profile change.
+    #[test]
+    fn req_notif_events_gates_the_delivered_event() {
+        let mut sub = create_test_subscription(None);
+
+        // Absent list == no restriction (an omitted filter is unconstrained).
+        for event in [
+            NotificationEventType::NfRegistered,
+            NotificationEventType::NfDeregistered,
+            NotificationEventType::NfProfileChanged,
+        ] {
+            assert!(subscription_accepts_event(&sub, event));
+        }
+
+        sub.req_notif_events = Some(vec!["NF_DEREGISTERED".to_string()]);
+        assert!(subscription_accepts_event(
+            &sub,
+            NotificationEventType::NfDeregistered
+        ));
+        assert!(
+            !subscription_accepts_event(&sub, NotificationEventType::NfRegistered),
+            "a subscriber that asked only for NF_DEREGISTERED must not be sent \
+             NF_REGISTERED"
+        );
+        assert!(!subscription_accepts_event(
+            &sub,
+            NotificationEventType::NfProfileChanged
+        ));
+
+        // Multiple requested events are all honoured.
+        sub.req_notif_events = Some(vec![
+            "NF_REGISTERED".to_string(),
+            "NF_PROFILE_CHANGED".to_string(),
+        ]);
+        assert!(subscription_accepts_event(
+            &sub,
+            NotificationEventType::NfRegistered
+        ));
+        assert!(subscription_accepts_event(
+            &sub,
+            NotificationEventType::NfProfileChanged
+        ));
+        assert!(!subscription_accepts_event(
+            &sub,
+            NotificationEventType::NfDeregistered
+        ));
+    }
+
+    /// `notifCondition` narrows NF_PROFILE_CHANGED to the attributes the
+    /// subscriber actually cares about.
+    #[test]
+    fn notif_condition_gates_profile_changes_by_attribute() {
+        use crate::nnrf_handler::NotifCondition;
+
+        let mut sub = create_test_subscription(None);
+        let load_change = vec!["load".to_string()];
+        let capacity_change = vec!["capacity".to_string()];
+
+        // Absent condition == no restriction.
+        assert!(subscription_accepts_profile_changes(&sub, &load_change));
+
+        sub.notif_condition = Some(NotifCondition {
+            monitored_attributes: Some(vec!["load".to_string()]),
+            unmonitored_attributes: None,
+        });
+        assert!(subscription_accepts_profile_changes(&sub, &load_change));
+        assert!(
+            !subscription_accepts_profile_changes(&sub, &capacity_change),
+            "monitoredAttributes is an allowlist: an unlisted attribute must not \
+             be notified"
+        );
+
+        sub.notif_condition = Some(NotifCondition {
+            monitored_attributes: None,
+            unmonitored_attributes: Some(vec!["load".to_string()]),
+        });
+        assert!(
+            !subscription_accepts_profile_changes(&sub, &load_change),
+            "unmonitoredAttributes is a denylist"
+        );
+        assert!(subscription_accepts_profile_changes(&sub, &capacity_change));
+
+        // A change touching several attributes is notified when ANY of them is
+        // monitored — dropping it would lose a change the subscriber asked for.
+        sub.notif_condition = Some(NotifCondition {
+            monitored_attributes: Some(vec!["load".to_string()]),
+            unmonitored_attributes: None,
+        });
+        assert!(subscription_accepts_profile_changes(
+            &sub,
+            &["capacity".to_string(), "load".to_string()]
+        ));
+
+        // An empty change list is a complete-replacement notification (the
+        // profile is carried instead of a change list), so it is not narrowed.
+        assert!(subscription_accepts_profile_changes(&sub, &[]));
+    }
+
+    /// `notifCondition` is expressed over top-level NFProfile attributes, so a
+    /// nested RFC 6902 path must reduce to its first segment.
+    #[test]
+    fn changed_attribute_names_reduce_a_json_pointer_to_its_first_segment() {
+        let changes = vec![
+            ChangeItem {
+                op: "replace".to_string(),
+                path: "/load".to_string(),
+                value: None,
+                orig_value: None,
+            },
+            ChangeItem {
+                op: "replace".to_string(),
+                path: "/nfServices/0/priority".to_string(),
+                value: None,
+                orig_value: None,
+            },
+            // A path with no leading slash, and the whole-document path, must
+            // not produce an empty attribute name that matches nothing.
+            ChangeItem {
+                op: "replace".to_string(),
+                path: "capacity".to_string(),
+                value: None,
+                orig_value: None,
+            },
+            ChangeItem {
+                op: "replace".to_string(),
+                path: "/".to_string(),
+                value: None,
+                orig_value: None,
+            },
+        ];
+        assert_eq!(
+            changed_attribute_names(&changes),
+            vec![
+                "load".to_string(),
+                "nfServices".to_string(),
+                "capacity".to_string()
+            ]
+        );
     }
 }

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -1262,6 +1262,8 @@ mod g21_strict_peer_tests {
             notification_uri: format!("http://127.0.0.1:{port}/nnwdaf-nfstatus-notify/v1/notify"),
             subscr_cond: None, // all NFs
             validity_duration: 3600,
+            req_notif_events: None,
+            notif_condition: None,
         });
 
         let client = SbiClient::with_host_port("127.0.0.1", port);


### PR DESCRIPTION
Closes #68

Ships the four gaps PR #219 left open, closing the umbrella: criteria **4, 5, 6, 7 and 9**. (#219 shipped 1–3 and 8.) Spec: `specs/fix-nrf-subscr-cond-hal-list-and-bootstrapping.md`.

Verified against `main` @ `d2b0304` — #219 moved most of the issue's cited line numbers again, so every site was re-located first.

## The serious one: `SubscrCond` collapsed to match-all (criterion 5)

Not a wire-shape problem, a delivery one. `SubscrCond` is a `oneOf` over **17** condition schemas; the old model was a three-field struct (`nfType`, `serviceName`, `nfInstanceId`) populated by reading those keys out of whatever object arrived. A conformant `NfSetCond`, `AmfCond`, `NfGroupCond`, `NetworkSliceCond`, `GuamiListCond`, `ScpDomainCond` or any `conditionType`-tagged condition carries **none** of the three, so it parsed to a condition with no criteria — and `subscription_matches` fell through every `if let` and returned `true`.

A subscriber that asked for one NF set was notified about **every NF in the registry**, and it looked like it worked, because notifications arrived.

Now the discriminator plus the condition object verbatim (`SubscrCond { kind, raw }` — same shape as the recorded decision to keep a received JSON object as-is and match on a canonical key). `subscr_cond_matches` has **no catch-all `=> true` arm**; all 17 arms compare real criteria against the profile document already stored verbatim in `NfProfile::attributes`. Keeping `raw` also fixed a quieter bug: the 201 body was rebuilt from the three parsed fields, so a consumer reading back its own subscription saw a condition narrower than the one it sent.

## Three judgement calls worth review

1. **A spec-valid condition this NRF cannot evaluate is refused with 400, not accepted.** `UpfCond.taiList` — TS 29.510 `UpfInfo` carries `smfServingArea`, `sNssaiUpfInfoList` and `interfaceUpfInfoList` and **no TAI list**, so a UPF profile holds nothing to compare a TAI against; the condition's prose promises what its own profile schema does not supply. And `NefCond`'s AF/identifier-range criteria (nested `gpsiRanges` / `externalGroupIdentifiersRanges`). Accepting either leaves only silent options — notify for every NF, or for none. Criterion 5 explicitly permits the refusal ("or rejects unknown/malformed conditions with 400") and it follows the recorded principle that an NF should advertise only what it can serve, but **this is a deliberate deviation and the call I'd most like a second opinion on**.
2. **Bootstrapping is served unconditionally, not behind the feature gate the issue suggests.** A cargo feature would put its tests outside `cargo test --workspace` — the CI gate — so the code would ship unexercised; an off-by-default runtime switch leaves the gap open for anyone who does not know to flip it. Read-only, and publishes only what an unauthenticated peer must read for bootstrapping to mean anything.
3. **An unusable `limit`/`page` is a 400, not an ignored parameter** — ignoring it returns a page the consumer did not ask for and cannot detect, which is exactly the old behaviour.

## The other four gaps

- **`reqNotifEvents` / `notifCondition` (criterion 4)** — parsed nowhere, so a subscriber asking only for `NF_DEREGISTERED` still got every registration and profile change. Now parsed, persisted, echoed and enforced at **all four** notify-all sites. The schema's mutually-exclusive `not` clause on `monitoredAttributes`/`unmonitoredAttributes` is enforced rather than silently resolved.
- **`validityTime` (criterion 4)** — read with `as_u64` though the type is a `DateTime` string, so **every conformant proposal silently fell through to the 24h default**. Now RFC 3339, clamped to the NRF maximum; a bare integer / malformed string / past time is a 400.
- **`GET /nf-instances` (criterion 6)** — `application/json` instead of `application/3gppHal+json`; bare strings under a mis-spelled `items` (the `UriList` schema names it `item`, values are `LinksValueSchema` `{href}` objects); `nf-type`/`limit`/`page` ignored outright (bound as `_request`). Results are now sorted before paging, because without a total order two requests for page 2 return different overlapping sets from a `HashMap`.
- **`GET /bootstrapping` (criterion 7)** — one path segment, so it never reached the service match and fell out at the `parts.len() < 3` guard as a 404. Now the six registered relation types of Table 6.4.6.3.3.1-1 as absolute hrefs, `ETag`/`Cache-Control`, `If-None-Match` → 304. `oauth2Required` reports the posture actually enforced. `ETag` is FNV-1a, deliberately not `DefaultHasher` (documented unstable across releases → would invalidate every cached document on a toolchain bump).
- **`PUT` replacement event (criterion 9)** — always `NF_REGISTERED`, even for `is_new == false`. TS 29.510 §5.2.2.3.1A: a replacement is a change, not an appearance. Subscribers were told a producer had just appeared that had been registered all along.

## Verification

Workspace **5779 → 5798 passed, 0 failed** (`cargo test --workspace` exit 0). `cargo clippy --workspace` (the CI gate) exit 0, **zero** warnings. `cargo fmt --all --check` clean. One pre-existing clippy warning from #219 fixed in passing.

**Revert-verified: 21 reverts, 21 bit.** Each fix undone individually, the named test watched to fail, then restored:

| revert | test made to fail |
|---|---|
| `subscr_cond_matches` → `true` | `narrow_conditions_do_not_match_an_unrelated_nf` |
| `conditionType` no longer implies an NF type | `conditiontype_conditions_are_restricted_to_their_own_nf_type` |
| unknown `subscrCond` falls back to a match-all kind | `subscribe_refuses_a_condition_it_cannot_honour` |
| unsupported criterion silently accepted | `subscribe_refuses_a_condition_it_cannot_honour` |
| `reqNotifEvents` gate removed | `req_notif_events_gates_the_delivered_event` |
| `notifCondition` gate removed | `notif_condition_gates_profile_changes_by_attribute` |
| `validityTime` back to `as_u64` | `subscribe_parses_validity_time_as_a_datetime_and_echoes_the_full_body` |
| `NotifCondition` accepts both forms at once | ″ |
| 201 body drops the verbatim `subscrCond` | ″ |
| `_links` back to bare-string `items` | `nf_list_is_a_hal_urilist_with_link_objects` |
| query params ignored again | ″ |
| paging sort removed (re-run 3×) | ″ |
| bootstrapping route removed | `bootstrapping_returns_hal_bootstrapping_info` |
| `If-None-Match` ignored | `bootstrapping_revalidates_with_an_etag` |
| event mapping hardcoded to `NF_REGISTERED` | `put_replacement_notifies_profile_changed_over_the_wire` |
| handler passes `is_new = true` regardless | ″ |
| `sd: ffffff` no longer ≡ absent | `identity_comparators_ignore_insignificant_differences` |
| TAC compared as a raw string | ″ |
| pattern-only `TacRange` treated as unbounded | `serving_area_conditions_match_a_tai_list_or_a_tai_range` |
| serving-area `taiList` narrowing removed | ″ |
| group ids not collected from `*InfoList` | `nf_group_conditions_read_the_group_id_out_of_the_info_container` |

Both halves of the `PUT` fix were reverted separately — testing only the mapping function would leave the part that was actually wrong (the handler passing `is_new`) unpinned. That test is **end-to-end over a real HTTP/2 subscriber**, because the notification is a `tokio::spawn`ed call and the only way to observe which event the handler chose is to be the subscriber.

**Not verified:** no live consumer, NF or restart beyond the in-process server. The `reqNotifEvents`/`notifCondition` gates are pinned at the predicate and at all four call sites, but no test drives a real subscriber through a filtered notification — their end-to-end behaviour rests on the call-site wiring being read correctly rather than observed. Docker E2E is skipped by CI. **GitNexus impact analysis was not run** (no MCP server connected), so `CLAUDE.md`'s mandate stays unsatisfiable — eighth consecutive PR to record it.