### PR TITLE
fix(udmd): produce SDM and EE notifications, validate SDM Subscribe, apply the EE patch (Closes #83)

### DIFF
--- a/specs/fix-udm-sdm-ee-notification-producers.md
+++ b/specs/fix-udm-sdm-ee-notification-producers.md
@@ -1,0 +1,123 @@
+# nextgcore #83 (UDM): SDM and EE notification producers, subscribe validation, EE patch
+
+Verified against `main` @ `6105306`. Every defect the issue describes was still present as written.
+
+`Closes #83`, with criteria 3 and 4 split to **#226** — see "Split".
+
+## Gap: both event-exposure surfaces were facades (criteria 2, 5)
+
+The load-bearing defect. A consumer could `POST` an `SdmSubscription` or an `EeSubscription`, get `201`,
+and then hear nothing ever again, because **no code path in the crate produced a notification**.
+`lib.rs` and `context.rs` both carried comments admitting it. The only outbound notification in udmd was
+the UECM deregistration one, which serves a different purpose entirely.
+
+### What triggers a notification
+
+The UDM is mostly a read-through to the UDR, so it observes few writes of its own. The ones it does
+observe are the UECM lifecycle transitions — an AMF or SMF registering, updating or deregistering — and
+those *are* changes to a monitored SDM resource (the UE's context data set) as well as EE-reportable
+events. Both producers therefore hook the same four sites in `uecm.rs`. That is coherent rather than
+coincidental: one transition, two audiences.
+
+`notify_ue_context_change` is shaped so any future data-set write can call it without knowing about
+subscriptions.
+
+### Decisions worth review
+
+* **On by default, with an off switch (`UDM_NOTIFY_DISABLE`).** The issue suggests off-by-default
+  feature gates. Rejected, and not for the usual "a cargo feature hides its tests from CI" reason
+  alone: the argument for gating *new outbound traffic* does not apply here, because a notification is
+  only ever sent to a `callbackReference` a consumer explicitly subscribed with. A deployment that
+  subscribes to nothing sees no new traffic at all. The switch exists for the case where a consumer
+  subscribes and then cannot cope with being notified.
+* **A distinct changed-resource and EE event type per transition.** AMF transitions change
+  `ue-context-in-amf-data`, SMF ones `ue-context-in-smf-data`; registration reports
+  `UE_REACHABILITY_FOR_DATA` and deregistration `LOSS_OF_CONNECTIVITY`. Collapsing either into one
+  value would wake every subscriber on every transition, or make the report unable to say what
+  happened.
+* **`monitoredResourceUris` narrows, but an EMPTY list does not.** Subscribing to a UE without naming
+  resources is a whole-UE subscription, not a subscription to nothing. (At *subscribe* time an empty
+  list is refused — see below — so the empty case only arises for subscriptions created before this
+  change or through another path.)
+* **EE scope matching covers exact-SUPI and `anyUE` only.** A subscription's `ue_identity` may also be
+  a GPSI or an external group id, and resolving those needs identifier translation this UDM does not
+  implement (tracked on #85). Matching them by guesswork would deliver **another UE's events**, so they
+  are skipped rather than approximated.
+* **Delivery is best-effort and never fails the triggering operation**, but it is `await`ed rather than
+  spawned, so the notification is ordered after the UDR write it reports: a subscriber that reacts by
+  reading the data set must not find the state the notification is about missing.
+* **The context lock is released before any `.await`.** Holding a `RwLock` across the outbound HTTP call
+  would deadlock the subscribe path against the notify path.
+
+`udm_sbi_send_dereg_notification` was generalised into `udm_sbi_send_callback_notification`: all three
+notifications are "POST this JSON to the absolute URI the consumer gave us", and one implementation
+means a fix to the URI parsing or the client reaches every notification the UDM sends.
+
+## Gap: SDM Subscribe accepted invalid subscriptions (criterion 1)
+
+The routed handler read `nfInstanceId`, `callbackReference` and `monitoredResourceUris` and then
+inserted the subscription regardless, answering `201`. A consumer with a bug in its subscribe request
+got a subscription id back, monitored nothing, and had no way to tell. `nudm_handler.rs` already
+contained exactly these checks — nothing routed to them.
+
+An **empty** `monitoredResourceUris` is refused as well as an absent one: the schema's `minItems` is 1,
+and an empty list is the shape a consumer produces when its own resource list came out empty, which is
+a bug to surface rather than a whole-UE subscription to infer.
+
+## Gap: EE UpdateEeSubscription discarded its patch (criterion 6)
+
+It answered `204` and dropped the body, so a consumer could "modify" `monitoringConfigurations` forever
+while the stored subscription never changed — lifecycle management that reports success and diverges
+from state.
+
+`apply_ee_patch` handles the `PatchItem` array form and, leniently, a merge-patch object. Two choices:
+**`remove` and `replace` on an absent member are errors, not silent no-ops** (a consumer patching a
+path that is not there has a wrong idea of the stored subscription, and `204` would confirm it); and a
+patch that changes `callbackReference` **updates the cached copy too**, or the next notification would
+go to the old URI.
+
+## Split: criteria 3 and 4 → #226
+
+#83's own *Suggested approach* marks this separable: "the multi-data-set/missing-data-set work is
+additive read-side … it may reasonably be split into a separate lower-priority issue since the
+load-bearing defect is the missing notification producers." Following the recorded convention for an
+author-marked split, it is filed as #226 and the parent closes.
+
+Worth noting for #226's priority: `ue-context-in-amf-data` is now more interesting than it was, because
+the producer added here reports changes to exactly that data set on every AMF transition. A subscriber
+is told the resource changed and then cannot read it.
+
+## Verification
+
+**11 new tests** (2 in `app`, 8 in `notify`, 1 in `uecm`). udmd 136 → 148 passed. Workspace
+`cargo test --workspace` green; `cargo clippy --workspace` (the CI gate) clean, zero warnings;
+`cargo fmt --all --check` clean.
+
+**Revert-verified: 20 reverts, 20 bit** — after fixing the harness twice and, more importantly, after
+one revert exposed a genuine hole.
+
+**The hole: the UECM wiring was untested.** Removing the `notify_ue_context_change` call from
+`process_amf_registration` left **every notify test green**, because all of them called the producer
+directly. The producer was covered nine ways and the line that invokes it was not covered at all —
+precisely the recorded lesson that extracting logic into a tested helper leaves the wiring untested.
+`uecm::tests::amf_registration_notifies_sdm_and_ee_subscribers` now drives a real
+`process_amf_registration` against a mock UDR and a stub callback server, and the revert of that single
+line fails it with `left: 0, right: 2`.
+
+**A second finding, about test isolation rather than product code.** The notify tests were flaky at
+roughly one run in four, failing with an `HTTP/2 connection error` that reads as the producer sending
+nothing. Cause: `app.rs`'s `test_http_generate_auth_data_flows` sets the process-global SBI profile
+override to `Dev` and never resets it, so these tests inherited **production TLS or plaintext depending
+on test order** while talking to a plaintext loopback stub. Two changes: declare the profile in the
+stub-server helper rather than inherit it, and serialize on the crate-wide `CONTEXT_GUARD` — the lock
+that sibling already takes — instead of a private lock that only serialized the new tests against each
+other. Stable over six consecutive runs after that. The tests also clear subscriptions **up front**
+rather than at the end, so a panicking test cannot leak an `anyUE` subscription into the next one.
+
+**Not verified:** no live consumer. The producers are asserted against in-process stub SBI servers
+reading real POST bodies off the wire, which covers the callback-URI parsing, the client and the body
+shapes, but not a conformance-tested peer. The SDM producer fires only on UECM transitions — a change
+to a data set written through some other path would not notify, because no such path exists in udmd
+today; that is a property of the crate rather than of this change, and the entry point is shaped to be
+called from one when it appears. Docker E2E is skipped by CI. GitNexus impact analysis, which CLAUDE.md
+mandates, was **not run** — no MCP server connected; twelfth consecutive PR to record it.

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -1052,6 +1052,31 @@ pub async fn handle_sdm_subscribe(supi: &str, request: &SbiRequest) -> SbiRespon
         })
         .unwrap_or_default();
 
+    // #83: nfInstanceId, callbackReference and monitoredResourceUris are
+    // mandatory in SdmSubscription (TS 29.503 §6.1.6.2.x). This handler used to
+    // accept a body missing all three and answer 201 — so a consumer with a bug
+    // in its subscribe request got a subscription id back, monitored nothing,
+    // and had no way to tell. `nudm_handler.rs` already had these very checks;
+    // nothing routed to them.
+    //
+    // An EMPTY monitoredResourceUris is refused as well as an absent one: the
+    // spec's minItems is 1, and an empty list is the shape a consumer produces
+    // when its own resource list came out empty — which is a bug to surface, not
+    // a whole-UE subscription to infer.
+    for (value_is_present, ie) in [
+        (nf_instance_id.is_some(), "nfInstanceId"),
+        (callback_reference.is_some(), "callbackReference"),
+        (!monitored_resource_uris.is_empty(), "monitoredResourceUris"),
+    ] {
+        if !value_is_present {
+            log::warn!("SDM Subscribe for {supi} is missing {ie}; refusing");
+            return send_bad_request(
+                &format!("SdmSubscription is missing mandatory {ie}"),
+                Some("MANDATORY_IE_MISSING"),
+            );
+        }
+    }
+
     // udmd-07: persist the subscription in the UDM context.
     let sub = UdmSdmSubscription::for_supi(
         supi,
@@ -1185,26 +1210,141 @@ pub async fn handle_ee_unsubscribe(ue_identity: &str, subscription_id: &str) -> 
     SbiResponse::with_status(204)
 }
 
-/// udmd#0: Nudm_EE UpdateEeSubscription (TS 29.503 5.5.2.4).
-/// JSON-Patch application deferred; 204 on existing sub / 404 otherwise (yaml 363).
+/// Nudm_EE UpdateEeSubscription (TS 29.503 §5.5.2.4.2).
+///
+/// #83: this used to answer 204 and discard the patch, so a consumer could
+/// "modify" `monitoringConfigurations` forever while the stored subscription
+/// never changed — subscription lifecycle management that reports success and
+/// diverges from state.
 pub async fn handle_ee_modify(
     ue_identity: &str,
     subscription_id: &str,
-    _request: &SbiRequest,
+    request: &SbiRequest,
 ) -> SbiResponse {
     log::info!("EE Modify: ueIdentity={ue_identity}, subscriptionId={subscription_id}");
-    let exists = {
+
+    let Some(mut sub) = ({
         let ctx = udm_self();
         let guard = ctx.read().ok();
         guard
             .as_ref()
             .and_then(|c| c.ee_subscription_find_by_id(subscription_id))
-            .is_some()
+    }) else {
+        return send_problem(404, "NOT_FOUND", "Subscription not found");
     };
-    if !exists {
+
+    let Some(body) = request.http.content.as_deref() else {
+        return send_bad_request("Missing request body", Some("MISSING_BODY"));
+    };
+    let patch: serde_json::Value = match serde_json::from_str(body) {
+        Ok(p) => p,
+        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+    };
+
+    let mut stored: serde_json::Value = match serde_json::from_str(&sub.raw) {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!("Stored EeSubscription {subscription_id} is not valid JSON: {e}");
+            return send_problem(500, "INTERNAL_ERROR", "stored subscription is corrupt");
+        }
+    };
+
+    if let Err(detail) = apply_ee_patch(&mut stored, &patch) {
+        return send_bad_request(&detail, Some("INVALID_MSG_FORMAT"));
+    }
+
+    // The callbackReference is cached alongside the raw body, so a patch that
+    // changes it must update both or the next notification goes to the old URI.
+    if let Some(cb) = stored.get("callbackReference").and_then(|v| v.as_str()) {
+        sub.callback_reference = cb.to_string();
+    }
+    sub.raw = stored.to_string();
+
+    let updated = {
+        let ctx = udm_self();
+        let guard = ctx.read().ok();
+        guard
+            .as_ref()
+            .is_some_and(|c| c.ee_subscription_update(sub))
+    };
+    if !updated {
         return send_problem(404, "NOT_FOUND", "Subscription not found");
     }
     SbiResponse::with_status(204)
+}
+
+/// Apply an `EeSubscription` patch in place.
+///
+/// TS 29.503 §5.5.2.4.2 uses a JSON `PatchItem` array (RFC 6902-shaped, as the
+/// rest of this codebase's SBI PATCH endpoints do). A merge-patch object is also
+/// accepted, because lenient peers send one and refusing it buys nothing.
+///
+/// `remove` and `replace` on an absent member are errors rather than silent
+/// no-ops: a consumer patching a path that is not there has a wrong idea of the
+/// stored subscription, and answering 204 would confirm it.
+fn apply_ee_patch(stored: &mut serde_json::Value, patch: &serde_json::Value) -> Result<(), String> {
+    let Some(ops) = patch.as_array() else {
+        // Merge patch (RFC 7396): top-level members replace their counterparts.
+        let Some(members) = patch.as_object() else {
+            return Err("patch must be a PatchItem array or a merge-patch object".to_string());
+        };
+        let Some(target) = stored.as_object_mut() else {
+            return Err("stored subscription is not a JSON object".to_string());
+        };
+        for (key, value) in members {
+            if value.is_null() {
+                target.remove(key);
+            } else {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+        return Ok(());
+    };
+
+    if ops.is_empty() {
+        return Err("patch carries no operations".to_string());
+    }
+    for op in ops {
+        let op_name = op
+            .get("op")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "PatchItem is missing op".to_string())?;
+        let path = op
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "PatchItem is missing path".to_string())?;
+        // Only top-level members of EeSubscription are addressable here; that is
+        // what the spec's patch targets (monitoringConfigurations,
+        // callbackReference, reportingOptions, ...). A deeper pointer is refused
+        // rather than half-applied.
+        let member = path.strip_prefix('/').unwrap_or(path);
+        if member.is_empty() || member.contains('/') {
+            return Err(format!(
+                "path {path:?} must address a top-level EeSubscription member"
+            ));
+        }
+        let target = stored
+            .as_object_mut()
+            .ok_or_else(|| "stored subscription is not a JSON object".to_string())?;
+        match op_name {
+            "add" | "replace" => {
+                let value = op
+                    .get("value")
+                    .ok_or_else(|| format!("{op_name} on {path:?} has no value"))?;
+                if op_name == "replace" && !target.contains_key(member) {
+                    return Err(format!("cannot replace absent member {path:?}"));
+                }
+                target.insert(member.to_string(), value.clone());
+            }
+            "remove" => {
+                if target.remove(member).is_none() {
+                    return Err(format!("cannot remove absent member {path:?}"));
+                }
+            }
+            other => return Err(format!("unsupported patch op {other:?}")),
+        }
+    }
+    Ok(())
 }
 
 /// udmd#1: Nudm_Sdm SoRAckInfo (TS 29.503 5.2.2.6, PUT /am-data/sor-ack).
@@ -3469,6 +3609,225 @@ mod tests {
         let ue2 = udm_self().read().unwrap().ue_find_by_supi(supi2).unwrap();
         assert!(ue2.upu_ack.is_none());
         assert!(ue2.expected_upu_xmac_iue.is_some());
+    }
+
+    // ==================================================================
+    // #83: SDM Subscribe validates its mandatory IEs; EE Modify applies
+    // the patch it used to discard.
+    // ==================================================================
+
+    fn sdm_subscribe_request(body: serde_json::Value) -> SbiRequest {
+        let mut req = SbiRequest::post("/nudm-sdm/v2/imsi-001010000000001/sdm-subscriptions");
+        req.http.content = Some(body.to_string());
+        req
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
+    async fn sdm_subscribe_refuses_a_subscription_missing_a_mandatory_ie() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        udm_context_init(64, 64);
+        let supi = "imsi-001010000000001";
+
+        let full = serde_json::json!({
+            "nfInstanceId": "nf-1",
+            "callbackReference": "http://consumer.example.com/cb",
+            "monitoredResourceUris": ["/nudm-sdm/v2/imsi-001010000000001/am-data"],
+        });
+
+        // Each mandatory IE removed in turn must be a 400 with a
+        // MANDATORY_IE_MISSING cause naming it. This handler used to answer 201
+        // for a body missing all three, so a consumer with a broken subscribe
+        // request got a subscription id back and monitored nothing.
+        for ie in ["nfInstanceId", "callbackReference", "monitoredResourceUris"] {
+            let mut body = full.clone();
+            body.as_object_mut().expect("object").remove(ie);
+            let resp = handle_sdm_subscribe(supi, &sdm_subscribe_request(body)).await;
+            assert_eq!(
+                resp.status, 400,
+                "a subscription missing {ie} must be refused"
+            );
+            let problem: serde_json::Value =
+                serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("JSON");
+            assert_eq!(problem["cause"], "MANDATORY_IE_MISSING", "for {ie}");
+            assert!(
+                problem["detail"].as_str().expect("detail").contains(ie),
+                "the refusal must name the missing IE: {problem}"
+            );
+        }
+
+        // An EMPTY monitoredResourceUris is refused too: minItems is 1, and an
+        // empty list is what a consumer produces when its own resource list came
+        // out empty — a bug to surface, not a whole-UE subscription to infer.
+        let mut empty = full.clone();
+        empty["monitoredResourceUris"] = serde_json::json!([]);
+        let resp = handle_sdm_subscribe(supi, &sdm_subscribe_request(empty)).await;
+        assert_eq!(resp.status, 400);
+
+        // A complete body is still accepted, with the v2 Location.
+        let resp = handle_sdm_subscribe(supi, &sdm_subscribe_request(full)).await;
+        assert_eq!(resp.status, 201);
+        let location = resp
+            .http
+            .get_header("location")
+            .expect("Location header")
+            .clone();
+        assert!(
+            location.contains("/nudm-sdm/v2/"),
+            "Nudm_SDM is v2; a v1 Location hands out an undefined path: {location}"
+        );
+
+        // Clean up so the notify tests are not perturbed by this subscription.
+        clear_sdm_subscriptions_for(supi);
+    }
+
+    /// Drop every SDM subscription for `supi`.
+    ///
+    /// A plain fn rather than inline in the async test: the read guard must not be
+    /// held across the test's remaining awaits, and keeping the borrow inside one
+    /// synchronous frame is the simplest way to guarantee that.
+    fn clear_sdm_subscriptions_for(supi: &str) {
+        let ctx = udm_self();
+        let Ok(context) = ctx.read() else { return };
+        for sub in context.sdm_subscriptions_for_supi(supi) {
+            context.sdm_subscription_remove(&sub.id);
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
+    async fn ee_modify_applies_the_patch_and_the_change_is_readable_back() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        udm_context_init(64, 64);
+        let ue = "imsi-001010000000083";
+
+        let original = serde_json::json!({
+            "callbackReference": "http://consumer.example.com/ee",
+            "monitoringConfigurations": { "1": { "eventType": "LOSS_OF_CONNECTIVITY" } },
+        });
+        let sub = crate::context::UdmEeSubscription::for_ue(
+            ue,
+            "http://consumer.example.com/ee",
+            original.to_string(),
+        );
+        let sub_id = sub.id.clone();
+        {
+            let ctx = udm_self();
+            let context = ctx.read().expect("context");
+            context.ee_subscription_insert(sub);
+        }
+
+        // PatchItem array form.
+        let patch = serde_json::json!([{
+            "op": "replace",
+            "path": "/monitoringConfigurations",
+            "value": { "2": { "eventType": "UE_REACHABILITY_FOR_DATA" } },
+        }]);
+        let mut req = SbiRequest::patch(format!("/nudm-ee/v1/{ue}/ee-subscriptions/{sub_id}"));
+        req.http.content = Some(patch.to_string());
+        let resp = handle_ee_modify(ue, &sub_id, &req).await;
+        assert_eq!(resp.status, 204);
+
+        // Read back: the stored subscription must actually have changed. This is
+        // the assertion the old handler could never satisfy — it returned 204 and
+        // discarded the patch, so lifecycle management reported success while
+        // diverging from state.
+        let stored = {
+            let ctx = udm_self();
+            let context = ctx.read().expect("context");
+            context.ee_subscription_find_by_id(&sub_id).expect("stored")
+        };
+        let raw: serde_json::Value = serde_json::from_str(&stored.raw).expect("stored JSON");
+        assert_eq!(
+            raw["monitoringConfigurations"]["2"]["eventType"],
+            "UE_REACHABILITY_FOR_DATA"
+        );
+        assert!(
+            raw["monitoringConfigurations"].get("1").is_none(),
+            "replace must replace the member, not merge into it: {raw}"
+        );
+
+        // A patch that changes the callbackReference updates the cached copy too,
+        // or the next notification goes to the old URI.
+        let repoint = serde_json::json!([{
+            "op": "replace",
+            "path": "/callbackReference",
+            "value": "http://elsewhere.example.com/ee",
+        }]);
+        let mut req = SbiRequest::patch(format!("/nudm-ee/v1/{ue}/ee-subscriptions/{sub_id}"));
+        req.http.content = Some(repoint.to_string());
+        assert_eq!(handle_ee_modify(ue, &sub_id, &req).await.status, 204);
+        let stored = {
+            let ctx = udm_self();
+            let context = ctx.read().expect("context");
+            context.ee_subscription_find_by_id(&sub_id).expect("stored")
+        };
+        assert_eq!(stored.callback_reference, "http://elsewhere.example.com/ee");
+
+        // An unknown subscription is still 404, and a malformed patch is a 400
+        // rather than a silent success.
+        let mut req = SbiRequest::patch("/nudm-ee/v1/x/ee-subscriptions/absent");
+        req.http.content = Some("[]".to_string());
+        assert_eq!(handle_ee_modify(ue, "absent", &req).await.status, 404);
+
+        for bad in [
+            serde_json::json!([]),
+            serde_json::json!([{ "op": "replace", "path": "/notThere", "value": 1 }]),
+            serde_json::json!([{ "op": "remove", "path": "/notThere" }]),
+            serde_json::json!([{ "op": "bogus", "path": "/callbackReference", "value": 1 }]),
+            serde_json::json!([{ "op": "replace", "path": "/a/b", "value": 1 }]),
+            serde_json::json!(42),
+        ] {
+            let mut req = SbiRequest::patch(format!("/nudm-ee/v1/{ue}/ee-subscriptions/{sub_id}"));
+            req.http.content = Some(bad.to_string());
+            assert_eq!(
+                handle_ee_modify(ue, &sub_id, &req).await.status,
+                400,
+                "patch {bad} must be refused"
+            );
+        }
+
+        clear_ee_subscription(&sub_id);
+    }
+
+    /// Drop one EE subscription by id (see `clear_sdm_subscriptions_for`).
+    fn clear_ee_subscription(id: &str) {
+        let ctx = udm_self();
+        let Ok(context) = ctx.read() else { return };
+        context.ee_subscription_remove(id);
+    }
+
+    #[test]
+    fn ee_patch_accepts_the_merge_patch_form_and_refuses_nonsense() {
+        let mut stored = serde_json::json!({ "callbackReference": "a", "keepMe": 1 });
+        // Merge patch (RFC 7396): members replace, an explicit null removes.
+        apply_ee_patch(
+            &mut stored,
+            &serde_json::json!({ "callbackReference": "b", "keepMe": null, "added": 2 }),
+        )
+        .expect("merge patch applies");
+        assert_eq!(stored["callbackReference"], "b");
+        assert!(stored.get("keepMe").is_none());
+        assert_eq!(stored["added"], 2);
+
+        // `add` creates a member that was not there; `replace` on the same
+        // absent member does not.
+        let mut fresh = serde_json::json!({});
+        apply_ee_patch(
+            &mut fresh,
+            &serde_json::json!([{ "op": "add", "path": "/new", "value": 1 }]),
+        )
+        .expect("add applies");
+        assert_eq!(fresh["new"], 1);
+        assert!(apply_ee_patch(
+            &mut serde_json::json!({}),
+            &serde_json::json!([{ "op": "replace", "path": "/new", "value": 1 }])
+        )
+        .is_err());
     }
 }
 

--- a/src/bins/nextgcore-udmd/src/context.rs
+++ b/src/bins/nextgcore-udmd/src/context.rs
@@ -1226,6 +1226,51 @@ impl UdmContext {
         ee_list.remove(id)
     }
 
+    /// Every SDM subscription monitoring `supi` (#83).
+    ///
+    /// Cloned out rather than handed out behind the lock, because the caller then
+    /// makes outbound HTTP calls: holding a `RwLock` across an `.await` is how the
+    /// notification path would deadlock the subscribe path.
+    pub fn sdm_subscriptions_for_supi(&self, supi: &str) -> Vec<UdmSdmSubscription> {
+        match self.sdm_subscription_list.read() {
+            Ok(list) => list.values().filter(|s| s.supi == supi).cloned().collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// Every EE subscription whose scope covers `supi` (#83).
+    ///
+    /// A subscription's `ue_identity` is a SUPI, a GPSI, an external group id or
+    /// the literal `anyUE` (TS 29.503 §5.5.2.2). Only the exact-SUPI and `anyUE`
+    /// forms are matched here: resolving a GPSI or a group id needs the
+    /// identifier translation this UDM does not implement (tracked on #85), and
+    /// matching them by guesswork would deliver another UE's events.
+    pub fn ee_subscriptions_for_supi(&self, supi: &str) -> Vec<UdmEeSubscription> {
+        match self.ee_subscription_list.read() {
+            Ok(list) => list
+                .values()
+                .filter(|s| s.ue_identity == supi || s.ue_identity == "anyUE")
+                .cloned()
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// Replace a stored EE subscription, returning false when it is not there.
+    pub fn ee_subscription_update(&self, sub: UdmEeSubscription) -> bool {
+        let mut list = match self.ee_subscription_list.write() {
+            Ok(l) => l,
+            Err(_) => return false,
+        };
+        match list.get_mut(&sub.id) {
+            Some(existing) => {
+                *existing = sub;
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Update SDM subscription in the context
     pub fn sdm_subscription_update(&self, subscription: &UdmSdmSubscription) -> bool {
         let mut sdm_list = self.sdm_subscription_list.write().unwrap();

--- a/src/bins/nextgcore-udmd/src/lib.rs
+++ b/src/bins/nextgcore-udmd/src/lib.rs
@@ -13,6 +13,7 @@ pub mod context;
 pub mod event;
 #[cfg(feature = "nes")]
 pub mod nes_driver; // issue #22 Network Energy Saving runtime (off by default)
+pub mod notify; // #83 Nudm_SDM Data Change Notification / Nudm_EE Event Occurrence
 pub mod nudm_handler;
 pub mod nudr_handler;
 pub mod sbi_path;

--- a/src/bins/nextgcore-udmd/src/notify.rs
+++ b/src/bins/nextgcore-udmd/src/notify.rs
@@ -1,0 +1,620 @@
+//! Nudm_SDM Data Change Notification and Nudm_EE Event Occurrence producers
+//! (TS 29.503 §5.2.2.5.2, §5.5.2.5).
+//!
+//! Before this module the UDM's event-exposure surfaces were facades: a consumer
+//! could `POST` an `SdmSubscription` or an `EeSubscription`, receive `201`, and
+//! then hear nothing ever again, because no code path in the crate produced a
+//! notification. `lib.rs` and `context.rs` both carried comments admitting it.
+//!
+//! # What triggers a notification
+//!
+//! The UDM is mostly a read-through to the UDR, so it observes few writes of its
+//! own. The ones it does observe are the UECM lifecycle transitions — an AMF or
+//! SMF registering, updating or deregistering a UE — and those *are* changes to a
+//! monitored SDM resource (the UE's context data set) as well as EE-reportable
+//! events. Both producers therefore hook the same sites in `uecm.rs`, which is
+//! coherent rather than coincidental: one transition, two audiences.
+//!
+//! [`notify_ue_context_change`] is the entry point, and is deliberately shaped so
+//! any future data-set write can call it without knowing about subscriptions.
+
+use serde_json::{json, Value};
+
+/// Env switch to silence both producers.
+///
+/// Default **on**. An off-by-default producer would leave the gap open for every
+/// deployment that did not know to flip it, and the usual argument for gating new
+/// outbound traffic does not apply here: a notification is only ever sent to a
+/// `callbackReference` a consumer explicitly subscribed with, so a deployment that
+/// subscribes to nothing sees no new traffic at all. The switch exists for the
+/// case where a consumer subscribes and then cannot cope with being notified.
+const NOTIFY_DISABLE_ENV: &str = "UDM_NOTIFY_DISABLE";
+
+/// Are the notification producers enabled?
+pub fn notifications_enabled() -> bool {
+    !matches!(
+        std::env::var(NOTIFY_DISABLE_ENV).as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE")
+    )
+}
+
+/// The UECM transition that occurred, as both an SDM changed-resource and an EE
+/// event type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UeContextEvent {
+    /// An AMF registered for 3GPP access (TS 29.503 §5.3.2.2.2).
+    AmfRegistered,
+    /// A registered AMF context was updated.
+    AmfContextUpdated,
+    /// The AMF deregistered (§5.3.2.3.2).
+    AmfDeregistered,
+    /// An SMF registered a PDU session (§5.3.2.2.4).
+    SmfRegistered,
+    /// An SMF deregistered its PDU session(s).
+    SmfDeregistered,
+}
+
+impl UeContextEvent {
+    /// The SDM data set this transition changes, as the resource-URI suffix a
+    /// subscriber's `monitoredResourceUris` would name.
+    ///
+    /// AMF transitions change the UE's AMF context data set; SMF transitions
+    /// change the SMF one. Reporting a single catch-all resource instead would
+    /// wake every subscriber on every transition.
+    pub fn changed_data_set(&self) -> &'static str {
+        match self {
+            Self::AmfRegistered | Self::AmfContextUpdated | Self::AmfDeregistered => {
+                "ue-context-in-amf-data"
+            }
+            Self::SmfRegistered | Self::SmfDeregistered => "ue-context-in-smf-data",
+        }
+    }
+
+    /// The Nudm_EE event type (TS 29.503 `EventType`) this transition reports as.
+    pub fn ee_event_type(&self) -> &'static str {
+        match self {
+            // A UE whose AMF context appears or is refreshed is reachable; one
+            // whose AMF context is gone is not (TS 29.503 EventType
+            // UE_REACHABILITY_FOR_DATA / LOSS_OF_CONNECTIVITY).
+            Self::AmfRegistered | Self::AmfContextUpdated => "UE_REACHABILITY_FOR_DATA",
+            Self::AmfDeregistered => "LOSS_OF_CONNECTIVITY",
+            Self::SmfRegistered | Self::SmfDeregistered => "PDN_CONNECTIVITY_STATUS",
+        }
+    }
+
+    /// Is this transition a deregistration? Used only for the report's own
+    /// human-readable framing, never for routing.
+    fn is_removal(&self) -> bool {
+        matches!(self, Self::AmfDeregistered | Self::SmfDeregistered)
+    }
+}
+
+/// Build the `ModificationNotification` body (TS 29.503 §6.1.6.2.x).
+///
+/// `notifyItems` carries one `NotifyItem` per changed resource, each with the
+/// resource's identifier and a `changes` list of RFC 7396-shaped `ChangeItem`s.
+pub fn build_modification_notification(supi: &str, event: UeContextEvent) -> Value {
+    let resource_id = format!("/nudm-sdm/v2/{supi}/{}", event.changed_data_set());
+    json!({
+        "notifyItems": [{
+            "resourceId": resource_id,
+            "changes": [{
+                // RFC 7396 op names, as ChangeItem uses (TS 29.571).
+                "op": if event.is_removal() { "REMOVE" } else { "REPLACE" },
+                "path": format!("/{}", event.changed_data_set()),
+            }],
+        }],
+    })
+}
+
+/// Build the `MonitoringReport` body (TS 29.503 §6.4.6.2.x).
+pub fn build_monitoring_report(
+    supi: &str,
+    subscription_id: &str,
+    event: UeContextEvent,
+    timestamp: &str,
+) -> Value {
+    json!({
+        "reportList": [{
+            "referenceId": subscription_id,
+            "eventType": event.ee_event_type(),
+            "report": {
+                "supi": supi,
+                "timeStamp": timestamp,
+            },
+        }],
+    })
+}
+
+/// Format `secs` since the Unix epoch as an RFC 3339 UTC timestamp.
+///
+/// Hand-rolled rather than pulling in a date/time crate, matching what nrfd
+/// already does for the same reason (`epoch_to_rfc3339`).
+pub fn epoch_to_rfc3339(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    // Howard Hinnant's civil_from_days.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y,
+        m,
+        d,
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60
+    )
+}
+
+/// Deliver SDM and EE notifications for a UECM transition.
+///
+/// Best-effort by design: a subscriber that is down must not fail the UECM
+/// operation that triggered the notification, so every delivery failure is logged
+/// and the next subscriber is still attempted. Returns
+/// `(sdm_delivered, ee_delivered)` so a caller — and a test — can see what
+/// actually went out rather than assuming.
+pub async fn notify_ue_context_change(supi: &str, event: UeContextEvent) -> (usize, usize) {
+    if !notifications_enabled() {
+        log::debug!("{NOTIFY_DISABLE_ENV} is set; not notifying for {supi} ({event:?})");
+        return (0, 0);
+    }
+
+    let ctx = crate::context::udm_self();
+    let (sdm_subs, ee_subs) = match ctx.read() {
+        Ok(context) => (
+            context.sdm_subscriptions_for_supi(supi),
+            context.ee_subscriptions_for_supi(supi),
+        ),
+        Err(_) => {
+            log::error!("UDM context lock poisoned; cannot notify for {supi}");
+            return (0, 0);
+        }
+    };
+    // The guard is dropped here, before any `.await`: holding the context lock
+    // across an outbound HTTP call would deadlock the subscribe path.
+    drop(ctx);
+
+    let mut sdm_delivered = 0usize;
+    let changed = event.changed_data_set();
+    for sub in &sdm_subs {
+        // TS 29.503 §5.2.2.5.2: notify only the resources the subscriber asked
+        // to monitor. An empty list is treated as "everything for this UE" —
+        // subscribing to a UE with no resource list is a whole-UE subscription,
+        // not a subscription to nothing.
+        if !sub.monitored_resource_uris.is_empty()
+            && !sub
+                .monitored_resource_uris
+                .iter()
+                .any(|uri| uri.contains(changed))
+        {
+            log::debug!(
+                "SDM subscription {} does not monitor {changed}; not notified",
+                sub.id
+            );
+            continue;
+        }
+        let Some(callback) = sub.callback_reference.as_deref() else {
+            log::warn!("SDM subscription {} has no callbackReference", sub.id);
+            continue;
+        };
+        let body = build_modification_notification(supi, event);
+        match crate::sbi_path::udm_sbi_send_callback_notification(callback, &body).await {
+            Ok(resp) => {
+                log::info!(
+                    "SDM ModificationNotification for {supi} ({changed}) -> {callback}: status={}",
+                    resp.status
+                );
+                sdm_delivered += 1;
+            }
+            Err(e) => log::warn!("SDM ModificationNotification to {callback} failed: {e}"),
+        }
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let timestamp = epoch_to_rfc3339(now);
+    let mut ee_delivered = 0usize;
+    for sub in &ee_subs {
+        let body = build_monitoring_report(supi, &sub.id, event, &timestamp);
+        match crate::sbi_path::udm_sbi_send_callback_notification(&sub.callback_reference, &body)
+            .await
+        {
+            Ok(resp) => {
+                log::info!(
+                    "EE MonitoringReport ({}) for {supi} -> {}: status={}",
+                    event.ee_event_type(),
+                    sub.callback_reference,
+                    resp.status
+                );
+                ee_delivered += 1;
+            }
+            Err(e) => log::warn!(
+                "EE MonitoringReport to {} failed: {e}",
+                sub.callback_reference
+            ),
+        }
+    }
+
+    (sdm_delivered, ee_delivered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::{udm_context_init, udm_self, UdmEeSubscription, UdmSdmSubscription};
+    use nextgcore_sbi::message::{SbiRequest, SbiResponse};
+    use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+    use std::sync::{Arc, Mutex};
+
+    /// The crate-wide serializer, not a lock of our own.
+    ///
+    /// Three separate pieces of process-global state are in play: the UDM context
+    /// these tests insert subscriptions into, the `UDM_NOTIFY_DISABLE` env var, and
+    /// the SBI profile override — which `app.rs`'s
+    /// `test_http_generate_auth_data_flows` also sets. A private lock only
+    /// serialized these tests against EACH OTHER, so that sibling could still flip
+    /// the profile to production between our stub starting and our POST going out;
+    /// the failure showed up roughly one run in four as an "HTTP/2 connection
+    /// error" that reads as the producer sending nothing. `CONTEXT_GUARD` is the
+    /// lock that sibling already takes.
+    fn notify_env_lock() -> &'static Mutex<()> {
+        &crate::test_support::CONTEXT_GUARD
+    }
+
+    /// A stub consumer that records every notification body it is POSTed.
+    ///
+    /// The returned `SbiServer` must be held: dropping it closes the listener and
+    /// every delivery then fails with connection-refused, which looks exactly
+    /// like the producer not sending anything.
+    async fn stub_callback() -> (SbiServer, String, Arc<Mutex<Vec<serde_json::Value>>>) {
+        // Declared, not inherited: these tests drive the production peer-call path
+        // against a loopback PLAINTEXT stub, i.e. a dev-profile deployment (issue
+        // #63). The override is process-global and `test_http_generate_auth_data_flows`
+        // in app.rs sets it without resetting, so before declaring it here these
+        // tests passed or failed on TEST ORDER — inheriting TLS when they ran
+        // first and plaintext when they ran after it. The symptom was an
+        // "HTTP/2 connection error" that reads as the producer sending nothing.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let seen: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let addr = nextgcore_sbi::test_support::ephemeral_addr();
+        let server = SbiServer::new(SbiServerConfig::new(addr));
+        server
+            .start(move |req: SbiRequest| {
+                let sink = Arc::clone(&sink);
+                async move {
+                    if let Some(body) = req.http.content.as_deref() {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+                            sink.lock().expect("sink").push(v);
+                        }
+                    }
+                    SbiResponse::with_status(204)
+                }
+            })
+            .await
+            .expect("stub callback starts");
+        // `start` spawns the accept loop, so wait for the port to accept before
+        // returning: otherwise the first POST races the listener and the test
+        // reads as "nothing was sent".
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let uri = format!("http://127.0.0.1:{}/callback", addr.port());
+        (server, uri, seen)
+    }
+
+    /// Drop every subscription that could reach `supi`, so each test starts from
+    /// a known state.
+    ///
+    /// `udm_context_init` does not reset the process-global context, and these
+    /// tests share it. Without this the `anyUE` EE subscription one of them
+    /// inserts would leak into the others' delivery counts — they would pass or
+    /// fail on test ORDER, which is the recorded process-global hazard in this
+    /// repo. Cleaning up front rather than at the end also survives a test that
+    /// panics part-way.
+    fn clear_subscriptions_for(supi: &str) {
+        let ctx = udm_self();
+        let Ok(guard) = ctx.read() else { return };
+        for sub in guard.sdm_subscriptions_for_supi(supi) {
+            guard.sdm_subscription_remove(&sub.id);
+        }
+        for sub in guard.ee_subscriptions_for_supi(supi) {
+            guard.ee_subscription_remove(&sub.id);
+        }
+    }
+
+    async fn wait_for(
+        seen: &Arc<Mutex<Vec<serde_json::Value>>>,
+        want: usize,
+    ) -> Vec<serde_json::Value> {
+        for _ in 0..100 {
+            {
+                let got = seen.lock().expect("sink");
+                if got.len() >= want {
+                    return got.clone();
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        seen.lock().expect("sink").clone()
+    }
+
+    #[test]
+    fn ue_context_events_map_to_their_data_set_and_ee_event_type() {
+        // AMF transitions change the AMF context data set, SMF ones the SMF data
+        // set. A single catch-all resource would wake every subscriber on every
+        // transition.
+        assert_eq!(
+            UeContextEvent::AmfRegistered.changed_data_set(),
+            "ue-context-in-amf-data"
+        );
+        assert_eq!(
+            UeContextEvent::AmfDeregistered.changed_data_set(),
+            "ue-context-in-amf-data"
+        );
+        assert_eq!(
+            UeContextEvent::SmfRegistered.changed_data_set(),
+            "ue-context-in-smf-data"
+        );
+        assert_ne!(
+            UeContextEvent::AmfRegistered.changed_data_set(),
+            UeContextEvent::SmfRegistered.changed_data_set()
+        );
+
+        // Reachability appearing and being lost are different EE events; the same
+        // value for both would make the report useless.
+        assert_eq!(
+            UeContextEvent::AmfRegistered.ee_event_type(),
+            "UE_REACHABILITY_FOR_DATA"
+        );
+        assert_eq!(
+            UeContextEvent::AmfDeregistered.ee_event_type(),
+            "LOSS_OF_CONNECTIVITY"
+        );
+        assert_ne!(
+            UeContextEvent::AmfRegistered.ee_event_type(),
+            UeContextEvent::AmfDeregistered.ee_event_type()
+        );
+    }
+
+    #[test]
+    fn notification_bodies_carry_the_spec_shapes() {
+        let m =
+            build_modification_notification("imsi-001010000000001", UeContextEvent::AmfRegistered);
+        let item = &m["notifyItems"][0];
+        assert_eq!(
+            item["resourceId"], "/nudm-sdm/v2/imsi-001010000000001/ue-context-in-amf-data",
+            "the resourceId must be the v2 SDM path the subscriber monitors: {m}"
+        );
+        assert_eq!(item["changes"][0]["op"], "REPLACE");
+        // A deregistration is a removal, not a replacement.
+        let d = build_modification_notification("imsi-1", UeContextEvent::AmfDeregistered);
+        assert_eq!(d["notifyItems"][0]["changes"][0]["op"], "REMOVE");
+
+        let r = build_monitoring_report(
+            "imsi-001010000000001",
+            "sub-9",
+            UeContextEvent::AmfDeregistered,
+            "2026-09-07T12:00:00Z",
+        );
+        let report = &r["reportList"][0];
+        assert_eq!(report["referenceId"], "sub-9");
+        assert_eq!(report["eventType"], "LOSS_OF_CONNECTIVITY");
+        assert_eq!(report["report"]["supi"], "imsi-001010000000001");
+        assert_eq!(report["report"]["timeStamp"], "2026-09-07T12:00:00Z");
+    }
+
+    #[test]
+    fn epoch_to_rfc3339_formats_utc() {
+        assert_eq!(epoch_to_rfc3339(0), "1970-01-01T00:00:00Z");
+        assert_eq!(epoch_to_rfc3339(1_000_000_000), "2001-09-09T01:46:40Z");
+        // A leap day, which an off-by-one in the civil-date conversion gets wrong.
+        assert_eq!(epoch_to_rfc3339(1_709_164_800), "2024-02-29T00:00:00Z");
+    }
+
+    /// Criteria 2 and 5 together: a real monitored-resource change delivers a
+    /// ModificationNotification to an SDM subscriber and a MonitoringReport to an
+    /// EE subscriber, at their actual callback URIs.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
+    async fn a_ue_context_change_notifies_sdm_and_ee_subscribers() {
+        let _serial = notify_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("UDM_NOTIFY_DISABLE");
+        udm_context_init(64, 64);
+        let supi = "imsi-001010000000083";
+        clear_subscriptions_for(supi);
+
+        let (_sdm_server, sdm_uri, sdm_seen) = stub_callback().await;
+        let (_ee_server, ee_uri, ee_seen) = stub_callback().await;
+
+        {
+            let ctx = udm_self();
+            let guard = ctx.read().expect("context");
+            guard.sdm_subscription_insert(UdmSdmSubscription::for_supi(
+                supi,
+                Some("nf-1".to_string()),
+                Some(sdm_uri.clone()),
+                vec![format!("/nudm-sdm/v2/{supi}/ue-context-in-amf-data")],
+            ));
+            guard.ee_subscription_insert(UdmEeSubscription::for_ue(
+                supi,
+                ee_uri.clone(),
+                r#"{"callbackReference":"x","monitoringConfigurations":{}}"#,
+            ));
+        }
+
+        let (sdm, ee) = notify_ue_context_change(supi, UeContextEvent::AmfRegistered).await;
+        assert_eq!(sdm, 1, "the SDM subscriber must be notified");
+        assert_eq!(ee, 1, "the EE subscriber must be notified");
+
+        let sdm_bodies = wait_for(&sdm_seen, 1).await;
+        assert_eq!(sdm_bodies.len(), 1, "got {sdm_bodies:?}");
+        assert_eq!(
+            sdm_bodies[0]["notifyItems"][0]["resourceId"],
+            format!("/nudm-sdm/v2/{supi}/ue-context-in-amf-data")
+        );
+
+        let ee_bodies = wait_for(&ee_seen, 1).await;
+        assert_eq!(ee_bodies.len(), 1, "got {ee_bodies:?}");
+        assert_eq!(
+            ee_bodies[0]["reportList"][0]["eventType"],
+            "UE_REACHABILITY_FOR_DATA"
+        );
+        assert_eq!(ee_bodies[0]["reportList"][0]["report"]["supi"], supi);
+    }
+
+    /// A subscription monitoring a DIFFERENT data set is not notified — otherwise
+    /// `monitoredResourceUris` would be decoration.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
+    async fn monitored_resource_uris_narrow_the_sdm_notification() {
+        let _serial = notify_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("UDM_NOTIFY_DISABLE");
+        udm_context_init(64, 64);
+        let supi = "imsi-001010000000084";
+        clear_subscriptions_for(supi);
+        let (_server, uri, seen) = stub_callback().await;
+
+        {
+            let ctx = udm_self();
+            let guard = ctx.read().expect("context");
+            guard.sdm_subscription_insert(UdmSdmSubscription::for_supi(
+                supi,
+                Some("nf-1".to_string()),
+                Some(uri.clone()),
+                // Monitors the SMF data set only.
+                vec![format!("/nudm-sdm/v2/{supi}/ue-context-in-smf-data")],
+            ));
+        }
+
+        // An AMF transition must not reach it...
+        let (sdm, _) = notify_ue_context_change(supi, UeContextEvent::AmfRegistered).await;
+        assert_eq!(
+            sdm, 0,
+            "a subscriber monitoring smf-data must not be woken by an AMF change"
+        );
+        assert!(seen.lock().expect("sink").is_empty());
+
+        // ...but an SMF transition must.
+        let (sdm, _) = notify_ue_context_change(supi, UeContextEvent::SmfRegistered).await;
+        assert_eq!(sdm, 1);
+        assert_eq!(wait_for(&seen, 1).await.len(), 1);
+    }
+
+    /// A subscription for a different SUPI is never notified, and `anyUE` EE
+    /// subscriptions are.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
+    async fn notifications_are_scoped_to_the_right_subscriber() {
+        let _serial = notify_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("UDM_NOTIFY_DISABLE");
+        udm_context_init(64, 64);
+        clear_subscriptions_for("imsi-001010000000085");
+        clear_subscriptions_for("imsi-001010000000999");
+        let (_server, uri, seen) = stub_callback().await;
+
+        {
+            let ctx = udm_self();
+            let guard = ctx.read().expect("context");
+            // SDM subscription for a DIFFERENT UE.
+            guard.sdm_subscription_insert(UdmSdmSubscription::for_supi(
+                "imsi-001010000000999",
+                Some("nf-1".to_string()),
+                Some(uri.clone()),
+                Vec::new(),
+            ));
+            // EE subscription scoped to every UE.
+            guard.ee_subscription_insert(UdmEeSubscription::for_ue("anyUE", uri.clone(), "{}"));
+        }
+
+        let (sdm, ee) =
+            notify_ue_context_change("imsi-001010000000085", UeContextEvent::AmfRegistered).await;
+        assert_eq!(sdm, 0, "another UE's SDM subscription must not be notified");
+        assert_eq!(ee, 1, "an anyUE EE subscription covers every UE");
+        assert_eq!(wait_for(&seen, 1).await.len(), 1);
+
+        // An anyUE subscription reaches every SUPI, so it must not outlive this
+        // test regardless of what runs next.
+        clear_subscriptions_for("imsi-001010000000085");
+        clear_subscriptions_for("imsi-001010000000999");
+    }
+
+    /// An SDM subscription with an EMPTY monitoredResourceUris is a whole-UE
+    /// subscription, not a subscription to nothing.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
+    async fn an_empty_monitored_list_is_a_whole_ue_subscription() {
+        let _serial = notify_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("UDM_NOTIFY_DISABLE");
+        udm_context_init(64, 64);
+        let supi = "imsi-001010000000086";
+        clear_subscriptions_for(supi);
+        let (_server, uri, seen) = stub_callback().await;
+        {
+            let ctx = udm_self();
+            let guard = ctx.read().expect("context");
+            guard.sdm_subscription_insert(UdmSdmSubscription::for_supi(
+                supi,
+                Some("nf-1".to_string()),
+                Some(uri.clone()),
+                Vec::new(),
+            ));
+        }
+        let (sdm, _) = notify_ue_context_change(supi, UeContextEvent::SmfRegistered).await;
+        assert_eq!(sdm, 1);
+        assert_eq!(wait_for(&seen, 1).await.len(), 1);
+    }
+
+    /// The off switch silences both producers, and is off-by-default.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
+    async fn the_disable_switch_silences_both_producers() {
+        let _serial = notify_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        udm_context_init(64, 64);
+        let supi = "imsi-001010000000087";
+        clear_subscriptions_for(supi);
+        let (_server, uri, seen) = stub_callback().await;
+        {
+            let ctx = udm_self();
+            let guard = ctx.read().expect("context");
+            guard.sdm_subscription_insert(UdmSdmSubscription::for_supi(
+                supi,
+                Some("nf-1".to_string()),
+                Some(uri.clone()),
+                Vec::new(),
+            ));
+            guard.ee_subscription_insert(UdmEeSubscription::for_ue(supi, uri.clone(), "{}"));
+        }
+
+        std::env::remove_var("UDM_NOTIFY_DISABLE");
+        assert!(
+            notifications_enabled(),
+            "the producers are on by default: an off-by-default producer leaves \
+             the gap open for anyone who does not know to flip it"
+        );
+
+        std::env::set_var("UDM_NOTIFY_DISABLE", "1");
+        assert!(!notifications_enabled());
+        let (sdm, ee) = notify_ue_context_change(supi, UeContextEvent::AmfRegistered).await;
+        assert_eq!((sdm, ee), (0, 0));
+        assert!(
+            seen.lock().expect("sink").is_empty(),
+            "nothing may go out while the switch is set"
+        );
+        std::env::remove_var("UDM_NOTIFY_DISABLE");
+    }
+}

--- a/src/bins/nextgcore-udmd/src/sbi_path.rs
+++ b/src/bins/nextgcore-udmd/src/sbi_path.rs
@@ -595,13 +595,27 @@ pub async fn udm_sbi_send_dereg_notification(
     callback_uri: &str,
     body: &serde_json::Value,
 ) -> Result<SbiResponse, String> {
+    udm_sbi_send_callback_notification(callback_uri, body).await
+}
+
+/// POST a notification body to an absolute `callbackReference` supplied by a
+/// consumer.
+///
+/// Shared by the UECM dereg notification and by the SDM / EE producers (#83):
+/// all three are "POST this JSON to the absolute URI the consumer gave us", and
+/// having one implementation means a fix to the URI parsing or the client reaches
+/// every notification the UDM sends.
+pub async fn udm_sbi_send_callback_notification(
+    callback_uri: &str,
+    body: &serde_json::Value,
+) -> Result<SbiResponse, String> {
     let (host, port, path) = parse_callback_uri(callback_uri)
-        .ok_or_else(|| format!("deregCallbackUri is not an absolute URI: {callback_uri}"))?;
+        .ok_or_else(|| format!("callback reference is not an absolute URI: {callback_uri}"))?;
     let client = global_context().get_client(&host, port).await;
     client
         .post_json(&path, body)
         .await
-        .map_err(|e| format!("Dereg notification POST to {callback_uri} failed: {e}"))
+        .map_err(|e| format!("Notification POST to {callback_uri} failed: {e}"))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bins/nextgcore-udmd/src/uecm.rs
+++ b/src/bins/nextgcore-udmd/src/uecm.rs
@@ -369,6 +369,22 @@ pub async fn process_amf_registration(supi: &str, body: &Value, client: &UdrClie
     // Local cache (UDR is the system of record).
     cache_amf_registration(supi, body);
 
+    // #83: the UE's AMF context data set just changed, so SDM subscribers
+    // monitoring it get a ModificationNotification and EE subscribers get a
+    // MonitoringReport. Awaited rather than spawned so the notification is
+    // ordered after the UDR write it reports: a subscriber that reacts by reading
+    // the data set must not find the state the notification is about missing.
+    // Delivery failures are logged inside and never fail this operation.
+    crate::notify::notify_ue_context_change(
+        supi,
+        if is_update {
+            crate::notify::UeContextEvent::AmfContextUpdated
+        } else {
+            crate::notify::UeContextEvent::AmfRegistered
+        },
+    )
+    .await;
+
     // udmd-06: 201 on create, 200 on update.
     let status = if is_update { 200 } else { 201 };
     let mut resp = SbiResponse::with_status(status)
@@ -484,6 +500,15 @@ pub async fn process_smf_registration(
         return resp;
     }
 
+    // #83: the UE's SMF context data set just changed, so SDM subscribers
+    // monitoring it get a ModificationNotification and EE subscribers get a
+    // MonitoringReport. Awaited rather than spawned so the notification is
+    // ordered after the UDR write it reports: a subscriber that reacts by reading
+    // the data set must not find the state the notification is about missing.
+    // Delivery failures are logged inside and never fail this operation.
+    crate::notify::notify_ue_context_change(supi, crate::notify::UeContextEvent::SmfRegistered)
+        .await;
+
     // udmd-06: 201 on create, 200 on update.
     let status = if is_update { 200 } else { 201 };
     let mut resp = SbiResponse::with_status(status)
@@ -518,6 +543,15 @@ pub async fn process_amf_deregistration(supi: &str, client: &UdrClient) -> SbiRe
         }
     }
 
+    // #83: the UE's AMF context data set just changed, so SDM subscribers
+    // monitoring it get a ModificationNotification and EE subscribers get a
+    // MonitoringReport. Awaited rather than spawned so the notification is
+    // ordered after the UDR write it reports: a subscriber that reacts by reading
+    // the data set must not find the state the notification is about missing.
+    // Delivery failures are logged inside and never fail this operation.
+    crate::notify::notify_ue_context_change(supi, crate::notify::UeContextEvent::AmfDeregistered)
+        .await;
+
     SbiResponse::with_status(204)
 }
 
@@ -532,6 +566,11 @@ pub async fn process_smf_deregistration(
     if let Err(e) = client.context_delete(supi, &relative).await {
         log::warn!("[{supi}] UDR SMF context DELETE failed: {e} (degraded)");
     }
+
+    // #83: the SMF context data set changed; see the AMF sites above.
+    crate::notify::notify_ue_context_change(supi, crate::notify::UeContextEvent::SmfDeregistered)
+        .await;
+
     SbiResponse::with_status(204)
 }
 
@@ -1517,5 +1556,128 @@ mod tests {
             1,
             "the (failed) dereg notification was attempted exactly once"
         );
+    }
+
+    /// #83 WIRING: a real `process_amf_registration` must produce the SDM and EE
+    /// notifications, not just the standalone producer.
+    ///
+    /// Written because revert-verification exposed the gap: removing the
+    /// `notify_ue_context_change` call from this function left every notify test
+    /// green, since they all called the producer directly. That is the recorded
+    /// lesson that a tested helper leaves the wiring untested — the helper was
+    /// covered nine ways and the one line that invokes it was not covered at all.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn amf_registration_notifies_sdm_and_ee_subscribers() {
+        use nextgcore_sbi::message::{SbiRequest as SReq, SbiResponse as SResp};
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+        use std::sync::Mutex as StdMutex;
+
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Declared, not inherited: loopback plaintext stub (see notify.rs).
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        std::env::remove_var("UDM_NOTIFY_DISABLE");
+        crate::context::udm_context_init(1024, 4096);
+
+        let supi = "imsi-001010000000883";
+        let seen: Arc<StdMutex<Vec<Value>>> = Arc::new(StdMutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let addr = nextgcore_sbi::test_support::ephemeral_addr();
+        let server = SbiServer::new(SbiServerConfig::new(addr));
+        server
+            .start(move |req: SReq| {
+                let sink = Arc::clone(&sink);
+                async move {
+                    if let Some(b) = req.http.content.as_deref() {
+                        if let Ok(v) = serde_json::from_str::<Value>(b) {
+                            sink.lock().expect("sink").push(v);
+                        }
+                    }
+                    SResp::with_status(204)
+                }
+            })
+            .await
+            .expect("stub callback starts");
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let uri = format!("http://127.0.0.1:{}/cb", addr.port());
+
+        {
+            let ctx = udm_self();
+            let context = ctx.read().expect("context");
+            // Clear anything a previous test left for this SUPI.
+            for sub in context.sdm_subscriptions_for_supi(supi) {
+                context.sdm_subscription_remove(&sub.id);
+            }
+            for sub in context.ee_subscriptions_for_supi(supi) {
+                context.ee_subscription_remove(&sub.id);
+            }
+            context.sdm_subscription_insert(crate::context::UdmSdmSubscription::for_supi(
+                supi,
+                Some("nf-1".to_string()),
+                Some(uri.clone()),
+                vec![format!("/nudm-sdm/v2/{supi}/ue-context-in-amf-data")],
+            ));
+            context.ee_subscription_insert(crate::context::UdmEeSubscription::for_ue(
+                supi,
+                uri.clone(),
+                "{}",
+            ));
+        }
+
+        let mock = Arc::new(MockUdr::new());
+        let client = UdrClient::Mock(mock.clone());
+        let resp = process_amf_registration(supi, &valid_amf_body(), &client).await;
+        assert_eq!(
+            resp.status, 201,
+            "the registration itself must still succeed"
+        );
+
+        // Both notifications must have gone out as a consequence of the
+        // registration, with no extra call from the test.
+        let bodies = {
+            let mut out = Vec::new();
+            for _ in 0..100 {
+                out = seen.lock().expect("sink").clone();
+                if out.len() >= 2 {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            out
+        };
+        assert_eq!(
+            bodies.len(),
+            2,
+            "an AMF registration must notify both the SDM and the EE subscriber: {bodies:?}"
+        );
+        assert!(
+            bodies.iter().any(|b| b["notifyItems"][0]["resourceId"]
+                == format!("/nudm-sdm/v2/{supi}/ue-context-in-amf-data")),
+            "no SDM ModificationNotification among {bodies:?}"
+        );
+        assert!(
+            bodies
+                .iter()
+                .any(|b| b["reportList"][0]["eventType"] == "UE_REACHABILITY_FOR_DATA"),
+            "no EE MonitoringReport among {bodies:?}"
+        );
+
+        {
+            let ctx = udm_self();
+            let context = ctx.read().expect("context");
+            for sub in context.sdm_subscriptions_for_supi(supi) {
+                context.sdm_subscription_remove(&sub.id);
+            }
+            for sub in context.ee_subscriptions_for_supi(supi) {
+                context.ee_subscription_remove(&sub.id);
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #83

Criteria 3 and 4 split to **#226**. Spec: `specs/fix-udm-sdm-ee-notification-producers.md`. Verified against `main` @ `6105306` — every defect the issue describes was still present as written.

## Criteria 2 + 5 — both event-exposure surfaces were facades

The load-bearing defect. A consumer could `POST` an `SdmSubscription` or an `EeSubscription`, get `201`, and then hear nothing ever again: **no code path in the crate produced a notification.** `lib.rs` and `context.rs` both carried comments admitting it.

**What triggers one.** The UDM is mostly a read-through to the UDR, so the writes it *does* observe are the UECM lifecycle transitions — and those are changes to a monitored SDM resource (the UE's context data set) as well as EE-reportable events. Both producers hook the same four sites in `uecm.rs`: one transition, two audiences.

Decisions worth a second look:

- **On by default, with an off switch (`UDM_NOTIFY_DISABLE`).** The issue suggests off-by-default gates; rejected, and not only for the "a cargo feature hides its tests from CI" reason. The argument for gating new outbound traffic does not apply: a notification only ever goes to a `callbackReference` a consumer **explicitly subscribed with**, so a deployment that subscribes to nothing sees no new traffic. The switch is for a consumer that subscribes and then cannot cope with being notified.
- **Distinct changed-resource and EE event type per transition.** AMF → `ue-context-in-amf-data`, SMF → `ue-context-in-smf-data`; registration → `UE_REACHABILITY_FOR_DATA`, deregistration → `LOSS_OF_CONNECTIVITY`. Collapsing either wakes every subscriber on every transition, or leaves the report unable to say what happened.
- **`monitoredResourceUris` narrows; an EMPTY list does not.** Subscribing to a UE without naming resources is a whole-UE subscription, not a subscription to nothing.
- **EE scope matching covers exact-SUPI and `anyUE` only.** A `ue_identity` may also be a GPSI or group id, and resolving those needs identifier translation this UDM lacks (#85). Approximating would deliver **another UE's events**.
- **Awaited, not spawned**, so the notification is ordered after the UDR write it reports; **the context lock is released before the outbound call**, or the notify path would deadlock the subscribe path.

`udm_sbi_send_dereg_notification` was generalised into `udm_sbi_send_callback_notification` — all three notifications are "POST this JSON to the absolute URI the consumer gave us", and one implementation means a fix to the URI parsing or the client reaches all of them.

## Criterion 1 — SDM Subscribe accepted invalid subscriptions

It read the three mandatory IEs and inserted the subscription regardless, answering `201`. A consumer with a broken subscribe request got a subscription id back, monitored nothing, and had no way to tell. `nudm_handler.rs` already contained exactly these checks with nothing routed to them. An **empty** `monitoredResourceUris` is refused too: `minItems` is 1, and an empty list is what a consumer produces when its own list came out empty — a bug to surface, not a whole-UE subscription to infer.

## Criterion 6 — EE UpdateEeSubscription discarded its patch

`204` and drop the body, so "modify" succeeded forever while stored state never changed. Now applies it (PatchItem array, plus merge-patch leniently). **`remove`/`replace` on an absent member are errors, not no-ops** — a consumer patching a path that is not there has a wrong idea of the subscription and `204` would confirm it — and a patch changing `callbackReference` refreshes the cached copy, or the next notification goes to the old URI.

## Split → #226

#83's own *Suggested approach* says the multi-data-set/missing-data-set work "may reasonably be split into a separate lower-priority issue since the load-bearing defect is the missing notification producers". Following the convention for an author-marked split, filed as #226.

Worth noting for its priority: `ue-context-in-amf-data` is now more interesting than when #83 was written, because the producer added here reports changes to exactly that data set on every AMF transition — a subscriber is told the resource changed and then cannot read it.

## Verification

Workspace **5822 → 5834 passed, 0 failed**. `cargo clippy --workspace` exit 0, **zero** warnings. `cargo fmt --all --check` clean. 11 new tests (udmd 136 → 148).

**Revert-verified: 20 reverts, 20 bit** — after one exposed a genuine hole and one exposed a flake.

**The hole: the UECM wiring was untested.** Removing the `notify_ue_context_change` call from `process_amf_registration` left **every notify test green**, because all of them called the producer directly. The producer was covered nine ways; the line that invokes it, not at all — the recorded lesson that a tested helper leaves the wiring untested. `uecm::tests::amf_registration_notifies_sdm_and_ee_subscribers` now drives a real `process_amf_registration` against a mock UDR and a stub callback server, and that single-line revert fails it with `left: 0, right: 2`.

**The flake, which was test isolation rather than product code.** The notify tests failed roughly one run in four with an `HTTP/2 connection error` that reads as the producer sending nothing. Cause: `app.rs`'s `test_http_generate_auth_data_flows` sets the process-global SBI profile override to `Dev` and never resets it, so these tests inherited **production TLS or plaintext depending on test order** while talking to a plaintext loopback stub. Fixed by declaring the profile in the stub helper and serializing on the crate-wide `CONTEXT_GUARD` — the lock that sibling already takes — rather than a private lock that only ordered the new tests against each other. Stable over six consecutive runs. Subscriptions are also cleared **up front**, so a panicking test cannot leak an `anyUE` subscription into the next.

**Not verified:** no live consumer. The producers are asserted against in-process stub SBI servers reading real POST bodies off the wire — covering callback-URI parsing, the client and the body shapes, but not a conformance-tested peer. The SDM producer fires only on UECM transitions; a data-set change through some other path would not notify, because no such path exists in udmd today. Docker E2E is skipped by CI. **GitNexus impact analysis was not run** (no MCP server connected) — twelfth consecutive PR to record it.