### PR TITLE
fix(udmd): separate the two AMF access registrations, route the UECM reads and dereg-amf, pin the AUSF and the authEventId (Closes #84)

### DIFF
--- a/specs/fix-udm-uecm-access-separation-and-ueau-lifecycle.md
+++ b/specs/fix-udm-uecm-access-separation-and-ueau-lifecycle.md
@@ -1,0 +1,235 @@
+# nextgcore #84 (UDM): UECM access separation, the missing reads, spec deregistration, and the UEAU auth-event lifecycle
+
+Verified against `main` @ `c414dac`. Every defect the issue describes was still present as written;
+the line cites had drifted by a few lines but named the right code.
+
+`Closes #84`.
+
+## Gap 1: `amf-non-3gpp-access` was not a resource, it was an alias (criteria 1, 2)
+
+The load-bearing defect, and the one with a real deployment consequence. `handle_amf_non3gpp_registration`
+parsed the body and then called `process_amf_registration`, which called `amf_context_put`, which
+formatted `.../context-data/amf-3gpp-access`. So a non-3GPP registration:
+
+* read the UE's **3GPP** registration as its "prior",
+* wrote itself over the **3GPP** UDR record,
+* emitted a `DeregistrationData` with `accessType: 3GPP_ACCESS` to the 3GPP AMF's callback,
+* answered `200` (update) instead of `201` (create), and
+* returned a `Location` naming `amf-3gpp-access`.
+
+For a UE registered over both accesses — a routine N3IWF/TNGF case — the non-3GPP registration therefore
+tore the live 3GPP registration down, and amfd's real dereg-notify consumer *keys on* `accessType`
+(`test_dereg_notify_strict_peer_non_3gpp_no_enqueue` exists precisely because it discriminates), so the
+3GPP AMF obediently started a network-initiated deregistration for a UE that had not gone anywhere.
+
+### The fix is a type, not a branch
+
+`UecmAccess` (`uecm.rs`) carries the access through every step that names a resource: the UDR
+`context-data` path, the local cache slot, the `Location` header, the validation schema and the
+`DeregistrationData.accessType`. `process_amf_registration` takes it as a **required parameter** rather
+than defaulting, because the defect was exactly a caller forgetting which access it was serving. The
+router (`route_uecm_registrations`) is now the only place that maps a path segment to an access.
+
+`UdrClient` lost its per-resource accessors (`amf_context_get/put/patch`, `smf_context_get/put`) in
+favour of `context_get/put/patch/delete(supi, resource, ...)`. That is the same "there is nowhere left
+to hardcode it" argument: the bug lived inside a helper whose name did not mention the resource it
+hardcoded.
+
+### Decisions worth review
+
+* **The local cache gained a second slot per access** (`non_3gpp_amf_instance_id`,
+  `non_3gpp_dereg_callback_uri` on `UdmUe`) rather than being keyed by a composite. A UE registered over
+  both accesses has *two* serving AMFs; answering the non-3GPP "who was the old AMF?" question with the
+  3GPP AMF is how a spurious deregistration gets sent.
+* **Deregistering one access does not drop the UE context.** The old code removed the whole `UdmUe` on
+  any deregistration. It is now removed only once neither access holds a registration, or the surviving
+  access loses the cached serving AMF that its next re-registration needs to notify.
+* **The non-3GPP schema is validated as itself.** `AmfNon3GppAccessRegistration` additionally requires
+  `imsVoPs`, so a body that is a valid 3GPP registration is now refused for non-3GPP access with
+  `400 MANDATORY_IE_MISSING`. This is stricter than before on a route that previously accepted anything
+  the 3GPP validator accepted. It is what the schema says, and nothing in this repo sends a non-3GPP
+  registration — amfd only ever registers on `amf-3gpp-access` — so the strictness costs no existing
+  caller. Flagged because it is the one place a conformant-but-sloppy peer would newly get a 400.
+
+## Gap 2: the mandatory UECM reads returned 405 (criterion 3)
+
+There was no `GET` arm for any UECM resource. Added, all as read-through to the UDR `context-data`
+resource, plus the two operations the UDM has to compose itself:
+
+| Operation | Route | Answer |
+|---|---|---|
+| `Get3GppRegistration` | `GET .../registrations/amf-3gpp-access` | stored `Amf3GppAccessRegistration` |
+| `GetNon3GppRegistration` | `GET .../registrations/amf-non-3gpp-access` | stored `AmfNon3GppAccessRegistration` |
+| `GetSmfRegistration` | `GET .../registrations/smf-registrations` | `SmfRegistrationInfo` |
+| individual SMF | `GET .../registrations/smf-registrations/{psi}` | stored `SmfRegistration` |
+| `GetLocationInfo` | `GET .../registrations/location` | composed `LocationInfo` |
+| SMSF (both accesses) | `PUT`/`GET`/`DELETE .../registrations/smsf-{3gpp,non-3gpp}-access` | `SmsfRegistration` |
+| IP-SM-GW | `PUT`/`GET`/`DELETE .../registrations/ip-sm-gw` | `IpSmGwRegistration` |
+
+Three shape decisions:
+
+* **`GetSmfRegistration` wraps, it does not forward.** The UDR collection resource answers with a bare
+  JSON array (TS 29.505); the UECM operation is defined to return `SmfRegistrationInfo` with its
+  `smfRegistrationList` member. The wrap happens in the UDM rather than hoping the consumer is lenient.
+  An **empty** list is a `404`, because `smfRegistrationList` has `minItems: 1` — "registered for
+  nothing" is not a representable answer.
+* **`LocationInfo` is composed from the AMF registrations, not read from a resource.** That is what the
+  IE holds: a list of `RegistrationLocationInfo`, each naming a serving AMF and the access types it
+  serves. One AMF serving both accesses yields **one** entry with two `accessTypeList` members, not two
+  entries — which is also what keeps the list inside its `maxItems: 2` bound.
+* **A UDR fault is `503`, never `404`.** `read_context_resource` distinguishes "UDR says 404" from "UDR
+  could not answer", because a `(H)GMLC` told `404` stops looking for the UE. `a_udr_fault_on_a_uecm_get_is_503_not_404`
+  pins all seven read paths.
+
+`LocationInfo.gpsi` is left absent rather than derived from the SUPI: they are different subscriber
+identities. The `cached_gpsi` hook returns `None` today and is documented as waiting on the UDM's
+identifier translation (#85).
+
+### Known limitation, and it is not this PR's to fix
+
+These resources are written to and read from UDR `context-data/{resource}`, which is correct
+(TS 29.505 §5.2.2). **udrd only implements `amf-3gpp-access` and `smf-registrations`** — every other
+`context-data` resource answers `404 Unknown context resource`
+(`bins/nextgcore-udrd/src/main.rs:853-863`). So against nextgcore's own UDR, the non-3GPP, SMSF and
+IP-SM-GW registrations are accepted (the write degrades, per the existing `udr_write_outcome` policy)
+and then read back as `404`. That is **#87**, which names `amf-non-3gpp-a...` in its own title. The
+tests here use a mock UDR that implements the resources generically, so they prove the UDM's half and
+say nothing about the UDR's. Stated plainly because this is the same shape as #226: a producer that
+reports state a consumer cannot yet read.
+
+## Gap 3: deregistration used a verb the spec does not define (criterion 4)
+
+`DELETE /nudm-uecm/v1/{supi}/registrations/amf-3gpp-access` was routed. TS 29.503 defines `PUT`, `GET`
+and `PATCH` on that resource and puts deregistration on a custom operation:
+`POST .../amf-3gpp-access/dereg-amf` with an `AmfDeregInfo`. The `DELETE` arm is gone (it now `405`s,
+which is what the method set says) and `dereg-amf` is routed.
+
+`AmfDeregInfo.deregReason` is **validated, not ignored**: it is the only thing distinguishing this from
+an accidental POST, and a `204` for a bodyless request reports a deregistration the consumer did not
+describe.
+
+**`purgeFlag: true` on the update PATCH is now a deregistration**, per TS 29.503 §5.3.2.4.2. This is not
+a hypothetical shape — it is exactly what this repo's own AMF sends
+(`bins/nextgcore-amfd/src/sbi_path.rs:1950`, `{"purgeFlag": true}`). Before this change the UDM answered
+`204`, patched the flag into the stored document and kept the registration, so the UDM went on naming a
+serving AMF that had already released the UE.
+
+The GUAMI ownership check is deliberately kept **conditional**: `Amf3GppAccessRegistrationModification`
+marks `guami` required, but amfd sends a bare purge with no GUAMI, and refusing that would convert a
+working deregistration into a `400`. An absent GUAMI is accepted; only a *disagreeing* one is refused
+with `403 INVALID_GUAMI`.
+
+### One existing test changed shape
+
+`test_amf_registration_update_matching_guami_returns_204_and_patches_udr` used `purgeFlag: true` in its
+PATCH body while asserting a UDR **PATCH** was issued. With purge now meaning deregistration, that body
+exercises the wrong branch, so the body was changed to a real field modification (`pei`) — the test
+still proves precisely what it was written to prove (GUAMI match ⇒ 204 + UDR PATCH), and the purge
+branch got its own test. Its twin, the GUAMI-mismatch test, was **strengthened**: it now asserts neither
+a PATCH nor a DELETE is issued.
+
+## Gap 4: `ausfInstanceId` was validated and then thrown away (criterion 5)
+
+`handle_generate_auth_data` required the IE, checked it was non-empty, and never stored it. `sor.rs` and
+`upu.rs` read `ue.ausf_instance_id`, always found `None`, and fell through to "any cached AUSF
+instance" — so in a multi-AUSF core the SoR/UPU MAC was computed by an AUSF that does not hold this
+UE's `K_AUSF`, and the UE's verification of `SoR-MAC-IAUSF` / `UPU-MAC-IAUSF` fails
+(TS 33.501 §6.14.2.1 / §6.15.2.1).
+
+One line stores it on the live path. The test registers **two** AUSF instances, records the second, and
+asserts both the SoR and the UPU protection request reached the recorded one and that the first
+received nothing — the "prefer the stored AUSF" branch at `sbi_path.rs` firing, rather than the
+arbitrary-first-instance fallback.
+
+**The dead `udm_nudm_ueau_handle_get` is deleted** (criterion 8). It was the *only* code that stored
+`ausf_instance_id`, it had no caller anywhere in the tree, and it was a second unreachable
+implementation of resynchronisation. Its two request structs (`AuthenticationInfoRequest`,
+`ResynchronizationInfo`) went with it since nothing else constructed them; a comment at the site records
+what was there and why. The rest of `nudm_handler.rs` is the same shape of C-port dead code — see
+"Follow-ups".
+
+## Gap 5: `DeleteAuth` was unrouted and its identifier was thrown away (criterion 6)
+
+`ConfirmAuth` minted `uuid::Uuid::new_v4()`, put it in the `Location` header and dropped it, so the
+`authEventId` an AUSF is told to address could never be matched again. `PUT /{supi}/auth-events/{authEventId}`
+was unrouted.
+
+The identifier is now pinned on the UE before the response is built (the same value in the header and in
+the context — a value that only ever reaches a header cannot be matched), and `DeleteAuth` is routed. A
+mismatched or unknown id is a **404, not a silent 204**: the AUSF is addressing a resource this UDM does
+not hold, and `204` would tell it an authentication result was revoked while the real one stayed. The
+revocation is single-use — the pinned id is cleared, so a replay finds nothing — and it also reaches the
+UDR (`DELETE authentication-status`), best-effort, matching the ConfirmAuth write it undoes.
+
+The request body is a mandatory `AuthEvent`, so it is validated to the same standard as ConfirmAuth's
+rather than accepted unread.
+
+## Gap 5b: a failed SQN advance still issued the AV (criterion 7)
+
+`handle_generate_auth_data` withheld the AV on a 5xx or a transport error from the UDR SQN `PATCH`, but
+a **non-5xx** failure logged `degraded — AV issued anyway` and returned a vector built from the
+un-advanced SQN. Because `ue.sqn` is re-read from UDR on every call, an unpersisted advance means the
+next authentication computes an AV from the *same* SQN — the reuse TS 33.102 §6.3.2 exists to prevent,
+and a replay window for anyone holding the earlier AV. A `404` is both the likeliest such status and the
+least alarming-looking, which is why it was the one being tolerated.
+
+Now **any** failed advance withholds the AV (`503`).
+
+### Why no flag
+
+The issue suggests gating the stricter behaviour "behind review with the existing strict-peer tests, or
+a feature flag if a staged rollout is preferred". No flag, for three reasons:
+
+1. The recorded decision (2026-09-07) is that an off-by-default cargo feature puts its tests outside
+   `cargo test --workspace`, which is this repo's gate, so the gated path ships unexercised.
+2. A runtime switch defaulting to the *lenient* behaviour leaves the SQN-reuse window open for every
+   deployment that does not know to flip it — and this is an authentication-replay property, which is
+   the one class where the repo's fail-closed precedent is unconditional.
+3. The only stated justification for leniency was "UDR may not have the auth-subscription resource", and
+   nextgcore's own udrd **does** implement `PATCH authentication-subscription`
+   (`bins/nextgcore-udrd/src/main.rs:667`). There is no deployment here that legitimately needs the
+   lenient path.
+
+The cost, stated plainly: a UDR that answers the SQN PATCH with anything but 2xx now blocks
+authentication entirely instead of degrading. That is the intended trade — a UE that cannot authenticate
+is visible, an SQN silently reused is not.
+
+## Verification
+
+* Workspace `cargo test`: **5849 passed, 0 failed** (from 5834). `cargo clippy --workspace --all-targets`:
+  0 errors, 0 new warnings. `cargo fmt --all --check`: clean.
+* **Revert-verified**, each against the named test:
+  * mapping `amf-non-3gpp-access` back to the 3GPP access → `test_http_uecm_registration_surface` fails
+    (`left: 200, right: 201` — the create/update status is the tell that it read the 3GPP record).
+  * pinning `accessType` to `3GPP_ACCESS` → `non_3gpp_reregistration_notifies_the_non_3gpp_amf` and
+    `get_location_info_composes_one_entry_per_serving_amf` fail.
+  * removing the `purgeFlag` branch → `purge_flag_patch_deregisters_rather_than_patching` fails.
+  * dropping the `ausf_instance_id` store → the AUSF-pinning assertion fails (`left: None`).
+  * removing the `DeleteAuth` route arm → the DeleteAuth assertion fails with `left: 405`.
+  * restoring the lenient non-5xx SQN branch → the withholding assertion fails (`left: 200, right: 503`).
+* The two wire-level tests drive the **real router** over HTTP (`udm_sbi_request_handler` behind a real
+  `SbiServer`) against mock UDR/AUSF servers, because "returns the stored resource rather than 405" is a
+  routing claim that a handler-level test cannot falsify. Both follow the recorded stub-listener rules:
+  the helper hands the server back so the caller keeps it alive, and polls `TcpStream::connect` before
+  returning. Both declare the Dev SBI profile and serialize on `test_support::CONTEXT_GUARD`, since they
+  set `UDR_SBI_*` and re-init the process-global UDM context.
+
+## Not in scope
+
+* `GET .../registrations` (`RegistrationDataSets`, §5.3.2.5.10) and the `nwdaf-registrations` resources
+  still `405`. `pei-update` / `roaming-info-update` now answer `501` rather than `405`, which is at least
+  an honest "not implemented" instead of an implied "wrong method".
+* The UDR side of the new `context-data` resources — **#87**.
+* SDM notifications for SMSF / IP-SM-GW registration changes: `notify_ue_context_change` covers AMF and
+  SMF transitions only, and adding a `ue-context-in-smsf-data` event is a #83-shaped change, not this
+  one.
+
+## Follow-ups worth filing
+
+`nudm_handler.rs` is a C-port module with **no external callers for any of its handlers**
+(`udm_nudm_uecm_handle_amf_registration`, `..._update`, `..._get`, `..._smf_registration`,
+`..._smf_deregistration`, `udm_nudm_sdm_handle_*`, `udm_nudm_ueau_handle_result_confirmation_inform`) —
+verified by grepping the whole tree. Only its small helpers (`hex_to_bytes`, `bytes_to_hex`) are live.
+This PR removed the one function criterion 8 named; the remaining ~700 lines are the same hazard the
+recorded dead-code learning describes: they read as a working UECM/SDM implementation and will keep
+attracting fixes that cannot run.

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -606,32 +606,8 @@ async fn udm_sbi_route(request: SbiRequest) -> SbiResponse {
             let resource = parts.get(3).unwrap_or(&"");
 
             match (*resource, method) {
-                ("registrations", "PUT") if parts.len() >= 5 && parts[4] == "amf-3gpp-access" => {
-                    handle_amf_registration(supi, &request).await
-                }
-                ("registrations", "PATCH") if parts.len() >= 5 && parts[4] == "amf-3gpp-access" => {
-                    handle_amf_registration_update(supi, &request).await
-                }
-                ("registrations", "DELETE")
-                    if parts.len() >= 5 && parts[4] == "amf-3gpp-access" =>
-                {
-                    handle_amf_deregistration(supi).await
-                }
-                // udmd-12: AMF non-3GPP access registration (TS 29.503 §5.3.3).
-                ("registrations", "PUT")
-                    if parts.len() >= 5 && parts[4] == "amf-non-3gpp-access" =>
-                {
-                    handle_amf_non3gpp_registration(supi, &request).await
-                }
-                ("registrations", "PUT") if parts.len() >= 6 && parts[4] == "smf-registrations" => {
-                    let pdu_session_id = parts[5];
-                    handle_smf_registration(supi, pdu_session_id, &request).await
-                }
-                ("registrations", "DELETE")
-                    if parts.len() >= 6 && parts[4] == "smf-registrations" =>
-                {
-                    let pdu_session_id = parts[5];
-                    handle_smf_deregistration(supi, pdu_session_id).await
+                ("registrations", _) => {
+                    route_uecm_registrations(supi, &parts, method, &request, uri).await
                 }
                 // udmd-12: UE context in SMF data (GET only, TS 29.503 §6.3.x).
                 ("ue-context-in-smf-data", "GET") => {
@@ -686,6 +662,12 @@ async fn udm_sbi_route(request: SbiRequest) -> SbiResponse {
                     handle_generate_auth_data(supi, &request).await
                 }
                 ("auth-events", _, "POST") => handle_auth_event(supi, &request).await,
+                // DeleteAuth: PUT /{supi}/auth-events/{authEventId}
+                // (TS 29.503 §5.4.2.3.3). The identifier is mandatory in the
+                // path, so a bare `PUT .../auth-events` is not this operation.
+                ("auth-events", auth_event_id, "PUT") if !auth_event_id.is_empty() => {
+                    handle_delete_auth(supi, auth_event_id, &request).await
+                }
                 _ => send_method_not_allowed(method, uri),
             }
         }
@@ -715,69 +697,237 @@ async fn udm_sbi_route(request: SbiRequest) -> SbiResponse {
 
 // UE Context Management handlers
 
-pub async fn handle_amf_registration(supi: &str, request: &SbiRequest) -> SbiResponse {
-    log::info!("AMF Registration: SUPI={supi}");
-
+/// Parse a request body as JSON, or return the ProblemDetails response.
+fn parse_request_json(request: &SbiRequest) -> Result<serde_json::Value, Box<SbiResponse>> {
     let body = match &request.http.content {
         Some(content) => content,
-        None => return send_bad_request("Missing request body", Some("MISSING_BODY")),
+        None => {
+            return Err(Box::new(send_bad_request(
+                "Missing request body",
+                Some("MISSING_BODY"),
+            )))
+        }
     };
+    serde_json::from_str(body).map_err(|e| {
+        Box::new(send_bad_request(
+            &format!("Invalid JSON: {e}"),
+            Some("INVALID_JSON"),
+        ))
+    })
+}
 
-    let reg_data: serde_json::Value = match serde_json::from_str(body) {
-        Ok(p) => p,
-        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+/// Route the `nudm-uecm` `.../registrations[/...]` resource tree
+/// (TS 29.503 §6.2.3).
+///
+/// Split out of [`udm_sbi_route`] because the tree is two segments deep with
+/// six sibling resources, and each of `amf-3gpp-access` and
+/// `amf-non-3gpp-access` carries PUT/PATCH/GET plus a custom operation. The
+/// access is resolved ONCE here, from the path, and handed to the UECM
+/// processors — the router is the only place that knows a resource name.
+async fn route_uecm_registrations(
+    supi: &str,
+    parts: &[&str],
+    method: &str,
+    request: &SbiRequest,
+    uri: &str,
+) -> SbiResponse {
+    use crate::uecm::UecmAccess;
+
+    let sub = parts.get(4).copied().unwrap_or("");
+    let tail = parts.get(5).copied().unwrap_or("");
+
+    // amf-3gpp-access / amf-non-3gpp-access (+ the dereg-amf custom operation).
+    if let Some(access) = UecmAccess::from_amf_resource(sub) {
+        // POST .../{amf-resource}/dereg-amf — TS 29.503 §5.3.2.4.2 DeregAMF.
+        if tail == "dereg-amf" {
+            if method != "POST" {
+                return send_method_not_allowed(method, uri);
+            }
+            return handle_dereg_amf(supi, request).await;
+        }
+        if !tail.is_empty() {
+            // pei-update / roaming-info-update and friends are not implemented.
+            return send_not_implemented(&format!("{sub}/{tail} is not yet implemented"));
+        }
+        return match method {
+            "PUT" => handle_amf_registration(supi, request, access).await,
+            "PATCH" => handle_amf_registration_update(supi, request, access).await,
+            "GET" => handle_amf_registration_get(supi, access).await,
+            _ => send_method_not_allowed(method, uri),
+        };
+    }
+
+    // smsf-3gpp-access / smsf-non-3gpp-access.
+    if let Some(access) = UecmAccess::from_smsf_resource(sub) {
+        return match method {
+            "PUT" => handle_smsf_registration(supi, request, access).await,
+            "GET" => handle_smsf_registration_get(supi, access).await,
+            "DELETE" => handle_smsf_deregistration(supi, access).await,
+            _ => send_method_not_allowed(method, uri),
+        };
+    }
+
+    match sub {
+        "smf-registrations" => match (method, tail.is_empty()) {
+            // Collection GET -> SmfRegistrationInfo (TS 29.503 §5.3.2.5).
+            ("GET", true) => handle_smf_registrations_get(supi).await,
+            ("GET", false) => handle_smf_registration_get(supi, tail).await,
+            ("PUT", false) => handle_smf_registration(supi, tail, request).await,
+            ("DELETE", false) => handle_smf_deregistration(supi, tail).await,
+            _ => send_method_not_allowed(method, uri),
+        },
+        "ip-sm-gw" => match method {
+            "PUT" => handle_ip_sm_gw_registration(supi, request).await,
+            "GET" => handle_ip_sm_gw_registration_get(supi).await,
+            "DELETE" => handle_ip_sm_gw_deregistration(supi).await,
+            _ => send_method_not_allowed(method, uri),
+        },
+        // GET .../registrations/location -> LocationInfo (TS 29.503 §5.3.2.5).
+        "location" if method == "GET" => handle_location_info_get(supi).await,
+        _ => send_method_not_allowed(method, uri),
+    }
+}
+
+pub async fn handle_amf_registration(
+    supi: &str,
+    request: &SbiRequest,
+    access: crate::uecm::UecmAccess,
+) -> SbiResponse {
+    log::info!("AMF Registration ({}): SUPI={supi}", access.amf_resource());
+
+    let reg_data = match parse_request_json(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
     };
 
     // udmd-03 (validate) -> udmd-01 (persist to UDR) -> udmd-02 (notify old AMF).
-    crate::uecm::process_amf_registration(supi, &reg_data, &crate::uecm::UdrClient::Live).await
-}
-
-pub async fn handle_amf_registration_update(supi: &str, request: &SbiRequest) -> SbiResponse {
-    log::info!("AMF Registration Update: SUPI={supi}");
-
-    let body = match &request.http.content {
-        Some(content) => content,
-        None => return send_bad_request("Missing request body", Some("MISSING_BODY")),
-    };
-
-    let update_data: serde_json::Value = match serde_json::from_str(body) {
-        Ok(p) => p,
-        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
-    };
-
-    // udmd-05: GUAMI ownership check + UDR PATCH.
-    crate::uecm::process_amf_registration_update(supi, &update_data, &crate::uecm::UdrClient::Live)
+    crate::uecm::process_amf_registration(supi, &reg_data, &crate::uecm::UdrClient::Live, access)
         .await
 }
 
-pub async fn handle_amf_deregistration(supi: &str) -> SbiResponse {
-    log::info!("AMF Deregistration: SUPI={supi}");
+pub async fn handle_amf_registration_update(
+    supi: &str,
+    request: &SbiRequest,
+    access: crate::uecm::UecmAccess,
+) -> SbiResponse {
+    log::info!(
+        "AMF Registration Update ({}): SUPI={supi}",
+        access.amf_resource()
+    );
 
-    // udmd-01: DELETE the UDR context-data before returning 204.
-    crate::uecm::process_amf_deregistration(supi, &crate::uecm::UdrClient::Live).await
+    let update_data = match parse_request_json(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
+    };
+
+    // udmd-05: GUAMI ownership check + UDR PATCH (or purge on purgeFlag).
+    crate::uecm::process_amf_registration_update(
+        supi,
+        &update_data,
+        &crate::uecm::UdrClient::Live,
+        access,
+    )
+    .await
 }
 
-/// udmd-12: AMF non-3GPP-access registration (PUT).
-///
-/// TS 29.503 §5.3.3 defines this for N3IWF/TNGF use cases.  We accept the
-/// request and persist via the same AMF context PUT path (same Nudr resource),
-/// returning 201/200 exactly like the 3GPP-access variant.
-pub async fn handle_amf_non3gpp_registration(supi: &str, request: &SbiRequest) -> SbiResponse {
-    log::info!("AMF Non-3GPP Registration: SUPI={supi}");
+/// `GET .../registrations/{amf-resource}` — TS 29.503 §5.3.2.5
+/// `Get3GppRegistration` / `GetNon3GppRegistration`.
+pub async fn handle_amf_registration_get(
+    supi: &str,
+    access: crate::uecm::UecmAccess,
+) -> SbiResponse {
+    log::info!(
+        "AMF Registration Get ({}): SUPI={supi}",
+        access.amf_resource()
+    );
+    crate::uecm::process_amf_registration_get(supi, &crate::uecm::UdrClient::Live, access).await
+}
 
-    let body = match &request.http.content {
-        Some(content) => content,
-        None => return send_bad_request("Missing request body", Some("MISSING_BODY")),
+/// `POST .../registrations/amf-3gpp-access/dereg-amf` — TS 29.503 §5.3.2.4.2.
+pub async fn handle_dereg_amf(supi: &str, request: &SbiRequest) -> SbiResponse {
+    log::info!("AMF Deregistration (dereg-amf): SUPI={supi}");
+    let info = match parse_request_json(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
     };
+    crate::uecm::process_dereg_amf(supi, &info, &crate::uecm::UdrClient::Live).await
+}
 
-    let reg_data: serde_json::Value = match serde_json::from_str(body) {
-        Ok(p) => p,
-        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+/// `PUT .../registrations/{smsf-resource}` — SMSF registration.
+pub async fn handle_smsf_registration(
+    supi: &str,
+    request: &SbiRequest,
+    access: crate::uecm::UecmAccess,
+) -> SbiResponse {
+    log::info!(
+        "SMSF Registration ({}): SUPI={supi}",
+        access.smsf_resource()
+    );
+    let reg_data = match parse_request_json(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
     };
+    crate::uecm::process_smsf_registration(supi, &reg_data, &crate::uecm::UdrClient::Live, access)
+        .await
+}
 
-    // Reuse the same UECM registration path — UDR resource key is different
-    // (/amf-non-3gpp-access) but the validation and persistence logic is the same.
-    crate::uecm::process_amf_registration(supi, &reg_data, &crate::uecm::UdrClient::Live).await
+/// `GET .../registrations/{smsf-resource}`.
+pub async fn handle_smsf_registration_get(
+    supi: &str,
+    access: crate::uecm::UecmAccess,
+) -> SbiResponse {
+    crate::uecm::process_smsf_registration_get(supi, &crate::uecm::UdrClient::Live, access).await
+}
+
+/// `DELETE .../registrations/{smsf-resource}`.
+pub async fn handle_smsf_deregistration(
+    supi: &str,
+    access: crate::uecm::UecmAccess,
+) -> SbiResponse {
+    log::info!(
+        "SMSF Deregistration ({}): SUPI={supi}",
+        access.smsf_resource()
+    );
+    crate::uecm::process_smsf_deregistration(supi, &crate::uecm::UdrClient::Live, access).await
+}
+
+/// `PUT .../registrations/ip-sm-gw` — IP-SM-GW registration.
+pub async fn handle_ip_sm_gw_registration(supi: &str, request: &SbiRequest) -> SbiResponse {
+    log::info!("IP-SM-GW Registration: SUPI={supi}");
+    let reg_data = match parse_request_json(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
+    };
+    crate::uecm::process_ip_sm_gw_registration(supi, &reg_data, &crate::uecm::UdrClient::Live).await
+}
+
+/// `GET .../registrations/ip-sm-gw`.
+pub async fn handle_ip_sm_gw_registration_get(supi: &str) -> SbiResponse {
+    crate::uecm::process_ip_sm_gw_registration_get(supi, &crate::uecm::UdrClient::Live).await
+}
+
+/// `DELETE .../registrations/ip-sm-gw`.
+pub async fn handle_ip_sm_gw_deregistration(supi: &str) -> SbiResponse {
+    log::info!("IP-SM-GW Deregistration: SUPI={supi}");
+    crate::uecm::process_ip_sm_gw_deregistration(supi, &crate::uecm::UdrClient::Live).await
+}
+
+/// `GET .../registrations/location` — TS 29.503 §5.3.2.5 `GetLocationInfo`.
+pub async fn handle_location_info_get(supi: &str) -> SbiResponse {
+    log::info!("UECM Location Info Get: SUPI={supi}");
+    crate::uecm::process_location_info_get(supi, &crate::uecm::UdrClient::Live).await
+}
+
+/// `GET .../registrations/smf-registrations` — the collection form.
+pub async fn handle_smf_registrations_get(supi: &str) -> SbiResponse {
+    log::info!("SMF Registrations Get (collection): SUPI={supi}");
+    crate::uecm::process_smf_registrations_get(supi, &crate::uecm::UdrClient::Live).await
+}
+
+/// `GET .../registrations/smf-registrations/{pduSessionId}`.
+pub async fn handle_smf_registration_get(supi: &str, pdu_session_id: &str) -> SbiResponse {
+    crate::uecm::process_smf_registration_get(supi, pdu_session_id, &crate::uecm::UdrClient::Live)
+        .await
 }
 
 pub async fn handle_smf_registration(
@@ -787,14 +937,9 @@ pub async fn handle_smf_registration(
 ) -> SbiResponse {
     log::info!("SMF Registration: SUPI={supi}, PDU Session={pdu_session_id}");
 
-    let body = match &request.http.content {
-        Some(content) => content,
-        None => return send_bad_request("Missing request body", Some("MISSING_BODY")),
-    };
-
-    let reg_data: serde_json::Value = match serde_json::from_str(body) {
-        Ok(p) => p,
-        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+    let reg_data = match parse_request_json(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
     };
 
     // udmd-03 (validate) -> udmd-01 (persist to UDR).
@@ -1672,18 +1817,16 @@ pub async fn handle_generate_auth_data(supi_or_suci: &str, request: &SbiRequest)
             )
         }
     };
-    if auth_info
-        .get("ausfInstanceId")
-        .and_then(|v| v.as_str())
-        .map(|s| s.is_empty())
-        .unwrap_or(true)
-    {
-        return send_problem(
-            400,
-            "MANDATORY_IE_MISSING",
-            "AuthenticationInfoRequest.ausfInstanceId is missing",
-        );
-    }
+    let ausf_instance_id = match auth_info.get("ausfInstanceId").and_then(|v| v.as_str()) {
+        Some(id) if !id.is_empty() => id,
+        _ => {
+            return send_problem(
+                400,
+                "MANDATORY_IE_MISSING",
+                "AuthenticationInfoRequest.ausfInstanceId is missing",
+            )
+        }
+    };
 
     // TS 33.501 §6.1.2: verify the serving network name is well-formed before
     // generating any authentication material (anti-bidding-down: a malformed
@@ -1813,6 +1956,12 @@ pub async fn handle_generate_auth_data(supi_or_suci: &str, request: &SbiRequest)
 
     ue.serving_network_name = Some(serving_network_name.to_string());
     ue.supi = Some(supi.clone());
+    // TS 33.501 §6.14.2.1 / §6.15.2.1: SoR and UPU protection must be computed
+    // by the AUSF that holds this UE's K_AUSF, i.e. the one that authenticated
+    // it. That is the AUSF named here, so record it now — before #84 the IE was
+    // validated and then dropped, leaving sor.rs / upu.rs to pick an arbitrary
+    // AUSF and produce a MAC the UE cannot verify.
+    ue.ausf_instance_id = Some(ausf_instance_id.to_string());
 
     let k_bytes = crate::nudm_handler::hex_to_bytes(k_hex);
     let opc_bytes = crate::nudm_handler::hex_to_bytes(opc_hex);
@@ -1932,19 +2081,20 @@ pub async fn handle_generate_auth_data(supi_or_suci: &str, request: &SbiRequest)
         Ok(r) if r.is_success() || r.status == 204 => {
             log::debug!("[{supi}] SQN advanced to 0x{new_sqn_hex}");
         }
-        Ok(r) if r.status >= 500 => {
+        Ok(r) => {
+            // ANY failed advance withholds the AV, not only a 5xx (#84).
+            //
+            // The stored SQN is re-read from UDR on every call, so an
+            // unpersisted advance means the NEXT authentication computes an AV
+            // from the SAME SQN — the reuse TS 33.102 §6.3.2 exists to prevent,
+            // and a replay window for anyone holding the earlier AV. A 404 is
+            // the likeliest such status and the least alarming-looking, which
+            // is exactly why it was the one being tolerated.
             log::error!(
-                "[{supi}] UDR SQN PATCH returned {}: refusing to issue AV",
+                "[{supi}] UDR SQN PATCH returned {}: refusing to issue AV (SQN not advanced)",
                 r.status
             );
             return nextgcore_sbi::server::send_service_unavailable("UDR SQN update failed");
-        }
-        Ok(r) => {
-            // Non-5xx (e.g. 404): UDR may not have auth-subscription resource; degrade.
-            log::warn!(
-                "[{supi}] UDR SQN PATCH returned {} (degraded — AV issued anyway)",
-                r.status
-            );
         }
         Err(e) => {
             // Transport failure: refuse to issue AV to prevent SQN replay.
@@ -2051,11 +2201,18 @@ pub async fn handle_auth_event(supi: &str, request: &SbiRequest) -> SbiResponse 
 
     log::info!("Auth Event: success={success}");
 
+    // The identifier of the AuthEvent resource this operation creates. Minted
+    // before the context write so the SAME value is both stored and returned in
+    // `Location`: DeleteAuth (TS 29.503 §5.4.2.3.3) addresses the UE by it, and
+    // a value that was only ever put in a header can never be matched again.
+    let event_id = uuid::Uuid::new_v4().to_string();
+
     // Record the auth event in the local UE context.
     {
         let ctx = udm_self();
         if let Ok(context) = ctx.read() {
             if let Some(mut ue) = context.ue_find_by_supi(supi) {
+                ue.auth_event_id = Some(event_id.clone());
                 ue.set_auth_event(crate::AuthEvent {
                     nf_instance_id: auth_event
                         .get("nfInstanceId")
@@ -2095,8 +2252,6 @@ pub async fn handle_auth_event(supi: &str, request: &SbiRequest) -> SbiResponse 
         }
     }
 
-    // Build a stable auth-event resource URI for the Location header.
-    let event_id = uuid::Uuid::new_v4().to_string();
     SbiResponse::with_status(201)
         .with_header(
             "Location",
@@ -2110,6 +2265,108 @@ pub async fn handle_auth_event(supi: &str, request: &SbiRequest) -> SbiResponse 
             "servingNetworkName": auth_event.get("servingNetworkName"),
         }))
         .unwrap_or_else(|_| SbiResponse::with_status(201))
+}
+
+/// `PUT /nudm-ueau/v1/{supi}/auth-events/{authEventId}` — TS 29.503 §5.4.2.3.3
+/// `DeleteAuth`: the AUSF revokes the authentication result the UDM stored on
+/// `ConfirmAuth`.
+///
+/// `authEventId` must be the identifier the UDM handed out in the `ConfirmAuth`
+/// `Location` header. A mismatch is a **404**, not a silent success: the AUSF is
+/// addressing a resource this UDM does not hold, and answering 204 would tell it
+/// an authentication result was revoked while the real one stayed.
+pub async fn handle_delete_auth(
+    supi: &str,
+    auth_event_id: &str,
+    request: &SbiRequest,
+) -> SbiResponse {
+    log::info!("Delete Auth: SUPI={supi} authEventId={auth_event_id}");
+
+    let body = match &request.http.content {
+        Some(content) => content,
+        None => return send_bad_request("Missing request body", Some("MISSING_BODY")),
+    };
+    let auth_event: serde_json::Value = match serde_json::from_str(body) {
+        Ok(p) => p,
+        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+    };
+    // The request body is a mandatory AuthEvent, so it is validated to the same
+    // standard as ConfirmAuth's rather than accepted unread.
+    for attr in [
+        "nfInstanceId",
+        "timeStamp",
+        "authType",
+        "servingNetworkName",
+    ] {
+        if auth_event
+            .get(attr)
+            .and_then(|v| v.as_str())
+            .map(|s| s.is_empty())
+            .unwrap_or(true)
+        {
+            return send_problem(
+                400,
+                "MANDATORY_IE_MISSING",
+                &format!("AuthEvent.{attr} is missing"),
+            );
+        }
+    }
+    if auth_event
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .is_none()
+    {
+        return send_problem(400, "MANDATORY_IE_MISSING", "AuthEvent.success is missing");
+    }
+
+    // Match the addressed resource against the identifier ConfirmAuth issued.
+    let mut stored_id: Option<String> = None;
+    {
+        let ctx = udm_self();
+        if let Ok(context) = ctx.read() {
+            stored_id = context
+                .ue_find_by_supi(supi)
+                .and_then(|ue| ue.auth_event_id.clone());
+        };
+    }
+    if stored_id.as_deref() != Some(auth_event_id) {
+        log::warn!("[{supi}] DeleteAuth for unknown authEventId {auth_event_id} — 404");
+        return send_problem(
+            404,
+            "CONTEXT_NOT_FOUND",
+            "No authentication event with this authEventId",
+        );
+    }
+
+    // Drop the local authentication result and the pinned identifier, so a
+    // replayed DeleteAuth for the same id now finds nothing (single-use).
+    {
+        let ctx = udm_self();
+        if let Ok(context) = ctx.read() {
+            if let Some(mut ue) = context.ue_find_by_supi(supi) {
+                ue.clear_auth_event();
+                ue.auth_event_id = None;
+                context.ue_update(&ue);
+            }
+        };
+    }
+
+    // The authentication status lives in the UDR (TS 29.505 §6.3.3), so the
+    // revocation has to reach it too. Best-effort, matching the ConfirmAuth
+    // write it undoes: a UDR without the resource must not make the AUSF
+    // believe the local revocation above did not happen.
+    match crate::udm_nudr_dr_send_auth_status_delete(supi).await {
+        Ok(r) if r.is_success() => {
+            log::debug!("[{supi}] Auth status deleted in UDR ({})", r.status);
+        }
+        Ok(r) => log::warn!(
+            "[{supi}] UDR auth-status DELETE returned {} (degraded)",
+            r.status
+        ),
+        Err(e) => log::warn!("[{supi}] UDR auth-status DELETE failed: {e} (degraded)"),
+    }
+
+    SbiResponse::with_status(204)
 }
 
 /// Initialize logging based on command line arguments
@@ -3828,6 +4085,622 @@ mod tests {
             &serde_json::json!([{ "op": "replace", "path": "/new", "value": 1 }])
         )
         .is_err());
+    }
+
+    // ========================================================================
+    // #84: the Nudm_UECM registration surface over the WIRE
+    //
+    // These drive the REAL router (`udm_sbi_request_handler`) over HTTP against
+    // a mock UDR that stores `context-data` resources, because the criteria are
+    // routing claims: "returns the stored resource rather than 405". A
+    // handler-level test cannot fail when a route arm is missing.
+    // ========================================================================
+
+    /// Shared in-memory `context-data` store for the mock UDR below, keyed by
+    /// the full Nudr resource path.
+    type CtxStore = Arc<std::sync::Mutex<std::collections::HashMap<String, serde_json::Value>>>;
+
+    /// Mock UDR implementing the `context-data` resources of TS 29.505 §5.2.2
+    /// generically: GET / PUT / PATCH / DELETE on any resource, plus the
+    /// `smf-registrations` collection GET that answers with a bare array (the
+    /// shape the real udrd returns, which the UDM has to wrap).
+    async fn mock_udr_context_data(store: CtxStore, request: SbiRequest) -> SbiResponse {
+        let method = request.header.method.clone();
+        let uri = request.header.uri.clone();
+        let path = uri.split('?').next().unwrap_or(&uri).to_string();
+        if !path.contains("/context-data/") {
+            return SbiResponse::with_status(404);
+        }
+        let body = || -> Option<serde_json::Value> {
+            request
+                .http
+                .content
+                .as_deref()
+                .and_then(|b| serde_json::from_str(b).ok())
+        };
+        let mut map = store.lock().expect("ctx store");
+        match method.as_str() {
+            "GET" => {
+                if path.ends_with("/smf-registrations") {
+                    let prefix = format!("{path}/");
+                    let list: Vec<serde_json::Value> = map
+                        .iter()
+                        .filter(|(k, _)| k.starts_with(&prefix))
+                        .map(|(_, v)| v.clone())
+                        .collect();
+                    if list.is_empty() {
+                        return SbiResponse::with_status(404);
+                    }
+                    return SbiResponse::with_status(200)
+                        .with_json_body(&serde_json::Value::Array(list))
+                        .unwrap_or_else(|_| SbiResponse::with_status(500));
+                }
+                match map.get(&path) {
+                    Some(doc) => SbiResponse::with_status(200)
+                        .with_json_body(doc)
+                        .unwrap_or_else(|_| SbiResponse::with_status(500)),
+                    None => SbiResponse::with_status(404),
+                }
+            }
+            "PUT" => match body() {
+                Some(doc) => {
+                    let created = map.insert(path, doc).is_none();
+                    SbiResponse::with_status(if created { 201 } else { 204 })
+                }
+                None => SbiResponse::with_status(400),
+            },
+            "PATCH" => {
+                let Some(patch) = body() else {
+                    return SbiResponse::with_status(400);
+                };
+                let Some(doc) = map.get_mut(&path) else {
+                    return SbiResponse::with_status(404);
+                };
+                if let (Some(target), Some(items)) = (doc.as_object_mut(), patch.as_object()) {
+                    for (k, v) in items {
+                        target.insert(k.clone(), v.clone());
+                    }
+                }
+                SbiResponse::with_status(204)
+            }
+            "DELETE" => {
+                map.remove(&path);
+                SbiResponse::with_status(204)
+            }
+            _ => SbiResponse::with_status(405),
+        }
+    }
+
+    /// Start the mock UDR and point udmd's UDR client at it. Returns the server
+    /// (the CALLER must keep it alive: dropping it closes the listener) and the
+    /// backing store.
+    async fn start_mock_udr_context_data() -> (SbiServer, CtxStore) {
+        let store: CtxStore = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let port = free_port();
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let handler_store = Arc::clone(&store);
+        server
+            .start(move |req: SbiRequest| {
+                let store = Arc::clone(&handler_store);
+                async move { mock_udr_context_data(store, req).await }
+            })
+            .await
+            .expect("mock UDR starts");
+        // SbiServer::start spawns its accept loop, so returning from it does not
+        // mean the port accepts yet (the recorded stub-listener lesson).
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        std::env::set_var("UDR_SBI_ADDR", "127.0.0.1");
+        std::env::set_var("UDR_SBI_PORT", port.to_string());
+        (server, store)
+    }
+
+    /// Start the real UDM SBI server and return it with a client for it.
+    async fn start_real_udm() -> (SbiServer, nextgcore_sbi::client::SbiClient) {
+        let port = free_port();
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        server
+            .start(udm_sbi_request_handler)
+            .await
+            .expect("udm starts");
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        (
+            server,
+            nextgcore_sbi::client::SbiClient::with_host_port("127.0.0.1", port),
+        )
+    }
+
+    fn json_body(resp: &SbiResponse) -> serde_json::Value {
+        serde_json::from_str(resp.http.content.as_deref().unwrap_or("null"))
+            .unwrap_or(serde_json::Value::Null)
+    }
+
+    fn amf_reg_body(instance: &str, rat: &str) -> serde_json::Value {
+        serde_json::json!({
+            "amfInstanceId": instance,
+            "deregCallbackUri":
+                format!("http://{instance}.example.org:7777/namf-callback/v1/imsi-x/dereg-notify"),
+            "guami": { "plmnId": { "mcc": "001", "mnc": "01" }, "amfId": "cafe00" },
+            "ratType": rat,
+            "imsVoPs": "HOMOGENEOUS_NON_SUPPORT"
+        })
+    }
+
+    /// The whole #84 UECM surface, driven through the real router:
+    /// dual-access registration without overwrite (criterion 1), every mandatory
+    /// GET answering 2xx instead of 405 (criterion 3), and both spec
+    /// deregistrations (criterion 4).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn test_http_uecm_registration_surface() {
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _ = env_logger::try_init();
+        udm_context_init(64, 64);
+        std::env::remove_var("UDM_NOTIFY_DISABLE");
+
+        let (udr_server, store) = start_mock_udr_context_data().await;
+        let (udm_server, client) = start_real_udm().await;
+
+        let supi = "imsi-001010000000846";
+        let reg = |r: &str| format!("/nudm-uecm/v1/{supi}/registrations/{r}");
+        let udr_key = |r: &str| format!("/nudr-dr/v2/subscription-data/{supi}/context-data/{r}");
+
+        // --- criterion 1: dual-access registration, no overwrite ------------
+        let three_gpp = amf_reg_body("amf-3gpp", "NR");
+        let resp = client
+            .put_json(&reg("amf-3gpp-access"), &three_gpp)
+            .await
+            .expect("3gpp PUT");
+        assert_eq!(resp.status, 201, "3GPP registration created");
+
+        let non_3gpp = amf_reg_body("amf-n3gpp", "VIRTUAL");
+        let resp = client
+            .put_json(&reg("amf-non-3gpp-access"), &non_3gpp)
+            .await
+            .expect("non-3gpp PUT");
+        assert_eq!(
+            resp.status, 201,
+            "the non-3GPP resource is created, not found: a 200 would mean the \
+             handler read the 3GPP registration"
+        );
+        assert_eq!(
+            resp.http.headers.get("location").map(String::as_str),
+            Some(reg("amf-non-3gpp-access").as_str())
+        );
+        {
+            let map = store.lock().expect("store");
+            assert_eq!(
+                map.get(&udr_key("amf-3gpp-access")),
+                Some(&three_gpp),
+                "the 3GPP UDR record must be untouched by the non-3GPP registration"
+            );
+            assert_eq!(
+                map.get(&udr_key("amf-non-3gpp-access")),
+                Some(&non_3gpp),
+                "the non-3GPP registration lives in its own UDR resource"
+            );
+        }
+
+        // --- criterion 3: the mandatory GETs are ROUTED (not 405) ----------
+        for (resource, expect_instance) in [
+            ("amf-3gpp-access", "amf-3gpp"),
+            ("amf-non-3gpp-access", "amf-n3gpp"),
+        ] {
+            let resp = client.get(&reg(resource)).await.expect("GET");
+            assert_eq!(resp.status, 200, "GET {resource} must be routed");
+            assert_eq!(
+                json_body(&resp)["amfInstanceId"],
+                expect_instance,
+                "GET {resource} returned the wrong access's registration"
+            );
+        }
+
+        // SMF registration + the collection and individual GETs.
+        let smf = serde_json::json!({
+            "smfInstanceId": "smf-1",
+            "pduSessionId": 5,
+            "singleNssai": { "sst": 1, "sd": "000001" },
+            "dnn": "internet",
+            "plmnId": { "mcc": "001", "mnc": "01" }
+        });
+        let resp = client
+            .put_json(&reg("smf-registrations/5"), &smf)
+            .await
+            .expect("smf PUT");
+        assert_eq!(resp.status, 201);
+        let resp = client
+            .get(&reg("smf-registrations"))
+            .await
+            .expect("smf collection GET");
+        assert_eq!(resp.status, 200, "GetSmfRegistration must be routed");
+        assert_eq!(
+            json_body(&resp)["smfRegistrationList"][0]["smfInstanceId"],
+            "smf-1",
+            "the collection is wrapped as SmfRegistrationInfo"
+        );
+        let resp = client
+            .get(&reg("smf-registrations/5"))
+            .await
+            .expect("smf individual GET");
+        assert_eq!(resp.status, 200);
+        assert_eq!(json_body(&resp)["smfInstanceId"], "smf-1");
+
+        // Location information, composed from both AMF registrations.
+        let resp = client.get(&reg("location")).await.expect("location GET");
+        assert_eq!(resp.status, 200, "GetLocationInfo must be routed");
+        let loc = json_body(&resp);
+        let entries = loc["registrationLocationInfoList"]
+            .as_array()
+            .expect("registrationLocationInfoList")
+            .clone();
+        assert_eq!(entries.len(), 2, "one entry per serving AMF: {entries:?}");
+        assert_eq!(loc["supi"], supi);
+
+        // SMSF and IP-SM-GW registrations round-trip.
+        let smsf = serde_json::json!({
+            "smsfInstanceId": "smsf-1",
+            "plmnId": { "mcc": "001", "mnc": "01" }
+        });
+        let resp = client
+            .put_json(&reg("smsf-3gpp-access"), &smsf)
+            .await
+            .expect("smsf PUT");
+        assert_eq!(resp.status, 201);
+        let resp = client
+            .get(&reg("smsf-3gpp-access"))
+            .await
+            .expect("smsf GET");
+        assert_eq!(resp.status, 200, "Get3GppSmsfRegistration must be routed");
+        assert_eq!(json_body(&resp)["smsfInstanceId"], "smsf-1");
+
+        let ipsmgw = serde_json::json!({ "ipsmgwFqdn": "ipsmgw.example.org" });
+        let resp = client
+            .put_json(&reg("ip-sm-gw"), &ipsmgw)
+            .await
+            .expect("ip-sm-gw PUT");
+        assert_eq!(resp.status, 201);
+        let resp = client.get(&reg("ip-sm-gw")).await.expect("ip-sm-gw GET");
+        assert_eq!(resp.status, 200, "GetIpSmGwRegistration must be routed");
+        assert_eq!(json_body(&resp)["ipsmgwFqdn"], "ipsmgw.example.org");
+
+        // --- criterion 4: the two spec deregistrations ---------------------
+        // POST .../amf-3gpp-access/dereg-amf, not DELETE on the resource.
+        let resp = client
+            .post_json(
+                &reg("amf-3gpp-access/dereg-amf"),
+                &serde_json::json!({ "deregReason": "SUBSCRIPTION_WITHDRAWN" }),
+            )
+            .await
+            .expect("dereg-amf POST");
+        assert_eq!(resp.status, 204, "dereg-amf must be routed");
+        let resp = client
+            .get(&reg("amf-3gpp-access"))
+            .await
+            .expect("GET after dereg");
+        assert_eq!(resp.status, 404, "the 3GPP registration is gone");
+        let resp = client
+            .get(&reg("amf-non-3gpp-access"))
+            .await
+            .expect("GET non-3gpp after 3gpp dereg");
+        assert_eq!(
+            resp.status, 200,
+            "deregistering 3GPP access must leave the non-3GPP registration"
+        );
+
+        // purgeFlag on the update PATCH deregisters (the shape amfd sends).
+        let resp = client
+            .patch_json(
+                &reg("amf-non-3gpp-access"),
+                &serde_json::json!({ "purgeFlag": true }),
+            )
+            .await
+            .expect("purge PATCH");
+        assert_eq!(resp.status, 204, "PATCH amf-non-3gpp-access must be routed");
+        let resp = client
+            .get(&reg("amf-non-3gpp-access"))
+            .await
+            .expect("GET after purge");
+        assert_eq!(resp.status, 404, "purgeFlag deregistered the UE");
+
+        udm_server.stop().await.expect("stop udm");
+        udr_server.stop().await.expect("stop udr");
+    }
+
+    // ========================================================================
+    // #84: UEAU — the authenticating AUSF is pinned, DeleteAuth is routed, and
+    // a failed SQN advance withholds the AV.
+    // ========================================================================
+
+    /// Mock UDR for the UEAU flow: serves authentication-subscription GET,
+    /// answers the SQN PATCH with a caller-controlled status, and counts
+    /// authentication-status writes/deletes.
+    #[derive(Default)]
+    struct UeauUdrState {
+        patch_status: std::sync::atomic::AtomicU16,
+        status_deletes: std::sync::atomic::AtomicUsize,
+    }
+
+    async fn mock_udr_ueau(state: Arc<UeauUdrState>, request: SbiRequest) -> SbiResponse {
+        let method = request.header.method.clone();
+        let uri = request.header.uri.clone();
+        let path = uri.split('?').next().unwrap_or(&uri).to_string();
+        if path.contains("authentication-status") {
+            if method == "DELETE" {
+                state
+                    .status_deletes
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+            return SbiResponse::with_status(204);
+        }
+        if !path.contains("authentication-subscription") {
+            return SbiResponse::with_status(404);
+        }
+        if method == "PATCH" {
+            return SbiResponse::with_status(
+                state.patch_status.load(std::sync::atomic::Ordering::SeqCst),
+            );
+        }
+        SbiResponse::with_status(200)
+            .with_json_body(&serde_json::json!({
+                "authenticationMethod": "5G_AKA",
+                "encPermanentKey": TEST_K_HEX,
+                "encOpcKey": TEST_OPC_HEX,
+                "authenticationManagementField": "8000",
+                "sequenceNumber": { "sqn": "000000000021", "sqnScheme": "NON_TIME_BASED" }
+            }))
+            .unwrap_or_else(|_| SbiResponse::with_status(500))
+    }
+
+    /// A stub AUSF that counts the Nausf_SoRProtection / UPUProtection requests
+    /// it receives. Registered in the shared SBI context under `instance_id` so
+    /// udmd's AUSF selection can resolve it.
+    async fn start_stub_ausf(
+        instance_id: &str,
+    ) -> (SbiServer, Arc<std::sync::atomic::AtomicUsize>) {
+        use nextgcore_sbi::context::{global_context, NfInstance, NfService};
+        use nextgcore_sbi::types::{NfType, SbiServiceType};
+
+        let hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = Arc::clone(&hits);
+        let port = free_port();
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        server
+            .start(move |_req: SbiRequest| {
+                let counter = Arc::clone(&counter);
+                async move {
+                    counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    // 204 with no SorSecurityInfo: the injector then withholds
+                    // (fail-closed). WHICH AUSF was asked is the whole question
+                    // here, so a successful protection is not needed.
+                    SbiResponse::with_status(204)
+                }
+            })
+            .await
+            .expect("stub AUSF starts");
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let mut instance = NfInstance::new(instance_id, NfType::Ausf);
+        instance.ipv4_addresses.push("127.0.0.1".to_string());
+        let mut svc = NfService::new("nausf-sorprotection", SbiServiceType::NausfAuth);
+        svc.versions = vec!["v1".to_string()];
+        svc.port = port;
+        instance.add_service(svc);
+        global_context().add_nf_instance(instance).await;
+        (server, hits)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn test_http_ueau_ausf_pinning_delete_auth_and_sqn_withholding() {
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _ = env_logger::try_init();
+        udm_context_init(64, 64);
+
+        let state = Arc::new(UeauUdrState::default());
+        state
+            .patch_status
+            .store(204, std::sync::atomic::Ordering::SeqCst);
+        let udr_port = free_port();
+        let udr_addr = SocketAddr::from(([127, 0, 0, 1], udr_port));
+        let udr_server = SbiServer::new(NextgcoreSbiServerConfig::new(udr_addr));
+        let handler_state = Arc::clone(&state);
+        udr_server
+            .start(move |req: SbiRequest| {
+                let state = Arc::clone(&handler_state);
+                async move { mock_udr_ueau(state, req).await }
+            })
+            .await
+            .expect("mock UDR starts");
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(udr_addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        std::env::set_var("UDR_SBI_ADDR", "127.0.0.1");
+        std::env::set_var("UDR_SBI_PORT", udr_port.to_string());
+
+        let (udm_server, client) = start_real_udm().await;
+        let supi = "imsi-001010000000001";
+        let gen_path = format!("/nudm-ueau/v1/{supi}/security-information/generate-auth-data");
+
+        // --- criterion 5a: the request's ausfInstanceId is PERSISTED ---------
+        // Two AUSFs exist; "ausf-a" is registered first, so it is what the
+        // "any cached AUSF" fallback would pick.
+        let (ausf_a_server, ausf_a_hits) = start_stub_ausf("ausf-a").await;
+        let (ausf_b_server, ausf_b_hits) = start_stub_ausf("ausf-b").await;
+
+        let resp = client
+            .post_json(
+                &gen_path,
+                &serde_json::json!({
+                    "servingNetworkName": TEST_SNN,
+                    "ausfInstanceId": "ausf-b"
+                }),
+            )
+            .await
+            .expect("generate-auth-data");
+        assert_eq!(
+            resp.status, 200,
+            "the AV is issued: {:?}",
+            resp.http.content
+        );
+        {
+            let ctx = udm_self();
+            let context = ctx.read().expect("context");
+            let ue = context.ue_find_by_supi(supi).expect("UE created");
+            assert_eq!(
+                ue.ausf_instance_id.as_deref(),
+                Some("ausf-b"),
+                "the authenticating AUSF must be recorded on the live path \
+                 (TS 33.501 §6.14.2.1: it holds K_AUSF)"
+            );
+        }
+
+        // --- criterion 5b: SoR and UPU select the RECORDED AUSF -------------
+        let am_data_sor = serde_json::json!({
+            "sorInfo": { "steeringContainer": [{ "plmnId": { "mcc": "001", "mnc": "01" } }],
+                         "ackInd": false }
+        })
+        .to_string();
+        let _ = crate::sor::maybe_inject_sor_info(supi, am_data_sor).await;
+        let am_data_upu = serde_json::json!({
+            "upuInfo": { "upuDataList": [{ "secPacket": "00" }], "upuAckInd": false }
+        })
+        .to_string();
+        let _ = crate::upu::maybe_inject_upu_info(supi, am_data_upu).await;
+
+        assert_eq!(
+            ausf_b_hits.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "both SoR and UPU protection must go to the AUSF that authenticated \
+             the UE, so the MAC is computed with the K_AUSF the UE holds"
+        );
+        assert_eq!(
+            ausf_a_hits.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the arbitrary-first-instance fallback must not fire when the \
+             authenticating AUSF is known"
+        );
+
+        // --- criterion 6: DeleteAuth round-trips the ConfirmAuth id ----------
+        let auth_event = serde_json::json!({
+            "nfInstanceId": "ausf-b",
+            "success": true,
+            "timeStamp": "2026-01-01T00:00:00Z",
+            "authType": "5G_AKA",
+            "servingNetworkName": TEST_SNN
+        });
+        let resp = client
+            .post_json(&format!("/nudm-ueau/v1/{supi}/auth-events"), &auth_event)
+            .await
+            .expect("ConfirmAuth");
+        assert_eq!(resp.status, 201);
+        let location = resp
+            .http
+            .headers
+            .get("location")
+            .cloned()
+            .expect("ConfirmAuth Location");
+        let event_id = location
+            .rsplit('/')
+            .next()
+            .expect("authEventId segment")
+            .to_string();
+        assert!(!event_id.is_empty());
+
+        // An id this UDM never issued is a 404, not a silent success.
+        let resp = client
+            .put_json(
+                &format!("/nudm-ueau/v1/{supi}/auth-events/not-the-issued-id"),
+                &auth_event,
+            )
+            .await
+            .expect("DeleteAuth wrong id");
+        assert_eq!(resp.status, 404, "an unknown authEventId must not 204");
+
+        let before = state
+            .status_deletes
+            .load(std::sync::atomic::Ordering::SeqCst);
+        let resp = client
+            .put_json(
+                &format!("/nudm-ueau/v1/{supi}/auth-events/{event_id}"),
+                &auth_event,
+            )
+            .await
+            .expect("DeleteAuth");
+        assert_eq!(
+            resp.status, 204,
+            "DeleteAuth on the issued id must be routed and accepted"
+        );
+        assert_eq!(
+            state
+                .status_deletes
+                .load(std::sync::atomic::Ordering::SeqCst),
+            before + 1,
+            "the revocation must reach the UDR authentication-status resource"
+        );
+        // Single-use: the pinned id is consumed.
+        let resp = client
+            .put_json(
+                &format!("/nudm-ueau/v1/{supi}/auth-events/{event_id}"),
+                &auth_event,
+            )
+            .await
+            .expect("DeleteAuth replay");
+        assert_eq!(resp.status, 404, "a replayed DeleteAuth finds nothing");
+
+        // --- criterion 7: a failed SQN advance withholds the AV -------------
+        state
+            .patch_status
+            .store(404, std::sync::atomic::Ordering::SeqCst);
+        let resp = client
+            .post_json(
+                &gen_path,
+                &serde_json::json!({
+                    "servingNetworkName": TEST_SNN,
+                    "ausfInstanceId": "ausf-b"
+                }),
+            )
+            .await
+            .expect("generate-auth-data with failing SQN PATCH");
+        assert_eq!(
+            resp.status, 503,
+            "a 404 on the SQN advance must withhold the AV: the stored SQN is \
+             re-read every call, so issuing would reuse it (TS 33.102 §6.3.2)"
+        );
+        let body = json_body(&resp);
+        assert!(
+            body.get("authenticationVector").is_none(),
+            "no authentication vector may be returned: {body}"
+        );
+
+        udm_server.stop().await.expect("stop udm");
+        udr_server.stop().await.expect("stop udr");
+        ausf_a_server.stop().await.expect("stop ausf-a");
+        ausf_b_server.stop().await.expect("stop ausf-b");
     }
 }
 

--- a/src/bins/nextgcore-udmd/src/context.rs
+++ b/src/bins/nextgcore-udmd/src/context.rs
@@ -129,10 +129,24 @@ pub struct UdmUe {
     pub serving_network_name: Option<String>,
     /// AUSF instance ID
     pub ausf_instance_id: Option<String>,
-    /// AMF instance ID
+    /// AMF instance ID serving the UE over **3GPP** access
     pub amf_instance_id: Option<String>,
-    /// Deregistration callback URI
+    /// Deregistration callback URI of the **3GPP**-access serving AMF
     pub dereg_callback_uri: Option<String>,
+    /// AMF instance ID serving the UE over **non-3GPP** access (#84).
+    ///
+    /// Separate from [`Self::amf_instance_id`] because `amf-3gpp-access` and
+    /// `amf-non-3gpp-access` are distinct UECM resources (TS 29.503 §6.2.3): a
+    /// UE may be registered over both at once, and a non-3GPP registration must
+    /// not evict the 3GPP one from this cache.
+    pub non_3gpp_amf_instance_id: Option<String>,
+    /// Deregistration callback URI of the **non-3GPP**-access serving AMF (#84).
+    pub non_3gpp_dereg_callback_uri: Option<String>,
+    /// Identifier of the `AuthEvent` resource created by the last ConfirmAuth
+    /// (TS 29.503 §5.4.2.3.2). Pinned so `DeleteAuth`
+    /// (`PUT /{supi}/auth-events/{authEventId}`, §5.4.2.3.3) can be matched
+    /// against the identifier the UDM actually handed out in `Location`.
+    pub auth_event_id: Option<String>,
     /// K key (16 bytes)
     pub k: [u8; NEXTGCORE_KEY_LEN],
     /// OPc key (16 bytes)
@@ -196,6 +210,9 @@ impl UdmUe {
             ausf_instance_id: None,
             amf_instance_id: None,
             dereg_callback_uri: None,
+            non_3gpp_amf_instance_id: None,
+            non_3gpp_dereg_callback_uri: None,
+            auth_event_id: None,
             k: [0u8; NEXTGCORE_KEY_LEN],
             opc: [0u8; NEXTGCORE_KEY_LEN],
             amf: [0u8; NEXTGCORE_AMF_LEN],

--- a/src/bins/nextgcore-udmd/src/lib.rs
+++ b/src/bins/nextgcore-udmd/src/lib.rs
@@ -68,13 +68,12 @@ pub mod test_support {
 // Re-export SBI path functions
 pub use sbi_path::{
     udm_ausf_send_sor_protect, udm_ausf_send_upu_protect, udm_nrf_deregister, udm_nrf_discover,
-    udm_nrf_heartbeat, udm_nrf_register, udm_nudr_dr_send_amf_context_get,
-    udm_nudr_dr_send_amf_context_patch, udm_nudr_dr_send_amf_context_put,
+    udm_nrf_heartbeat, udm_nrf_register, udm_nudr_dr_send_auth_status_delete,
     udm_nudr_dr_send_auth_status_put, udm_nudr_dr_send_auth_subscription_get,
     udm_nudr_dr_send_auth_subscription_patch, udm_nudr_dr_send_context_delete,
+    udm_nudr_dr_send_context_get, udm_nudr_dr_send_context_patch, udm_nudr_dr_send_context_put,
     udm_nudr_dr_send_provisioned_data_get, udm_nudr_dr_send_provisioned_data_get_with_params,
-    udm_nudr_dr_send_smf_context_get, udm_nudr_dr_send_smf_context_put, udm_sbi_close,
-    udm_sbi_discover_and_send_nudr_dr, udm_sbi_is_running, udm_sbi_open,
+    udm_sbi_close, udm_sbi_discover_and_send_nudr_dr, udm_sbi_is_running, udm_sbi_open,
     udm_sbi_send_dereg_notification, udm_sbi_send_request, SbiServer, SbiServerConfig, SbiXact,
 };
 

--- a/src/bins/nextgcore-udmd/src/nudm_handler.rs
+++ b/src/bins/nextgcore-udmd/src/nudm_handler.rs
@@ -5,12 +5,8 @@
 
 use crate::context::{
     udm_self, Amf3GppAccessRegistration, AuthEvent, AuthType, Guami, PlmnId, RatType,
-    SmfRegistration, UdmSdmSubscription, NEXTGCORE_RAND_LEN, NEXTGCORE_SQN_LEN,
+    SmfRegistration, UdmSdmSubscription,
 };
-use crate::nudr_handler::UdmSbiState;
-
-use nextgcore_crypt::kdf;
-use nextgcore_crypt::milenage::NEXTGCORE_AUTS_LEN;
 
 /// HTTP status codes
 pub mod http_status {
@@ -88,21 +84,6 @@ impl HandlerResult {
     }
 }
 
-/// Authentication info request data
-#[derive(Debug, Clone, Default)]
-pub struct AuthenticationInfoRequest {
-    pub serving_network_name: Option<String>,
-    pub ausf_instance_id: Option<String>,
-    pub resynchronization_info: Option<ResynchronizationInfo>,
-}
-
-/// Resynchronization info for re-sync procedure
-#[derive(Debug, Clone, Default)]
-pub struct ResynchronizationInfo {
-    pub rand: Option<String>,
-    pub auts: Option<String>,
-}
-
 /// AMF 3GPP Access Registration request
 #[derive(Debug, Clone, Default)]
 pub struct Amf3GppAccessRegistrationRequest {
@@ -162,148 +143,14 @@ pub struct AuthEventRequest {
     pub auth_removal_ind: Option<bool>,
 }
 
-/// Handle NUDM UEAU get request (security-information)
-/// Port of udm_nudm_ueau_handle_get()
-pub fn udm_nudm_ueau_handle_get(
-    udm_ue_id: u64,
-    _stream_id: u64,
-    request: &AuthenticationInfoRequest,
-) -> (HandlerResult, Option<UdmSbiState>) {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let mut udm_ue = match context.ue_find_by_id(udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found [{udm_ue_id}]");
-            return (HandlerResult::bad_request("UDM UE not found"), None);
-        }
-    };
-    drop(context);
-
-    log::debug!("[{}] Handle NUDM UEAU get request", udm_ue.suci);
-
-    // Validate AuthenticationInfoRequest
-    let serving_network_name = match &request.serving_network_name {
-        Some(name) if !name.is_empty() => name.clone(),
-        _ => {
-            log::error!("[{}] No servingNetworkName", udm_ue.suci);
-            return (HandlerResult::bad_request("No servingNetworkName"), None);
-        }
-    };
-
-    let ausf_instance_id = match &request.ausf_instance_id {
-        Some(id) if !id.is_empty() => id.clone(),
-        _ => {
-            log::error!("[{}] No ausfInstanceId", udm_ue.suci);
-            return (HandlerResult::bad_request("No ausfInstanceId"), None);
-        }
-    };
-
-    // Store serving network name and AUSF instance ID
-    udm_ue.serving_network_name = Some(serving_network_name);
-    udm_ue.ausf_instance_id = Some(ausf_instance_id);
-
-    // Update UE in context
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-    context.ue_update(&udm_ue);
-    drop(context);
-
-    // Check for resynchronization info
-    if let Some(ref resync_info) = request.resynchronization_info {
-        // Handle resynchronization procedure
-        let rand_str = match &resync_info.rand {
-            Some(r) if !r.is_empty() => r,
-            _ => {
-                log::error!("[{}] No RAND", udm_ue.suci);
-                return (HandlerResult::bad_request("No RAND"), None);
-            }
-        };
-
-        let auts_str = match &resync_info.auts {
-            Some(a) if !a.is_empty() => a,
-            _ => {
-                log::error!("[{}] No AUTS", udm_ue.suci);
-                return (HandlerResult::bad_request("No AUTS"), None);
-            }
-        };
-
-        // Convert hex strings to bytes
-        let rand_bytes = hex_to_bytes(rand_str);
-        let auts_bytes = hex_to_bytes(auts_str);
-
-        if rand_bytes.len() != NEXTGCORE_RAND_LEN {
-            log::error!("[{}] Invalid RAND length", udm_ue.suci);
-            return (HandlerResult::bad_request("Invalid RAND"), None);
-        }
-
-        // Compare RAND with stored value
-        if rand_bytes != udm_ue.rand {
-            log::error!("[{}] Invalid RAND", udm_ue.suci);
-            return (HandlerResult::bad_request("Invalid RAND"), None);
-        }
-
-        if auts_bytes.len() != NEXTGCORE_AUTS_LEN {
-            log::error!("[{}] Invalid AUTS length", udm_ue.suci);
-            return (HandlerResult::bad_request("Invalid AUTS"), None);
-        }
-
-        // Extract concealed SQN_MS from AUTS (first 6 bytes)
-        let mut conc_sqn_ms = [0u8; NEXTGCORE_SQN_LEN];
-        conc_sqn_ms.copy_from_slice(&auts_bytes[..NEXTGCORE_SQN_LEN]);
-
-        // Use nextgcore_auc_sqn() to derive SQN_MS and MAC-S from AUTS
-        // This verifies the AUTS by recomputing MAC-S with f1* and comparing
-        let rand_arr: &[u8; NEXTGCORE_RAND_LEN] = match rand_bytes.as_slice().try_into() {
-            Ok(arr) => arr,
-            Err(_) => {
-                log::error!("[{}] RAND array conversion failed", udm_ue.suci);
-                return (HandlerResult::bad_request("RAND conversion failed"), None);
-            }
-        };
-        let (sqn_ms, mac_s) =
-            match kdf::nextgcore_auc_sqn(&udm_ue.opc, &udm_ue.k, rand_arr, &conc_sqn_ms) {
-                Ok(result) => result,
-                Err(e) => {
-                    log::error!("[{}] SQN extraction failed: {:?}", udm_ue.suci, e);
-                    return (HandlerResult::bad_request("SQN extraction failed"), None);
-                }
-            };
-
-        // Verify MAC-S matches the MAC-S in AUTS (bytes 6..14)
-        if mac_s != auts_bytes[NEXTGCORE_SQN_LEN..NEXTGCORE_AUTS_LEN] {
-            log::error!("[{}] AUTS MAC-S verification failed", udm_ue.suci);
-            return (HandlerResult::bad_request("AUTS verification failed"), None);
-        }
-
-        // Set new SQN = SQN_MS + 1 (prevents replay)
-        let sqn_ms_val = buffer_to_u64(&sqn_ms);
-        let new_sqn = (sqn_ms_val + 1) & 0xFFFFFFFFFFFF;
-        let mut new_sqn_bytes = [0u8; NEXTGCORE_SQN_LEN];
-        u64_to_buffer(new_sqn, &mut new_sqn_bytes);
-
-        // Update UE with new SQN
-        let ctx = udm_self();
-        let context = ctx.read().unwrap();
-        if let Some(mut ue) = context.ue_find_by_id(udm_ue_id) {
-            ue.sqn = new_sqn_bytes;
-            context.ue_update(&ue);
-        }
-        drop(context);
-
-        log::debug!(
-            "[{}] SQN resynchronization completed (new SQN=0x{:012x})",
-            udm_ue.suci,
-            new_sqn
-        );
-    }
-
-    // Send request to UDR for authentication subscription
-    // Return state to indicate we need to query UDR
-    (HandlerResult::ok(), Some(UdmSbiState::NoState))
-}
-
+/// The dead `udm_nudm_ueau_handle_get` used to live here: a C-port handler that
+/// validated `servingNetworkName` / `ausfInstanceId`, stored them on the UE and
+/// ran AUTS resynchronisation, with NO caller anywhere in the tree. It was the
+/// only code that persisted `ausf_instance_id`, so `sor.rs` and `upu.rs` always
+/// read `None` and picked an arbitrary AUSF (#84 gap 4). The live path in
+/// `app.rs::handle_generate_auth_data` now stores it, and the dead copy is gone
+/// rather than kept as a second, unreachable implementation of the same
+/// procedure.
 /// Handle NUDM UEAU result confirmation inform (auth-events)
 /// Port of udm_nudm_ueau_handle_result_confirmation_inform()
 pub fn udm_nudm_ueau_handle_result_confirmation_inform(

--- a/src/bins/nextgcore-udmd/src/sbi_path.rs
+++ b/src/bins/nextgcore-udmd/src/sbi_path.rs
@@ -472,79 +472,67 @@ pub async fn udm_nudr_dr_send_provisioned_data_get_with_params(
 // UECM context-data persistence (Nudr_DataRepository, TS 29.505) — udmd-01/02
 // ---------------------------------------------------------------------------
 
-/// GET the stored AMF 3GPP-access registration from UDR (udmd-02 prior read).
+/// Build the UDR `context-data` URI for a resource under a SUPI.
 ///
-/// Builds: `GET /nudr-dr/v2/subscription-data/{supi}/context-data/amf-3gpp-access`
-pub async fn udm_nudr_dr_send_amf_context_get(supi: &str) -> Result<SbiResponse, String> {
-    let path = format!("/nudr-dr/v2/subscription-data/{supi}/context-data/amf-3gpp-access");
+/// `resource` is the path under `context-data/`, e.g. `amf-3gpp-access`,
+/// `amf-non-3gpp-access`, `smsf-3gpp-access`, `ip-sm-gw`, `smf-registrations`
+/// or `smf-registrations/{psi}` (TS 29.505 §5.2.2).
+fn context_data_path(supi: &str, resource: &str) -> String {
+    format!("/nudr-dr/v2/subscription-data/{supi}/context-data/{resource}")
+}
+
+/// GET a UECM `context-data` resource from UDR (#84 read-through, udmd-02
+/// prior read).
+///
+/// Builds: `GET /nudr-dr/v2/subscription-data/{supi}/context-data/{resource}`
+pub async fn udm_nudr_dr_send_context_get(
+    supi: &str,
+    resource: &str,
+) -> Result<SbiResponse, String> {
+    let path = context_data_path(supi, resource);
     udm_sbi_discover_and_send_nudr_dr(0, 0, SbiRequest::get(&path)).await
 }
 
-/// PUT the AMF 3GPP-access registration to UDR (udmd-01).
+/// PUT a UECM `context-data` resource to UDR (udmd-01).
 ///
-/// Builds: `PUT /nudr-dr/v2/subscription-data/{supi}/context-data/amf-3gpp-access`
-pub async fn udm_nudr_dr_send_amf_context_put(
+/// Builds: `PUT /nudr-dr/v2/subscription-data/{supi}/context-data/{resource}`
+pub async fn udm_nudr_dr_send_context_put(
     supi: &str,
+    resource: &str,
     body: &serde_json::Value,
 ) -> Result<SbiResponse, String> {
-    let path = format!("/nudr-dr/v2/subscription-data/{supi}/context-data/amf-3gpp-access");
+    let path = context_data_path(supi, resource);
     let request = SbiRequest::put(&path)
         .with_json_body(body)
-        .map_err(|e| format!("Failed to serialize AMF context: {e}"))?;
+        .map_err(|e| format!("Failed to serialize {resource} context: {e}"))?;
     udm_sbi_discover_and_send_nudr_dr(0, 0, request).await
 }
 
-/// PUT a per-PDU-session SMF registration to UDR (udmd-01).
+/// PATCH a UECM `context-data` resource in UDR (udmd-05: purgeFlag /
+/// modification).
 ///
-/// Builds: `PUT /nudr-dr/v2/subscription-data/{supi}/context-data/smf-registrations/{psi}`
-pub async fn udm_nudr_dr_send_smf_context_put(
+/// Builds: `PATCH /nudr-dr/v2/subscription-data/{supi}/context-data/{resource}`
+pub async fn udm_nudr_dr_send_context_patch(
     supi: &str,
-    psi: &str,
+    resource: &str,
     body: &serde_json::Value,
 ) -> Result<SbiResponse, String> {
-    let path = format!("/nudr-dr/v2/subscription-data/{supi}/context-data/smf-registrations/{psi}");
-    let request = SbiRequest::put(&path)
+    let path = context_data_path(supi, resource);
+    let request = SbiRequest::patch(&path)
         .with_json_body(body)
-        .map_err(|e| format!("Failed to serialize SMF registration: {e}"))?;
+        .map_err(|e| format!("Failed to serialize {resource} context patch: {e}"))?;
     udm_sbi_discover_and_send_nudr_dr(0, 0, request).await
 }
 
 /// DELETE a UECM context-data resource from UDR (udmd-01 deregistration).
 ///
-/// `relative_path` is the resource under `context-data/`, e.g.
-/// `amf-3gpp-access` or `smf-registrations/{psi}`. Builds:
-/// `DELETE /nudr-dr/v2/subscription-data/{supi}/context-data/{relative_path}`
+/// Builds: `DELETE /nudr-dr/v2/subscription-data/{supi}/context-data/{resource}`
 pub async fn udm_nudr_dr_send_context_delete(
     supi: &str,
-    relative_path: &str,
+    resource: &str,
 ) -> Result<SbiResponse, String> {
-    let path = format!("/nudr-dr/v2/subscription-data/{supi}/context-data/{relative_path}");
+    let path = context_data_path(supi, resource);
     udm_sbi_discover_and_send_nudr_dr(0, 0, SbiRequest::delete(&path)).await
-}
-
-/// PATCH the AMF 3GPP-access registration in UDR (udmd-05: purgeFlag / modification).
-///
-/// Builds: `PATCH /nudr-dr/v2/subscription-data/{supi}/context-data/amf-3gpp-access`
-pub async fn udm_nudr_dr_send_amf_context_patch(
-    supi: &str,
-    body: &serde_json::Value,
-) -> Result<SbiResponse, String> {
-    let path = format!("/nudr-dr/v2/subscription-data/{supi}/context-data/amf-3gpp-access");
-    let request = SbiRequest::patch(&path)
-        .with_json_body(body)
-        .map_err(|e| format!("Failed to serialize AMF context patch: {e}"))?;
-    udm_sbi_discover_and_send_nudr_dr(0, 0, request).await
-}
-
-/// GET the stored SMF registration from UDR (udmd-06: create vs update check).
-///
-/// Builds: `GET /nudr-dr/v2/subscription-data/{supi}/context-data/smf-registrations/{psi}`
-pub async fn udm_nudr_dr_send_smf_context_get(
-    supi: &str,
-    psi: &str,
-) -> Result<SbiResponse, String> {
-    let path = format!("/nudr-dr/v2/subscription-data/{supi}/context-data/smf-registrations/{psi}");
-    udm_sbi_discover_and_send_nudr_dr(0, 0, SbiRequest::get(&path)).await
 }
 
 /// PUT an AuthEvent to the UDR authentication-status resource (udmd-09).
@@ -560,6 +548,21 @@ pub async fn udm_nudr_dr_send_auth_status_put(
         .with_json_body(body)
         .map_err(|e| format!("Failed to serialize auth status body: {e}"))?;
     udm_sbi_discover_and_send_nudr_dr(0, 0, request).await
+}
+
+/// DELETE the UDR authentication-status resource for a SUPI (#84 `DeleteAuth`).
+///
+/// TS 29.503 §5.4.2.3.3: `DeleteAuth` removes the authentication result the UDM
+/// stored on `ConfirmAuth`, which lives in the UDR
+/// (`authentication-data/authentication-status`, TS 29.505 §6.3.3). The
+/// collection form is addressed because the UDM stores one status per serving
+/// network and an `authEventId` names the UDM's own resource, not a network.
+///
+/// Builds: `DELETE /nudr-dr/v2/subscription-data/{supi}/authentication-data/authentication-status`
+pub async fn udm_nudr_dr_send_auth_status_delete(supi: &str) -> Result<SbiResponse, String> {
+    let path =
+        format!("/nudr-dr/v2/subscription-data/{supi}/authentication-data/authentication-status");
+    udm_sbi_discover_and_send_nudr_dr(0, 0, SbiRequest::delete(&path)).await
 }
 
 /// Parse an absolute SBI callback URI into `(host, port, path)`.

--- a/src/bins/nextgcore-udmd/src/uecm.rs
+++ b/src/bins/nextgcore-udmd/src/uecm.rs
@@ -73,6 +73,78 @@ fn require_obj<'a>(v: &'a Value, key: &str, label: &str) -> Result<&'a Value, Pr
     }
 }
 
+/// Which AMF access-registration resource a UECM request addresses.
+///
+/// `amf-3gpp-access` and `amf-non-3gpp-access` are **distinct** resources with
+/// distinct operations (TS 29.503 §6.2.3, §5.3.2.4.2), and a UE may be
+/// registered over both at once. The access is therefore threaded through every
+/// step that names a resource — the UDR `context-data` path, the local cache
+/// slot, the `Location` header and the `DeregistrationData.accessType` — as an
+/// explicit parameter rather than defaulted, because the defect this type fixes
+/// (#84) was a non-3GPP registration silently reusing the 3GPP helper and
+/// tearing the UE's 3GPP registration down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UecmAccess {
+    /// 3GPP access (`amf-3gpp-access`, `smsf-3gpp-access`).
+    ThreeGpp,
+    /// Non-3GPP access (`amf-non-3gpp-access`, `smsf-non-3gpp-access`) — the
+    /// N3IWF / TNGF / W-AGF cases of TS 23.501 §4.2.8.
+    Non3Gpp,
+}
+
+impl UecmAccess {
+    /// The AMF-registration resource name, both as the UECM sub-resource and as
+    /// the UDR `context-data` resource (TS 29.505 §5.2.2).
+    pub fn amf_resource(self) -> &'static str {
+        match self {
+            Self::ThreeGpp => "amf-3gpp-access",
+            Self::Non3Gpp => "amf-non-3gpp-access",
+        }
+    }
+
+    /// The SMSF-registration resource name for this access.
+    pub fn smsf_resource(self) -> &'static str {
+        match self {
+            Self::ThreeGpp => "smsf-3gpp-access",
+            Self::Non3Gpp => "smsf-non-3gpp-access",
+        }
+    }
+
+    /// The TS 29.571 `AccessType` enum value for this access. Carried on the
+    /// `DeregistrationData` the old AMF keys its network-initiated
+    /// deregistration on, so it must name the access that actually changed.
+    pub fn access_type(self) -> &'static str {
+        match self {
+            Self::ThreeGpp => "3GPP_ACCESS",
+            Self::Non3Gpp => "NON_3GPP_ACCESS",
+        }
+    }
+
+    /// The `Location` URI of the AMF-registration resource for `supi`.
+    pub fn amf_location(self, supi: &str) -> String {
+        format!("/nudm-uecm/v1/{supi}/registrations/{}", self.amf_resource())
+    }
+
+    /// Resolve a UECM path segment to its access, or `None` when the segment
+    /// names neither AMF-registration resource.
+    pub fn from_amf_resource(segment: &str) -> Option<Self> {
+        match segment {
+            "amf-3gpp-access" => Some(Self::ThreeGpp),
+            "amf-non-3gpp-access" => Some(Self::Non3Gpp),
+            _ => None,
+        }
+    }
+
+    /// Resolve a UECM path segment to its access for the SMSF resources.
+    pub fn from_smsf_resource(segment: &str) -> Option<Self> {
+        match segment {
+            "smsf-3gpp-access" => Some(Self::ThreeGpp),
+            "smsf-non-3gpp-access" => Some(Self::Non3Gpp),
+            _ => None,
+        }
+    }
+}
+
 /// Validate the mandatory IEs of an `Amf3GppAccessRegistration`
 /// (TS 29.503 §6.2.6): `amfInstanceId`, `deregCallbackUri`,
 /// `guami{amfId, plmnId{mcc, mnc}}`, `ratType`.
@@ -93,6 +165,81 @@ pub fn validate_amf_3gpp_registration(body: &Value) -> Result<(), ProblemDetails
     require_str(plmn, "mcc", "Amf3GppAccessRegistration.guami.plmnId.mcc")?;
     require_str(plmn, "mnc", "Amf3GppAccessRegistration.guami.plmnId.mnc")?;
     require_str(body, "ratType", "Amf3GppAccessRegistration.ratType")?;
+    Ok(())
+}
+
+/// Validate the mandatory IEs of an `AmfNon3GppAccessRegistration`
+/// (TS 29.503 §6.2.6.2.x): the `Amf3GppAccessRegistration` set **plus**
+/// `imsVoPs`, which the non-3GPP schema additionally marks required.
+pub fn validate_amf_non_3gpp_registration(body: &Value) -> Result<(), ProblemDetails> {
+    require_str(
+        body,
+        "amfInstanceId",
+        "AmfNon3GppAccessRegistration.amfInstanceId",
+    )?;
+    require_str(
+        body,
+        "deregCallbackUri",
+        "AmfNon3GppAccessRegistration.deregCallbackUri",
+    )?;
+    let guami = require_obj(body, "guami", "AmfNon3GppAccessRegistration.guami")?;
+    require_str(guami, "amfId", "AmfNon3GppAccessRegistration.guami.amfId")?;
+    let plmn = require_obj(guami, "plmnId", "AmfNon3GppAccessRegistration.guami.plmnId")?;
+    require_str(plmn, "mcc", "AmfNon3GppAccessRegistration.guami.plmnId.mcc")?;
+    require_str(plmn, "mnc", "AmfNon3GppAccessRegistration.guami.plmnId.mnc")?;
+    require_str(body, "ratType", "AmfNon3GppAccessRegistration.ratType")?;
+    require_str(body, "imsVoPs", "AmfNon3GppAccessRegistration.imsVoPs")?;
+    Ok(())
+}
+
+/// Validate an AMF access registration for `access`.
+pub fn validate_amf_registration(body: &Value, access: UecmAccess) -> Result<(), ProblemDetails> {
+    match access {
+        UecmAccess::ThreeGpp => validate_amf_3gpp_registration(body),
+        UecmAccess::Non3Gpp => validate_amf_non_3gpp_registration(body),
+    }
+}
+
+/// Validate the mandatory IEs of an `SmsfRegistration` (TS 29.503 §6.2.6.2.9):
+/// `smsfInstanceId` and `plmnId{mcc, mnc}`.
+pub fn validate_smsf_registration(body: &Value) -> Result<(), ProblemDetails> {
+    require_str(body, "smsfInstanceId", "SmsfRegistration.smsfInstanceId")?;
+    let plmn = require_obj(body, "plmnId", "SmsfRegistration.plmnId")?;
+    require_str(plmn, "mcc", "SmsfRegistration.plmnId.mcc")?;
+    require_str(plmn, "mnc", "SmsfRegistration.plmnId.mnc")?;
+    Ok(())
+}
+
+/// The `IpSmGwRegistration` address members (TS 29.503 §6.2.6.2.16). The schema
+/// is an `anyOf` over "at least one of these is present", so the check is
+/// presence-of-any rather than a fixed required list.
+const IP_SM_GW_ADDRESS_IES: [&str; 5] = [
+    "ipSmGwMapAddress",
+    "ipSmGwDiameterAddress",
+    "ipsmgwIpv4",
+    "ipsmgwIpv6",
+    "ipsmgwFqdn",
+];
+
+/// Validate an `IpSmGwRegistration`: at least one address member must be
+/// present, else the registration names no IP-SM-GW to route to.
+pub fn validate_ip_sm_gw_registration(body: &Value) -> Result<(), ProblemDetails> {
+    if !body.is_object() {
+        return Err(ProblemDetails::mandatory_ie_missing(
+            "IpSmGwRegistration must be a JSON object",
+        ));
+    }
+    let has_address = IP_SM_GW_ADDRESS_IES.iter().any(|ie| match body.get(*ie) {
+        None | Some(Value::Null) => false,
+        Some(Value::String(s)) => !s.is_empty(),
+        Some(_) => true,
+    });
+    if !has_address {
+        return Err(ProblemDetails::mandatory_ie_missing(format!(
+            "IpSmGwRegistration requires one of: {}",
+            IP_SM_GW_ADDRESS_IES.join(", ")
+        )));
+    }
     Ok(())
 }
 
@@ -131,62 +278,61 @@ pub enum UdrClient {
 }
 
 impl UdrClient {
-    async fn amf_context_get(&self, supi: &str) -> Result<SbiResponse, String> {
+    /// GET a `context-data` resource. `resource` is the path under
+    /// `context-data/`, e.g. `amf-non-3gpp-access` or `smf-registrations/5`.
+    ///
+    /// One generic accessor per verb rather than one pair per resource: the #84
+    /// overwrite existed because `amf_context_put` hardcoded
+    /// `amf-3gpp-access`, and a hardcoded resource cannot be got wrong twice if
+    /// there is nowhere left to hardcode it.
+    async fn context_get(&self, supi: &str, resource: &str) -> Result<SbiResponse, String> {
         match self {
-            UdrClient::Live => crate::sbi_path::udm_nudr_dr_send_amf_context_get(supi).await,
+            UdrClient::Live => crate::sbi_path::udm_nudr_dr_send_context_get(supi, resource).await,
             #[cfg(test)]
-            UdrClient::Mock(m) => Ok(m.amf_context_get(supi)),
+            UdrClient::Mock(m) => Ok(m.context_get(supi, resource)),
         }
     }
 
-    async fn amf_context_put(&self, supi: &str, body: &Value) -> Result<SbiResponse, String> {
-        match self {
-            UdrClient::Live => crate::sbi_path::udm_nudr_dr_send_amf_context_put(supi, body).await,
-            #[cfg(test)]
-            UdrClient::Mock(m) => Ok(m.amf_context_put(supi, body)),
-        }
-    }
-
-    async fn smf_context_put(
+    /// PUT a `context-data` resource.
+    async fn context_put(
         &self,
         supi: &str,
-        psi: &str,
+        resource: &str,
         body: &Value,
     ) -> Result<SbiResponse, String> {
         match self {
             UdrClient::Live => {
-                crate::sbi_path::udm_nudr_dr_send_smf_context_put(supi, psi, body).await
+                crate::sbi_path::udm_nudr_dr_send_context_put(supi, resource, body).await
             }
             #[cfg(test)]
-            UdrClient::Mock(m) => Ok(m.smf_context_put(supi, psi, body)),
+            UdrClient::Mock(m) => Ok(m.context_put(supi, resource, body)),
         }
     }
 
-    async fn context_delete(&self, supi: &str, relative_path: &str) -> Result<SbiResponse, String> {
+    /// PATCH a `context-data` resource.
+    async fn context_patch(
+        &self,
+        supi: &str,
+        resource: &str,
+        body: &Value,
+    ) -> Result<SbiResponse, String> {
         match self {
             UdrClient::Live => {
-                crate::sbi_path::udm_nudr_dr_send_context_delete(supi, relative_path).await
+                crate::sbi_path::udm_nudr_dr_send_context_patch(supi, resource, body).await
             }
             #[cfg(test)]
-            UdrClient::Mock(m) => Ok(m.context_delete(supi, relative_path)),
+            UdrClient::Mock(m) => Ok(m.context_patch(supi, resource, body)),
         }
     }
 
-    async fn amf_context_patch(&self, supi: &str, body: &Value) -> Result<SbiResponse, String> {
+    /// DELETE a `context-data` resource.
+    async fn context_delete(&self, supi: &str, resource: &str) -> Result<SbiResponse, String> {
         match self {
             UdrClient::Live => {
-                crate::sbi_path::udm_nudr_dr_send_amf_context_patch(supi, body).await
+                crate::sbi_path::udm_nudr_dr_send_context_delete(supi, resource).await
             }
             #[cfg(test)]
-            UdrClient::Mock(m) => Ok(m.amf_context_patch(supi, body)),
-        }
-    }
-
-    async fn smf_context_get(&self, supi: &str, psi: &str) -> Result<SbiResponse, String> {
-        match self {
-            UdrClient::Live => crate::sbi_path::udm_nudr_dr_send_smf_context_get(supi, psi).await,
-            #[cfg(test)]
-            UdrClient::Mock(m) => Ok(m.smf_context_get(supi, psi)),
+            UdrClient::Mock(m) => Ok(m.context_delete(supi, resource)),
         }
     }
 
@@ -209,9 +355,14 @@ impl UdrClient {
 // Live UECM handlers (validate -> persist -> notify)
 // ---------------------------------------------------------------------------
 
-/// Read the prior AMF registration: UDR first (udmd-02), then the local cache.
-async fn read_prior_amf_registration(supi: &str, client: &UdrClient) -> Option<Value> {
-    if let Ok(resp) = client.amf_context_get(supi).await {
+/// Read the prior AMF registration for `access`: UDR first (udmd-02), then the
+/// local cache.
+async fn read_prior_amf_registration(
+    supi: &str,
+    client: &UdrClient,
+    access: UecmAccess,
+) -> Option<Value> {
+    if let Ok(resp) = client.context_get(supi, access.amf_resource()).await {
         if resp.is_success() {
             if let Some(v) = resp
                 .http
@@ -223,42 +374,63 @@ async fn read_prior_amf_registration(supi: &str, client: &UdrClient) -> Option<V
             }
         }
     }
-    cached_prior_amf_registration(supi)
+    cached_prior_amf_registration(supi, access)
 }
 
 /// Local-cache fallback for the prior AMF registration (amfInstanceId +
 /// deregCallbackUri), used when UDR has no stored context-data.
-fn cached_prior_amf_registration(supi: &str) -> Option<Value> {
+///
+/// Reads the cache slot for `access`: a UE registered over both accesses has two
+/// serving AMFs, and answering the non-3GPP question with the 3GPP AMF would
+/// send that AMF a deregistration for a registration it never lost.
+fn cached_prior_amf_registration(supi: &str, access: UecmAccess) -> Option<Value> {
     let ctx = udm_self();
     let context = ctx.read().ok()?;
     let ue = context.ue_find_by_supi(supi)?;
-    let amf_id = ue.amf_instance_id.clone()?;
+    let (amf_id, callback) = match access {
+        UecmAccess::ThreeGpp => (ue.amf_instance_id.clone()?, ue.dereg_callback_uri),
+        UecmAccess::Non3Gpp => (
+            ue.non_3gpp_amf_instance_id.clone()?,
+            ue.non_3gpp_dereg_callback_uri,
+        ),
+    };
     Some(json!({
         "amfInstanceId": amf_id,
-        "deregCallbackUri": ue.dereg_callback_uri,
+        "deregCallbackUri": callback,
     }))
 }
 
 /// Cache the serving-AMF identity locally so udmd-02 still works when UDR does
-/// not persist context-data.
-fn cache_amf_registration(supi: &str, body: &Value) {
+/// not persist context-data. `None` clears the slot (deregistration).
+fn cache_amf_registration(supi: &str, body: Option<&Value>, access: UecmAccess) {
     let ctx = udm_self();
     let context = match ctx.read() {
         Ok(c) => c,
         Err(_) => return,
     };
+    // A clear (`body == None`) never creates a UE: it would be created only to
+    // be removed again by the deregistration that asked for the clear.
     let ue = context
         .ue_find_by_supi(supi)
-        .or_else(|| context.ue_add(supi));
+        .or_else(|| body.and_then(|_| context.ue_add(supi)));
     if let Some(mut ue) = ue {
-        ue.amf_instance_id = body
-            .get("amfInstanceId")
-            .and_then(|v| v.as_str())
-            .map(String::from);
-        ue.dereg_callback_uri = body
-            .get("deregCallbackUri")
-            .and_then(|v| v.as_str())
-            .map(String::from);
+        let field = |key: &str| {
+            body.and_then(|b| b.get(key))
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        };
+        let amf_instance_id = field("amfInstanceId");
+        let dereg_callback_uri = field("deregCallbackUri");
+        match access {
+            UecmAccess::ThreeGpp => {
+                ue.amf_instance_id = amf_instance_id;
+                ue.dereg_callback_uri = dereg_callback_uri;
+            }
+            UecmAccess::Non3Gpp => {
+                ue.non_3gpp_amf_instance_id = amf_instance_id;
+                ue.non_3gpp_dereg_callback_uri = dereg_callback_uri;
+            }
+        }
         context.ue_update(&ue);
     }
 }
@@ -266,17 +438,26 @@ fn cache_amf_registration(supi: &str, body: &Value) {
 /// Build the Nudm_UECM `DeregistrationData` notification body (TS 29.503
 /// §5.3.2.3.2): `deregReason` + `accessType`. Both members are mandatory — the
 /// old AMF's dereg-notify handler keys its network-initiated deregistration on
-/// `accessType` (WSB-4), so it must be present on the wire. The old AMF's
-/// registration was superseded by a fresh UE initial registration in the new
-/// AMF over 3GPP access. Exposed so peer NF crates (amfd) can drive the exact
-/// wire body through their real handler in strict-peer tests.
-pub fn build_dereg_notification_body() -> Value {
-    json!({ "deregReason": "UE_INITIAL_REGISTRATION", "accessType": "3GPP_ACCESS" })
+/// `accessType` (WSB-4), so it must be present on the wire, and it must name the
+/// access whose registration was actually superseded: a 3GPP-access value on a
+/// non-3GPP re-registration makes the old AMF tear down a 3GPP registration
+/// that is still live (#84). The old AMF's registration was superseded by a
+/// fresh UE initial registration in the new AMF over that access. Exposed so
+/// peer NF crates (amfd) can drive the exact wire body through their real
+/// handler in strict-peer tests.
+pub fn build_dereg_notification_body(access: UecmAccess) -> Value {
+    json!({ "deregReason": "UE_INITIAL_REGISTRATION", "accessType": access.access_type() })
 }
 
 /// udmd-02: notify the old AMF if the serving AMF changed; suppress when the new
 /// amfInstanceId equals the old one.
-async fn notify_old_amf_if_changed(supi: &str, prior: &Value, new: &Value, client: &UdrClient) {
+async fn notify_old_amf_if_changed(
+    supi: &str,
+    prior: &Value,
+    new: &Value,
+    client: &UdrClient,
+    access: UecmAccess,
+) {
     let old_id = prior.get("amfInstanceId").and_then(|v| v.as_str());
     let new_id = new.get("amfInstanceId").and_then(|v| v.as_str());
     let old_uri = prior.get("deregCallbackUri").and_then(|v| v.as_str());
@@ -288,7 +469,7 @@ async fn notify_old_amf_if_changed(supi: &str, prior: &Value, new: &Value, clien
         // Suppression rule (TS 29.503 §5.3.2.2.2): same serving AMF, no notify.
         return;
     }
-    let dereg = build_dereg_notification_body();
+    let dereg = build_dereg_notification_body(access);
     match client.send_dereg_notification(old_uri, &dereg).await {
         Ok(resp) => log::info!(
             "[{supi}] Deregistration notification to old AMF {old_uri} -> {}",
@@ -339,16 +520,32 @@ fn guami_matches(a: &Value, b: &Value) -> bool {
             == b.pointer("/plmnId/mnc").and_then(|x| x.as_str())
 }
 
-/// Process an AMF 3GPP-access registration PUT (udmd-03/01/02/06).
-pub async fn process_amf_registration(supi: &str, body: &Value, client: &UdrClient) -> SbiResponse {
+/// Process an AMF access registration PUT for `access`
+/// (udmd-03/01/02/06; TS 29.503 §5.3.2.2.2 `3GppRegistration` /
+/// §5.3.2.4.2 `Non3GppRegistration`).
+///
+/// `access` selects the resource end to end — validation schema, UDR
+/// `context-data` resource, cache slot, `Location` and the
+/// `DeregistrationData.accessType` — so a non-3GPP registration cannot touch the
+/// 3GPP one (#84).
+pub async fn process_amf_registration(
+    supi: &str,
+    body: &Value,
+    client: &UdrClient,
+    access: UecmAccess,
+) -> SbiResponse {
     // udmd-03: reject payloads missing any mandatory IE.
-    if let Err(problem) = validate_amf_3gpp_registration(body) {
-        log::warn!("[{supi}] AMF registration rejected: {}", problem.detail);
+    if let Err(problem) = validate_amf_registration(body, access) {
+        log::warn!(
+            "[{supi}] AMF {} registration rejected: {}",
+            access.amf_resource(),
+            problem.detail
+        );
         return problem.into_response();
     }
 
     // udmd-02: read the prior registration before overwriting.
-    let prior = read_prior_amf_registration(supi, client).await;
+    let prior = read_prior_amf_registration(supi, client, access).await;
     // udmd-06: remember whether a prior registration existed for status-code choice.
     let is_update = prior.is_some();
 
@@ -356,18 +553,18 @@ pub async fn process_amf_registration(supi: &str, body: &Value, client: &UdrClie
     if let Some(resp) = udr_write_outcome(
         supi,
         "AMF context PUT",
-        client.amf_context_put(supi, body).await,
+        client.context_put(supi, access.amf_resource(), body).await,
     ) {
         return resp;
     }
 
     // udmd-02: notify the old AMF if the serving AMF changed.
     if let Some(prior) = prior {
-        notify_old_amf_if_changed(supi, &prior, body, client).await;
+        notify_old_amf_if_changed(supi, &prior, body, client, access).await;
     }
 
     // Local cache (UDR is the system of record).
-    cache_amf_registration(supi, body);
+    cache_amf_registration(supi, Some(body), access);
 
     // #83: the UE's AMF context data set just changed, so SDM subscribers
     // monitoring it get a ModificationNotification and EE subscribers get a
@@ -396,58 +593,117 @@ pub async fn process_amf_registration(supi: &str, body: &Value, client: &UdrClie
         }))
         .unwrap_or_else(|_| SbiResponse::with_status(status));
     if status == 201 {
-        resp = resp.with_header(
-            "Location",
-            format!("/nudm-uecm/v1/{supi}/registrations/amf-3gpp-access"),
-        );
+        resp = resp.with_header("Location", access.amf_location(supi));
     }
     resp
 }
 
-/// Process a PATCH to the AMF 3GPP-access registration (udmd-05).
+/// Read a `context-data` resource and parse it, mapping the UDR outcome to the
+/// UECM read semantics: `Ok(Some(doc))` when stored, `Ok(None)` when UDR says
+/// 404, `Err(response)` when UDR could not answer.
+///
+/// Shared by every UECM GET so a UDR fault is never reported to the consumer as
+/// "not registered" — the distinction the read handlers below depend on.
+async fn read_context_resource(
+    supi: &str,
+    client: &UdrClient,
+    resource: &str,
+) -> Result<Option<Value>, SbiResponse> {
+    match client.context_get(supi, resource).await {
+        Ok(resp) if resp.is_success() => match resp
+            .http
+            .content
+            .as_deref()
+            .and_then(|b| serde_json::from_str::<Value>(b).ok())
+        {
+            Some(v) => Ok(Some(v)),
+            None => {
+                log::error!("[{supi}] UDR {resource} GET returned unparseable body");
+                Err(nextgcore_sbi::server::send_service_unavailable(
+                    "UDR response invalid",
+                ))
+            }
+        },
+        Ok(resp) if resp.status == 404 => Ok(None),
+        Ok(resp) => {
+            log::error!("[{supi}] UDR {resource} GET returned {}", resp.status);
+            Err(nextgcore_sbi::server::send_service_unavailable(
+                "UDR context GET failed",
+            ))
+        }
+        Err(e) => {
+            log::warn!("[{supi}] UDR {resource} GET failed: {e}");
+            Err(nextgcore_sbi::server::send_service_unavailable(
+                "UDR unavailable",
+            ))
+        }
+    }
+}
+
+/// A `404 CONTEXT_NOT_FOUND` for an addressed-but-unregistered UECM resource.
+fn context_not_found(resource: &str) -> SbiResponse {
+    ProblemDetails {
+        status: 404,
+        cause: "CONTEXT_NOT_FOUND".to_string(),
+        detail: format!("No {resource} registration stored for this UE"),
+    }
+    .into_response()
+}
+
+/// Process a GET of an AMF access registration (TS 29.503 §5.3.2.5
+/// `Get3GppRegistration` / `GetNon3GppRegistration`): read-through to the UDR
+/// `context-data` resource for `access`.
+pub async fn process_amf_registration_get(
+    supi: &str,
+    client: &UdrClient,
+    access: UecmAccess,
+) -> SbiResponse {
+    match read_context_resource(supi, client, access.amf_resource()).await {
+        Ok(Some(doc)) => SbiResponse::with_status(200)
+            .with_json_body(&doc)
+            .unwrap_or_else(|_| nextgcore_sbi::server::send_internal_error("serialize failed")),
+        Ok(None) => context_not_found(access.amf_resource()),
+        Err(resp) => resp,
+    }
+}
+
+/// Process a PATCH to an AMF access registration (udmd-05; TS 29.503
+/// §5.3.2.4.2 `UpdateAmfRegistration` / `UpdateNon3GppRegistration`).
 ///
 /// Validates that the GUAMI in the PATCH body matches the stored registration
 /// (ownership check, TS 29.503 §5.3.2.4); applies the update to UDR on match.
+/// A `purgeFlag` of `true` is a **deregistration**, not a field update: TS 29.503
+/// §5.3.2.4.2 defines it as the AMF telling the UDM the UE's context is gone, so
+/// leaving the registration in place after acknowledging it (as this handler did
+/// before #84) makes the UDM keep answering with a serving AMF that has already
+/// released the UE.
 pub async fn process_amf_registration_update(
     supi: &str,
     body: &Value,
     client: &UdrClient,
+    access: UecmAccess,
 ) -> SbiResponse {
     // Read the stored registration.
-    let stored = match client.amf_context_get(supi).await {
-        Ok(resp) if resp.is_success() => {
-            match resp
-                .http
-                .content
-                .as_deref()
-                .and_then(|b| serde_json::from_str::<Value>(b).ok())
-            {
-                Some(v) => v,
-                None => {
-                    log::error!("[{supi}] UDR AMF context GET returned unparseable body");
-                    return nextgcore_sbi::server::send_service_unavailable("UDR response invalid");
-                }
-            }
-        }
-        Ok(resp) if resp.status == 404 => {
+    let stored = match read_context_resource(supi, client, access.amf_resource()).await {
+        Ok(Some(v)) => v,
+        Ok(None) => {
             return ProblemDetails {
                 status: 404,
-                cause: "NOT_FOUND".to_string(),
+                cause: "CONTEXT_NOT_FOUND".to_string(),
                 detail: "No AMF registration found for this SUPI".to_string(),
             }
             .into_response();
         }
-        Ok(resp) => {
-            log::error!("[{supi}] UDR AMF context GET returned {}", resp.status);
-            return nextgcore_sbi::server::send_service_unavailable("UDR context GET failed");
-        }
-        Err(e) => {
-            log::warn!("[{supi}] UDR AMF context GET failed: {e} (no prior stored)");
-            return nextgcore_sbi::server::send_service_unavailable("UDR unavailable");
-        }
+        Err(resp) => return resp,
     };
 
     // GUAMI ownership check (TS 29.503 §5.3.2.4).
+    //
+    // Checked only when the PATCH carries a GUAMI. The IE is required by the
+    // `Amf3GppAccessRegistrationModification` schema, but the repo's own AMF
+    // sends a bare `{"purgeFlag": true}` on deregistration, and refusing that
+    // would turn a working deregistration into a 400 — so an absent GUAMI is
+    // accepted and only a *disagreeing* one is refused.
     if let (Some(stored_guami), Some(req_guami)) = (stored.get("guami"), body.get("guami")) {
         if !guami_matches(stored_guami, req_guami) {
             log::warn!("[{supi}] PATCH rejected: GUAMI mismatch");
@@ -460,16 +716,53 @@ pub async fn process_amf_registration_update(
         }
     }
 
+    // purgeFlag == true is a deregistration (TS 29.503 §5.3.2.4.2), so the
+    // resource is removed rather than patched.
+    if body.get("purgeFlag").and_then(|v| v.as_bool()) == Some(true) {
+        log::info!(
+            "[{supi}] UECM PATCH carries purgeFlag -> deregistering {}",
+            access.amf_resource()
+        );
+        return process_amf_deregistration(supi, client, access).await;
+    }
+
     // Apply the PATCH to UDR.
     if let Some(err_resp) = udr_write_outcome(
         supi,
         "AMF context PATCH",
-        client.amf_context_patch(supi, body).await,
+        client
+            .context_patch(supi, access.amf_resource(), body)
+            .await,
     ) {
         return err_resp;
     }
 
     SbiResponse::with_status(204)
+}
+
+/// Process a `POST .../registrations/amf-3gpp-access/dereg-amf` (TS 29.503
+/// §5.3.2.4.2 `DeregAMF`), the spec-defined AMF deregistration.
+///
+/// The body is an `AmfDeregInfo`, whose only member — `deregReason` — is
+/// mandatory. It is validated rather than ignored because the reason is the
+/// only thing distinguishing this from an accidental POST, and a 204 for a
+/// bodyless request would report a deregistration the consumer did not describe.
+pub async fn process_dereg_amf(supi: &str, body: &Value, client: &UdrClient) -> SbiResponse {
+    if let Err(problem) = require_str(body, "deregReason", "AmfDeregInfo.deregReason") {
+        log::warn!("[{supi}] dereg-amf rejected: {}", problem.detail);
+        return problem.into_response();
+    }
+    let reason = body
+        .get("deregReason")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    log::info!("[{supi}] UECM dereg-amf (deregReason={reason})");
+    process_amf_deregistration(supi, client, UecmAccess::ThreeGpp).await
+}
+
+/// The UDR `context-data` resource for one PDU session's SMF registration.
+fn smf_registration_resource(pdu_session_id: &str) -> String {
+    format!("smf-registrations/{pdu_session_id}")
 }
 
 /// Process an SMF registration PUT (udmd-03/01/06).
@@ -485,9 +778,11 @@ pub async fn process_smf_registration(
         return problem.into_response();
     }
 
+    let resource = smf_registration_resource(pdu_session_id);
+
     // udmd-06: check whether a prior registration exists.
     let is_update = matches!(
-        client.smf_context_get(supi, pdu_session_id).await,
+        client.context_get(supi, &resource).await,
         Ok(resp) if resp.is_success()
     );
 
@@ -495,7 +790,7 @@ pub async fn process_smf_registration(
     if let Some(resp) = udr_write_outcome(
         supi,
         "SMF context PUT",
-        client.smf_context_put(supi, pdu_session_id, body).await,
+        client.context_put(supi, &resource, body).await,
     ) {
         return resp;
     }
@@ -528,18 +823,31 @@ pub async fn process_smf_registration(
     resp
 }
 
-/// Process an AMF deregistration DELETE (udmd-01): purge UDR context-data, then
-/// return 204.
-pub async fn process_amf_deregistration(supi: &str, client: &UdrClient) -> SbiResponse {
-    if let Err(e) = client.context_delete(supi, "amf-3gpp-access").await {
+/// Process an AMF deregistration for `access` (udmd-01): purge the UDR
+/// context-data resource for that access, then return 204.
+///
+/// The local UE context is only dropped once **neither** access holds a
+/// registration: a UE deregistering from non-3GPP access while still registered
+/// over 3GPP must keep its cached 3GPP serving AMF, or the next 3GPP
+/// re-registration cannot find an old AMF to notify.
+pub async fn process_amf_deregistration(
+    supi: &str,
+    client: &UdrClient,
+    access: UecmAccess,
+) -> SbiResponse {
+    if let Err(e) = client.context_delete(supi, access.amf_resource()).await {
         log::warn!("[{supi}] UDR AMF context DELETE failed: {e} (degraded)");
     }
 
-    // Local cache cleanup (mirror legacy behavior).
+    // Local cache cleanup: clear this access's slot, and drop the UE entirely
+    // only when the other access is not registered either.
+    cache_amf_registration(supi, None, access);
     let ctx = udm_self();
     if let Ok(context) = ctx.read() {
         if let Some(ue) = context.ue_find_by_supi(supi) {
-            context.ue_remove(ue.id);
+            if ue.amf_instance_id.is_none() && ue.non_3gpp_amf_instance_id.is_none() {
+                context.ue_remove(ue.id);
+            }
         }
     }
 
@@ -562,7 +870,7 @@ pub async fn process_smf_deregistration(
     pdu_session_id: &str,
     client: &UdrClient,
 ) -> SbiResponse {
-    let relative = format!("smf-registrations/{pdu_session_id}");
+    let relative = smf_registration_resource(pdu_session_id);
     if let Err(e) = client.context_delete(supi, &relative).await {
         log::warn!("[{supi}] UDR SMF context DELETE failed: {e} (degraded)");
     }
@@ -574,37 +882,299 @@ pub async fn process_smf_deregistration(
     SbiResponse::with_status(204)
 }
 
+/// Process a GET of one PDU session's SMF registration (TS 29.503 §5.3.2.5).
+pub async fn process_smf_registration_get(
+    supi: &str,
+    pdu_session_id: &str,
+    client: &UdrClient,
+) -> SbiResponse {
+    let resource = smf_registration_resource(pdu_session_id);
+    match read_context_resource(supi, client, &resource).await {
+        Ok(Some(doc)) => SbiResponse::with_status(200)
+            .with_json_body(&doc)
+            .unwrap_or_else(|_| nextgcore_sbi::server::send_internal_error("serialize failed")),
+        Ok(None) => context_not_found(&resource),
+        Err(resp) => resp,
+    }
+}
+
+/// Process a GET of the SMF-registration **collection** (TS 29.503 §5.3.2.5
+/// `GetSmfRegistration`), returning an `SmfRegistrationInfo`.
+///
+/// The UDR collection resource answers with a bare JSON array (TS 29.505), while
+/// the UECM operation is defined to return the `SmfRegistrationInfo` object with
+/// its `smfRegistrationList` member — so the wrap happens here rather than
+/// forwarding the UDR shape and hoping the consumer is lenient. An empty list is
+/// a 404: `smfRegistrationList` has `minItems: 1`, so "registered for nothing"
+/// is not a representable answer.
+pub async fn process_smf_registrations_get(supi: &str, client: &UdrClient) -> SbiResponse {
+    let doc = match read_context_resource(supi, client, "smf-registrations").await {
+        Ok(Some(doc)) => doc,
+        Ok(None) => return context_not_found("smf-registrations"),
+        Err(resp) => return resp,
+    };
+    // Accept both the UDR array form and an already-wrapped object, so a UDR
+    // that grows the object form later does not double-wrap.
+    let list = match &doc {
+        Value::Array(items) => items.clone(),
+        Value::Object(_) => match doc.get("smfRegistrationList").and_then(|v| v.as_array()) {
+            Some(items) => items.clone(),
+            // A single SmfRegistration document: treat as a one-element list.
+            None => vec![doc.clone()],
+        },
+        _ => {
+            log::error!("[{supi}] UDR smf-registrations returned neither array nor object");
+            return nextgcore_sbi::server::send_service_unavailable("UDR response invalid");
+        }
+    };
+    if list.is_empty() {
+        return context_not_found("smf-registrations");
+    }
+    SbiResponse::with_status(200)
+        .with_json_body(&json!({ "smfRegistrationList": list }))
+        .unwrap_or_else(|_| nextgcore_sbi::server::send_internal_error("serialize failed"))
+}
+
+/// Process a GET of the UE's location information (TS 29.503 §5.3.2.5
+/// `GetLocationInfo`), returning a `LocationInfo`.
+///
+/// Composed from the stored AMF registrations rather than read from a UDR
+/// resource of its own, because that is what the IE holds: `LocationInfo` is a
+/// list of `RegistrationLocationInfo`, each naming the serving AMF and the
+/// access types it serves. One AMF serving both accesses therefore yields ONE
+/// entry with two `accessTypeList` members — not two entries — which is also
+/// what keeps the list inside its `maxItems: 2` bound.
+pub async fn process_location_info_get(supi: &str, client: &UdrClient) -> SbiResponse {
+    let three_gpp = read_context_resource(supi, client, UecmAccess::ThreeGpp.amf_resource()).await;
+    let non_3gpp = read_context_resource(supi, client, UecmAccess::Non3Gpp.amf_resource()).await;
+    // A UDR fault on either read is reported as such: answering with a partial
+    // location would claim the UE is registered over one access only.
+    let three_gpp = match three_gpp {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let non_3gpp = match non_3gpp {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    let mut entries: Vec<Value> = Vec::new();
+    for (reg, access) in [
+        (three_gpp, UecmAccess::ThreeGpp),
+        (non_3gpp, UecmAccess::Non3Gpp),
+    ] {
+        let Some(reg) = reg else { continue };
+        let Some(amf_instance_id) = reg.get("amfInstanceId").and_then(|v| v.as_str()) else {
+            log::warn!(
+                "[{supi}] stored {} registration has no amfInstanceId — omitted from LocationInfo",
+                access.amf_resource()
+            );
+            continue;
+        };
+        // Same AMF on both accesses -> one entry carrying both access types.
+        if let Some(existing) = entries
+            .iter_mut()
+            .find(|e| e.get("amfInstanceId").and_then(|v| v.as_str()) == Some(amf_instance_id))
+        {
+            if let Some(list) = existing
+                .get_mut("accessTypeList")
+                .and_then(|v| v.as_array_mut())
+            {
+                list.push(json!(access.access_type()));
+            }
+            continue;
+        }
+        let mut entry = json!({
+            "amfInstanceId": amf_instance_id,
+            "accessTypeList": [access.access_type()],
+        });
+        if let (Some(obj), Some(guami)) = (entry.as_object_mut(), reg.get("guami")) {
+            obj.insert("guami".to_string(), guami.clone());
+            if let Some(plmn) = guami.get("plmnId") {
+                obj.insert("plmnId".to_string(), plmn.clone());
+            }
+        }
+        entries.push(entry);
+    }
+
+    if entries.is_empty() {
+        return context_not_found("location");
+    }
+    let mut info = json!({ "registrationLocationInfoList": entries, "supi": supi });
+    if let (Some(obj), Some(gpsi)) = (info.as_object_mut(), cached_gpsi(supi)) {
+        obj.insert("gpsi".to_string(), json!(gpsi));
+    }
+    SbiResponse::with_status(200)
+        .with_json_body(&info)
+        .unwrap_or_else(|_| nextgcore_sbi::server::send_internal_error("serialize failed"))
+}
+
+/// The UE's GPSI, if the UDM happens to hold one.
+///
+/// Always `None` today: the UDM never learns a GPSI, which is its own tracked
+/// defect (#205 on the AMF side, #85 for the UDM's identifier translation). The
+/// hook exists so `LocationInfo.gpsi` is populated the moment a GPSI is
+/// available rather than fabricating one from the SUPI, which would be a
+/// different subscriber identity.
+fn cached_gpsi(_supi: &str) -> Option<String> {
+    None
+}
+
+/// Process an SMSF registration PUT for `access` (TS 29.503 §5.3.2.x
+/// `3GppSmsfRegistration` / `Non3GppSmsfRegistration`).
+pub async fn process_smsf_registration(
+    supi: &str,
+    body: &Value,
+    client: &UdrClient,
+    access: UecmAccess,
+) -> SbiResponse {
+    if let Err(problem) = validate_smsf_registration(body) {
+        log::warn!("[{supi}] SMSF registration rejected: {}", problem.detail);
+        return problem.into_response();
+    }
+    let resource = access.smsf_resource();
+    let is_update = matches!(
+        client.context_get(supi, resource).await,
+        Ok(resp) if resp.is_success()
+    );
+    if let Some(resp) = udr_write_outcome(
+        supi,
+        "SMSF context PUT",
+        client.context_put(supi, resource, body).await,
+    ) {
+        return resp;
+    }
+    let status = if is_update { 200 } else { 201 };
+    let mut resp = SbiResponse::with_status(status)
+        .with_json_body(body)
+        .unwrap_or_else(|_| SbiResponse::with_status(status));
+    if status == 201 {
+        resp = resp.with_header(
+            "Location",
+            format!("/nudm-uecm/v1/{supi}/registrations/{resource}"),
+        );
+    }
+    resp
+}
+
+/// Process an SMSF registration GET for `access` (TS 29.503
+/// `Get3GppSmsfRegistration` / `GetNon3GppSmsfRegistration`).
+pub async fn process_smsf_registration_get(
+    supi: &str,
+    client: &UdrClient,
+    access: UecmAccess,
+) -> SbiResponse {
+    match read_context_resource(supi, client, access.smsf_resource()).await {
+        Ok(Some(doc)) => SbiResponse::with_status(200)
+            .with_json_body(&doc)
+            .unwrap_or_else(|_| nextgcore_sbi::server::send_internal_error("serialize failed")),
+        Ok(None) => context_not_found(access.smsf_resource()),
+        Err(resp) => resp,
+    }
+}
+
+/// Process an SMSF deregistration DELETE for `access`
+/// (`3GppSmsfDeregistration` / `Non3GppSmsfDeregistration`).
+pub async fn process_smsf_deregistration(
+    supi: &str,
+    client: &UdrClient,
+    access: UecmAccess,
+) -> SbiResponse {
+    if let Err(e) = client.context_delete(supi, access.smsf_resource()).await {
+        log::warn!("[{supi}] UDR SMSF context DELETE failed: {e} (degraded)");
+    }
+    SbiResponse::with_status(204)
+}
+
+/// The UDR `context-data` resource holding the IP-SM-GW registration.
+const IP_SM_GW_RESOURCE: &str = "ip-sm-gw";
+
+/// Process an IP-SM-GW registration PUT (TS 29.503 `IpSmGwRegistration`).
+pub async fn process_ip_sm_gw_registration(
+    supi: &str,
+    body: &Value,
+    client: &UdrClient,
+) -> SbiResponse {
+    if let Err(problem) = validate_ip_sm_gw_registration(body) {
+        log::warn!(
+            "[{supi}] IP-SM-GW registration rejected: {}",
+            problem.detail
+        );
+        return problem.into_response();
+    }
+    let is_update = matches!(
+        client.context_get(supi, IP_SM_GW_RESOURCE).await,
+        Ok(resp) if resp.is_success()
+    );
+    if let Some(resp) = udr_write_outcome(
+        supi,
+        "IP-SM-GW context PUT",
+        client.context_put(supi, IP_SM_GW_RESOURCE, body).await,
+    ) {
+        return resp;
+    }
+    let status = if is_update { 200 } else { 201 };
+    let mut resp = SbiResponse::with_status(status)
+        .with_json_body(body)
+        .unwrap_or_else(|_| SbiResponse::with_status(status));
+    if status == 201 {
+        resp = resp.with_header(
+            "Location",
+            format!("/nudm-uecm/v1/{supi}/registrations/{IP_SM_GW_RESOURCE}"),
+        );
+    }
+    resp
+}
+
+/// Process an IP-SM-GW registration GET (`GetIpSmGwRegistration`).
+pub async fn process_ip_sm_gw_registration_get(supi: &str, client: &UdrClient) -> SbiResponse {
+    match read_context_resource(supi, client, IP_SM_GW_RESOURCE).await {
+        Ok(Some(doc)) => SbiResponse::with_status(200)
+            .with_json_body(&doc)
+            .unwrap_or_else(|_| nextgcore_sbi::server::send_internal_error("serialize failed")),
+        Ok(None) => context_not_found(IP_SM_GW_RESOURCE),
+        Err(resp) => resp,
+    }
+}
+
+/// Process an IP-SM-GW deregistration DELETE (`IpSmGwDeregistration`).
+pub async fn process_ip_sm_gw_deregistration(supi: &str, client: &UdrClient) -> SbiResponse {
+    if let Err(e) = client.context_delete(supi, IP_SM_GW_RESOURCE).await {
+        log::warn!("[{supi}] UDR IP-SM-GW context DELETE failed: {e} (degraded)");
+    }
+    SbiResponse::with_status(204)
+}
+
 // ---------------------------------------------------------------------------
 // Test double (mock UDR)
 // ---------------------------------------------------------------------------
 
-/// A recorded outgoing UDR/AMF operation (test-only).
+/// A recorded outgoing UDR / old-AMF operation (test-only).
+///
+/// `resource` is the `context-data` resource the call addressed
+/// (`amf-3gpp-access`, `amf-non-3gpp-access`, `smf-registrations/5`, ...), so a
+/// test can pin *which* resource a handler touched — the assertion the #84
+/// overwrite defect needed and did not have.
 #[cfg(test)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum UdrCall {
-    AmfGet {
+    CtxGet {
         supi: String,
+        resource: String,
     },
-    AmfPut {
+    CtxPut {
         supi: String,
+        resource: String,
         body: Value,
     },
-    AmfPatch {
+    CtxPatch {
         supi: String,
+        resource: String,
         body: Value,
     },
-    SmfGet {
+    CtxDelete {
         supi: String,
-        psi: String,
-    },
-    SmfPut {
-        supi: String,
-        psi: String,
-        body: Value,
-    },
-    Delete {
-        supi: String,
-        path: String,
+        resource: String,
     },
     DeregNotify {
         callback_uri: String,
@@ -612,16 +1182,20 @@ pub enum UdrCall {
     },
 }
 
-/// Stateful mock UDR: `amf_context_get` returns the last value stored by
-/// `amf_context_put` (or a seeded prior), so re-registration scenarios behave
-/// like a real repository.
+/// Stateful mock UDR: `context_get` returns the last value stored by
+/// `context_put` for the SAME resource (or a seeded prior), so re-registration
+/// scenarios behave like a real repository and a write to one resource is
+/// invisible to a read of another.
 #[cfg(test)]
 pub struct MockUdr {
-    stored_amf: std::sync::Mutex<Option<Value>>,
-    stored_smf: std::sync::Mutex<std::collections::HashMap<String, Value>>,
+    stored: std::sync::Mutex<std::collections::HashMap<String, Value>>,
     put_status: u16,
     patch_status: u16,
     dereg_status: u16,
+    /// When set, every `context_get` answers with this status instead of
+    /// consulting `stored` — the UDR-fault case a read handler must not confuse
+    /// with "no such registration".
+    get_status: Option<u16>,
     calls: std::sync::Mutex<Vec<UdrCall>>,
 }
 
@@ -629,19 +1203,33 @@ pub struct MockUdr {
 impl MockUdr {
     fn new() -> Self {
         Self {
-            stored_amf: std::sync::Mutex::new(None),
-            stored_smf: std::sync::Mutex::new(std::collections::HashMap::new()),
+            stored: std::sync::Mutex::new(std::collections::HashMap::new()),
             put_status: 201,
             patch_status: 204,
             dereg_status: 204,
+            get_status: None,
             calls: std::sync::Mutex::new(Vec::new()),
         }
     }
 
+    /// Make every `context_get` fail with `status`.
+    fn with_get_status(mut self, status: u16) -> Self {
+        self.get_status = Some(status);
+        self
+    }
+
+    /// Seed a stored `amf-3gpp-access` registration.
     fn with_prior(prior: Value) -> Self {
-        let m = Self::new();
-        *m.stored_amf.lock().unwrap() = Some(prior);
-        m
+        Self::new().with_stored(UecmAccess::ThreeGpp.amf_resource(), prior)
+    }
+
+    /// Seed an arbitrary stored `context-data` resource.
+    fn with_stored(self, resource: &str, doc: Value) -> Self {
+        self.stored
+            .lock()
+            .unwrap()
+            .insert(resource.to_string(), doc);
+        self
     }
 
     /// Override the status the mocked old-AMF dereg-notify callback returns
@@ -653,11 +1241,20 @@ impl MockUdr {
         self
     }
 
-    fn amf_context_get(&self, supi: &str) -> SbiResponse {
-        self.calls.lock().unwrap().push(UdrCall::AmfGet {
+    /// The document currently stored under `resource`, if any.
+    fn stored_doc(&self, resource: &str) -> Option<Value> {
+        self.stored.lock().unwrap().get(resource).cloned()
+    }
+
+    fn context_get(&self, supi: &str, resource: &str) -> SbiResponse {
+        self.calls.lock().unwrap().push(UdrCall::CtxGet {
             supi: supi.to_string(),
+            resource: resource.to_string(),
         });
-        match self.stored_amf.lock().unwrap().clone() {
+        if let Some(status) = self.get_status {
+            return SbiResponse::with_status(status);
+        }
+        match self.stored_doc(resource) {
             Some(v) => SbiResponse::with_status(200)
                 .with_json_body(&v)
                 .unwrap_or_else(|_| SbiResponse::with_status(200)),
@@ -665,53 +1262,34 @@ impl MockUdr {
         }
     }
 
-    fn amf_context_put(&self, supi: &str, body: &Value) -> SbiResponse {
-        self.calls.lock().unwrap().push(UdrCall::AmfPut {
+    fn context_put(&self, supi: &str, resource: &str, body: &Value) -> SbiResponse {
+        self.calls.lock().unwrap().push(UdrCall::CtxPut {
             supi: supi.to_string(),
+            resource: resource.to_string(),
             body: body.clone(),
         });
-        *self.stored_amf.lock().unwrap() = Some(body.clone());
+        self.stored
+            .lock()
+            .unwrap()
+            .insert(resource.to_string(), body.clone());
         SbiResponse::with_status(self.put_status)
     }
 
-    fn amf_context_patch(&self, supi: &str, body: &Value) -> SbiResponse {
-        self.calls.lock().unwrap().push(UdrCall::AmfPatch {
+    fn context_patch(&self, supi: &str, resource: &str, body: &Value) -> SbiResponse {
+        self.calls.lock().unwrap().push(UdrCall::CtxPatch {
             supi: supi.to_string(),
+            resource: resource.to_string(),
             body: body.clone(),
         });
         SbiResponse::with_status(self.patch_status)
     }
 
-    fn smf_context_get(&self, supi: &str, psi: &str) -> SbiResponse {
-        self.calls.lock().unwrap().push(UdrCall::SmfGet {
+    fn context_delete(&self, supi: &str, resource: &str) -> SbiResponse {
+        self.calls.lock().unwrap().push(UdrCall::CtxDelete {
             supi: supi.to_string(),
-            psi: psi.to_string(),
+            resource: resource.to_string(),
         });
-        let key = format!("{supi}:{psi}");
-        match self.stored_smf.lock().unwrap().get(&key).cloned() {
-            Some(v) => SbiResponse::with_status(200)
-                .with_json_body(&v)
-                .unwrap_or_else(|_| SbiResponse::with_status(200)),
-            None => SbiResponse::with_status(404),
-        }
-    }
-
-    fn smf_context_put(&self, supi: &str, psi: &str, body: &Value) -> SbiResponse {
-        self.calls.lock().unwrap().push(UdrCall::SmfPut {
-            supi: supi.to_string(),
-            psi: psi.to_string(),
-            body: body.clone(),
-        });
-        let key = format!("{supi}:{psi}");
-        self.stored_smf.lock().unwrap().insert(key, body.clone());
-        SbiResponse::with_status(self.put_status)
-    }
-
-    fn context_delete(&self, supi: &str, path: &str) -> SbiResponse {
-        self.calls.lock().unwrap().push(UdrCall::Delete {
-            supi: supi.to_string(),
-            path: path.to_string(),
-        });
+        self.stored.lock().unwrap().remove(resource);
         SbiResponse::with_status(204)
     }
 
@@ -793,7 +1371,13 @@ mod tests {
             let body = remove_path(valid_amf_body(), path);
             let mock = Arc::new(MockUdr::new());
             let client = UdrClient::Mock(mock.clone());
-            let resp = process_amf_registration("imsi-001010000000301", &body, &client).await;
+            let resp = process_amf_registration(
+                "imsi-001010000000301",
+                &body,
+                &client,
+                UecmAccess::ThreeGpp,
+            )
+            .await;
             assert_eq!(resp.status, 400, "missing {path:?} should be 400");
             assert_eq!(
                 problem_cause(&resp).as_deref(),
@@ -802,10 +1386,10 @@ mod tests {
             );
             // Validation must short-circuit before any UDR write.
             assert!(
-                !mock
-                    .calls()
-                    .iter()
-                    .any(|c| matches!(c, UdrCall::AmfPut { .. })),
+                !mock.calls().iter().any(|c| matches!(
+                    c,
+                    UdrCall::CtxPut { resource, .. } if resource == "amf-3gpp-access"
+                )),
                 "missing {path:?} must not persist to UDR"
             );
         }
@@ -845,8 +1429,13 @@ mod tests {
         crate::context::udm_context_init(1024, 4096);
         let mock = Arc::new(MockUdr::new());
         let client = UdrClient::Mock(mock.clone());
-        let resp =
-            process_amf_registration("imsi-001010000000303", &valid_amf_body(), &client).await;
+        let resp = process_amf_registration(
+            "imsi-001010000000303",
+            &valid_amf_body(),
+            &client,
+            UecmAccess::ThreeGpp,
+        )
+        .await;
         assert_eq!(resp.status, 201);
     }
 
@@ -867,11 +1456,15 @@ mod tests {
         let mock = Arc::new(MockUdr::new());
         let client = UdrClient::Mock(mock.clone());
 
-        let resp = process_amf_registration(supi, &body, &client).await;
+        let resp = process_amf_registration(supi, &body, &client, UecmAccess::ThreeGpp).await;
         assert_eq!(resp.status, 201);
 
         let put = mock.calls().into_iter().find_map(|c| match c {
-            UdrCall::AmfPut { supi, body } => Some((supi, body)),
+            UdrCall::CtxPut {
+                supi,
+                resource,
+                body,
+            } if resource == "amf-3gpp-access" => Some((supi, body)),
             _ => None,
         });
         let (put_supi, put_body) = put.expect("an AMF context PUT was issued to UDR");
@@ -890,12 +1483,16 @@ mod tests {
         assert_eq!(resp.status, 201);
 
         let put = mock.calls().into_iter().find_map(|c| match c {
-            UdrCall::SmfPut { supi, psi, body } => Some((supi, psi, body)),
+            UdrCall::CtxPut {
+                supi,
+                resource,
+                body,
+            } if resource.starts_with("smf-registrations/") => Some((supi, resource, body)),
             _ => None,
         });
-        let (put_supi, psi, put_body) = put.expect("an SMF context PUT was issued to UDR");
+        let (put_supi, resource, put_body) = put.expect("an SMF context PUT was issued to UDR");
         assert_eq!(put_supi, supi);
-        assert_eq!(psi, "5");
+        assert_eq!(resource, "smf-registrations/5");
         assert_eq!(put_body, body);
     }
 
@@ -913,8 +1510,13 @@ mod tests {
         mock.put_status = 500;
         let mock = Arc::new(mock);
         let client = UdrClient::Mock(mock.clone());
-        let resp =
-            process_amf_registration("imsi-001010000000312", &valid_amf_body(), &client).await;
+        let resp = process_amf_registration(
+            "imsi-001010000000312",
+            &valid_amf_body(),
+            &client,
+            UecmAccess::ThreeGpp,
+        )
+        .await;
         assert_eq!(resp.status, 503, "UDR 5xx maps to 503");
     }
 
@@ -931,12 +1533,12 @@ mod tests {
         let supi = "imsi-001010000000313";
         let mock = Arc::new(MockUdr::new());
         let client = UdrClient::Mock(mock.clone());
-        let resp = process_amf_deregistration(supi, &client).await;
+        let resp = process_amf_deregistration(supi, &client, UecmAccess::ThreeGpp).await;
         assert_eq!(resp.status, 204);
         assert!(
             mock.calls().iter().any(|c| matches!(
                 c,
-                UdrCall::Delete { path, .. } if path == "amf-3gpp-access"
+                UdrCall::CtxDelete { resource, .. } if resource == "amf-3gpp-access"
             )),
             "deregistration issues a UDR context-data DELETE"
         );
@@ -959,7 +1561,13 @@ mod tests {
             "guami": { "plmnId": { "mcc": "001", "mnc": "01" }, "amfId": "deadff" },
             "purgeFlag": true
         });
-        let resp = process_amf_registration_update("imsi-udmd05-0001", &wrong_guami, &client).await;
+        let resp = process_amf_registration_update(
+            "imsi-udmd05-0001",
+            &wrong_guami,
+            &client,
+            UecmAccess::ThreeGpp,
+        )
+        .await;
         assert_eq!(resp.status, 403, "wrong GUAMI must be 403");
         assert_eq!(
             problem_cause(&resp).as_deref(),
@@ -971,8 +1579,8 @@ mod tests {
             !mock
                 .calls()
                 .iter()
-                .any(|c| matches!(c, UdrCall::AmfPatch { .. })),
-            "UDR PATCH must not be issued when GUAMI mismatches"
+                .any(|c| matches!(c, UdrCall::CtxPatch { .. } | UdrCall::CtxDelete { .. })),
+            "neither a UDR PATCH nor a DELETE may be issued when GUAMI mismatches"
         );
     }
 
@@ -987,16 +1595,25 @@ mod tests {
         let mock = Arc::new(MockUdr::with_prior(stored));
         let client = UdrClient::Mock(mock.clone());
 
+        // A genuine field modification, NOT a purge: `purgeFlag: true` is a
+        // deregistration (TS 29.503 §5.3.2.4.2) and is covered by its own test
+        // below, so using it here would test the wrong branch of this handler.
         let patch = json!({
             "guami": { "plmnId": { "mcc": "001", "mnc": "01" }, "amfId": "cafe00" },
-            "purgeFlag": true
+            "pei": "imeisv-1234567890123456"
         });
-        let resp = process_amf_registration_update("imsi-udmd05-0002", &patch, &client).await;
+        let resp = process_amf_registration_update(
+            "imsi-udmd05-0002",
+            &patch,
+            &client,
+            UecmAccess::ThreeGpp,
+        )
+        .await;
         assert_eq!(resp.status, 204, "matching GUAMI must be 204");
         assert!(
             mock.calls()
                 .iter()
-                .any(|c| matches!(c, UdrCall::AmfPatch { .. })),
+                .any(|c| matches!(c, UdrCall::CtxPatch { .. })),
             "UDR PATCH must be issued when GUAMI matches"
         );
     }
@@ -1008,7 +1625,13 @@ mod tests {
         let client = UdrClient::Mock(mock);
         let patch =
             json!({ "guami": { "plmnId": { "mcc": "001", "mnc": "01" }, "amfId": "cafe00" } });
-        let resp = process_amf_registration_update("imsi-udmd05-0003", &patch, &client).await;
+        let resp = process_amf_registration_update(
+            "imsi-udmd05-0003",
+            &patch,
+            &client,
+            UecmAccess::ThreeGpp,
+        )
+        .await;
         assert_eq!(resp.status, 404);
     }
 
@@ -1029,7 +1652,8 @@ mod tests {
         let client = UdrClient::Mock(mock.clone());
 
         // First PUT → no prior → 201 + Location
-        let resp = process_amf_registration(supi, &valid_amf_body(), &client).await;
+        let resp =
+            process_amf_registration(supi, &valid_amf_body(), &client, UecmAccess::ThreeGpp).await;
         assert_eq!(resp.status, 201, "first PUT must be 201");
         // set_header lowercases all header keys (HTTP/2 convention).
         let loc = resp
@@ -1044,7 +1668,8 @@ mod tests {
         );
 
         // Second PUT → prior exists → 200
-        let resp = process_amf_registration(supi, &valid_amf_body(), &client).await;
+        let resp =
+            process_amf_registration(supi, &valid_amf_body(), &client, UecmAccess::ThreeGpp).await;
         assert_eq!(resp.status, 200, "second PUT must be 200");
     }
 
@@ -1095,7 +1720,7 @@ mod tests {
         body_b["amfInstanceId"] = json!("amf-b-0002");
         body_b["deregCallbackUri"] =
             json!("http://amf-b.example.org:7777/namf-callback/v1/imsi-x/dereg-notify");
-        let resp = process_amf_registration(supi, &body_b, &client).await;
+        let resp = process_amf_registration(supi, &body_b, &client, UecmAccess::ThreeGpp).await;
         assert_eq!(
             resp.status, 200,
             "re-registration over existing AMF-A must be 200 (update)"
@@ -1122,7 +1747,7 @@ mod tests {
 
         // Re-register with the SAME AMF-B id -> suppressed, no new notification.
         // Still an update (prior = AMF-B now stored) → 200.
-        let resp = process_amf_registration(supi, &body_b, &client).await;
+        let resp = process_amf_registration(supi, &body_b, &client, UecmAccess::ThreeGpp).await;
         assert_eq!(
             resp.status, 200,
             "same-AMF re-registration still updates the resource → 200"
@@ -1171,7 +1796,7 @@ mod tests {
         body_b["amfInstanceId"] = json!("amf-b-0002");
         body_b["deregCallbackUri"] =
             json!("http://amf-b.example.org:7777/namf-callback/v1/imsi-x/dereg-notify");
-        let _ = process_amf_registration(supi, &body_b, &client).await;
+        let _ = process_amf_registration(supi, &body_b, &client, UecmAccess::ThreeGpp).await;
 
         mock.calls()
             .into_iter()
@@ -1419,7 +2044,7 @@ mod tests {
         });
         assert_eq!(
             from_amfd_struct,
-            build_dereg_notification_body(),
+            build_dereg_notification_body(UecmAccess::ThreeGpp),
             "amfd's DeregistrationData wire form must be field/value-identical to \
              udmd's emitted body (TS 29.503 §5.3.2.3.2 cross-decode pin)"
         );
@@ -1433,7 +2058,7 @@ mod tests {
         let ue_id = seed_amf_ue(supi, 60_103);
         let path = format!("/namf-callback/v1/{supi}/dereg-notify");
         let req = SbiRequest::post(path)
-            .with_json_body(&build_dereg_notification_body())
+            .with_json_body(&build_dereg_notification_body(UecmAccess::ThreeGpp))
             .expect("json");
         let resp = nextgcore_amfd::namf_request_handler(req).await;
         assert_eq!(resp.status, 204, "amfd decodes udmd's body -> 204");
@@ -1546,7 +2171,7 @@ mod tests {
         body_b["amfInstanceId"] = json!("amf-b-0002");
         body_b["deregCallbackUri"] =
             json!("http://amf-b.example.org:7777/namf-callback/v1/imsi-x/dereg-notify");
-        let resp = process_amf_registration(supi, &body_b, &client).await;
+        let resp = process_amf_registration(supi, &body_b, &client, UecmAccess::ThreeGpp).await;
         assert_eq!(
             resp.status, 200,
             "a failing dereg notification must NOT wedge re-registration"
@@ -1633,7 +2258,8 @@ mod tests {
 
         let mock = Arc::new(MockUdr::new());
         let client = UdrClient::Mock(mock.clone());
-        let resp = process_amf_registration(supi, &valid_amf_body(), &client).await;
+        let resp =
+            process_amf_registration(supi, &valid_amf_body(), &client, UecmAccess::ThreeGpp).await;
         assert_eq!(
             resp.status, 201,
             "the registration itself must still succeed"
@@ -1679,5 +2305,594 @@ mod tests {
                 context.ee_subscription_remove(&sub.id);
             }
         }
+    }
+
+    // ----- #84: the two AMF access registrations are separate resources ------
+
+    /// A valid `AmfNon3GppAccessRegistration` (the 3GPP set plus `imsVoPs`).
+    fn valid_non_3gpp_body() -> Value {
+        let mut b = valid_amf_body();
+        b["amfInstanceId"] = json!("amf-n3-0001");
+        b["deregCallbackUri"] =
+            json!("http://amf-n3.example.org:7777/namf-callback/v1/imsi-x/dereg-notify");
+        b["ratType"] = json!("VIRTUAL");
+        b["imsVoPs"] = json!("HOMOGENEOUS_SUPPORT");
+        b
+    }
+
+    /// #84 gap 1, the load-bearing one: registering over non-3GPP access must
+    /// not read, rewrite or delete the `amf-3gpp-access` record, and must not
+    /// tell the 3GPP AMF anything at all.
+    ///
+    /// Revert check: hardcoding `UecmAccess::ThreeGpp` inside
+    /// `process_amf_registration` (the pre-#84 behaviour, where
+    /// `handle_amf_non3gpp_registration` called the 3GPP helper) fails the
+    /// stored-3GPP-record assertion with AMF-N3's id.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn non_3gpp_registration_leaves_the_3gpp_record_intact() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::context::udm_context_init(1024, 4096);
+        let supi = "imsi-001010000000840";
+
+        let mock = Arc::new(MockUdr::new());
+        let client = UdrClient::Mock(mock.clone());
+
+        let three_gpp = valid_amf_body();
+        let resp = process_amf_registration(supi, &three_gpp, &client, UecmAccess::ThreeGpp).await;
+        assert_eq!(resp.status, 201, "3GPP registration creates the resource");
+
+        let non_3gpp = valid_non_3gpp_body();
+        let resp = process_amf_registration(supi, &non_3gpp, &client, UecmAccess::Non3Gpp).await;
+        assert_eq!(
+            resp.status, 201,
+            "the non-3GPP resource does not exist yet, so this is a CREATE — a 200 \
+             would mean it found the 3GPP registration"
+        );
+        assert_eq!(
+            resp.http.headers.get("location").map(String::as_str),
+            Some(format!("/nudm-uecm/v1/{supi}/registrations/amf-non-3gpp-access").as_str()),
+            "Location must name the non-3GPP resource"
+        );
+
+        // The 3GPP record is byte-identical to what was registered.
+        assert_eq!(
+            mock.stored_doc("amf-3gpp-access").as_ref(),
+            Some(&three_gpp),
+            "the non-3GPP registration overwrote the 3GPP record"
+        );
+        assert_eq!(
+            mock.stored_doc("amf-non-3gpp-access").as_ref(),
+            Some(&non_3gpp),
+            "the non-3GPP registration must be stored under its own resource"
+        );
+
+        // Nothing addressed at the 3GPP resource after its own PUT, and the
+        // 3GPP AMF was never told its registration ended.
+        let calls = mock.calls();
+        let three_gpp_writes = calls
+            .iter()
+            .filter(|c| {
+                matches!(
+                    c,
+                    UdrCall::CtxPut { resource, .. }
+                        | UdrCall::CtxPatch { resource, .. }
+                        | UdrCall::CtxDelete { resource, .. }
+                        if resource == "amf-3gpp-access"
+                )
+            })
+            .count();
+        assert_eq!(
+            three_gpp_writes, 1,
+            "exactly one write to amf-3gpp-access (its own registration): {calls:?}"
+        );
+        assert_eq!(
+            deregister_count(&calls),
+            0,
+            "a non-3GPP registration must not deregister the 3GPP AMF"
+        );
+
+        // Both cache slots are populated independently.
+        let ctx = udm_self();
+        let context = ctx.read().expect("context");
+        let ue = context.ue_find_by_supi(supi).expect("UE cached");
+        assert_eq!(ue.amf_instance_id.as_deref(), Some("amf-a-0001"));
+        assert_eq!(ue.non_3gpp_amf_instance_id.as_deref(), Some("amf-n3-0001"));
+    }
+
+    /// #84 gap 1/2: a non-3GPP re-registration notifies the OLD NON-3GPP AMF,
+    /// with `accessType: NON_3GPP_ACCESS`, and leaves the 3GPP AMF alone.
+    ///
+    /// Revert check: `build_dereg_notification_body` with `accessType` pinned to
+    /// `3GPP_ACCESS` fails the accessType assertion — and that value is what
+    /// makes amfd tear a live 3GPP registration down (see the strict-peer twin
+    /// `test_dereg_notify_strict_peer_non_3gpp_no_enqueue`).
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn non_3gpp_reregistration_notifies_the_non_3gpp_amf() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::context::udm_context_init(1024, 4096);
+        let supi = "imsi-001010000000841";
+
+        let n3_old_uri = "http://amf-n3-old.example.org:7777/namf-callback/v1/imsi-x/dereg-notify";
+        let mock = Arc::new(
+            MockUdr::new()
+                .with_stored(
+                    "amf-3gpp-access",
+                    json!({
+                        "amfInstanceId": "amf-3gpp-live",
+                        "deregCallbackUri": "http://amf-3gpp.example.org:7777/namf-callback/v1/imsi-x/dereg-notify",
+                        "guami": { "plmnId": { "mcc": "001", "mnc": "01" }, "amfId": "cafe00" },
+                        "ratType": "NR"
+                    }),
+                )
+                .with_stored(
+                    "amf-non-3gpp-access",
+                    json!({
+                        "amfInstanceId": "amf-n3-old",
+                        "deregCallbackUri": n3_old_uri,
+                        "guami": { "plmnId": { "mcc": "001", "mnc": "01" }, "amfId": "cafe01" },
+                        "ratType": "VIRTUAL",
+                        "imsVoPs": "HOMOGENEOUS_SUPPORT"
+                    }),
+                ),
+        );
+        let client = UdrClient::Mock(mock.clone());
+
+        let resp =
+            process_amf_registration(supi, &valid_non_3gpp_body(), &client, UecmAccess::Non3Gpp)
+                .await;
+        assert_eq!(resp.status, 200, "the non-3GPP resource existed -> update");
+
+        let calls = mock.calls();
+        assert_eq!(
+            deregister_count(&calls),
+            1,
+            "exactly one dereg notification"
+        );
+        let (uri, body) = calls
+            .iter()
+            .find_map(|c| match c {
+                UdrCall::DeregNotify { callback_uri, body } => {
+                    Some((callback_uri.clone(), body.clone()))
+                }
+                _ => None,
+            })
+            .expect("a dereg notification was sent");
+        assert_eq!(uri, n3_old_uri, "the OLD NON-3GPP AMF is the one notified");
+        assert_eq!(
+            body.get("accessType").and_then(|v| v.as_str()),
+            Some("NON_3GPP_ACCESS"),
+            "DeregistrationData must name the access that actually changed"
+        );
+        assert_eq!(
+            mock.stored_doc("amf-3gpp-access")
+                .and_then(|d| d["amfInstanceId"].as_str().map(String::from))
+                .as_deref(),
+            Some("amf-3gpp-live"),
+            "the 3GPP registration is untouched"
+        );
+    }
+
+    /// The non-3GPP schema additionally requires `imsVoPs`
+    /// (TS 29.503 `AmfNon3GppAccessRegistration`), so a body that would be a
+    /// valid 3GPP registration is refused here — and refused before any write.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn non_3gpp_registration_requires_ims_vo_ps() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::context::udm_context_init(1024, 4096);
+        let mock = Arc::new(MockUdr::new());
+        let client = UdrClient::Mock(mock.clone());
+        let resp = process_amf_registration(
+            "imsi-001010000000842",
+            &valid_amf_body(),
+            &client,
+            UecmAccess::Non3Gpp,
+        )
+        .await;
+        assert_eq!(resp.status, 400);
+        assert_eq!(
+            problem_cause(&resp).as_deref(),
+            Some("MANDATORY_IE_MISSING")
+        );
+        assert!(
+            mock.calls()
+                .iter()
+                .all(|c| !matches!(c, UdrCall::CtxPut { .. })),
+            "a rejected registration must not write to UDR"
+        );
+        // The same body IS valid for 3GPP access, so the refusal is about the
+        // non-3GPP schema and not about the body being malformed in general.
+        let resp = process_amf_registration(
+            "imsi-001010000000842",
+            &valid_amf_body(),
+            &client,
+            UecmAccess::ThreeGpp,
+        )
+        .await;
+        assert_eq!(resp.status, 201);
+    }
+
+    // ----- #84 gap 2: the UECM read operations -------------------------------
+
+    #[tokio::test]
+    async fn get_amf_registration_returns_the_stored_record_per_access() {
+        for access in [UecmAccess::ThreeGpp, UecmAccess::Non3Gpp] {
+            let stored = json!({ "amfInstanceId": format!("amf-for-{}", access.amf_resource()) });
+            let mock = Arc::new(MockUdr::new().with_stored(access.amf_resource(), stored.clone()));
+            let client = UdrClient::Mock(mock.clone());
+
+            let resp = process_amf_registration_get("imsi-1", &client, access).await;
+            assert_eq!(resp.status, 200, "{} GET", access.amf_resource());
+            let body: Value =
+                serde_json::from_str(resp.http.content.as_deref().expect("body")).unwrap();
+            assert_eq!(body, stored, "the stored record is returned verbatim");
+
+            // The OTHER access is not registered, so its GET is a 404 — the read
+            // must not fall through to the resource that happens to exist.
+            let other = match access {
+                UecmAccess::ThreeGpp => UecmAccess::Non3Gpp,
+                UecmAccess::Non3Gpp => UecmAccess::ThreeGpp,
+            };
+            let resp = process_amf_registration_get("imsi-1", &client, other).await;
+            assert_eq!(resp.status, 404, "{} GET", other.amf_resource());
+            assert_eq!(
+                problem_cause(&resp).as_deref(),
+                Some("CONTEXT_NOT_FOUND"),
+                "TS 29.503 Table 6.2.7.3-1"
+            );
+        }
+    }
+
+    /// A UDR fault on a UECM GET must NOT be reported as "not registered": a 404
+    /// would tell a consumer the UE has no serving AMF when the truth is that
+    /// the UDM could not find out — and a `(H)GMLC` acting on that answer stops
+    /// looking for the UE.
+    #[tokio::test]
+    async fn a_udr_fault_on_a_uecm_get_is_503_not_404() {
+        let mock = Arc::new(MockUdr::new().with_get_status(500));
+        let client = UdrClient::Mock(mock);
+        for resp in [
+            process_amf_registration_get("imsi-1", &client, UecmAccess::ThreeGpp).await,
+            process_amf_registration_get("imsi-1", &client, UecmAccess::Non3Gpp).await,
+            process_smf_registrations_get("imsi-1", &client).await,
+            process_smf_registration_get("imsi-1", "5", &client).await,
+            process_location_info_get("imsi-1", &client).await,
+            process_smsf_registration_get("imsi-1", &client, UecmAccess::ThreeGpp).await,
+            process_ip_sm_gw_registration_get("imsi-1", &client).await,
+        ] {
+            assert_eq!(
+                resp.status, 503,
+                "a UDR 5xx must surface as 503, never as an empty-but-successful read"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn get_smf_registrations_wraps_the_udr_array_as_smf_registration_info() {
+        let reg = valid_smf_body();
+        let mock = Arc::new(MockUdr::new().with_stored("smf-registrations", json!([reg.clone()])));
+        let client = UdrClient::Mock(mock);
+
+        let resp = process_smf_registrations_get("imsi-1", &client).await;
+        assert_eq!(resp.status, 200);
+        let body: Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).unwrap();
+        assert_eq!(
+            body["smfRegistrationList"],
+            json!([reg]),
+            "TS 29.503 SmfRegistrationInfo wraps the list the UDR returns bare"
+        );
+
+        // minItems: 1 — an empty collection is not a representable answer.
+        let mock = Arc::new(MockUdr::new().with_stored("smf-registrations", json!([])));
+        let client = UdrClient::Mock(mock);
+        let resp = process_smf_registrations_get("imsi-1", &client).await;
+        assert_eq!(resp.status, 404, "an empty smfRegistrationList is a 404");
+    }
+
+    #[tokio::test]
+    async fn get_individual_smf_registration_addresses_the_pdu_session() {
+        let reg = valid_smf_body();
+        let mock = Arc::new(MockUdr::new().with_stored("smf-registrations/5", json!(reg.clone())));
+        let client = UdrClient::Mock(mock.clone());
+
+        let resp = process_smf_registration_get("imsi-1", "5", &client).await;
+        assert_eq!(resp.status, 200);
+        let body: Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).unwrap();
+        assert_eq!(body, reg);
+
+        let resp = process_smf_registration_get("imsi-1", "6", &client).await;
+        assert_eq!(resp.status, 404, "another PDU session is not this one");
+    }
+
+    /// `GetLocationInfo` is composed from the AMF registrations: one entry per
+    /// serving AMF, with every access that AMF serves in its `accessTypeList`.
+    #[tokio::test]
+    async fn get_location_info_composes_one_entry_per_serving_amf() {
+        let guami = json!({ "plmnId": { "mcc": "001", "mnc": "01" }, "amfId": "cafe00" });
+
+        // Two different AMFs -> two entries, one access type each.
+        let mock = Arc::new(
+            MockUdr::new()
+                .with_stored(
+                    "amf-3gpp-access",
+                    json!({ "amfInstanceId": "amf-a", "guami": guami }),
+                )
+                .with_stored("amf-non-3gpp-access", json!({ "amfInstanceId": "amf-b" })),
+        );
+        let client = UdrClient::Mock(mock);
+        let resp = process_location_info_get("imsi-1", &client).await;
+        assert_eq!(resp.status, 200);
+        let body: Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).unwrap();
+        let list = body["registrationLocationInfoList"]
+            .as_array()
+            .expect("list")
+            .clone();
+        assert_eq!(list.len(), 2, "two serving AMFs -> two entries: {list:?}");
+        assert_eq!(list[0]["amfInstanceId"], "amf-a");
+        assert_eq!(list[0]["accessTypeList"], json!(["3GPP_ACCESS"]));
+        assert_eq!(list[0]["guami"], guami, "the GUAMI is carried when stored");
+        assert_eq!(list[1]["amfInstanceId"], "amf-b");
+        assert_eq!(list[1]["accessTypeList"], json!(["NON_3GPP_ACCESS"]));
+        assert_eq!(body["supi"], "imsi-1");
+        assert!(
+            body.get("gpsi").is_none(),
+            "no GPSI is known, so none is fabricated"
+        );
+
+        // ONE AMF serving both accesses -> ONE entry with both access types,
+        // which is also what keeps the list inside maxItems: 2.
+        let mock = Arc::new(
+            MockUdr::new()
+                .with_stored("amf-3gpp-access", json!({ "amfInstanceId": "amf-both" }))
+                .with_stored(
+                    "amf-non-3gpp-access",
+                    json!({ "amfInstanceId": "amf-both" }),
+                ),
+        );
+        let client = UdrClient::Mock(mock);
+        let resp = process_location_info_get("imsi-1", &client).await;
+        let body: Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).unwrap();
+        let list = body["registrationLocationInfoList"].as_array().unwrap();
+        assert_eq!(list.len(), 1, "one AMF -> one entry: {list:?}");
+        assert_eq!(
+            list[0]["accessTypeList"],
+            json!(["3GPP_ACCESS", "NON_3GPP_ACCESS"])
+        );
+
+        // No registration at all -> 404 (TS 29.503 §5.3.2.5.9 step 2b).
+        let mock = Arc::new(MockUdr::new());
+        let client = UdrClient::Mock(mock);
+        let resp = process_location_info_get("imsi-1", &client).await;
+        assert_eq!(resp.status, 404);
+    }
+
+    #[tokio::test]
+    async fn smsf_registration_round_trips_per_access() {
+        for access in [UecmAccess::ThreeGpp, UecmAccess::Non3Gpp] {
+            let mock = Arc::new(MockUdr::new());
+            let client = UdrClient::Mock(mock.clone());
+
+            // Mandatory IEs first: smsfInstanceId + plmnId.
+            let resp = process_smsf_registration(
+                "imsi-1",
+                &json!({ "smsfInstanceId": "smsf-1" }),
+                &client,
+                access,
+            )
+            .await;
+            assert_eq!(resp.status, 400, "plmnId is mandatory");
+
+            let body = json!({
+                "smsfInstanceId": "smsf-1",
+                "plmnId": { "mcc": "001", "mnc": "01" }
+            });
+            let resp = process_smsf_registration("imsi-1", &body, &client, access).await;
+            assert_eq!(resp.status, 201, "{}", access.smsf_resource());
+            assert_eq!(
+                resp.http.headers.get("location").map(String::as_str),
+                Some(
+                    format!(
+                        "/nudm-uecm/v1/imsi-1/registrations/{}",
+                        access.smsf_resource()
+                    )
+                    .as_str()
+                )
+            );
+
+            let resp = process_smsf_registration_get("imsi-1", &client, access).await;
+            assert_eq!(resp.status, 200, "the SMSF registration reads back");
+            let got: Value =
+                serde_json::from_str(resp.http.content.as_deref().expect("body")).unwrap();
+            assert_eq!(got, body);
+
+            let resp = process_smsf_deregistration("imsi-1", &client, access).await;
+            assert_eq!(resp.status, 204);
+            let resp = process_smsf_registration_get("imsi-1", &client, access).await;
+            assert_eq!(resp.status, 404, "deregistration removed it");
+        }
+    }
+
+    #[tokio::test]
+    async fn ip_sm_gw_registration_round_trips_and_requires_an_address() {
+        let mock = Arc::new(MockUdr::new());
+        let client = UdrClient::Mock(mock.clone());
+
+        // anyOf: a registration naming no IP-SM-GW address routes nowhere.
+        let resp =
+            process_ip_sm_gw_registration("imsi-1", &json!({ "unriIndicator": true }), &client)
+                .await;
+        assert_eq!(resp.status, 400);
+        assert_eq!(
+            problem_cause(&resp).as_deref(),
+            Some("MANDATORY_IE_MISSING")
+        );
+
+        for address in [
+            json!({ "ipsmgwFqdn": "ipsmgw.example.org" }),
+            json!({ "ipsmgwIpv4": "10.0.0.9" }),
+            json!({ "ipSmGwMapAddress": "491721075423" }),
+        ] {
+            let mock = Arc::new(MockUdr::new());
+            let client = UdrClient::Mock(mock.clone());
+            let resp = process_ip_sm_gw_registration("imsi-1", &address, &client).await;
+            assert_eq!(resp.status, 201, "{address} must be accepted");
+            let resp = process_ip_sm_gw_registration_get("imsi-1", &client).await;
+            assert_eq!(resp.status, 200);
+            let got: Value =
+                serde_json::from_str(resp.http.content.as_deref().expect("body")).unwrap();
+            assert_eq!(got, address);
+        }
+
+        let resp = process_ip_sm_gw_deregistration("imsi-1", &client).await;
+        assert_eq!(resp.status, 204);
+    }
+
+    // ----- #84 gap 3: spec deregistration -----------------------------------
+
+    /// `POST .../amf-3gpp-access/dereg-amf` is the spec deregistration: it needs
+    /// an `AmfDeregInfo.deregReason` and it removes the registration.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn dereg_amf_requires_a_reason_and_deletes_the_registration() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::context::udm_context_init(1024, 4096);
+        let supi = "imsi-001010000000843";
+        let mock = Arc::new(MockUdr::with_prior(valid_amf_body()));
+        let client = UdrClient::Mock(mock.clone());
+
+        // No deregReason -> 400, and nothing deleted.
+        let resp = process_dereg_amf(supi, &json!({}), &client).await;
+        assert_eq!(resp.status, 400);
+        assert_eq!(
+            problem_cause(&resp).as_deref(),
+            Some("MANDATORY_IE_MISSING")
+        );
+        assert!(
+            mock.stored_doc("amf-3gpp-access").is_some(),
+            "a rejected dereg-amf must not delete the registration"
+        );
+
+        let resp = process_dereg_amf(
+            supi,
+            &json!({ "deregReason": "SUBSCRIPTION_WITHDRAWN" }),
+            &client,
+        )
+        .await;
+        assert_eq!(resp.status, 204);
+        assert!(
+            mock.stored_doc("amf-3gpp-access").is_none(),
+            "dereg-amf removes the UDR context-data resource"
+        );
+    }
+
+    /// `purgeFlag: true` on the update PATCH is a deregistration
+    /// (TS 29.503 §5.3.2.4.2) — the shape this repo's own AMF sends. Before #84
+    /// it was acknowledged with 204 and patched into the stored document, so the
+    /// UDM kept answering with a serving AMF that had released the UE.
+    ///
+    /// Revert check: dropping the `purgeFlag` branch makes the stored record
+    /// survive and this test fails on the `is_none()` assertion.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn purge_flag_patch_deregisters_rather_than_patching() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::context::udm_context_init(1024, 4096);
+        let supi = "imsi-001010000000844";
+        let mock = Arc::new(MockUdr::with_prior(valid_amf_body()));
+        let client = UdrClient::Mock(mock.clone());
+
+        // Exactly what nextgcore's AMF sends: a bare purge, no GUAMI.
+        let resp = process_amf_registration_update(
+            supi,
+            &json!({ "purgeFlag": true }),
+            &client,
+            UecmAccess::ThreeGpp,
+        )
+        .await;
+        assert_eq!(resp.status, 204);
+        assert!(
+            mock.stored_doc("amf-3gpp-access").is_none(),
+            "purgeFlag must deregister the UE, not patch the flag into the record"
+        );
+        assert!(
+            mock.calls().iter().any(|c| matches!(
+                c,
+                UdrCall::CtxDelete { resource, .. } if resource == "amf-3gpp-access"
+            )),
+            "the purge issues a UDR context-data DELETE"
+        );
+        // A purge on one access leaves the other alone.
+        assert!(
+            !mock.calls().iter().any(|c| matches!(
+                c,
+                UdrCall::CtxDelete { resource, .. } if resource == "amf-non-3gpp-access"
+            )),
+            "a 3GPP purge must not delete the non-3GPP registration"
+        );
+    }
+
+    /// Deregistering one access keeps the other access's cached serving AMF, so
+    /// the next re-registration on the surviving access still has an old AMF to
+    /// notify.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
+    async fn deregistering_one_access_keeps_the_other_cached() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::context::udm_context_init(1024, 4096);
+        let supi = "imsi-001010000000845";
+        let mock = Arc::new(MockUdr::new());
+        let client = UdrClient::Mock(mock.clone());
+
+        let _ =
+            process_amf_registration(supi, &valid_amf_body(), &client, UecmAccess::ThreeGpp).await;
+        let _ =
+            process_amf_registration(supi, &valid_non_3gpp_body(), &client, UecmAccess::Non3Gpp)
+                .await;
+
+        let resp = process_amf_deregistration(supi, &client, UecmAccess::Non3Gpp).await;
+        assert_eq!(resp.status, 204);
+
+        let ctx = udm_self();
+        let context = ctx.read().expect("context");
+        let ue = context
+            .ue_find_by_supi(supi)
+            .expect("the UE survives a single-access deregistration");
+        assert_eq!(
+            ue.amf_instance_id.as_deref(),
+            Some("amf-a-0001"),
+            "the 3GPP serving AMF is still cached"
+        );
+        assert!(
+            ue.non_3gpp_amf_instance_id.is_none(),
+            "the deregistered access's slot is cleared"
+        );
+        drop(context);
+
+        // Deregistering the remaining access drops the UE entirely.
+        let resp = process_amf_deregistration(supi, &client, UecmAccess::ThreeGpp).await;
+        assert_eq!(resp.status, 204);
+        let context = ctx.read().expect("context");
+        assert!(
+            context.ue_find_by_supi(supi).is_none(),
+            "with neither access registered the UE context is dropped"
+        );
     }
 }


### PR DESCRIPTION
Closes #84