### PR TITLE
fix(udmd): delete the second, unreachable Nudm UECM/SDM/UEAU implementation (Closes #236)

### DIFF
--- a/specs/fix-udmd-delete-unreachable-nudm-handler-implementation.md
+++ b/specs/fix-udmd-delete-unreachable-nudm-handler-implementation.md
@@ -1,0 +1,163 @@
+# nextgcore #236 (udmd): delete the second, unreachable Nudm UECM/SDM/UEAU implementation
+
+Verified against `main` @ `4ec257a`. Every claim in the issue's reference table still held exactly as
+written — re-run of the `grep -rn '<fn>' --include='*.rs' src/ | grep -v nudm_handler.rs` count reproduced
+seven zeros and two ones (`sess_sm.rs:261`, `:268`), and the line cites had not drifted.
+
+`Closes #236`.
+
+## The question the issue said to answer first
+
+> Confirm whether the `sess_sm` / `udm_sm` session state machine is meant to be driven at all. If it is
+> dead too, that is the larger finding and should be settled first — deleting the handlers while leaving a
+> state machine that calls them is the wrong order.
+
+**It is dead, and the proof is one grep: nothing in the tree constructs a `UdmEvent::sbi_server` or a
+`UdmEvent::sbi_client`.** Both constructors exist (`event.rs:183`, `:203`) and have zero callers —
+not in production code, not in tests. The chain that would reach the two surviving handlers is
+
+```
+UdmEventId::SbiServer  ->  udm_sm::handle_sbi_server_event   (udm_sm.rs:127)
+                       ->  udm_sm::handle_nudm_request       (:234)
+                       ->  udm_sm::handle_sess_request       (:351)
+                       ->  sess_sm::dispatch                 (:399)
+                       ->  nudm_handler::udm_nudm_uecm_handle_smf_registration
+```
+
+and its first link never fires. The only event the daemon ever dispatches is `UdmEvent::sbi_timer`, built
+in `app.rs:3220` inside `run_event_loop_async` from an expired timer. So `UdmSmContext` *is* constructed
+and initialised in production (`app.rs:333-334`), but its `ue_sms` and `sess_sms` maps are permanently
+empty and only its timer branch is ever entered. The live Nudm surface is `app.rs::udm_sbi_route`
+dispatching to `uecm.rs` and `app.rs`'s own handlers, exactly as the issue says.
+
+That answer makes the deletion order safe: there is no live state machine to break.
+
+It also means the *state machine itself* is the larger finding, and it is filed separately rather than
+folded in here — see "Follow-up filed" below.
+
+## What was removed
+
+Nine handlers, each with a live counterpart already serving the same procedure:
+
+| removed from `nudm_handler.rs` | live implementation |
+|---|---|
+| `udm_nudm_uecm_handle_amf_registration` | `uecm::process_amf_registration` (`uecm.rs:531`) |
+| `udm_nudm_uecm_handle_amf_registration_update` | `uecm::process_amf_registration_update` (`:680`) |
+| `udm_nudm_uecm_handle_amf_registration_get` | `uecm::process_amf_registration_get` (`:656`) |
+| `udm_nudm_uecm_handle_smf_registration` | `uecm::process_smf_registration` (`:769`) |
+| `udm_nudm_uecm_handle_smf_deregistration` | `uecm::process_smf_deregistration` (`:868`) |
+| `udm_nudm_ueau_handle_result_confirmation_inform` | `app::handle_auth_event` (`app.rs:2949`) |
+| `udm_nudm_sdm_handle_subscription_create` | `app.rs::handle_sdm_subscribe` (routed at `app.rs:804`) |
+| `udm_nudm_sdm_handle_subscription_delete` | the `sdm-subscriptions` DELETE arm (`app.rs:805`) |
+| `udm_nudm_sdm_handle_subscription_provisioned` | the `ue-context-in-smf-data` GET arm (`app.rs:817`) |
+
+Plus everything that only fed them: the seven request structs
+(`Amf3GppAccessRegistrationRequest`, `Amf3GppAccessRegistrationModificationRequest`, `GuamiRequest`,
+`PlmnIdRequest`, `SmfRegistrationRequest`, `SdmSubscriptionRequest`, `AuthEventRequest`), the private
+helpers `parse_amf_id` and `guami_matches`, and the two `HandlerResult` constructors nothing else used
+(`created`, `not_found`) with `http_status::NOT_FOUND`.
+
+`nudm_handler.rs` goes 1001 lines -> 186, and what is left is exactly what has a live caller:
+`HandlerResult` / `http_status` (returned by `nudr_handler.rs`) and `hex_to_bytes` / `bytes_to_hex` (used
+by `app.rs`, `sor.rs`, `upu.rs`, `nudr_handler.rs`).
+
+### Two things found in passing, both beyond what the issue reported
+
+**`buffer_to_u64` and `u64_to_buffer` had no caller at all, not even a dead one.** They were exercised
+only by four of their own tests. They are the same class as the handlers but with a shorter blast radius,
+and criterion 2 ("whatever remains has a live caller") covers them, so they went too.
+
+**The `ue-context-in-smf-data` pair is the one place where the dead copy was the *more* dishonest of the
+two.** `udm_nudm_sdm_handle_subscription_provisioned` returned `HandlerResult::ok()` with the body
+comment "In real implementation, this would return actual SMF context data" — i.e. it answered success
+while producing nothing. The live route answers 501. Deleting the dead one removes a fabricated success,
+not a capability. (The resource itself is one of the absent SDM data sets tracked by #226; this change
+does not touch that.)
+
+## `sess_sm.rs`: the two call sites, and why they were not repointed
+
+The issue's step 2 offers "point its two call sites at `uecm::process_smf_registration` /
+`process_smf_deregistration` so there is one implementation". **Deliberately not done**, because the
+state machine is unreachable: repointing dead code at the live functions would give
+`uecm::process_smf_registration` an apparent second caller and make the state-machine path read as
+integrated when nothing drives it. Naming the live implementation in a doc comment carries the same
+information without the false call graph.
+
+Instead the two arms got the treatment `ue_sm.rs` already carries from the earlier `udmd-04` pass — the
+handler call removed, the structure kept, a doc comment saying the live HTTP dispatcher owns the
+procedure. `sess_sm.rs` is simply the file that pass missed; `ue_sm.rs:228-273` and `:333` are the
+precedent this now matches.
+
+Two details recorded in those comments because they say something about the code that was there:
+
+* the `PUT` arm built a **default-constructed** `SmfRegistrationRequest` under the comment "In
+  production, parse SmfRegistrationRequest from HTTP body". The parsing was never written, so had the arm
+  ever been reached it would have registered an SMF with no instance id, no PSI, no S-NSSAI and no DNN —
+  and `udm_nudm_uecm_handle_smf_registration` would have rejected its own caller with
+  `400 No smfInstanceId`.
+* `handle_nudr_dr_response` hardcoded the HTTP method to `"PUT"` and the status to `204` rather than
+  reading either from the response it was dispatched for, so it could only ever report one outcome.
+
+## Verification
+
+Workspace: **5931 passed / 0 failed** over two consecutive clean full runs, against a `main` baseline of
+**5938 / 0** taken on this branch before any edit. The difference is exactly the seven deleted tests
+(`test_handler_result_created`, `test_parse_amf_id`, `test_guami_matches`, `test_buffer_to_u64`,
+`test_u64_to_buffer`, `test_buffer_to_u64_conversion`, `test_u64_to_buffer_roundtrip`), each of which
+tested a symbol this change removes. `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
+
+### A pre-existing flake was hit on the way, and it is written down rather than dismissed
+
+The **first** whole-workspace run failed with two failures in `nextgcore-sgwud`
+(`gtp_path::tests::path_fails_only_after_exceeding_n3_requests` and `::path_state_is_per_peer`) — a crate
+this change does not touch. Recorded rather than waved away, because the rule here is to treat a failure
+in an untouched crate as a real signal until proven otherwise, and to write down any dismissal.
+
+It is proven unrelated two ways: `bins/nextgcore-sgwud/Cargo.toml` declares no dependency on
+`nextgcore-udmd`, so the `sgwud` test binary is identical to `main`'s; and the pair reproduces on its own
+at ~40% (5 failures in 12 runs of `cargo test -p nextgcore-sgwud gtp_path`).
+
+Root-caused to two independent process-global races, both in `gtp_path.rs`:
+
+* **the env var.** `n3_requests()` (`:362`) reads `SGWU_GTPU_N3_REQUESTS` on every call, and three
+  concurrent tests set it to *different* values — `"3"` at `:1257`, `"1"` at `:1283`, `"1"` at `:1308` —
+  each removing it at the end. A sibling flipping it to `1` makes the `N3=3` test's second probe exceed the
+  threshold. The resulting message, "2 unanswered must not yet be a failure with N3=3", reads exactly like
+  the off-by-one TS 23.007 §20.3.1 defect the test exists to pin, which is the recorded hazard of a harness
+  failure wearing the shape of the bug it guards.
+* **the whole-map assertion.** `failed_gtpu_paths()` (`:434`) returns every failed peer in the
+  process-global `GTPU_PATHS` map (`:345`), so `assert_eq!(failed_gtpu_paths(), vec![dead])` (`:1316`, and
+  the same shape at `:1270`) holds only while no other test has a failed path. The observed
+  `left: [10.61.0.1, 10.61.0.3]` is the other test's peer leaking in. Distinct peers do not help; the
+  shared *view* is the problem.
+
+The fix is the guard pattern this repo already uses (`pind/src/main.rs:970`, `easdfd/src/main.rs:690`,
+`eesd/src/auth.rs:81`, `udmd`'s `test_support::CONTEXT_GUARD`) plus peer-scoped assertions instead of
+whole-map equality. Deliberately **not** done here: it is another crate and another defect, and folding it
+into a udmd deletion would make this diff unreviewable against #236. It has no tracker item yet.
+
+**On revert-verification.** This change adds no behaviour, so there is no behavioural claim to make a
+test fail against — the recorded rule is about guards for new behaviour, and inventing a guard for a
+deletion would be the decorative-test failure mode the project already records. What stands in for it
+here is stronger than a test: *the compiler*. Every claim of the form "X had no caller" is falsified at
+build time if it is wrong, and `cargo check -p nextgcore-udmd --all-targets` plus the whole-workspace
+build are the check. The one claim the compiler cannot make is "and no caller reaches it at runtime
+either", which is what the `UdmEvent::sbi_server`-has-no-constructor grep answers instead.
+
+## Ceiling
+
+`sess_sm.rs`'s two remaining stubs, and `ue_sm.rs`'s three, are unreachable and stay that way. This
+change does not make the state machine reachable, does not delete it, and does not test it beyond the
+four existing state-transition tests it already had. That is the follow-up's job.
+
+## Follow-up filed: #242
+
+**The state-machine trio's whole SBI half is unreachable, and `udmd`'s `nudr_handler.rs` is dead behind
+it.** All five public functions of `bins/nextgcore-udmd/src/nudr_handler.rs` now have zero external
+callers: four already did before this change, and the fifth
+(`udm_nudr_dr_handle_smf_registration`) was reached only from the `sess_sm.rs` arm this change strips.
+That is ~1000 more lines of the same class as #233 / #234 / #236, but deleting it belongs with the
+decision about the state machine that referenced it — settling one without the other repeats the
+wrong-order mistake #236 warned about. Filed as its own issue rather than expanded into this PR, so the
+diff stays reviewable against the issue that asked for it. Note `udrd` and `pcfd` have their own,
+*live* `nudr_handler` modules; this is a `udmd`-only finding.

--- a/src/bins/nextgcore-udmd/src/nudm_handler.rs
+++ b/src/bins/nextgcore-udmd/src/nudm_handler.rs
@@ -1,21 +1,58 @@
-//! NUDM Handler Functions
+//! Shared helpers left over from the `src/udm/nudm-handler.c` port.
 //!
-//! Port of src/udm/nudm-handler.c - NUDM service handlers
-//! Handles NUDM-UEAU, NUDM-UECM, and NUDM-SDM service requests
-
-use crate::context::{
-    udm_self, Amf3GppAccessRegistration, AuthEvent, AuthType, Guami, PlmnId, RatType,
-    SmfRegistration, UdmSdmSubscription,
-};
+//! This module no longer handles any Nudm service request. It once held a
+//! second, unreachable Nudm UECM/SDM/UEAU implementation beside the live one in
+//! [`crate::uecm`] and [`crate::app`]; see the removal note below for what went
+//! and why. What remains is the [`HandlerResult`] / [`http_status`] pair that
+//! [`crate::nudr_handler`] returns, plus the hex codec that `app.rs`, `sor.rs`
+//! and `upu.rs` use for wire-format key material.
+//!
+//! ## Removed in #236: nine unreachable Nudm handlers
+//!
+//! Every handler below had a live counterpart already serving the same
+//! procedure, so the file was two implementations of one thing with nothing
+//! marking which was which:
+//!
+//! | removed | live implementation that serves it |
+//! |---|---|
+//! | `udm_nudm_uecm_handle_amf_registration` | [`crate::uecm::process_amf_registration`] |
+//! | `udm_nudm_uecm_handle_amf_registration_update` | [`crate::uecm::process_amf_registration_update`] |
+//! | `udm_nudm_uecm_handle_amf_registration_get` | [`crate::uecm::process_amf_registration_get`] |
+//! | `udm_nudm_uecm_handle_smf_registration` | [`crate::uecm::process_smf_registration`] |
+//! | `udm_nudm_uecm_handle_smf_deregistration` | [`crate::uecm::process_smf_deregistration`] |
+//! | `udm_nudm_ueau_handle_result_confirmation_inform` | [`crate::app::handle_auth_event`] |
+//! | `udm_nudm_sdm_handle_subscription_create` | `app.rs::handle_sdm_subscribe` |
+//! | `udm_nudm_sdm_handle_subscription_delete` | the `sdm-subscriptions` DELETE arm of `app.rs::udm_sbi_route` |
+//! | `udm_nudm_sdm_handle_subscription_provisioned` | the `ue-context-in-smf-data` GET arm, which answers 501 |
+//!
+//! Seven had no reference anywhere outside this file. The two SMF ones were
+//! reached only from [`crate::sess_sm`], whose SBI half is itself unreachable —
+//! `UdmEvent::sbi_server` has no constructor in the tree, so the live router
+//! (`app.rs::udm_sbi_route`) is the only thing that ever serves a Nudm request.
+//! The `ue-context-in-smf-data` case is worth naming: the removed handler
+//! returned `HandlerResult::ok()` while doing nothing, whereas the live route
+//! answers 501, so the dead copy was the more dishonest of the two.
+//!
+//! Also removed, having had no non-test caller at all: `parse_amf_id`,
+//! `guami_matches` (the live GUAMI comparison is `uecm.rs`'s, which operates on
+//! the parsed JSON), `buffer_to_u64` and `u64_to_buffer`, together with the
+//! request structs that only fed the deleted handlers
+//! (`Amf3GppAccessRegistrationRequest`, `Amf3GppAccessRegistrationModificationRequest`,
+//! `GuamiRequest`, `PlmnIdRequest`, `SmfRegistrationRequest`,
+//! `SdmSubscriptionRequest`, `AuthEventRequest`) and the two `HandlerResult`
+//! constructors only they used (`created`, `not_found`).
+//!
+//! This continues PR #228, which removed `udm_nudm_ueau_handle_get` from here
+//! for the same reason: it was the only code that persisted `ausf_instance_id`
+//! and it had no caller, so SoR/UPU always picked an arbitrary AUSF (#84 gap 4).
 
 /// HTTP status codes
 pub mod http_status {
     pub const OK: u16 = 200;
-    pub const CREATED: u16 = 201;
     pub const NO_CONTENT: u16 = 204;
     pub const BAD_REQUEST: u16 = 400;
     pub const FORBIDDEN: u16 = 403;
-    pub const NOT_FOUND: u16 = 404;
+    pub const CREATED: u16 = 201;
     pub const INTERNAL_SERVER_ERROR: u16 = 500;
 }
 
@@ -33,15 +70,6 @@ impl HandlerResult {
         Self {
             success: true,
             status: http_status::OK,
-            error_message: None,
-            error_cause: None,
-        }
-    }
-
-    pub fn created() -> Self {
-        Self {
-            success: true,
-            status: http_status::CREATED,
             error_message: None,
             error_cause: None,
         }
@@ -73,721 +101,6 @@ impl HandlerResult {
             error_cause: cause.map(|s| s.to_string()),
         }
     }
-
-    pub fn not_found(message: &str) -> Self {
-        Self {
-            success: false,
-            status: http_status::NOT_FOUND,
-            error_message: Some(message.to_string()),
-            error_cause: None,
-        }
-    }
-}
-
-/// AMF 3GPP Access Registration request
-#[derive(Debug, Clone, Default)]
-pub struct Amf3GppAccessRegistrationRequest {
-    pub amf_instance_id: Option<String>,
-    pub dereg_callback_uri: Option<String>,
-    pub guami: Option<GuamiRequest>,
-    pub rat_type: Option<String>,
-}
-
-/// GUAMI request data
-#[derive(Debug, Clone, Default)]
-pub struct GuamiRequest {
-    pub amf_id: Option<String>,
-    pub plmn_id: Option<PlmnIdRequest>,
-}
-
-/// PLMN ID request data
-#[derive(Debug, Clone, Default)]
-pub struct PlmnIdRequest {
-    pub mcc: Option<String>,
-    pub mnc: Option<String>,
-}
-
-/// AMF 3GPP Access Registration Modification request
-#[derive(Debug, Clone, Default)]
-pub struct Amf3GppAccessRegistrationModificationRequest {
-    pub guami: Option<GuamiRequest>,
-    pub purge_flag: Option<bool>,
-}
-
-/// SMF Registration request
-#[derive(Debug, Clone, Default)]
-pub struct SmfRegistrationRequest {
-    pub smf_instance_id: Option<String>,
-    pub pdu_session_id: Option<u8>,
-    pub single_nssai: Option<String>,
-    pub dnn: Option<String>,
-    pub plmn_id: Option<PlmnIdRequest>,
-}
-
-/// SDM Subscription request
-#[derive(Debug, Clone, Default)]
-pub struct SdmSubscriptionRequest {
-    pub nf_instance_id: Option<String>,
-    pub callback_reference: Option<String>,
-    pub monitored_resource_uris: Vec<String>,
-}
-
-/// Auth Event request
-#[derive(Debug, Clone, Default)]
-pub struct AuthEventRequest {
-    pub nf_instance_id: Option<String>,
-    pub success: Option<bool>,
-    pub time_stamp: Option<String>,
-    pub auth_type: Option<String>,
-    pub serving_network_name: Option<String>,
-    pub auth_removal_ind: Option<bool>,
-}
-
-/// The dead `udm_nudm_ueau_handle_get` used to live here: a C-port handler that
-/// validated `servingNetworkName` / `ausfInstanceId`, stored them on the UE and
-/// ran AUTS resynchronisation, with NO caller anywhere in the tree. It was the
-/// only code that persisted `ausf_instance_id`, so `sor.rs` and `upu.rs` always
-/// read `None` and picked an arbitrary AUSF (#84 gap 4). The live path in
-/// `app.rs::handle_generate_auth_data` now stores it, and the dead copy is gone
-/// rather than kept as a second, unreachable implementation of the same
-/// procedure.
-/// Handle NUDM UEAU result confirmation inform (auth-events)
-/// Port of udm_nudm_ueau_handle_result_confirmation_inform()
-pub fn udm_nudm_ueau_handle_result_confirmation_inform(
-    udm_ue_id: u64,
-    _stream_id: u64,
-    request: &AuthEventRequest,
-) -> HandlerResult {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let mut udm_ue = match context.ue_find_by_id(udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found [{udm_ue_id}]");
-            return HandlerResult::bad_request("UDM UE not found");
-        }
-    };
-    drop(context);
-
-    log::debug!(
-        "[{}] Handle NUDM UEAU result confirmation inform",
-        udm_ue.suci
-    );
-
-    // Validate AuthEvent
-    let nf_instance_id = match &request.nf_instance_id {
-        Some(id) if !id.is_empty() => id.clone(),
-        _ => {
-            log::error!("[{}] No nfInstanceId", udm_ue.suci);
-            return HandlerResult::bad_request("No nfInstanceId");
-        }
-    };
-
-    let success = match request.success {
-        Some(s) => s,
-        None => {
-            log::error!("[{}] No success", udm_ue.suci);
-            return HandlerResult::bad_request("No success");
-        }
-    };
-
-    let time_stamp = match &request.time_stamp {
-        Some(ts) if !ts.is_empty() => ts.clone(),
-        _ => {
-            log::error!("[{}] No timeStamp", udm_ue.suci);
-            return HandlerResult::bad_request("No timeStamp");
-        }
-    };
-
-    let auth_type_str = match &request.auth_type {
-        Some(at) if !at.is_empty() => at.clone(),
-        _ => {
-            log::error!("[{}] No authType", udm_ue.suci);
-            return HandlerResult::bad_request("No authType");
-        }
-    };
-
-    let serving_network_name = match &request.serving_network_name {
-        Some(snn) if !snn.is_empty() => snn.clone(),
-        _ => {
-            log::error!("[{}] No servingNetworkName", udm_ue.suci);
-            return HandlerResult::bad_request("No servingNetworkName");
-        }
-    };
-
-    // Parse auth type
-    let auth_type = match auth_type_str.as_str() {
-        "5G_AKA" => Some(AuthType::FiveGAka),
-        "EAP_AKA_PRIME" => Some(AuthType::EapAkaPrime),
-        "EAP_TLS" => Some(AuthType::EapTls),
-        _ => None,
-    };
-
-    // Create and store auth event
-    let auth_event = AuthEvent {
-        nf_instance_id: Some(nf_instance_id),
-        success,
-        time_stamp: Some(time_stamp),
-        auth_type,
-        serving_network_name: Some(serving_network_name),
-    };
-
-    udm_ue.set_auth_event(auth_event);
-
-    // Update UE in context
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-    context.ue_update(&udm_ue);
-    drop(context);
-
-    // Send request to UDR to update authentication status
-    // This would trigger udm_nudr_dr_build_update_authentication_status
-    HandlerResult::ok()
-}
-
-/// Handle NUDM UECM AMF registration
-/// Port of udm_nudm_uecm_handle_amf_registration()
-pub fn udm_nudm_uecm_handle_amf_registration(
-    udm_ue_id: u64,
-    _stream_id: u64,
-    request: &Amf3GppAccessRegistrationRequest,
-) -> HandlerResult {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let mut udm_ue = match context.ue_find_by_id(udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found [{udm_ue_id}]");
-            return HandlerResult::bad_request("UDM UE not found");
-        }
-    };
-    drop(context);
-
-    let supi = udm_ue.supi.clone().unwrap_or_else(|| udm_ue.suci.clone());
-    log::debug!("[{supi}] Handle NUDM UECM AMF registration");
-
-    // Validate Amf3GppAccessRegistration
-    let amf_instance_id = match &request.amf_instance_id {
-        Some(id) if !id.is_empty() => id.clone(),
-        _ => {
-            log::error!("[{supi}] No amfInstanceId");
-            return HandlerResult::bad_request("No amfInstanceId");
-        }
-    };
-
-    let dereg_callback_uri = match &request.dereg_callback_uri {
-        Some(uri) if !uri.is_empty() => uri.clone(),
-        _ => {
-            log::error!("[{supi}] No dregCallbackUri");
-            return HandlerResult::bad_request("No dregCallbackUri");
-        }
-    };
-
-    // Validate GUAMI
-    let guami_req = match &request.guami {
-        Some(g) => g,
-        None => {
-            log::error!("[{supi}] No Guami");
-            return HandlerResult::bad_request("No Guami");
-        }
-    };
-
-    let amf_id = match &guami_req.amf_id {
-        Some(id) if !id.is_empty() => id.clone(),
-        _ => {
-            log::error!("[{supi}] No Guami.AmfId");
-            return HandlerResult::bad_request("No Guami.AmfId");
-        }
-    };
-
-    let plmn_id_req = match &guami_req.plmn_id {
-        Some(p) => p,
-        None => {
-            log::error!("[{supi}] No PlmnId");
-            return HandlerResult::bad_request("No PlmnId");
-        }
-    };
-
-    let mcc = match &plmn_id_req.mcc {
-        Some(m) if !m.is_empty() => m.clone(),
-        _ => {
-            log::error!("[{supi}] No PlmnId.Mcc");
-            return HandlerResult::bad_request("No PlmnId.Mcc");
-        }
-    };
-
-    let mnc = match &plmn_id_req.mnc {
-        Some(m) if !m.is_empty() => m.clone(),
-        _ => {
-            log::error!("[{supi}] No PlmnId.Mnc");
-            return HandlerResult::bad_request("No PlmnId.Mnc");
-        }
-    };
-
-    // Validate RAT type
-    if request.rat_type.is_none() {
-        log::error!("[{supi}] No RatType");
-        return HandlerResult::bad_request("No RatType");
-    }
-
-    // Parse RAT type
-    let rat_type = match request.rat_type.as_deref() {
-        Some("NR") => RatType::Nr,
-        Some("EUTRA") => RatType::Eutra,
-        Some("WLAN") => RatType::Wlan,
-        Some("VIRTUAL") => RatType::Virtual,
-        _ => RatType::Nr,
-    };
-
-    // Parse AMF ID (hex string to components)
-    let amf_id_parsed = parse_amf_id(&amf_id);
-
-    // Store registration data
-    udm_ue.dereg_callback_uri = Some(dereg_callback_uri.clone());
-    udm_ue.guami = Guami {
-        plmn_id: PlmnId { mcc, mnc },
-        amf_id: amf_id_parsed,
-    };
-    udm_ue.rat_type = rat_type;
-
-    // Store AMF 3GPP access registration
-    let registration = Amf3GppAccessRegistration {
-        amf_instance_id: Some(amf_instance_id),
-        dereg_callback_uri: Some(dereg_callback_uri),
-        guami: Some(udm_ue.guami.clone()),
-        rat_type: Some(rat_type),
-    };
-    udm_ue.set_amf_3gpp_access_registration(registration);
-
-    // Update UE in context
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-    context.ue_update(&udm_ue);
-    drop(context);
-
-    // Send request to UDR to update AMF context
-    HandlerResult::ok()
-}
-
-/// Handle NUDM UECM AMF registration update
-/// Port of udm_nudm_uecm_handle_amf_registration_update()
-pub fn udm_nudm_uecm_handle_amf_registration_update(
-    udm_ue_id: u64,
-    _stream_id: u64,
-    request: &Amf3GppAccessRegistrationModificationRequest,
-) -> HandlerResult {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let udm_ue = match context.ue_find_by_id(udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found [{udm_ue_id}]");
-            return HandlerResult::bad_request("UDM UE not found");
-        }
-    };
-    drop(context);
-
-    let supi = udm_ue.supi.clone().unwrap_or_else(|| udm_ue.suci.clone());
-    log::debug!("[{supi}] Handle NUDM UECM AMF registration update");
-
-    // Validate GUAMI
-    let guami_req = match &request.guami {
-        Some(g) => g,
-        None => {
-            log::error!("[{supi}] No Guami");
-            return HandlerResult::bad_request("No Guami");
-        }
-    };
-
-    let amf_id = match &guami_req.amf_id {
-        Some(id) if !id.is_empty() => id.clone(),
-        _ => {
-            log::error!("[{supi}] No Guami.AmfId");
-            return HandlerResult::bad_request("No Guami.AmfId");
-        }
-    };
-
-    let plmn_id_req = match &guami_req.plmn_id {
-        Some(p) => p,
-        None => {
-            log::error!("[{supi}] No PlmnId");
-            return HandlerResult::bad_request("No PlmnId");
-        }
-    };
-
-    let mcc = match &plmn_id_req.mcc {
-        Some(m) if !m.is_empty() => m.clone(),
-        _ => {
-            log::error!("[{supi}] No PlmnId.Mcc");
-            return HandlerResult::bad_request("No PlmnId.Mcc");
-        }
-    };
-
-    let mnc = match &plmn_id_req.mnc {
-        Some(m) if !m.is_empty() => m.clone(),
-        _ => {
-            log::error!("[{supi}] No PlmnId.Mnc");
-            return HandlerResult::bad_request("No PlmnId.Mnc");
-        }
-    };
-
-    // Parse received GUAMI
-    let recv_guami = Guami {
-        plmn_id: PlmnId { mcc, mnc },
-        amf_id: parse_amf_id(&amf_id),
-    };
-
-    // Check if received GUAMI matches stored GUAMI
-    // TS 29.503: 5.3.2.4.2 AMF deregistration for 3GPP access
-    if !guami_matches(&recv_guami, &udm_ue.guami) {
-        log::error!("[{supi}] Guami mismatch");
-        return HandlerResult::forbidden("Guami mismatch", Some("INVALID_GUAMI"));
-    }
-
-    // Handle purge flag if present
-    if let Some(purge_flag) = request.purge_flag {
-        let ctx = udm_self();
-        let context = ctx.read().unwrap();
-        if let Some(mut ue) = context.ue_find_by_id(udm_ue_id) {
-            if let Some(ref mut _reg) = ue.amf_3gpp_access_registration {
-                // Note: purge_flag stored in registration and sent to UDR on PATCH request
-                log::debug!("[{supi}] Setting purge flag to {purge_flag}");
-            }
-            context.ue_update(&ue);
-        }
-        drop(context);
-    }
-
-    // Send PATCH request to UDR
-    HandlerResult::ok()
-}
-
-/// Handle NUDM UECM AMF registration get
-/// Port of udm_nudm_uecm_handle_amf_registration_get()
-pub fn udm_nudm_uecm_handle_amf_registration_get(
-    udm_ue_id: u64,
-    _stream_id: u64,
-    resource_name: &str,
-) -> (HandlerResult, Option<Amf3GppAccessRegistration>) {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let udm_ue = match context.ue_find_by_id(udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found [{udm_ue_id}]");
-            return (HandlerResult::bad_request("UDM UE not found"), None);
-        }
-    };
-    drop(context);
-
-    let supi = udm_ue.supi.clone().unwrap_or_else(|| udm_ue.suci.clone());
-    log::debug!("[{supi}] Handle NUDM UECM AMF registration get");
-
-    match resource_name {
-        "registrations" => {
-            if let Some(ref registration) = udm_ue.amf_3gpp_access_registration {
-                (HandlerResult::ok(), Some(registration.clone()))
-            } else {
-                log::error!("Invalid UE Identifier [{}]", udm_ue.suci);
-                (HandlerResult::bad_request("Invalid UE Identifier"), None)
-            }
-        }
-        _ => {
-            log::error!("Invalid resource name [{resource_name}]");
-            (HandlerResult::bad_request("Invalid resource name"), None)
-        }
-    }
-}
-
-/// Handle NUDM UECM SMF registration
-/// Port of udm_nudm_uecm_handle_smf_registration()
-pub fn udm_nudm_uecm_handle_smf_registration(
-    sess_id: u64,
-    _stream_id: u64,
-    request: &SmfRegistrationRequest,
-) -> HandlerResult {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let mut sess = match context.sess_find_by_id(sess_id) {
-        Some(s) => s,
-        None => {
-            log::error!("UDM session not found [{sess_id}]");
-            return HandlerResult::bad_request("UDM session not found");
-        }
-    };
-
-    let udm_ue = match context.ue_find_by_id(sess.udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found for session [{sess_id}]");
-            return HandlerResult::bad_request("UDM UE not found");
-        }
-    };
-    drop(context);
-
-    let supi = udm_ue.supi.clone().unwrap_or_else(|| udm_ue.suci.clone());
-    log::debug!("[{}:{}] Handle NUDM UECM SMF registration", supi, sess.psi);
-
-    // Validate SmfRegistration
-    let smf_instance_id = match &request.smf_instance_id {
-        Some(id) if !id.is_empty() => id.clone(),
-        _ => {
-            log::error!("[{}:{}] No smfInstanceId", supi, sess.psi);
-            return HandlerResult::bad_request("No smfInstanceId");
-        }
-    };
-
-    let pdu_session_id = match request.pdu_session_id {
-        Some(id) if id > 0 => id,
-        _ => {
-            log::error!("[{}:{}] No pduSessionId", supi, sess.psi);
-            return HandlerResult::bad_request("No pduSessionId");
-        }
-    };
-
-    let single_nssai = match &request.single_nssai {
-        Some(nssai) if !nssai.is_empty() => nssai.clone(),
-        _ => {
-            log::error!("[{}:{}] No singleNssai", supi, sess.psi);
-            return HandlerResult::bad_request("No singleNssai");
-        }
-    };
-
-    let dnn = match &request.dnn {
-        Some(d) if !d.is_empty() => d.clone(),
-        _ => {
-            log::error!("[{}:{}] No dnn", supi, sess.psi);
-            return HandlerResult::bad_request("No dnn");
-        }
-    };
-
-    // Validate PLMN ID
-    let plmn_id_req = match &request.plmn_id {
-        Some(p) => p,
-        None => {
-            log::error!("[{}:{}] No plmnId", supi, sess.psi);
-            return HandlerResult::bad_request("No plmnId");
-        }
-    };
-
-    let mcc = match &plmn_id_req.mcc {
-        Some(m) if !m.is_empty() => m.clone(),
-        _ => {
-            log::error!("[{}:{}] No plmnId.mcc", supi, sess.psi);
-            return HandlerResult::bad_request("No plmnId.mcc");
-        }
-    };
-
-    let mnc = match &plmn_id_req.mnc {
-        Some(m) if !m.is_empty() => m.clone(),
-        _ => {
-            log::error!("[{}:{}] No plmnId.mnc", supi, sess.psi);
-            return HandlerResult::bad_request("No plmnId.mnc");
-        }
-    };
-
-    // Store SMF registration
-    let smf_registration = SmfRegistration {
-        smf_instance_id: Some(smf_instance_id),
-        pdu_session_id,
-        single_nssai: Some(single_nssai),
-        dnn: Some(dnn),
-        plmn_id: Some(PlmnId { mcc, mnc }),
-    };
-    sess.set_smf_registration(smf_registration);
-
-    // Update session in context
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-    context.sess_update(&sess);
-    drop(context);
-
-    // Send request to UDR to update SMF context
-    HandlerResult::ok()
-}
-
-/// Handle NUDM UECM SMF deregistration
-/// Port of udm_nudm_uecm_handle_smf_deregistration()
-pub fn udm_nudm_uecm_handle_smf_deregistration(sess_id: u64, _stream_id: u64) -> HandlerResult {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let sess = match context.sess_find_by_id(sess_id) {
-        Some(s) => s,
-        None => {
-            log::error!("UDM session not found [{sess_id}]");
-            return HandlerResult::bad_request("UDM session not found");
-        }
-    };
-
-    let udm_ue = match context.ue_find_by_id(sess.udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found for session [{sess_id}]");
-            return HandlerResult::bad_request("UDM UE not found");
-        }
-    };
-    drop(context);
-
-    let supi = udm_ue.supi.clone().unwrap_or_else(|| udm_ue.suci.clone());
-    log::debug!(
-        "[{}:{}] Handle NUDM UECM SMF deregistration",
-        supi,
-        sess.psi
-    );
-
-    // Send request to UDR to delete SMF context
-    HandlerResult::ok()
-}
-
-/// Handle NUDM SDM subscription provisioned (ue-context-in-smf-data)
-/// Port of udm_nudm_sdm_handle_subscription_provisioned()
-pub fn udm_nudm_sdm_handle_subscription_provisioned(
-    udm_ue_id: u64,
-    _stream_id: u64,
-    resource_name: &str,
-) -> HandlerResult {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let udm_ue = match context.ue_find_by_id(udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found [{udm_ue_id}]");
-            return HandlerResult::bad_request("UDM UE not found");
-        }
-    };
-    drop(context);
-
-    let supi = udm_ue.supi.clone().unwrap_or_else(|| udm_ue.suci.clone());
-    log::debug!("[{supi}] Handle NUDM SDM subscription provisioned");
-
-    match resource_name {
-        "ue-context-in-smf-data" => {
-            // Return empty UeContextInSmfData
-            // In real implementation, this would return actual SMF context data
-            HandlerResult::ok()
-        }
-        _ => {
-            log::error!("Invalid resource name [{resource_name}]");
-            HandlerResult::bad_request("Invalid resource name")
-        }
-    }
-}
-
-/// Handle NUDM SDM subscription create
-/// Port of udm_nudm_sdm_handle_subscription_create()
-pub fn udm_nudm_sdm_handle_subscription_create(
-    udm_ue_id: u64,
-    _stream_id: u64,
-    request: &SdmSubscriptionRequest,
-) -> (HandlerResult, Option<UdmSdmSubscription>) {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let udm_ue = match context.ue_find_by_id(udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found [{udm_ue_id}]");
-            return (HandlerResult::bad_request("UDM UE not found"), None);
-        }
-    };
-
-    let supi = udm_ue.supi.clone().unwrap_or_else(|| udm_ue.suci.clone());
-    log::debug!("[{supi}] Handle NUDM SDM subscription create");
-
-    // Validate SDMSubscription
-    if request.nf_instance_id.is_none()
-        || request
-            .nf_instance_id
-            .as_ref()
-            .map(|s| s.is_empty())
-            .unwrap_or(true)
-    {
-        log::error!("[{supi}] No nfInstanceId");
-        return (HandlerResult::bad_request("No nfInstanceId"), None);
-    }
-
-    if request.callback_reference.is_none()
-        || request
-            .callback_reference
-            .as_ref()
-            .map(|s| s.is_empty())
-            .unwrap_or(true)
-    {
-        log::error!("[{supi}] No callbackReference");
-        return (HandlerResult::bad_request("No callbackReference"), None);
-    }
-
-    if request.monitored_resource_uris.is_empty() {
-        log::error!("[{supi}] No monitoredResourceUris");
-        return (HandlerResult::bad_request("No monitoredResourceUris"), None);
-    }
-
-    // Add SDM subscription
-    let subscription = match context.sdm_subscription_add(udm_ue_id) {
-        Some(mut sub) => {
-            sub.data_change_callback_uri = request.callback_reference.clone();
-            context.sdm_subscription_update(&sub);
-            sub
-        }
-        None => {
-            log::error!("[{supi}] sdm_subscription_add() failed");
-            return (
-                HandlerResult::bad_request("sdm_subscription_add() failed"),
-                None,
-            );
-        }
-    };
-    drop(context);
-
-    log::debug!("[{}] SDM subscription created: {}", supi, subscription.id);
-    (HandlerResult::created(), Some(subscription))
-}
-
-/// Handle NUDM SDM subscription delete
-/// Port of udm_nudm_sdm_handle_subscription_delete()
-pub fn udm_nudm_sdm_handle_subscription_delete(
-    udm_ue_id: u64,
-    _stream_id: u64,
-    subscription_id: Option<&str>,
-) -> HandlerResult {
-    let ctx = udm_self();
-    let context = ctx.read().unwrap();
-
-    let udm_ue = match context.ue_find_by_id(udm_ue_id) {
-        Some(ue) => ue,
-        None => {
-            log::error!("UDM UE not found [{udm_ue_id}]");
-            return HandlerResult::bad_request("UDM UE not found");
-        }
-    };
-
-    let supi = udm_ue.supi.clone().unwrap_or_else(|| udm_ue.suci.clone());
-    log::debug!("[{supi}] Handle NUDM SDM subscription delete");
-
-    let sub_id = match subscription_id {
-        Some(id) if !id.is_empty() => id,
-        _ => {
-            log::error!("[{supi}] No subscriptionID");
-            return HandlerResult::bad_request("No subscriptionID");
-        }
-    };
-
-    // Find and remove subscription
-    if context.sdm_subscription_find_by_id(sub_id).is_some() {
-        context.sdm_subscription_remove(sub_id);
-        log::debug!("[{supi}] SDM subscription deleted: {sub_id}");
-        HandlerResult::no_content()
-    } else {
-        log::error!("Subscription to be deleted does not exist [{sub_id}]");
-        HandlerResult::not_found("Subscription Not found")
-    }
 }
 
 // Helper functions
@@ -805,48 +118,6 @@ pub fn bytes_to_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
-/// Convert buffer to u64
-fn buffer_to_u64(buf: &[u8]) -> u64 {
-    let mut result: u64 = 0;
-    for &byte in buf {
-        result = (result << 8) | (byte as u64);
-    }
-    result
-}
-
-/// Convert u64 to buffer
-fn u64_to_buffer(value: u64, buf: &mut [u8]) {
-    let len = buf.len();
-    for i in 0..len {
-        buf[len - 1 - i] = ((value >> (i * 8)) & 0xFF) as u8;
-    }
-}
-
-/// Parse AMF ID from hex string
-fn parse_amf_id(amf_id_str: &str) -> crate::context::AmfId {
-    // AMF ID is 24 bits: 8-bit region + 10-bit set + 6-bit pointer
-    let bytes = hex_to_bytes(amf_id_str);
-    if bytes.len() >= 3 {
-        let value = ((bytes[0] as u32) << 16) | ((bytes[1] as u32) << 8) | (bytes[2] as u32);
-        crate::context::AmfId {
-            region: ((value >> 16) & 0xFF) as u8,
-            set: ((value >> 6) & 0x3FF) as u16,
-            pointer: (value & 0x3F) as u8,
-        }
-    } else {
-        crate::context::AmfId::default()
-    }
-}
-
-/// Check if two GUAMIs match
-fn guami_matches(a: &Guami, b: &Guami) -> bool {
-    a.plmn_id.mcc == b.plmn_id.mcc
-        && a.plmn_id.mnc == b.plmn_id.mnc
-        && a.amf_id.region == b.amf_id.region
-        && a.amf_id.set == b.amf_id.set
-        && a.amf_id.pointer == b.amf_id.pointer
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -857,13 +128,6 @@ mod tests {
         assert!(result.success);
         assert_eq!(result.status, http_status::OK);
         assert!(result.error_message.is_none());
-    }
-
-    #[test]
-    fn test_handler_result_created() {
-        let result = HandlerResult::created();
-        assert!(result.success);
-        assert_eq!(result.status, http_status::CREATED);
     }
 
     #[test]
@@ -911,91 +175,12 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_to_u64() {
-        let buf = [0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
-        assert_eq!(buffer_to_u64(&buf), 1);
-
-        let buf2 = [0x00, 0x00, 0x00, 0x00, 0x01, 0x00];
-        assert_eq!(buffer_to_u64(&buf2), 256);
-    }
-
-    #[test]
-    fn test_u64_to_buffer() {
-        let mut buf = [0u8; 6];
-        u64_to_buffer(1, &mut buf);
-        assert_eq!(buf, [0x00, 0x00, 0x00, 0x00, 0x00, 0x01]);
-
-        u64_to_buffer(256, &mut buf);
-        assert_eq!(buf, [0x00, 0x00, 0x00, 0x00, 0x01, 0x00]);
-    }
-
-    #[test]
-    fn test_parse_amf_id() {
-        // AMF ID: region=0x01, set=0x002, pointer=0x01
-        // Binary: 00000001 00000000 10000001 = 0x010081
-        let amf_id = parse_amf_id("010081");
-        assert_eq!(amf_id.region, 0x01);
-        assert_eq!(amf_id.set, 0x002);
-        assert_eq!(amf_id.pointer, 0x01);
-    }
-
-    #[test]
-    fn test_guami_matches() {
-        let guami1 = Guami {
-            plmn_id: PlmnId {
-                mcc: "001".to_string(),
-                mnc: "01".to_string(),
-            },
-            amf_id: crate::context::AmfId {
-                region: 1,
-                set: 2,
-                pointer: 3,
-            },
-        };
-
-        let guami2 = guami1.clone();
-        assert!(guami_matches(&guami1, &guami2));
-
-        let guami3 = Guami {
-            plmn_id: PlmnId {
-                mcc: "001".to_string(),
-                mnc: "02".to_string(), // Different MNC
-            },
-            amf_id: crate::context::AmfId {
-                region: 1,
-                set: 2,
-                pointer: 3,
-            },
-        };
-        assert!(!guami_matches(&guami1, &guami3));
-    }
-
-    #[test]
     fn test_hex_to_bytes_invalid_length() {
-        // Test that invalid RAND length is handled
+        // A short hex string yields the bytes it does contain rather than
+        // padding or erroring: `app.rs` relies on the caller length-checking the
+        // result (a 2-byte RAND is not silently widened to 16).
         let hex = "0123"; // Only 2 bytes instead of 16
         let bytes = hex_to_bytes(hex);
         assert_eq!(bytes.len(), 2);
-    }
-
-    #[test]
-    fn test_buffer_to_u64_conversion() {
-        // Test SQN conversion edge cases
-        let buf = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
-        let val = buffer_to_u64(&buf);
-        assert_eq!(val, 0xFFFFFFFFFFFF);
-
-        let buf2 = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-        let val2 = buffer_to_u64(&buf2);
-        assert_eq!(val2, 0);
-    }
-
-    #[test]
-    fn test_u64_to_buffer_roundtrip() {
-        let mut buf = [0u8; 6];
-        let original = 0x123456789ABC;
-        u64_to_buffer(original, &mut buf);
-        let converted = buffer_to_u64(&buf);
-        assert_eq!(converted & 0xFFFFFFFFFFFF, original & 0xFFFFFFFFFFFF);
     }
 }

--- a/src/bins/nextgcore-udmd/src/sess_sm.rs
+++ b/src/bins/nextgcore-udmd/src/sess_sm.rs
@@ -4,9 +4,7 @@
 
 use crate::context::udm_self;
 use crate::event::{UdmEvent, UdmEventId};
-use crate::nudm_handler;
-use crate::nudr_handler;
-use crate::sbi_response::{send_error_response, send_method_not_allowed_response};
+use crate::sbi_response::send_error_response;
 
 /// UDM Session state type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -243,43 +241,32 @@ impl UdmSessSmContext {
     }
 
     /// Handle NUDM UECM requests for session
+    ///
+    /// udmd-04 / #236: SMF registration and deregistration are handled by the
+    /// live async HTTP dispatcher (`app.rs::udm_sbi_route` ->
+    /// [`crate::uecm::process_smf_registration`] /
+    /// [`crate::uecm::process_smf_deregistration`]). The state-machine branch is
+    /// a legacy Open5GS port that was never wired to the HTTP path — nothing in
+    /// the tree constructs a `UdmEvent::sbi_server`, so this is unreachable. It
+    /// used to call `nudm_handler`'s own second implementation of both
+    /// procedures, and did so with a **default-constructed**
+    /// `SmfRegistrationRequest` (the removed body-parsing was never written), so
+    /// had it ever been reached it would have registered an empty SMF. The
+    /// handler calls have been removed with those handlers; the structure is
+    /// kept for future extension only, matching `ue_sm.rs`.
     fn handle_nudm_uecm_request(
         &mut self,
-        suci: &str,
-        psi: u8,
-        method: &str,
-        resource_components: &[String],
-        stream_id: u64,
+        _suci: &str,
+        _psi: u8,
+        _method: &str,
+        _resource_components: &[String],
+        _stream_id: u64,
     ) {
-        let resource = resource_components.get(1).map(|s| s.as_str());
-
-        match resource {
-            Some("registrations") => match method {
-                "PUT" => {
-                    // Note: In production, parse SmfRegistrationRequest from HTTP body
-                    let request = nudm_handler::SmfRegistrationRequest::default();
-                    let _result = nudm_handler::udm_nudm_uecm_handle_smf_registration(
-                        self.sess_id,
-                        stream_id,
-                        &request,
-                    );
-                }
-                "DELETE" => {
-                    let _result = nudm_handler::udm_nudm_uecm_handle_smf_deregistration(
-                        self.sess_id,
-                        stream_id,
-                    );
-                }
-                _ => {
-                    log::error!("[{suci}:{psi}] Invalid HTTP method [{method}]");
-                    send_method_not_allowed_response(stream_id, method, "nudm-uecm/registrations");
-                }
-            },
-            _ => {
-                log::error!("[{suci}:{psi}] Invalid resource name [{resource:?}]");
-                send_error_response(stream_id, 404, &format!("Resource not found: {resource:?}"));
-            }
-        }
+        log::debug!(
+            "UDM Sess SM [{}:{}]: UECM request on state-machine path — handled by HTTP dispatcher",
+            self.udm_ue_id,
+            self.sess_id
+        );
     }
 
     /// Handle SBI client events in operational state
@@ -333,42 +320,24 @@ impl UdmSessSmContext {
     }
 
     /// Handle NUDR DR responses for session
+    ///
+    /// udmd-04 / #236: see [`Self::handle_nudm_uecm_request`]. The removed body
+    /// hardcoded the HTTP method to `"PUT"` and the status to `204` rather than
+    /// reading either from the response it was dispatched for, so it could only
+    /// ever have reported one outcome.
     fn handle_nudr_dr_response(
         &mut self,
-        suci: &str,
+        _suci: &str,
         _supi: Option<&str>,
-        psi: u8,
-        resource_components: &[String],
-        stream_id: u64,
+        _psi: u8,
+        _resource_components: &[String],
+        _stream_id: u64,
     ) {
-        let resource = resource_components.first().map(|s| s.as_str());
-
-        match resource {
-            Some("subscription-data") => {
-                let resource2 = resource_components.get(2).map(|s| s.as_str());
-                match resource2 {
-                    Some("context-data") => {
-                        let resource3 =
-                            resource_components.get(3).map(|s| s.as_str()).unwrap_or("");
-                        // Note: HTTP method and status extracted from SBI response message headers
-                        let (_result, _registration) =
-                            nudr_handler::udm_nudr_dr_handle_smf_registration(
-                                self.sess_id,
-                                stream_id,
-                                "PUT", // HTTP method
-                                resource3,
-                                204, // HTTP status
-                            );
-                    }
-                    _ => {
-                        log::error!("[{suci}:{psi}] Invalid resource name [{resource2:?}]");
-                    }
-                }
-            }
-            _ => {
-                log::error!("[{suci}:{psi}] Invalid resource name [{resource:?}]");
-            }
-        }
+        log::debug!(
+            "UDM Sess SM [{}:{}]: NUDR-DR response on state-machine path — handled by HTTP dispatcher",
+            self.udm_ue_id,
+            self.sess_id
+        );
     }
 
     /// Handle exception state


### PR DESCRIPTION
`Closes #236`.

Spec: [`specs/fix-udmd-delete-unreachable-nudm-handler-implementation.md`](specs/fix-udmd-delete-unreachable-nudm-handler-implementation.md).

## The question #236 said to answer first

> Confirm whether the `sess_sm` / `udm_sm` session state machine is meant to be driven at all. If it is
> dead too, that is the larger finding and should be settled first.

**It is dead, and the proof is one grep: nothing in the tree constructs a `UdmEvent::sbi_server` or a
`UdmEvent::sbi_client`.** Both constructors exist (`event.rs:183`, `:203`) and have zero callers — not in
production, not in tests. The only event the daemon dispatches is `UdmEvent::sbi_timer`, built at
`app.rs:3220` from an expired timer. So `UdmSmContext` really is constructed and initialised
(`app.rs:333-334`), but its `ue_sms` / `sess_sms` maps are permanently empty and only its timer branch is
ever entered. The chain that would have reached the two surviving handlers —

```
UdmEventId::SbiServer -> udm_sm::handle_sbi_server_event -> handle_nudm_request
                      -> handle_sess_request -> sess_sm::dispatch
                      -> nudm_handler::udm_nudm_uecm_handle_smf_registration
```

— never gets its first link. That answer is what makes the deletion order safe: there was no live state
machine to break.

## What was deleted

Nine handlers, each with a live counterpart already serving the same procedure:

| removed | live implementation |
|---|---|
| `udm_nudm_uecm_handle_amf_registration` | `uecm::process_amf_registration` (`uecm.rs:531`) |
| `udm_nudm_uecm_handle_amf_registration_update` | `uecm::process_amf_registration_update` (`:680`) |
| `udm_nudm_uecm_handle_amf_registration_get` | `uecm::process_amf_registration_get` (`:656`) |
| `udm_nudm_uecm_handle_smf_registration` | `uecm::process_smf_registration` (`:769`) |
| `udm_nudm_uecm_handle_smf_deregistration` | `uecm::process_smf_deregistration` (`:868`) |
| `udm_nudm_ueau_handle_result_confirmation_inform` | `app::handle_auth_event` (`app.rs:2949`) |
| `udm_nudm_sdm_handle_subscription_create` | `handle_sdm_subscribe` (routed `app.rs:804`) |
| `udm_nudm_sdm_handle_subscription_delete` | the `sdm-subscriptions` DELETE arm (`app.rs:805`) |
| `udm_nudm_sdm_handle_subscription_provisioned` | the `ue-context-in-smf-data` GET arm (`app.rs:817`) |

Plus everything that only fed them: seven request structs, `parse_amf_id`, `guami_matches` (the live GUAMI
comparison is `uecm.rs`'s, on parsed JSON), and the two `HandlerResult` constructors nothing else used.

`nudm_handler.rs` goes **1001 -> 186 lines**, and what remains is exactly what has a live caller:
`HandlerResult` / `http_status` (returned by `nudr_handler.rs`) and `hex_to_bytes` / `bytes_to_hex` (used by
`app.rs`, `sor.rs`, `upu.rs`).

## Two findings beyond the issue's report

- **`buffer_to_u64` and `u64_to_buffer` had no caller at all** — not even a dead one, only four of their
  own tests. Criterion 2 ("whatever remains has a live caller") takes them too.
- **The `ue-context-in-smf-data` pair is the one place the dead copy was the *more* dishonest of the two.**
  The removed handler returned `HandlerResult::ok()` under a comment promising real data later — success
  while producing nothing. The live route answers 501. Deleting the dead one removes a fabricated success,
  not a capability. (The resource itself is one of the absent SDM data sets tracked by #226; untouched here.)

## Why `sess_sm`'s two call sites were not repointed

#236's step 2 offers "point its two call sites at `uecm::process_smf_registration` /
`process_smf_deregistration`". **Deliberately not done**: repointing dead code would give
`process_smf_registration` an apparent second caller and make the state-machine path read as integrated
when nothing drives it. A doc comment naming the live implementation carries the same information without
the false call graph.

Instead both arms got the treatment `ue_sm.rs` already carries from the earlier `udmd-04` pass — handler
call removed, structure kept, comment saying the HTTP dispatcher owns the procedure. `sess_sm.rs` is simply
the file that pass missed (`ue_sm.rs:228-273`, `:333` are the precedent). Two details recorded in those
comments because they say something about what was there:

- the `PUT` arm built a **default-constructed** `SmfRegistrationRequest` under a comment saying production
  would parse the body. It never did — so had the arm been reached, the handler would have rejected its own
  caller with `400 No smfInstanceId`.
- `handle_nudr_dr_response` hardcoded the method to `"PUT"` and the status to `204` rather than reading
  either from the response it was dispatched for, so it could only ever report one outcome.

## Verification

- **Workspace 5931 passed / 0 failed** over two consecutive clean runs, against a **5938 / 0** baseline
  taken on this branch before any edit. The difference is exactly the seven deleted tests, each of which
  tested a symbol this removes.
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
- **No revert-verification, on purpose.** This adds no behaviour, so there is no guard to make fail;
  inventing one would be the decorative-test failure mode this project already records. The compiler is the
  stronger check for every "X had no caller" claim, and the `UdmEvent::sbi_server`-has-no-constructor grep
  answers the one claim the compiler cannot make.

### A pre-existing flake was hit and is written down rather than dismissed

The **first** workspace run failed with two failures in `nextgcore-sgwud`
(`gtp_path::tests::path_fails_only_after_exceeding_n3_requests`, `::path_state_is_per_peer`) — a crate this
does not touch. Proven unrelated: `sgwud` declares no dependency on `nextgcore-udmd`, so its test binary is
identical to `main`'s, and the pair reproduces alone at ~40% (5 failures in 12 runs). Root-caused to two
process-global races in `gtp_path.rs`: three tests set `SGWU_GTPU_N3_REQUESTS` to *different* values
(`:1257` = 3, `:1283` = 1, `:1308` = 1) while `n3_requests()` re-reads it on every call, and two assertions
compare the *whole* `failed_gtpu_paths()` map (`:1270`, `:1316`) so another test's failed peer leaks in —
which is exactly the observed `left: [10.61.0.1, 10.61.0.3]`. Note the first failure message reads
*"2 unanswered must not yet be a failure with N3=3"*, i.e. it wears the shape of the off-by-one TS 23.007
§20.3.1 defect the test exists to pin. Left for its own change (another crate, another defect); it has
**no tracker item**.

## Ceiling

`sess_sm.rs`'s two remaining stubs and `ue_sm.rs`'s three stay unreachable. This change does not make the
state machine reachable, delete it, or test it beyond the four state-transition tests it already had.

## Follow-up filed: #242

The state-machine trio's whole SBI half is unreachable **and `udmd`'s `nudr_handler.rs` is dead behind it**
— all five public functions now have zero external callers, four of which already did before this change;
the fifth was reached only from the `sess_sm` arm stripped here. Filed rather than folded in: deleting
~1000 more lines belongs with the decision about the state machine that referenced it, and settling one
without the other repeats the wrong-order mistake #236 warned about. (`udrd` and `pcfd` have their own,
*live* `nudr_handler` modules — this is `udmd`-only.)

## GitNexus

`nextgcore/CLAUDE.md` mandates `gitnexus_impact` / `gitnexus_detect_changes` before editing and committing.
No GitNexus MCP server is connected in this environment, so that mandate is unsatisfiable — 23rd
consecutive PR in this state. Blast radius was established by exhaustive `grep` over `src/**/*.rs` plus
`cargo check -p nextgcore-udmd --all-targets` and the whole-workspace build instead.