### PR TITLE
fix(upfd,gtp): carry the QER's reflective-QoS and paging-policy markings onto the downlink header (Closes #81)

### DIFF
--- a/specs/fix-upf-reflective-qos-markings.md
+++ b/specs/fix-upf-reflective-qos-markings.md
@@ -1,0 +1,88 @@
+# nextgcore #81 (UPF): QER RQI/PPI reach the downlink header; the vestigial peer registry goes
+
+Verified against `main` @ `3d17f28`. The issue's cites are from `76ea248`, and **its second gap has since
+been fixed** — see "Already done".
+
+`Closes #81`.
+
+## Already done on main (re-verified, not re-implemented)
+
+Gap 2 (no missed-heartbeat failure declaration) landed in #218 during the #61 work, after this issue was
+written:
+
+* `PfcpServer` tracks `outstanding: HashSet<u32>` and `consecutive_misses` (`pfcp_path.rs`), inserted on
+  heartbeat send and cleared on any Heartbeat Response.
+* `close_heartbeat_round` counts consecutive **unanswered rounds** and calls `declare_peer_failure` at
+  `HEARTBEAT_MAX_MISSES` (3), releasing the association and its sessions — criterion 4.
+* The dead `n4_no_heartbeat` sweep over `peer_nodes` was removed, and its guard (elapsed wall-clock
+  rather than missed responses) with it.
+
+So criterion 5's "**or its replacement per-peer registry**" is satisfied by state that lives next to the
+socket that sends and receives the heartbeats, rather than by a separate map. What was left of the old
+design is dealt with below.
+
+## Gap: RQI and PPI were parsed nowhere and could never reach the wire (criteria 1-3)
+
+`parse_create_qer` stopped at the QFI. `ParsedCreateQer` and `DataPlaneQer` had no fields to hold the
+markings. And every downlink G-PDU went out through `PduSessionContainer::dl`, which hardcodes
+`rqi = false` and `ppi = None`. So reflective QoS (TS 23.501 §5.7.5) and paging-policy differentiation
+were **silently inert no matter what the SMF provisioned** — an interop surprise rather than a visible
+failure, because the packets still flowed and the QFI was still correct.
+
+The GTP-U codec already supported both fields, so no wire-format work was needed. What was added:
+
+* **`pfcp_ie::RQI = 123`** and **`PAGING_POLICY_INDICATOR = 158`**, taken from the TS 29.244 IE-type
+  table, with the bit layouts from §8.2.88 (octet 5 bit 1, rest spare) and §8.2.116 (octet 5 bits 1-3,
+  value 0-7). Only bit 1 of the RQI IE is read — a test pins that `0xFE` in the spare bits does **not**
+  set the flag, because reading the whole octet would turn every spare bit into a reflective-QoS trigger.
+* **A PPI wider than 3 bits is masked, not dropped**, at both the parse and the encode step, so a
+  mis-provisioned QER still yields a well-formed header rather than an omitted field.
+* **`PduSessionContainer::dl_with_marking`** alongside the existing `dl`. Kept separate rather than
+  adding parameters to `dl`: the great majority of downlink packets carry neither marking and should not
+  pay for an options struct, and a caller with markings to set is making a deliberate choice.
+  `build_gtpu_header_with_qfi` and `encapsulate_dl_gpdu` now delegate to the marked variants with both
+  off, so there is exactly one place that lays out the header.
+* **`DataPlaneQer`'s `Clone` copies the markings.** Its `Clone` is hand-written and copies field by
+  field, so a new field is silently dropped by default — and the data plane clones QERs, which would
+  have disabled reflective QoS wherever a copy was taken while the original still looked correct. A test
+  asserts the round trip *through* a clone.
+* **The buffered-DL flush path is marked too.** That path forwards against the *session's* QFI rather
+  than a per-packet PDR/QER match (pre-existing behaviour), so the markings are taken from the QER that
+  owns that same QFI — same flow, same treatment. Without this, the packets that woke the UE would be
+  the only ones stripped, which is precisely when a paging policy matters.
+
+## Gap residue: `peer_nodes` deleted (criterion 5)
+
+#218 removed the sweep but left the map: declared, default-initialised, cleared in one place, never
+inserted into, and read only by two tests asserting it was empty. That is exactly the shape this repo has
+twice recorded as a hazard — an unpopulated per-peer registry reads as a peer table the UPF maintains,
+and the next person adding heartbeat state would reasonably put it there, back into a map with no
+readers. `PfcpNode` is retained: it is still the type used for association bookkeeping.
+
+## Verification
+
+**6 new tests** (1 in `n4_build`, 5 in `data_plane`). upfd 285 → 290 passed. Workspace
+`cargo test --workspace` green; `cargo clippy --workspace` (the CI gate) clean, zero warnings;
+`cargo fmt --all --check` clean.
+
+**Revert-verified: 10 reverts, 10 bit.** Including the two halves of the forwarding wiring separately
+(the encapsulator call *and* reading the QER's fields), and an inverted case — making the *unmarked*
+path set RQI — so the regression guard is shown to be load-bearing rather than trivially true.
+
+**The wiring test earned its keep, and it is worth recording why.** An earlier patch script asserted on
+four anchors and the fourth did not match, so it raised before writing — silently dropping the
+forwarding-path edit while the helper edits from a previous script had already landed. Every helper-level
+assertion passed. `dl_forwarding_applies_the_qer_markings_to_the_sent_gpdu` — which drives a real packet
+through `handle_downlink_packet` and reads the markings off the G-PDU the gNB socket receives — failed
+with `left: 0, right: 64`, which is what sent me back to look. This is the recorded lesson that
+extracting logic into a tested helper leaves the *wiring* untested, encountered live rather than in
+principle.
+
+**Not verified:** no gNB. The cross-repo note on the issue still holds — this is coupled to
+NextgCoreLab/nextgsim#44, and marking without enforcement is inert: the gNB extracts QFI/RQI from the
+container but runs no SDAP entity, so nothing acts on the bit yet. What is established here is that the
+bit and the PPI reach the wire in the TS 38.415 §5.5.2 field positions, asserted at the byte level
+against a header parsed out of a really-sent G-PDU. The heartbeat criteria (4, 5) were re-verified by
+reading `close_heartbeat_round` and by the existing suite staying green; no new test was written for
+behaviour #218 already covers. Docker E2E is skipped by CI. GitNexus impact analysis, which CLAUDE.md
+mandates, was **not run** — no MCP server connected; eleventh consecutive PR to record it.

--- a/src/bins/nextgcore-upfd/src/data_plane.rs
+++ b/src/bins/nextgcore-upfd/src/data_plane.rs
@@ -453,10 +453,26 @@ pub fn build_gtpu_header_with_seq(
 /// layout (E flag, length units, padding, next-type chaining) is shared
 /// with the rest of the stack.
 pub fn build_gtpu_header_with_qfi(teid: u32, payload_len: u16, qfi: u8) -> Vec<u8> {
+    build_gtpu_header_with_marking(teid, payload_len, qfi, false, None)
+}
+
+/// Build a downlink G-PDU header whose PDU Session Container carries the QoS
+/// markings the QER provisioned (TS 38.415 §5.5.2).
+///
+/// `build_gtpu_header_with_qfi` is the unmarked case and delegates here, so there
+/// is exactly one place that lays out the header.
+pub fn build_gtpu_header_with_marking(
+    teid: u32,
+    payload_len: u16,
+    qfi: u8,
+    rqi: bool,
+    ppi: Option<u8>,
+) -> Vec<u8> {
     use bytes::BytesMut;
     use nextgcore_gtp::v1::types::{ExtensionHeaderType, Gtp1ExtHeader, PduSessionContainer};
 
-    let ext = Gtp1ExtHeader::pdu_session_container(&PduSessionContainer::dl(qfi));
+    let ext =
+        Gtp1ExtHeader::pdu_session_container(&PduSessionContainer::dl_with_marking(qfi, rqi, ppi));
     let ext_len = ext.encoded_len();
 
     let mut header = Vec::with_capacity(12 + ext_len);
@@ -484,9 +500,26 @@ pub fn build_gtpu_header_with_qfi(teid: u32, payload_len: u16, qfi: u8) -> Vec<u
 /// the PDU Session Container extension header is added so the gNB can map
 /// the packet to the correct QoS flow (TS 38.415).
 pub fn encapsulate_dl_gpdu(inner_ip: &[u8], teid: u32, qfi: Option<u8>) -> Vec<u8> {
+    encapsulate_dl_gpdu_marked(inner_ip, teid, qfi, false, None)
+}
+
+/// Encapsulate a downlink packet, applying the QER's reflective-QoS and
+/// paging-policy markings to the PDU Session Container.
+///
+/// The markings were parsed from the QER and then dropped: every downlink G-PDU
+/// went out through `PduSessionContainer::dl`, which hardcodes `rqi = false` and
+/// `ppi = None`, so reflective QoS and paging-policy differentiation were
+/// silently inert no matter what the SMF asked for.
+pub fn encapsulate_dl_gpdu_marked(
+    inner_ip: &[u8],
+    teid: u32,
+    qfi: Option<u8>,
+    rqi: bool,
+    ppi: Option<u8>,
+) -> Vec<u8> {
     match qfi {
         Some(q) => {
-            let header = build_gtpu_header_with_qfi(teid, inner_ip.len() as u16, q);
+            let header = build_gtpu_header_with_marking(teid, inner_ip.len() as u16, q, rqi, ppi);
             let mut pkt = Vec::with_capacity(header.len() + inner_ip.len());
             pkt.extend_from_slice(&header);
             pkt.extend_from_slice(inner_ip);
@@ -936,6 +969,11 @@ pub struct DataPlaneQer {
     /// Guaranteed Bit Rate downlink (kbps, 0 = none)
     pub dl_gbr: u64,
     pub qfi: Option<u8>,
+    /// Reflective QoS Indicator provisioned by the SMF (TS 29.244 §8.2.88).
+    /// Written onto every downlink PDU Session Information header for this QER.
+    pub rqi: bool,
+    /// Paging Policy Indicator provisioned by the SMF (TS 29.244 §8.2.116).
+    pub ppi: Option<u8>,
     /// DSCP value for outer GTP-U IP header (computed from QFI)
     pub dscp: u8,
     /// True when this QER carries an XR delay-critical GBR 5QI (82-85,
@@ -958,6 +996,8 @@ impl Clone for DataPlaneQer {
         qer.ul_gate_open = self.ul_gate_open;
         qer.dl_gate_open = self.dl_gate_open;
         qer.qfi = self.qfi;
+        qer.rqi = self.rqi;
+        qer.ppi = self.ppi;
         qer.dscp = self.dscp;
         qer.is_xr = self.is_xr;
         qer.set_mbr(self.ul_mbr, self.dl_mbr);
@@ -977,6 +1017,10 @@ impl DataPlaneQer {
             ul_gbr: 0,
             dl_gbr: 0,
             qfi: None,
+            // Off unless the SMF provisions them: reflective QoS and a paging
+            // policy are opt-in per QER (TS 29.244 §8.2.88, §8.2.116).
+            rqi: false,
+            ppi: None,
             dscp: 0,
             is_xr: false,
             ul_mbr_bucket: std::sync::Mutex::new(None),
@@ -2335,6 +2379,10 @@ impl DataPlane {
 
         let mut dscp_to_apply: Option<u8> = None;
         let mut qfi_to_apply: Option<u8> = None;
+        // Reflective QoS / paging-policy markings for the PDU Session Container,
+        // taken from the matched QER (TS 38.415 §5.5.2).
+        let mut rqi_to_apply = false;
+        let mut ppi_to_apply: Option<u8> = None;
         let dl_pkt_tuple = if ip_version == IP_VERSION_4 {
             PacketTuple::from_ipv4_packet(pkt)
         } else {
@@ -2380,6 +2428,8 @@ impl DataPlane {
                     dscp_to_apply = Some(qer.dscp);
                 }
                 qfi_to_apply = qer.qfi;
+                rqi_to_apply = qer.rqi;
+                ppi_to_apply = qer.ppi;
             }
         }
         if qfi_to_apply.is_none() {
@@ -2464,7 +2514,8 @@ impl DataPlane {
         // Build GTP-U encapsulated packet, carrying the QFI in a PDU Session
         // Container extension header on N3 (TS 38.415 / TS 29.281 5.2.2.7). The
         // inner IP packet is forwarded byte-for-byte intact.
-        let gtpu_pkt = encapsulate_dl_gpdu(pkt, dl_teid, qfi_to_apply);
+        let gtpu_pkt =
+            encapsulate_dl_gpdu_marked(pkt, dl_teid, qfi_to_apply, rqi_to_apply, ppi_to_apply);
 
         // Send to gNB
         match gtpu.send_to(&gtpu_pkt, gnb_addr).await {
@@ -2524,10 +2575,29 @@ impl DataPlane {
             .map(|ip| SocketAddr::new(IpAddr::V4(ip), GTPU_PORT))
             .unwrap_or(session.gnb_addr);
         let qfi = session.qfi;
+        // Buffered packets are flushed against the SESSION's QFI rather than a
+        // per-packet PDR/QER match (pre-existing behaviour of this path), so the
+        // markings are taken from the QER that owns that same QFI — same flow,
+        // same reflective-QoS and paging-policy treatment. Without this the
+        // packets that woke the UE would be the only ones stripped of their
+        // markings, which is precisely when a paging policy matters.
+        let (rqi, ppi) = match qfi {
+            Some(q) => session
+                .qers
+                .read()
+                .ok()
+                .and_then(|qers| {
+                    qers.values()
+                        .find(|qer| qer.qfi == Some(q))
+                        .map(|qer| (qer.rqi, qer.ppi))
+                })
+                .unwrap_or((false, None)),
+            None => (false, None),
+        };
         let mut sent = 0usize;
         for pkt in pkts {
             let len = pkt.len() as u64;
-            let gtpu_pkt = encapsulate_dl_gpdu(&pkt, teid, qfi);
+            let gtpu_pkt = encapsulate_dl_gpdu_marked(&pkt, teid, qfi, rqi, ppi);
             match gtpu.send_to(&gtpu_pkt, addr).await {
                 Ok(_) => {
                     sent += 1;
@@ -4785,5 +4855,254 @@ mod tests {
             header.teid, 0,
             "non-zero TEID must trigger Error Indication path"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // #81 criteria 2 + 3: RQI/PPI reach the downlink PDU Session Container.
+    // ------------------------------------------------------------------
+
+    /// Locate the PDU Session Container content inside a downlink G-PDU built by
+    /// `build_gtpu_header_with_marking`.
+    ///
+    /// Returns `(octet0, octet1, rest)` of the container frame. Parsed out of the
+    /// real header rather than asserted against a hand-written byte string, so the
+    /// test still means something if the header layout changes.
+    fn dl_container_of(gpdu: &[u8]) -> (u8, u8, Vec<u8>) {
+        // 0: flags, 1: msg type, 2-3: length, 4-7: TEID, 8-9: seq, 10: npdu,
+        // 11: next-ext-type, 12: ext length (in 4-octet units), 13..: content.
+        assert_eq!(gpdu[0] & 0x04, 0x04, "E flag must be set");
+        assert_eq!(
+            gpdu[11],
+            nextgcore_gtp::v1::types::ExtensionHeaderType::PduSessionContainer as u8
+        );
+        let ext_units = gpdu[12] as usize;
+        let ext_total = ext_units * 4;
+        // content = ext bytes minus the length octet and the trailing next-ext octet
+        let content = &gpdu[13..12 + ext_total - 1];
+        (content[0], content[1], content[2..].to_vec())
+    }
+
+    #[test]
+    fn downlink_container_carries_the_rqi_bit_and_ppi_field() {
+        // TS 38.415 §5.5.2: octet 1 of DL PDU SESSION INFORMATION is
+        // PPP(bit 8) | RQI(bit 7) | QFI(bits 1-6); the PPI octet follows when PPP
+        // is set, as PPI(bits 6-8) | spare.
+        let marked = build_gtpu_header_with_marking(0xAABBCCDD, 100, 9, true, Some(5));
+        let (octet0, octet1, rest) = dl_container_of(&marked);
+        assert_eq!(octet0 >> 4, 0, "PDU Type 0 = DL PDU SESSION INFORMATION");
+        assert_eq!(octet1 & 0x3F, 9, "QFI");
+        assert_eq!(octet1 & 0x40, 0x40, "RQI bit set");
+        assert_eq!(octet1 & 0x80, 0x80, "PPP bit set because a PPI is present");
+        assert_eq!(rest[0] >> 5, 5, "PPI value in bits 6-8");
+
+        // RQI without PPI: the PPP bit stays clear and no PPI octet is added.
+        let rqi_only = build_gtpu_header_with_marking(1, 10, 9, true, None);
+        let (_, octet1, rest) = dl_container_of(&rqi_only);
+        assert_eq!(octet1 & 0x40, 0x40, "RQI set");
+        assert_eq!(octet1 & 0x80, 0, "PPP clear when there is no PPI");
+        assert!(
+            rest.is_empty(),
+            "no PPI octet may be emitted when PPP is clear: {rest:02x?}"
+        );
+
+        // Regression guard, exactly as the criterion asks: a session whose QER
+        // sets neither leaves both clear. This is what every downlink packet used
+        // to look like regardless of what the SMF provisioned.
+        let unmarked = build_gtpu_header_with_qfi(0xAABBCCDD, 100, 9);
+        let (_, octet1, rest) = dl_container_of(&unmarked);
+        assert_eq!(octet1 & 0x3F, 9, "QFI still carried");
+        assert_eq!(octet1 & 0x40, 0, "RQI must stay clear");
+        assert_eq!(octet1 & 0x80, 0, "PPP must stay clear");
+        assert!(rest.is_empty());
+    }
+
+    /// The whole chain the criterion names: PFCP QER bytes → `parse_create_qer` →
+    /// `DataPlaneQer` (including through a `Clone`) → the encapsulated downlink
+    /// G-PDU's container.
+    #[test]
+    fn qer_markings_travel_from_pfcp_to_the_downlink_header() {
+        fn ie(ie_type: u16, value: &[u8]) -> Vec<u8> {
+            let mut out = ie_type.to_be_bytes().to_vec();
+            out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+            out.extend_from_slice(value);
+            out
+        }
+        let mut ies = ie(crate::n4_build::pfcp_ie::QER_ID, &3u32.to_be_bytes());
+        ies.extend_from_slice(&ie(25, &[0x00]));
+        ies.extend_from_slice(&ie(crate::n4_build::pfcp_ie::QFI, &[6]));
+        ies.extend_from_slice(&ie(123, &[0x01])); // RQI
+        ies.extend_from_slice(&ie(158, &[0x03])); // PPI = 3
+
+        let parsed = crate::n4_build::parse_create_qer(&ies).expect("QER parses");
+
+        // The install step upfd's main.rs performs.
+        let mut qer = DataPlaneQer::new(parsed.qer_id);
+        qer.qfi = parsed.qfi;
+        qer.rqi = parsed.rqi;
+        qer.ppi = parsed.ppi;
+
+        // Clone must carry them: the data plane clones QERs, and a Clone that
+        // dropped the markings would disable reflective QoS wherever a copy is
+        // taken while the original still looked correct.
+        let cloned = qer.clone();
+        assert!(cloned.rqi);
+        assert_eq!(cloned.ppi, Some(3));
+        assert_eq!(cloned.qfi, Some(6));
+
+        let inner = [
+            0x45u8, 0x00, 0x00, 0x14, 0, 0, 0, 0, 64, 17, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
+        ];
+        let gpdu = encapsulate_dl_gpdu_marked(&inner, 0x1234, cloned.qfi, cloned.rqi, cloned.ppi);
+        let (_, octet1, rest) = dl_container_of(&gpdu);
+        assert_eq!(octet1 & 0x3F, 6);
+        assert_eq!(octet1 & 0x40, 0x40, "RQI must reach the wire");
+        assert_eq!(rest[0] >> 5, 3, "PPI must reach the wire");
+        // The inner packet is still forwarded byte-for-byte.
+        assert!(gpdu.ends_with(&inner));
+
+        // And the unmarked path through the same encapsulator is unchanged.
+        let plain = encapsulate_dl_gpdu(&inner, 0x1234, Some(6));
+        let (_, octet1, rest) = dl_container_of(&plain);
+        assert_eq!(
+            octet1 & 0xC0,
+            0,
+            "no markings without a QER asking for them"
+        );
+        assert!(rest.is_empty());
+    }
+
+    /// The WIRING, not just the helpers: drive a real downlink packet through
+    /// `handle_downlink_packet` with a QER carrying RQI/PPI and read the markings
+    /// off the G-PDU the gNB actually receives.
+    ///
+    /// Without this, every assertion above could pass while the forwarding site
+    /// still called the unmarked encapsulator — which is exactly the defect, since
+    /// the QER was parsed and then dropped on the way to the wire.
+    #[tokio::test]
+    async fn dl_forwarding_applies_the_qer_markings_to_the_sent_gpdu() {
+        let ue_ip = Ipv4Addr::new(10, 45, 0, 11);
+        let gnb_sock = TokioUdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let gnb_addr = gnb_sock.local_addr().unwrap();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let dp = DataPlane::new(shutdown);
+        let upf_sock = TokioUdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let dp = DataPlane {
+            gtpu_socket: Some(Arc::new(upf_sock)),
+            ..dp
+        };
+        dp.add_session_from_pfcp(
+            0x81,
+            0x1081,
+            ue_ip,
+            0x100,
+            0x200,
+            gnb_addr,
+            Some(1),
+            Some(9),
+        );
+
+        let session = dp.sessions.find_by_seid(0x81).unwrap();
+        let mut qer = DataPlaneQer::new(11);
+        qer.set_qfi(9);
+        qer.rqi = true;
+        qer.ppi = Some(4);
+        session.qers.write().unwrap().insert(11, qer);
+        if let Some(far) = session.fars.write().unwrap().get_mut(&2) {
+            far.ohc_addr = None;
+        }
+        {
+            let mut pdrs = session.pdrs.write().unwrap();
+            for p in pdrs.iter_mut() {
+                if p.source_interface == SRC_INTF_CORE {
+                    p.qer_id = Some(11);
+                }
+            }
+        }
+
+        let mut inner = make_ipv4_udp_packet([8, 8, 8, 8], ue_ip.octets(), 53, 1234);
+        finalize_ipv4(&mut inner);
+        let gtpu = dp.gtpu_socket.as_ref().unwrap().clone();
+        dp.handle_downlink_packet(&inner, &gtpu).await;
+
+        let mut buf = [0u8; 2048];
+        let (len, _) = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            gnb_sock.recv_from(&mut buf),
+        )
+        .await
+        .expect("DL G-PDU must arrive")
+        .unwrap();
+
+        let (_, octet1, rest) = dl_container_of(&buf[..len]);
+        assert_eq!(octet1 & 0x3F, 9, "QFI");
+        assert_eq!(
+            octet1 & 0x40,
+            0x40,
+            "the forwarding path must apply the QER's RQI, not just the helper"
+        );
+        assert_eq!(octet1 & 0x80, 0x80, "PPP set for the PPI");
+        assert_eq!(rest[0] >> 5, 4, "PPI value");
+    }
+
+    /// The same path with a QER that asks for neither leaves both clear — so the
+    /// test above is pinning the markings rather than a header that always sets
+    /// them.
+    #[tokio::test]
+    async fn dl_forwarding_leaves_the_markings_clear_without_a_qer_asking() {
+        let ue_ip = Ipv4Addr::new(10, 45, 0, 12);
+        let gnb_sock = TokioUdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let gnb_addr = gnb_sock.local_addr().unwrap();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let dp = DataPlane::new(shutdown);
+        let upf_sock = TokioUdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let dp = DataPlane {
+            gtpu_socket: Some(Arc::new(upf_sock)),
+            ..dp
+        };
+        dp.add_session_from_pfcp(
+            0x82,
+            0x1082,
+            ue_ip,
+            0x100,
+            0x200,
+            gnb_addr,
+            Some(1),
+            Some(9),
+        );
+
+        let session = dp.sessions.find_by_seid(0x82).unwrap();
+        let mut qer = DataPlaneQer::new(12);
+        qer.set_qfi(9);
+        session.qers.write().unwrap().insert(12, qer);
+        if let Some(far) = session.fars.write().unwrap().get_mut(&2) {
+            far.ohc_addr = None;
+        }
+        {
+            let mut pdrs = session.pdrs.write().unwrap();
+            for p in pdrs.iter_mut() {
+                if p.source_interface == SRC_INTF_CORE {
+                    p.qer_id = Some(12);
+                }
+            }
+        }
+
+        let mut inner = make_ipv4_udp_packet([8, 8, 8, 8], ue_ip.octets(), 53, 1234);
+        finalize_ipv4(&mut inner);
+        let gtpu = dp.gtpu_socket.as_ref().unwrap().clone();
+        dp.handle_downlink_packet(&inner, &gtpu).await;
+
+        let mut buf = [0u8; 2048];
+        let (len, _) = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            gnb_sock.recv_from(&mut buf),
+        )
+        .await
+        .expect("DL G-PDU must arrive")
+        .unwrap();
+
+        let (_, octet1, rest) = dl_container_of(&buf[..len]);
+        assert_eq!(octet1 & 0x3F, 9, "QFI still carried");
+        assert_eq!(octet1 & 0xC0, 0, "RQI and PPP must both stay clear");
+        assert!(rest.is_empty(), "no PPI octet: {rest:02x?}");
     }
 }

--- a/src/bins/nextgcore-upfd/src/main.rs
+++ b/src/bins/nextgcore-upfd/src/main.rs
@@ -636,6 +636,11 @@ async fn run_async_event_loop(
                 // defects are why it is gone rather than repaired: the state it
                 // needed already exists on the server, next to the socket that
                 // sends and receives the heartbeats.
+                //
+                // `peer_nodes` itself is now deleted too (#81): leaving an
+                // unpopulated per-peer registry behind reads as a peer table the
+                // UPF maintains, and the next person to add heartbeat state would
+                // reasonably put it there -- back into the map with no readers.
 
                 // Process pending PFCP transactions (check for timeouts)
                 let stale_seqs: Vec<u32> = pfcp_ctx
@@ -816,6 +821,11 @@ async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEve
                         let mut dp_qers = std::collections::HashMap::new();
                         for q in &qers {
                             let mut qer = DataPlaneQer::new(q.qer_id);
+                            // Reflective QoS / paging policy the SMF asked for.
+                            // Parsed since #81; previously decoded nowhere, so a
+                            // QER requesting them had no effect on the wire.
+                            qer.rqi = q.rqi;
+                            qer.ppi = q.ppi;
                             qer.ul_gate_open = q.ul_gate == 0;
                             qer.dl_gate_open = q.dl_gate == 0;
                             qer.set_mbr(q.ul_mbr, q.dl_mbr);
@@ -929,6 +939,11 @@ async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEve
                     let mut dp_qers = session.qers.write().unwrap();
                     for q in &updated_qers {
                         let mut qer = DataPlaneQer::new(q.qer_id);
+                        // Reflective QoS / paging policy the SMF asked for.
+                        // Parsed since #81; previously decoded nowhere, so a
+                        // QER requesting them had no effect on the wire.
+                        qer.rqi = q.rqi;
+                        qer.ppi = q.ppi;
                         qer.ul_gate_open = q.ul_gate == 0;
                         qer.dl_gate_open = q.dl_gate == 0;
                         qer.set_mbr(q.ul_mbr, q.dl_mbr);

--- a/src/bins/nextgcore-upfd/src/n4_build.rs
+++ b/src/bins/nextgcore-upfd/src/n4_build.rs
@@ -148,6 +148,10 @@ pub mod pfcp_ie {
     pub const QER_ID: u16 = 109;
     pub const PDN_TYPE: u16 = 113;
     pub const QFI: u16 = 124;
+    /// Reflective QoS Indicator (TS 29.244 §8.2.88)
+    pub const RQI: u16 = 123;
+    /// Paging Policy Indicator (TS 29.244 §8.2.116)
+    pub const PAGING_POLICY_INDICATOR: u16 = 158;
     pub const FRAMED_ROUTE: u16 = 153;
     pub const FRAMED_IPV6_ROUTE: u16 = 155;
     pub const APN_DNN: u16 = 159;
@@ -1534,6 +1538,24 @@ pub fn parse_create_qer(data: &[u8]) -> Result<ParsedCreateQer, &'static str> {
         }
     }
 
+    // RQI (TS 29.244 §8.2.88, IE type 123): octet 5 bit 1, rest spare. Parsed so
+    // the SMF can actually turn reflective QoS on — it was decoded nowhere, so a
+    // QER asking for it was silently ignored and the downlink header always went
+    // out with RQI clear.
+    if let Some(ie) = ParsedIe::find_ie(&ies, pfcp_ie::RQI) {
+        if !ie.value.is_empty() {
+            qer.rqi = ie.value[0] & 0x01 != 0;
+        }
+    }
+
+    // Paging Policy Indicator (TS 29.244 §8.2.116, IE type 158): octet 5 bits
+    // 1-3 carry a value 0-7, the rest is spare.
+    if let Some(ie) = ParsedIe::find_ie(&ies, pfcp_ie::PAGING_POLICY_INDICATOR) {
+        if !ie.value.is_empty() {
+            qer.ppi = Some(ie.value[0] & 0x07);
+        }
+    }
+
     Ok(qer)
 }
 
@@ -1548,6 +1570,11 @@ pub struct ParsedCreateQer {
     pub ul_gbr: u64,
     pub dl_gbr: u64,
     pub qfi: Option<u8>,
+    /// Reflective QoS Indicator (TS 29.244 §8.2.88): set on downlink packets
+    /// matching this QER so the UE derives its uplink rule (TS 23.501 §5.7.5).
+    pub rqi: bool,
+    /// Paging Policy Indicator (TS 29.244 §8.2.116), 0-7 when provisioned.
+    pub ppi: Option<u8>,
 }
 
 /// Parse Create URR IE
@@ -2475,5 +2502,62 @@ mod tests {
             Some(7),
             "parsed choose_id must be Some(7)"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // #81 criterion 1: the QER's RQI and PPI are parsed, not dropped.
+    // ------------------------------------------------------------------
+
+    /// Frame a PFCP IE: 2-octet type, 2-octet length, value.
+    fn ie(ie_type: u16, value: &[u8]) -> Vec<u8> {
+        let mut out = ie_type.to_be_bytes().to_vec();
+        out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+        out.extend_from_slice(value);
+        out
+    }
+
+    fn qer_ies(extra: &[Vec<u8>]) -> Vec<u8> {
+        let mut buf = ie(pfcp_ie::QER_ID, &7u32.to_be_bytes());
+        // Gate Status: UL and DL both OPEN.
+        buf.extend_from_slice(&ie(25, &[0x00]));
+        buf.extend_from_slice(&ie(pfcp_ie::QFI, &[9]));
+        for e in extra {
+            buf.extend_from_slice(e);
+        }
+        buf
+    }
+
+    #[test]
+    fn create_qer_parses_the_rqi_and_ppi_flags() {
+        // RQI is IE 123, octet 5 bit 1 (TS 29.244 §8.2.88); PPI is IE 158,
+        // octet 5 bits 1-3 (§8.2.116).
+        let qer =
+            parse_create_qer(&qer_ies(&[ie(123, &[0x01]), ie(158, &[0x05])])).expect("QER parses");
+        assert_eq!(qer.qer_id, 7);
+        assert_eq!(qer.qfi, Some(9));
+        assert!(qer.rqi, "RQI=1 must be parsed, not dropped at the QFI");
+        assert_eq!(qer.ppi, Some(5));
+
+        // The spare bits above RQI must not be read as the flag.
+        let spare_only = parse_create_qer(&qer_ies(&[ie(123, &[0xFE])])).expect("QER parses");
+        assert!(
+            !spare_only.rqi,
+            "only bit 1 of the RQI IE is the flag; the spare bits are not"
+        );
+
+        // A PPI value wider than 3 bits is masked to the wire range, not dropped.
+        let wide_ppi = parse_create_qer(&qer_ies(&[ie(158, &[0xFF])])).expect("QER parses");
+        assert_eq!(wide_ppi.ppi, Some(0x07));
+
+        // Absent IEs leave both off: this is the regression guard for every QER
+        // that does not ask for reflective QoS.
+        let bare = parse_create_qer(&qer_ies(&[])).expect("QER parses");
+        assert!(!bare.rqi);
+        assert_eq!(bare.ppi, None);
+
+        // RQI=0 explicitly signalled is still off (TS 29.244 §5.7.5: the SMF sets
+        // the bit to 0 to turn reflective QoS off for the flow).
+        let explicit_off = parse_create_qer(&qer_ies(&[ie(123, &[0x00])])).expect("QER parses");
+        assert!(!explicit_off.rqi);
     }
 }

--- a/src/bins/nextgcore-upfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-upfd/src/pfcp_path.rs
@@ -179,7 +179,6 @@ pub struct PfcpPathContext {
     pub local_node_id: NodeId,
     pub local_addr: Option<SocketAddr>,
     pub recovery_time_stamp: u32,
-    pub peer_nodes: HashMap<String, PfcpNode>,
     pub next_sequence: u32,
     pub transactions: HashMap<u32, PfcpXact>,
 }
@@ -191,7 +190,6 @@ impl PfcpPathContext {
             local_node_id: NodeId::Ipv4(Ipv4Addr::UNSPECIFIED),
             local_addr: None,
             recovery_time_stamp: 0,
-            peer_nodes: HashMap::new(),
             next_sequence: 1,
             transactions: HashMap::new(),
         }
@@ -364,7 +362,6 @@ pub fn pfcp_open(ctx: &mut PfcpPathContext, local_addr: SocketAddr) -> Result<()
 /// Close PFCP path (cleanup)
 /// Port of upf_pfcp_close
 pub fn pfcp_close(ctx: &mut PfcpPathContext) {
-    ctx.peer_nodes.clear();
     ctx.transactions.clear();
     ctx.local_addr = None;
     log::info!("PFCP path closed");
@@ -2351,7 +2348,6 @@ mod tests {
     fn test_pfcp_path_context_new() {
         let ctx = PfcpPathContext::new();
         assert_eq!(ctx.next_sequence, 1);
-        assert!(ctx.peer_nodes.is_empty());
         assert!(ctx.transactions.is_empty());
     }
 
@@ -2410,7 +2406,6 @@ mod tests {
 
         assert!(ctx.local_addr.is_none());
         assert!(ctx.transactions.is_empty());
-        assert!(ctx.peer_nodes.is_empty());
     }
 
     #[test]

--- a/src/libs/nextgcore-gtp/src/v1/types.rs
+++ b/src/libs/nextgcore-gtp/src/v1/types.rs
@@ -298,6 +298,26 @@ impl PduSessionContainer {
         })
     }
 
+    /// Create a DL PDU SESSION INFORMATION frame carrying the QoS markings the
+    /// UPF was provisioned with (TS 38.415 §5.5.2).
+    ///
+    /// `rqi` triggers reflective QoS at the UE (TS 23.501 §5.7.5); `ppi` selects
+    /// a paging policy. Separate from [`Self::dl`] because the great majority of
+    /// downlink packets carry neither and should not pay for an options struct —
+    /// and because a caller that has markings to set is making a deliberate
+    /// choice, not defaulting.
+    pub fn dl_with_marking(qfi: u8, rqi: bool, ppi: Option<u8>) -> Self {
+        Self::Dl(DlPduSessionInformation {
+            qfi: qfi & 0x3F,
+            rqi,
+            // The PPI is 3 bits on the wire (values 0-7, TS 38.415 §5.5.3.7); a
+            // provisioned value wider than that is masked rather than dropped,
+            // so a mis-provisioned QER still yields a well-formed header.
+            ppi: ppi.map(|p| p & 0x07),
+            ..Default::default()
+        })
+    }
+
     /// Create a minimal UL PDU SESSION INFORMATION frame with the given QFI
     pub fn ul(qfi: u8) -> Self {
         Self::Ul(UlPduSessionInformation {


### PR DESCRIPTION
Closes #81

Spec: `specs/fix-upf-reflective-qos-markings.md`. Verified against `main` @ `3d17f28`.

## Gap 2 was already fixed — re-verified, not reimplemented

The missed-heartbeat failure declaration landed in **#218** during the #61 work, *after* this issue was written:

- `PfcpServer` tracks `outstanding: HashSet<u32>` + `consecutive_misses`, inserted on heartbeat send and cleared on any response.
- `close_heartbeat_round` counts consecutive **unanswered rounds** and calls `declare_peer_failure` at `HEARTBEAT_MAX_MISSES` (3), releasing the association and its sessions — **criterion 4**.
- The dead `n4_no_heartbeat` sweep and its elapsed-wall-clock guard are gone.

Criterion 5's "**or its replacement per-peer registry**" is satisfied by state that lives next to the socket sending and receiving the heartbeats. What remained of the old design is dealt with below.

## Gap 1 — RQI/PPI were parsed nowhere and could never reach the wire (criteria 1–3)

`parse_create_qer` stopped at the QFI; `ParsedCreateQer` and `DataPlaneQer` had no fields to hold the markings; and every downlink G-PDU went out through `PduSessionContainer::dl`, which hardcodes `rqi = false` and `ppi = None`. Reflective QoS (TS 23.501 §5.7.5) and paging-policy differentiation were **silently inert no matter what the SMF provisioned** — an interop surprise rather than a visible failure, because packets still flowed and the QFI was still correct.

The GTP-U codec already had both fields, so no wire-format work was needed:

- **`RQI = 123`, `PAGING_POLICY_INDICATOR = 158`** from the TS 29.244 IE-type table, with the §8.2.88 / §8.2.116 bit layouts. **Only bit 1 of the RQI IE is read** — a test pins that `0xFE` in the spare bits does *not* set the flag, because reading the whole octet would turn every spare bit into a reflective-QoS trigger.
- **A PPI wider than 3 bits is masked, not dropped**, at parse *and* encode, so a mis-provisioned QER still yields a well-formed header rather than an omitted field.
- **`PduSessionContainer::dl_with_marking`** alongside `dl`, kept separate rather than adding parameters: most downlink packets carry neither marking and should not pay for an options struct, and a caller with markings to set is making a deliberate choice. The unmarked helpers now delegate to the marked ones, so one place lays out the header.
- **`DataPlaneQer`'s hand-written `Clone` copies them.** It copies field by field, so a new field is dropped by default — and the data plane clones QERs, which would have disabled reflective QoS wherever a copy was taken while the original still looked correct. A test asserts the round trip *through* a clone.
- **The buffered-DL flush path is marked too**, taking them from the QER owning the session's QFI (that path forwards on session QFI rather than a per-packet match — pre-existing). Without it, the packets that woke the UE would be the only ones stripped, which is precisely when a paging policy matters.

## `peer_nodes` deleted (criterion 5 residue)

#218 removed the sweep but left the map: declared, default-initialised, cleared in one place, **never inserted into**, read only by two tests asserting it was empty. That is the shape this repo has twice recorded as a hazard (#217, #221) — an unpopulated per-peer registry reads as a peer table the UPF maintains, and the next person adding heartbeat state would reasonably put it back into a map with no readers. `PfcpNode` is retained; it is still used for association bookkeeping.

## Verification

Workspace **5817 → 5822 passed, 0 failed**. `cargo clippy --workspace` exit 0, **zero** warnings. `cargo fmt --all --check` clean. 6 new tests (upfd 285 → 290).

**Revert-verified: 10 reverts, 10 bit** — including the two halves of the forwarding wiring separately (the encapsulator call *and* reading the QER's fields), and an **inverted** case (making the *unmarked* path set RQI) so the regression guard is shown load-bearing rather than trivially true.

**The wiring test earned its keep, and how is worth recording.** An earlier patch script asserted on four anchors, the fourth did not match, and it raised *before writing* — silently dropping the forwarding-path edit while helper edits from a previous script had already landed. Every helper-level assertion passed. `dl_forwarding_applies_the_qer_markings_to_the_sent_gpdu`, which drives a real packet through `handle_downlink_packet` and reads the markings off the G-PDU the gNB socket receives, failed with `left: 0, right: 64` — which is what sent me back to look. The recorded lesson that a tested helper leaves the *wiring* untested, met live rather than in principle.

**Not verified:** no gNB. The cross-repo note on the issue holds — coupled to NextgCoreLab/nextgsim#44, and marking without enforcement is inert: the gNB extracts QFI/RQI from the container but runs no SDAP entity, so nothing acts on the bit yet. What is established is that the bit and the PPI reach the wire in the TS 38.415 §5.5.2 field positions, asserted at the byte level against a header parsed out of a really-sent G-PDU. Criteria 4 and 5 were re-verified by reading `close_heartbeat_round` and by the existing suite staying green; no new test for behaviour #218 already covers. Docker E2E is skipped by CI. **GitNexus impact analysis was not run** (no MCP server connected) — eleventh consecutive PR to record it.