### PR TITLE
fix(sbi+NFs): deregister from the NRF on shutdown, and bound the discovery cache by validityPeriod (Closes #235)

### DIFF
--- a/specs/fix-nrf-deregister-on-shutdown-and-discovery-cache-validity.md
+++ b/specs/fix-nrf-deregister-on-shutdown-and-discovery-cache-validity.md
@@ -1,0 +1,193 @@
+# nextgcore #235: deregister from the NRF on shutdown, and stop selecting a discovery-cache entry forever
+
+Verified against `main` @ `4ec257a`. Both gaps were still present exactly as described. Three details in
+the issue's inventory turned out to be understated — see "What the issue understated".
+
+`Closes #235`.
+
+## Gap 1: nothing deregistered, and the one client that existed had no caller
+
+`udmd` owned the workspace's only `NFDeregister` client (`udm_nrf_deregister`, `sbi_path.rs:321`) and
+**never called it** — `grep` for it returned the definition and the `lib.rs:71` re-export, nothing else.
+Sixteen other registering NFs had no client at all. So every NF left its profile behind on exit and the
+NRF handed it to consumers until the supervision timer expired.
+
+### The design point: the ID is recorded by the library, not passed at 17 call sites
+
+Every NF that registers an `NFProfile` also spawns the shared heartbeat worker. That is not an
+approximation — it is an exact coincidence, and it is what makes the fix small:
+
+| | registers `nnrf-nfm` | spawns heartbeat worker |
+|---|---|---|
+| amfd, ausfd, bsfd, dccfd, easdfd, lmfd, mbsmfd, nefd, nsacfd, nssfd, nwdafd, pcfd, smfd, tsctsf, udmd, udrd, upfd | yes (17) | yes (17) |
+| pind | no — `PIND-01` removed its registration deliberately | no |
+| scpd, seppd | no — `nnrf-disc` consumers only | no |
+| nrfd | n/a (it *is* the NRF; own housekeeping) | no |
+| eesd, hssd, mmed, pcrfd, sgwcd, sgwud, webui | no | no |
+
+So `spawn_heartbeat_worker_with_load` records the instance ID into a library-owned slot, and
+`deregister_self()` takes **no argument**. That matters more than it looks: an ID threaded by hand through
+17 shutdown sites is exactly where a copy-paste error lives, and a `DELETE
+/nnrf-nfm/v1/nf-instances/{someone-else's-id}` is a worse bug than no deregistration at all.
+
+### Ordering, and what is deliberately swallowed
+
+* **Deregister BEFORE stopping the listener.** The reverse order opens the bad window — not serving, but
+  still advertised. This order opens the harmless one: briefly serving while no longer advertised.
+* **Pause the heartbeat before the DELETE.** A tick landing after the DELETE would `PATCH` a profile that
+  no longer exists, which reads to an operator as the NRF losing registrations rather than as an ordering
+  bug here. The issue #22 NES deregister action already established this ordering; this reuses it.
+* **404 is success.** A profile the NRF does not hold is the state we wanted. An NF shutting down after
+  its supervision timer already expired should not log a warning that invites investigation.
+* **A failure is logged, never returned.** `deregister_self` returns `bool` (was a DELETE issued at all),
+  not `Result`. Refusing to exit because the NRF is unreachable would be worse than the stale profile this
+  is pre-empting, and the supervision timer is still the backstop.
+
+`amfd` is the one NF where the insertion point needed a decision: it has both `shutdown()` and
+`shutdown_async()`, and only the async one can await. It is also the only one with a caller
+(`lib.rs:954`) — the sync twin is dead — so the deregistration goes in `shutdown_async`.
+
+Two hand-rolled DELETEs were migrated onto the one client: `udmd`'s uncalled `udm_nrf_deregister` (deleted,
+with a comment at the site recording why) and the inline DELETE in `udmd`'s NES sleep path
+(`nes_driver.rs:136`), which additionally gains the 404-is-success handling it lacked.
+
+## Gap 2: a cached NF profile was selectable for the whole process lifetime
+
+`SbiContext::nf_instances` was a bare `HashMap<String, NfInstance>` with no expiry, no eviction and no
+re-discovery. The compound failure the issue names is the real one: the stale entry is never dropped
+**and** a peer that registers later is never learned, so a rolling restart can leave a consumer
+permanently pointed at a dead endpoint while the NRF is entirely correct.
+
+### TTL from `validityPeriod`, plus evict-on-transport-failure
+
+Taken over the fuller `Nnrf_NFManagement` status-notify subscription, as the issue recommends: it removes
+the permanent-staleness case without adding a subscription lifecycle to every consumer. The map now holds
+a `CachedNfInstance { instance, expires_at: Option<Instant> }`.
+
+Design decisions worth review:
+
+* **Expired entries read as ABSENT rather than being flagged.** `get_nf_instance`,
+  `find_nf_instances_by_type`, `find_nf_instances_by_service` and `nf_instance_count` all skip them. This
+  is what makes re-discovery free: every consumer already has a "not in cache -> discover" branch (e.g.
+  `amfd`'s `resolve_service_endpoint`, which re-discovers on a miss precisely because a late-registering
+  NSACF was invisible), and an expired entry now takes it.
+* **`Instant`, not wall-clock.** A clock step must not make a live entry look expired or a dead one live.
+* **`add_nf_instance` still means "never expires", and that is deliberate.** The strict-peer harnesses seed
+  the registry by hand to stand in for an NRF; giving them a TTL would make them flake on timing. The
+  doc-comment says loudly that it opts out and points at the with-validity variant, and there is a test
+  pinning the difference so a later reader does not "tidy" the two into consistency.
+* **A missing `validityPeriod` falls back to 3600s, not to forever.** 3600 matches `nrfd`'s own
+  `NRF_DISC_VALIDITY_PERIOD` default. The point of a fallback is that a *foreign* NRF omitting the member
+  must not mean "cache this peer for the process lifetime"; an hour is a bound, not a guess at intent.
+* **An explicit `validityPeriod: 0` is honoured as zero.** An NRF saying "do not cache this" is an
+  instruction. Coercing it to the default would be the lower-configuration-layer-can-never-win mistake.
+* **Eviction fires on a TRANSPORT failure only, never on an error status.** A 4xx/5xx means the peer
+  answered: the endpoint is live and its profile is fine. Evicting on a 500 would drop a healthy peer
+  because it was briefly unhappy.
+* **`evict_nf_instance_on_failure` is separate from `remove_nf_instance` and returns whether it removed
+  anything.** The name carries the reason at the call site, and the return lets a caller log the difference
+  between "we dropped the stale peer" and "someone else already had" instead of claiming an eviction it did
+  not perform.
+
+Wired at all four production discovery writers (`amfd/sbi_path.rs`, `ausfd/app.rs`, `udmd/sbi_path.rs`,
+`nssfd/main.rs`) — each reads the `validityPeriod` once for the whole `SearchResult`, which is where
+TS 29.510 puts it: it is a property of the answer, not of an individual profile. Eviction is wired at
+`udmd`'s two send paths, which are the two shapes: resolve-by-ID (`udm_sbi_send_request`) and
+select-by-type-then-send (`udm_sbi_discover_and_send_nudr_dr`, which now remembers *which* profile it
+selected so it can evict that one).
+
+## What the issue understated
+
+1. **Four production cache writers, not two.** The issue cites `amfd/sbi_path.rs:505` and
+   `udmd/sbi_path.rs:305` as examples; the full set is those plus `ausfd/app.rs:1960` and
+   `nssfd/main.rs:3008`. All four are wired.
+2. **`udmd` had TWO hand-rolled DELETEs, not one.** Besides the uncalled `udm_nrf_deregister`, the NES
+   sleep path (`nes_driver.rs:136`, feature-gated) had its own inline copy. Adding a third per-NF copy was
+   the thing most worth avoiding here.
+3. **The set of registering NFs is exactly the set that spawns the heartbeat worker.** The issue lists NFs
+   with no deregistration client, which is accurate, but does not note this coincidence — and it is the
+   whole reason the fix needed no per-NF ID plumbing.
+
+## Verification
+
+Workspace: **5949 passed / 0 failed** across three consecutive full runs (baseline on `main` for this
+branch: 5938 / 0 — the difference is the eleven tests added here). `cargo clippy --workspace` and
+`cargo fmt --all -- --check` clean. Three consecutive
+runs rather than two because this change adds port-binding tests and touches process-global state, which
+is the bar this project settled on for exactly that case.
+
+**Fifteen behavioural claims individually revert-verified** — each reverted in isolation, with the named
+test confirmed to have actually RUN and then FAILED, and the tree restored afterwards:
+
+| # | claim | test that bit |
+|---|---|---|
+| 1 | `find_nf_instances_by_type` skips expired | `expired_instance_reads_as_a_cache_miss_on_every_path` |
+| 2 | `get_nf_instance` skips expired | same |
+| 3 | `find_nf_instances_by_service` skips expired | same |
+| 4 | `nf_instance_count` skips expired | same |
+| 5 | `purge_expired_nf_instances` drops expired | `purge_expired_drops_only_the_expired` |
+| 6 | `add_nf_instance` never expires | `add_without_validity_never_expires` |
+| 7 | eviction actually removes | `eviction_on_failure_removes_the_entry_and_reports_whether_it_did` |
+| 8 | `validityPeriod` drives the TTL and `0` is honoured | `search_result_validity_reads_the_member_and_honours_zero` |
+| 9 | spawning the heartbeat worker records the ID | `test_registered_nf_instance_id_plumbing` |
+| 10 | `deregister_self` issues the DELETE | `test_shared_deregister_self_removes_the_profile_from_the_real_nrf` |
+| 11 | the heartbeat is paused before the DELETE | same |
+| 12 | a 404 from the NRF is success | same |
+| 13 | `udmd` by-ID send evicts on transport failure | `transport_failure_evicts_the_cached_instance_by_id` |
+| 14 | `udmd` by-type send evicts the profile it selected | `transport_failure_evicts_the_selected_udr` |
+| 15 | `udmd` discovery passes the validity into the cache | `discovery_honours_the_search_result_validity_period` |
+
+The revert harness checked itself against the four ways a revert lies: the anchor was asserted **unique**
+in its file, a compile failure was treated as inconclusive rather than as a bite, the named test had to be
+seen to run (a zero-tests-ran summary is inconclusive), and each substitution was read for semantic
+equivalence before being trusted.
+
+Claim 10 is the one that matters most and is proved against the **real NRF handler**, not a mock:
+`nrfd`'s own test module starts a real `SbiServer` on `nrf_sbi_request_handler`, registers a profile over
+HTTP, then calls `deregister_self()` and asserts the profile is gone from `nf_manager()` — `nrfd`'s actual
+registry — and that a subsequent GET is 404. The existing
+`test_http_lifecycle_register_discover_patch_deregister` already proved `nrfd`'s DELETE handler, but it
+drives the DELETE by hand; what was unproven, and is now proved, is that the shared client added to 17
+shutdown paths reaches it.
+
+### Two authoring traps hit and fixed in-session, both worth recording
+
+**The SBI profile defaults to Production, so a test that dials loopback gets a TLS error, not a refused
+connection.** The first version of the two eviction tests passed — but at the wrong layer: `get_client`
+built a TLS client and failed on a missing `/etc/nextgcore/tls/client.crt` rather than being refused by the
+closed port the test comment described. A TLS setup error *is* a transport failure, so the eviction
+assertion held and the test looked fine; the mechanism it documented was simply not the mechanism it
+exercised, and which one it got depended on whether a sibling test had already forced Dev. All three new
+`udmd` tests now set `set_sbi_profile_override(SbiProfile::Dev)` explicitly, matching the eleven existing
+sites that do.
+
+**A `.first()` over the process-global cache picked a sibling test's profile.** The by-type eviction test
+intermittently evicted the by-ID test's UDR instead of its own, because `find_nf_instances_by_type`
+returns a `HashMap`-ordered view of a process-global map. Distinct IDs did not help — distinctness was
+never the problem, the shared view was. Fixed by taking `udmd`'s existing process-wide
+`test_support::CONTEXT_GUARD` (poison-tolerant, so one failing test does not turn its siblings into
+misleading second failures) in all three tests, then confirming 6 consecutive clean runs of
+`cargo test -p nextgcore-udmd --lib`. The test's doc comment now records that it *did* race, so nobody
+removes the guard on the grounds that the IDs are distinct.
+
+## Ceilings
+
+Stated rather than papered over:
+
+* **No test drives any NF's `main()` shutdown**, so the seventeen one-line insertions are compile-checked
+  and reviewed but not observed firing. There is no shutdown harness for any NF in this repo to hang such a
+  test off. What *is* observed is the function they all call, end-to-end against the real NRF. The
+  distinguishing risk is therefore "one NF's line is in an unreachable branch", which review covers and a
+  test would not, since a test would have to call the same function.
+* **Only `udmd`'s discovery writer has a validity test.** `amfd`, `ausfd` and `nssfd` carry the same three
+  lines and are type-checked, but no test observes their cached entries expiring. This is the recorded
+  "the helper is tested and the wiring is not" pattern, reduced from four instances to three rather than
+  eliminated; each would need its own stub-NRF harness.
+* **Eviction is wired in `udmd` only.** `amfd`'s `resolve_service_endpoint` returns `(host, port)` and
+  discards the instance ID, so evicting there means threading the ID out to every send site — a bigger
+  refactor than this issue asks for. `amfd` still benefits from the TTL half: an expired entry takes its
+  existing re-discovery branch.
+* **`purge_expired_nf_instances` has no production caller.** The reads already ignore expired entries, so
+  it is bookkeeping (stopping a long-lived consumer accumulating dead profiles), not correctness. It is
+  tested, and deliberately not wired to a timer here: adding a background task to every NF is a separate
+  decision from bounding the reads.

--- a/src/bins/nextgcore-amfd/src/lib.rs
+++ b/src/bins/nextgcore-amfd/src/lib.rs
@@ -788,6 +788,12 @@ impl AmfApp {
     pub async fn shutdown_async(&mut self) {
         log::info!("Shutting down AMF...");
 
+        // #235: NFDeregister (TS 29.510 5.2.2.2.3) first, so the NRF stops
+        // handing this profile to consumers instead of waiting out its
+        // supervision timer. Only the async path can do it — the sync
+        // `shutdown()` above cannot await, and has no caller.
+        nextgcore_sbi::heartbeat::deregister_self().await;
+
         // Close NGAP
         ngap_path::amf_ngap_close().await;
 

--- a/src/bins/nextgcore-amfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-amfd/src/sbi_path.rs
@@ -441,6 +441,11 @@ pub async fn amf_nrf_discover(target_nf_type: &str, service_name: &str) -> Resul
     let json: serde_json::Value =
         serde_json::from_str(&body).map_err(|e| format!("Invalid NRF discovery response: {e}"))?;
 
+    // #235: the SearchResult's validityPeriod bounds how long these profiles may
+    // be selected. Read once for the whole result, which is where TS 29.510 puts
+    // it — it is a property of the answer, not of an individual profile.
+    let validity = nextgcore_sbi::context::search_result_validity(&json);
+
     if let Some(nf_instances) = json.get("nfInstances").and_then(|v| v.as_array()) {
         for nf_json in nf_instances {
             let nf_id = nf_json
@@ -502,8 +507,13 @@ pub async fn amf_nrf_discover(target_nf_type: &str, service_name: &str) -> Resul
                 }
             }
 
-            sbi_ctx.add_nf_instance(instance).await;
-            log::info!("Discovered {nf_type_str} instance: {nf_id}");
+            sbi_ctx
+                .add_nf_instance_with_validity(instance, validity)
+                .await;
+            log::info!(
+                "Discovered {nf_type_str} instance: {nf_id} (valid for {}s)",
+                validity.as_secs()
+            );
         }
     }
 

--- a/src/bins/nextgcore-ausfd/src/app.rs
+++ b/src/bins/nextgcore-ausfd/src/app.rs
@@ -366,6 +366,12 @@ pub async fn run() -> Result<()> {
     // Graceful shutdown
     log::info!("Shutting down...");
 
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     // Stop SBI server
     sbi_server
         .stop()
@@ -1899,6 +1905,10 @@ async fn discover_nf_from_nrf(target_nf_type: &str, service_name: &str) -> Resul
     let json: serde_json::Value =
         serde_json::from_str(&body).map_err(|e| format!("Invalid NRF discovery response: {e}"))?;
 
+    // #235: the SearchResult's validityPeriod bounds how long these profiles may
+    // be selected; without it a cached peer was chosen for the process lifetime.
+    let validity = nextgcore_sbi::context::search_result_validity(&json);
+
     // Parse NF instances from discovery response
     if let Some(nf_instances) = json.get("nfInstances").and_then(|v| v.as_array()) {
         for nf_json in nf_instances {
@@ -1957,8 +1967,13 @@ async fn discover_nf_from_nrf(target_nf_type: &str, service_name: &str) -> Resul
                 }
             }
 
-            sbi_ctx.add_nf_instance(instance).await;
-            log::info!("Discovered {nf_type_str} instance: {nf_id}");
+            sbi_ctx
+                .add_nf_instance_with_validity(instance, validity)
+                .await;
+            log::info!(
+                "Discovered {nf_type_str} instance: {nf_id} (valid for {}s)",
+                validity.as_secs()
+            );
         }
     }
 

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -329,6 +329,12 @@ pub async fn run() -> Result<()> {
     // Graceful shutdown
     log::info!("Shutting down...");
 
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     // Stop SBI server
     sbi_server
         .stop()

--- a/src/bins/nextgcore-dccfd/src/main.rs
+++ b/src/bins/nextgcore-dccfd/src/main.rs
@@ -381,6 +381,13 @@ async fn main() -> Result<()> {
     }
 
     log::info!("DCCF shutting down");
+
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes away, so
+    // the NRF stops handing this profile to consumers instead of waiting out its
+    // supervision timer. Stopping the server first would open the bad window:
+    // not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     sbi_server
         .stop()
         .await

--- a/src/bins/nextgcore-easdfd/src/main.rs
+++ b/src/bins/nextgcore-easdfd/src/main.rs
@@ -339,6 +339,12 @@ async fn main() -> Result<()> {
     }
 
     log::info!("Shutting down...");
+
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
     sbi_server
         .stop()
         .await

--- a/src/bins/nextgcore-lmfd/src/main.rs
+++ b/src/bins/nextgcore-lmfd/src/main.rs
@@ -309,6 +309,12 @@ async fn main() -> Result<()> {
     }
 
     log::info!("Shutting down...");
+
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
     sbi_server
         .stop()
         .await

--- a/src/bins/nextgcore-mbsmfd/src/main.rs
+++ b/src/bins/nextgcore-mbsmfd/src/main.rs
@@ -275,6 +275,12 @@ async fn main() -> Result<()> {
 
     // Graceful shutdown
     log::info!("Shutting down...");
+
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
     sbi_server
         .stop()
         .await

--- a/src/bins/nextgcore-nefd/src/main.rs
+++ b/src/bins/nextgcore-nefd/src/main.rs
@@ -521,6 +521,12 @@ async fn main() -> Result<()> {
     }
 
     log::info!("Shutting down...");
+
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
     sbi_server
         .stop()
         .await

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -4143,6 +4143,116 @@ mod tests {
         outcome.expect("lifecycle test timed out");
     }
 
+    /// #235: the SHARED shutdown-path deregistration client really does remove
+    /// the profile from this NRF's real registry.
+    ///
+    /// The lifecycle test above already proves `nrfd`'s DELETE handler over HTTP,
+    /// but it drives the DELETE by hand. What was unproven is that
+    /// `nextgcore_sbi::heartbeat::deregister_self()` — the one line now added to
+    /// every registering NF's shutdown path — reaches that handler: the right
+    /// method, the right URI, and the instance ID it recorded at registration
+    /// rather than one passed in. So this drives the client, not the request.
+    ///
+    /// `nrfd` touches neither the global SBI context nor the heartbeat statics
+    /// anywhere else, so no guard is needed; the test still restores both.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_shared_deregister_self_removes_the_profile_from_the_real_nrf() {
+        use serde_json::json;
+
+        let addr = nextgcore_sbi::test_support::ephemeral_addr();
+        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        server
+            .start(nrf_sbi_request_handler)
+            .await
+            .expect("SBI server starts");
+
+        let client = nextgcore_sbi::client::SbiClient::with_host_port("127.0.0.1", addr.port());
+        let nf_id = "5e9b1c0a-4444-4f6a-8888-0123456789ab";
+
+        let body = async {
+            // Register a real profile through the real handler.
+            let profile = json!({
+                "nfInstanceId": nf_id,
+                "nfType": "UDM",
+                "nfStatus": "REGISTERED",
+                "heartBeatTimer": 10,
+                "ipv4Addresses": ["10.4.4.4"],
+                "nfServices": [{
+                    "serviceInstanceId": "svc-0",
+                    "serviceName": "nudm-sdm",
+                    "versions": [{"apiVersionInUri": "v2", "apiFullVersion": "2.0.0"}],
+                    "scheme": "http",
+                    "ipEndPoints": [{"ipv4Address": "10.4.4.4", "port": 7777}]
+                }]
+            });
+            let resp = client
+                .put_json(&format!("/nnrf-nfm/v1/nf-instances/{nf_id}"), &profile)
+                .await
+                .expect("PUT register");
+            assert_eq!(resp.status, 201);
+
+            // Stand in for what an NF's startup does: point the global SBI
+            // context at this NRF, and record the ID the heartbeat worker would
+            // have recorded.
+            let sbi_ctx = nextgcore_sbi::context::global_context();
+            sbi_ctx
+                .set_nrf_uri(format!("http://127.0.0.1:{}", addr.port()))
+                .await;
+            nextgcore_sbi::heartbeat::set_registered_nf_instance_id(nf_id);
+
+            // The shutdown path, called exactly as the 17 NFs now call it.
+            assert!(
+                nextgcore_sbi::heartbeat::deregister_self().await,
+                "a recorded instance ID must produce a DELETE"
+            );
+
+            // The profile is gone from the REAL registry, not merely from a
+            // recorded request list.
+            assert!(
+                nf_manager().get(nf_id).is_none(),
+                "deregister_self must remove the profile from the NRF registry"
+            );
+            let resp = client
+                .get(&format!("/nnrf-nfm/v1/nf-instances/{nf_id}"))
+                .await
+                .expect("GET after deregister");
+            assert_eq!(resp.status, 404);
+
+            // Heartbeats are paused BEFORE the DELETE, so a tick cannot PATCH a
+            // profile that no longer exists.
+            assert!(
+                nextgcore_sbi::heartbeat::heartbeat_paused(),
+                "deregistration must pause the heartbeat worker"
+            );
+
+            // Deregistering again gets a real 404 from the real handler, and that
+            // must read as success: a profile the NRF does not hold is the state
+            // we wanted, and an NF shutting down after its supervision timer
+            // already expired should not log an alarming warning.
+            assert!(
+                nextgcore_sbi::heartbeat::deregister_nf(nf_id).await.is_ok(),
+                "a 404 from the NRF means the profile is gone, which is success"
+            );
+
+            // With no recorded ID there is nothing to deregister, and the caller
+            // is told so rather than a bare DELETE being sent to /nf-instances/.
+            nextgcore_sbi::heartbeat::clear_registered_nf_instance_id();
+            assert!(
+                !nextgcore_sbi::heartbeat::deregister_self().await,
+                "no recorded instance ID must issue no DELETE"
+            );
+        };
+
+        let outcome = tokio::time::timeout(Duration::from_secs(30), body).await;
+
+        // Restore the process-globals this test mutated.
+        nextgcore_sbi::heartbeat::set_heartbeat_paused(false);
+        nextgcore_sbi::heartbeat::clear_registered_nf_instance_id();
+        client.close().await;
+        server.stop().await.expect("server stops");
+        outcome.expect("deregister test timed out");
+    }
+
     // -----------------------------------------------------------------
     // SBI OAuth2 knob (T1.1): config parsing + the NRF-as-issuer rule
     // -----------------------------------------------------------------

--- a/src/bins/nextgcore-nsacfd/src/main.rs
+++ b/src/bins/nextgcore-nsacfd/src/main.rs
@@ -416,6 +416,12 @@ async fn main() -> Result<()> {
 
     // Graceful shutdown
     log::info!("Shutting down...");
+
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
     with_nsacf_context(|c| c.save_state());
     sbi_server
         .stop()

--- a/src/bins/nextgcore-nssfd/src/main.rs
+++ b/src/bins/nextgcore-nssfd/src/main.rs
@@ -596,6 +596,12 @@ async fn main() -> Result<()> {
     // Graceful shutdown
     log::info!("Shutting down...");
 
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     // Stop SBI server
     sbi_server
         .stop()
@@ -2951,6 +2957,10 @@ async fn discover_nf_from_nrf(target_nf_type: &str, service_name: &str) -> Resul
     let json: serde_json::Value =
         serde_json::from_str(&body).map_err(|e| format!("Invalid NRF discovery response: {e}"))?;
 
+    // #235: the SearchResult's validityPeriod bounds how long these profiles may
+    // be selected; without it a cached peer was chosen for the process lifetime.
+    let validity = nextgcore_sbi::context::search_result_validity(&json);
+
     if let Some(nf_instances) = json.get("nfInstances").and_then(|v| v.as_array()) {
         for nf_json in nf_instances {
             let nf_id = nf_json
@@ -3005,8 +3015,13 @@ async fn discover_nf_from_nrf(target_nf_type: &str, service_name: &str) -> Resul
                 }
             }
 
-            sbi_ctx.add_nf_instance(instance).await;
-            log::info!("Discovered {nf_type_str} instance: {nf_id}");
+            sbi_ctx
+                .add_nf_instance_with_validity(instance, validity)
+                .await;
+            log::info!(
+                "Discovered {nf_type_str} instance: {nf_id} (valid for {}s)",
+                validity.as_secs()
+            );
         }
     }
 

--- a/src/bins/nextgcore-nssfd/src/main.rs
+++ b/src/bins/nextgcore-nssfd/src/main.rs
@@ -3139,6 +3139,22 @@ async fn run_event_loop_async(
 
 #[cfg(test)]
 mod tests {
+    /// Process-wide lock for tests that re-initialise the process-global NSSF
+    /// context.
+    ///
+    /// `nssf_context_init` WIPES that context, and 27 tests in this file call it.
+    /// Cargo runs them concurrently in one process, so one test's init landed
+    /// between another's init and its assertion — the second then computed its
+    /// answer from an empty context. That is how CI saw
+    /// `test_nsselection_ue_cu_no_requested_nssai_no_allowed_list` fail with
+    /// "must include configuredNssai derived from subscribedNssai" while the same
+    /// run's retry failed two DIFFERENT tests instead: different symptoms, one
+    /// cause. Before this, nssfd had no test guard of any kind.
+    ///
+    /// Poison-tolerant, so one failing test does not turn its siblings into
+    /// misleading second failures.
+    static NSSF_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     use super::*;
     use nextgcore_sbi::client::SbiClient;
     use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
@@ -3776,6 +3792,7 @@ mod tests {
     /// 403 SNSSAI_NOT_SUPPORTED; nothing stored, no notification spawned.
     #[tokio::test]
     async fn test_availability_put_unsupported_snssai_403() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _state_guard = availability_state_guard().await;
         nssf_context_init(512);
         // Restrict the PLMN to sst=1 only; the PUT reports sst=2 (outside it).
@@ -3812,6 +3829,7 @@ mod tests {
     /// (b) PUT with an empty NF Id -> 403 NOT_AUTHORIZED.
     #[tokio::test]
     async fn test_availability_put_empty_nf_id_403_not_authorized() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _state_guard = availability_state_guard().await;
         nssf_context_init(512);
         with_nssf_context(|c| c.set_plmn_supported_snssais(None)); // no restriction
@@ -3842,6 +3860,7 @@ mod tests {
     /// -> 200 and stored.
     #[tokio::test]
     async fn test_availability_put_all_supported_200_stored() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _state_guard = availability_state_guard().await;
         nssf_context_init(512);
         with_nssf_context(|c| c.set_plmn_supported_snssais(None)); // default allow-all
@@ -3873,6 +3892,7 @@ mod tests {
     /// unchanged.
     #[tokio::test]
     async fn test_availability_patch_unsupported_snssai_403_original_unchanged() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _state_guard = availability_state_guard().await;
         nssf_context_init(512);
         // Restrict to sst=1: the initial PUT (sst=1) is accepted; the PATCH
@@ -3948,6 +3968,7 @@ mod tests {
     /// includes restrictedSnssaiList containing the expected RestrictedSnssai.
     #[tokio::test]
     async fn test_availability_authorized_response_restricted_snssai_list() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = availability_state_guard().await;
         nssf_context_init(512);
         with_nssf_context(|c| {
@@ -3998,6 +4019,7 @@ mod tests {
     /// supportedSnssaiList equals the input (back-compat).
     #[tokio::test]
     async fn test_availability_authorized_response_no_restriction_no_restricted_list() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = availability_state_guard().await;
         nssf_context_init(512);
         with_nssf_context(|c| c.clear_plmn_snssai_restrictions());
@@ -4032,6 +4054,7 @@ mod tests {
     /// authorized_availability_response returns 204 when no entries remain.
     #[test]
     fn test_availability_authorized_response_empty_entries_is_204() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         nssf_context_init(512);
         let doc = serde_json::json!({"supportedNssaiAvailabilityData": []});
         let resp = authorized_availability_response(&doc);
@@ -4046,6 +4069,7 @@ mod tests {
     /// authorized_availability_response returns 200 when entries are present.
     #[tokio::test]
     async fn test_availability_authorized_response_nonempty_is_200() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = availability_state_guard().await;
         nssf_context_init(512);
         with_nssf_context(|c| c.clear_plmn_snssai_restrictions());
@@ -4069,6 +4093,7 @@ mod tests {
     /// → response allowedSnssaiList contains only A.
     #[tokio::test]
     async fn test_pdu_nsselection_allowed_narrowed_to_requested_snssai() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _state_guard = availability_state_guard().await;
         nssf_context_init(512);
         // Configure three NSIs so the old all-NSIs path would have returned 3.
@@ -4128,6 +4153,7 @@ mod tests {
     /// is stored for the test nfId).
     #[tokio::test]
     async fn test_availability_patch_wrong_content_type_415() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         nssf_context_init(512);
 
         let wrong_ct_req =
@@ -4169,6 +4195,7 @@ mod tests {
     /// allowedNssaiList (TS 29.531 §5.2.2.2.4).
     #[test]
     fn test_nsselection_ue_cu_no_requested_nssai_no_allowed_list() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         nssf_context_init(512);
         let info_json = serde_json::json!({
             "subscribedNssai": [
@@ -4194,6 +4221,7 @@ mod tests {
     /// (same as registration scenario).
     #[test]
     fn test_nsselection_ue_cu_with_requested_nssai_includes_allowed_list() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         nssf_context_init(512);
         let info_json = serde_json::json!({
             "subscribedNssai": [
@@ -4220,6 +4248,7 @@ mod tests {
     /// includes targetAmfSet even when no candidateAmfList is produced.
     #[tokio::test]
     async fn test_registration_success_includes_target_amf_set_when_configured() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = availability_state_guard().await;
         nssf_context_init(512);
         with_nssf_context(|c| c.set_target_amf_set("001-01-01-001"));
@@ -4250,6 +4279,7 @@ mod tests {
     /// is absent from the registration response.
     #[tokio::test]
     async fn test_registration_success_no_target_amf_set_when_not_configured() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = availability_state_guard().await;
         nssf_context_init(512);
         with_nssf_context(|c| c.clear_target_amf_set());
@@ -4282,6 +4312,7 @@ mod tests {
     /// YAML shape rather than a hand-built struct, so a schema drift breaks it.
     #[test]
     fn shipped_nsi_config_block_is_deserialised_and_installed() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // The global NSSF context defaults to max_num_of_nf = 0, so `nsi_add`
         // refuses EVERY insert until `init` runs. Without this the assertions
         // below pass for the wrong reason -- the revert-verify pass caught
@@ -4337,6 +4368,7 @@ nssf:
     /// An `nsi` entry with no `s_nssai` is skipped, not defaulted to SST 0.
     #[test]
     fn nsi_entry_without_snssai_is_skipped_rather_than_defaulted() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // The global NSSF context defaults to max_num_of_nf = 0, so `nsi_add`
         // refuses EVERY insert until `init` runs. Without this the assertions
         // below pass for the wrong reason -- the revert-verify pass caught
@@ -4380,6 +4412,7 @@ nssf:
     /// this test evidence about the shipped daemon rather than about the store.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn pdu_session_selection_succeeds_for_a_configured_nsi() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // The global NSSF context defaults to max_num_of_nf = 0, so `nsi_add`
         // refuses EVERY insert until `init` runs. Without this the assertions
         // below pass for the wrong reason -- the revert-verify pass caught
@@ -4516,6 +4549,7 @@ nssf:
     /// S-NSSAIs from the configured NSI table, and 403 when none resolves.
     #[test]
     fn other_purpose_scenario_is_routed_and_returns_nsi_ids() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // The global NSSF context defaults to max_num_of_nf = 0, so `nsi_add`
         // refuses EVERY insert until `init` runs. Without this the assertions
         // below pass for the wrong reason -- the revert-verify pass caught
@@ -4771,6 +4805,7 @@ nssf:
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)]
     async fn availability_write_requires_the_caller_to_own_the_document() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _state_guard = availability_state_guard().await;
         let _posture = with_authz_posture(true);
         nssf_context_init(512);
@@ -4850,6 +4885,7 @@ nssf:
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)]
     async fn availability_patch_and_delete_are_bound_to_the_owner() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _state_guard = availability_state_guard().await;
         let _posture = with_authz_posture(true);
         nssf_context_init(512);
@@ -4930,6 +4966,7 @@ nssf:
     /// matching, and the sweep removes it.
     #[test]
     fn subscription_expiry_is_assigned_enforced_and_swept() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         nssf_context_init(512);
         let created = subscription_from_json(
             "sub-94-expiry",
@@ -5022,6 +5059,7 @@ nssf:
     /// #94 criterion 5: `taiList` is optional, and `acceptedEvents` is returned.
     #[test]
     fn subscription_create_treats_tai_list_as_optional_and_returns_accepted_events() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         nssf_context_init(512);
 
         // Only the two members the schema marks required.
@@ -5099,6 +5137,7 @@ nssf:
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)]
     async fn configured_restrictions_round_trip_under_the_conformant_key() {
+        let _guard = NSSF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _state_guard = availability_state_guard().await;
         nssf_context_init(512);
         with_nssf_context(|c| c.clear_plmn_snssai_restrictions());

--- a/src/bins/nextgcore-nssfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-nssfd/src/sbi_path.rs
@@ -155,29 +155,40 @@ mod tests {
         assert!(!config.tls_enabled);
     }
 
+    /// The open/close lifecycle AND the already-running refusal, in ONE test.
+    ///
+    /// These were two tests, and they raced with each other by construction:
+    /// both began by storing `false` into the process-global
+    /// `SBI_SERVER_RUNNING`, so one test's "Reset state" landed between the
+    /// other's open and its assertion. CI saw exactly that —
+    /// `assertion failed: !nssf_sbi_is_running()` in one and
+    /// `assertion failed: result.is_err()` in the other, in the same run.
+    ///
+    /// Merged rather than serialised with a lock, following the pattern the
+    /// heartbeat statics already use in `nextgcore-sbi`: when the subject IS a
+    /// process-global, mutation and assertion belong in a single test, which
+    /// removes the race instead of scheduling around it.
     #[test]
-    fn test_sbi_open_close() {
-        // Reset state
+    fn test_sbi_open_close_and_already_running() {
         SBI_SERVER_RUNNING.store(false, Ordering::SeqCst);
 
         let result = nssf_sbi_open(None);
         assert!(result.is_ok());
         assert!(nssf_sbi_is_running());
 
+        // A second open while running is refused rather than silently accepted.
+        let again = nssf_sbi_open(None);
+        assert!(
+            again.is_err(),
+            "opening an already-running server must fail"
+        );
+        assert!(
+            nssf_sbi_is_running(),
+            "the refusal must not close the server"
+        );
+
         nssf_sbi_close();
         assert!(!nssf_sbi_is_running());
-    }
-
-    #[test]
-    fn test_sbi_open_already_running() {
-        // Reset state
-        SBI_SERVER_RUNNING.store(false, Ordering::SeqCst);
-
-        let _ = nssf_sbi_open(None);
-        let result = nssf_sbi_open(None);
-        assert!(result.is_err());
-
-        nssf_sbi_close();
     }
 
     #[test]

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -397,6 +397,12 @@ async fn main() -> Result<()> {
     }
 
     log::info!("Shutting down...");
+
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
     sbi_server
         .stop()
         .await

--- a/src/bins/nextgcore-pcfd/src/app.rs
+++ b/src/bins/nextgcore-pcfd/src/app.rs
@@ -500,6 +500,12 @@ pub async fn run() -> Result<()> {
     // Graceful shutdown
     log::info!("Shutting down...");
 
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     // Stop SBI server
     sbi_server
         .stop()

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -675,6 +675,12 @@ async fn main() -> Result<()> {
 
     log::info!("Shutting down...");
 
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     // Stop SBI server
     sbi_server
         .stop()

--- a/src/bins/nextgcore-tsctsf/src/main.rs
+++ b/src/bins/nextgcore-tsctsf/src/main.rs
@@ -237,6 +237,12 @@ async fn main() -> Result<()> {
     }
 
     log::info!("Shutting down...");
+
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
     sbi_server
         .stop()
         .await

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -563,6 +563,12 @@ pub async fn run() -> Result<()> {
     // Graceful shutdown
     log::info!("Shutting down...");
 
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     // Stop SBI server
     sbi_server
         .stop()

--- a/src/bins/nextgcore-udmd/src/lib.rs
+++ b/src/bins/nextgcore-udmd/src/lib.rs
@@ -68,16 +68,15 @@ pub mod test_support {
 // Re-export SBI path functions
 pub use sbi_path::{
     udm_amf_send_mt_ue_context_info, udm_ausf_send_sor_protect, udm_ausf_send_upu_protect,
-    udm_nrf_deregister, udm_nrf_discover, udm_nrf_heartbeat, udm_nrf_register,
-    udm_nudr_dr_send_auth_status_delete, udm_nudr_dr_send_auth_status_put,
-    udm_nudr_dr_send_auth_subscription_get, udm_nudr_dr_send_auth_subscription_patch,
-    udm_nudr_dr_send_context_delete, udm_nudr_dr_send_context_get, udm_nudr_dr_send_context_patch,
-    udm_nudr_dr_send_context_put, udm_nudr_dr_send_provisioned_data_get,
-    udm_nudr_dr_send_provisioned_data_get_with_params, udm_nudr_dr_send_subscription_data_delete,
-    udm_nudr_dr_send_subscription_data_get, udm_nudr_dr_send_subscription_data_patch,
-    udm_nudr_dr_send_subscription_data_put, udm_sbi_close, udm_sbi_discover_and_send_nudr_dr,
-    udm_sbi_is_running, udm_sbi_open, udm_sbi_send_dereg_notification, udm_sbi_send_request,
-    SbiServer, SbiServerConfig, SbiXact,
+    udm_nrf_discover, udm_nrf_heartbeat, udm_nrf_register, udm_nudr_dr_send_auth_status_delete,
+    udm_nudr_dr_send_auth_status_put, udm_nudr_dr_send_auth_subscription_get,
+    udm_nudr_dr_send_auth_subscription_patch, udm_nudr_dr_send_context_delete,
+    udm_nudr_dr_send_context_get, udm_nudr_dr_send_context_patch, udm_nudr_dr_send_context_put,
+    udm_nudr_dr_send_provisioned_data_get, udm_nudr_dr_send_provisioned_data_get_with_params,
+    udm_nudr_dr_send_subscription_data_delete, udm_nudr_dr_send_subscription_data_get,
+    udm_nudr_dr_send_subscription_data_patch, udm_nudr_dr_send_subscription_data_put,
+    udm_sbi_close, udm_sbi_discover_and_send_nudr_dr, udm_sbi_is_running, udm_sbi_open,
+    udm_sbi_send_dereg_notification, udm_sbi_send_request, SbiServer, SbiServerConfig, SbiXact,
 };
 
 // Wave-6 F-04: expose the am-data SoR injection entry point for strict-peer

--- a/src/bins/nextgcore-udmd/src/nes_driver.rs
+++ b/src/bins/nextgcore-udmd/src/nes_driver.rs
@@ -123,23 +123,12 @@ impl NesActions for NrfNesActions {
                 // A deleted profile must not be PATCHed: pause heartbeats.
                 nextgcore_sbi::heartbeat::set_heartbeat_paused(true);
                 tokio::spawn(async move {
-                    let ctx = nextgcore_sbi::context::global_context();
-                    let Some(nrf_uri) = ctx.get_nrf_uri().await else {
-                        return;
-                    };
-                    let Some((host, port)) = crate::app::parse_nrf_host_port(&nrf_uri) else {
-                        return;
-                    };
-                    let client = ctx.get_client(&host, port).await;
-                    let path = format!("/nnrf-nfm/v1/nf-instances/{id}");
-                    match client
-                        .send_request(nextgcore_sbi::message::SbiRequest::delete(&path))
-                        .await
-                    {
-                        Ok(resp) if resp.is_success() => {
-                            log::info!("NES: deregistered from NRF (sleep)");
-                        }
-                        Ok(resp) => log::warn!("NES deregister returned {}", resp.status),
+                    // #235: this used to hand-roll the DELETE. It now goes
+                    // through the one NFDeregister client, so the NES sleep path
+                    // and the shutdown path cannot drift apart — and it inherits
+                    // the 404-is-success handling the inline copy lacked.
+                    match nextgcore_sbi::heartbeat::deregister_nf(&id).await {
+                        Ok(()) => log::info!("NES: deregistered from NRF (sleep)"),
                         Err(e) => log::warn!("NES deregister failed: {e}"),
                     }
                 });

--- a/src/bins/nextgcore-udmd/src/sbi_path.rs
+++ b/src/bins/nextgcore-udmd/src/sbi_path.rs
@@ -283,6 +283,10 @@ pub async fn udm_nrf_discover(
     let search_result: serde_json::Value = serde_json::from_str(&body)
         .map_err(|e| format!("Failed to parse NRF discovery response: {e}"))?;
 
+    // #235: the SearchResult's validityPeriod bounds how long these profiles may
+    // be selected; without it a cached peer was chosen for the process lifetime.
+    let validity = nextgcore_sbi::context::search_result_validity(&search_result);
+
     let mut instances = Vec::new();
     if let Some(nf_instances) = search_result.get("nfInstances").and_then(|v| v.as_array()) {
         for nf_json in nf_instances {
@@ -301,8 +305,10 @@ pub async fn udm_nrf_discover(
                 }
             }
 
-            // Cache discovered instance in SBI context
-            sbi_ctx.add_nf_instance(instance.clone()).await;
+            // Cache discovered instance in SBI context, bounded by validityPeriod
+            sbi_ctx
+                .add_nf_instance_with_validity(instance.clone(), validity)
+                .await;
             instances.push(instance);
         }
     }
@@ -315,30 +321,12 @@ pub async fn udm_nrf_discover(
     Ok(instances)
 }
 
-/// Deregister from NRF and close SBI server
-///
-/// Port of udm_sbi_close()
-pub async fn udm_nrf_deregister(nrf_host: &str, nrf_port: u16) -> Result<(), String> {
-    let sbi_ctx = global_context();
-    if let Some(self_instance) = sbi_ctx.get_self_instance().await {
-        let client = sbi_ctx.get_client(nrf_host, nrf_port).await;
-        let path = format!("/nnrf-nfm/v1/nf-instances/{}", self_instance.id);
-        let request = SbiRequest::delete(&path);
-
-        match client.send_request(request).await {
-            Ok(response) if response.is_success() => {
-                log::info!("UDM deregistered from NRF");
-            }
-            Ok(response) => {
-                log::warn!("NRF deregister returned status {}", response.status);
-            }
-            Err(e) => {
-                log::warn!("NRF deregister failed: {e}");
-            }
-        }
-    }
-    Ok(())
-}
+// #235: `udm_nrf_deregister(nrf_host, nrf_port)` used to live here — a per-NF
+// copy of NFDeregister that had NO caller, so udmd never actually deregistered
+// despite owning the only client in the workspace. The one client is now
+// `nextgcore_sbi::heartbeat::deregister_nf`, driven from `app.rs`'s shutdown
+// path via `deregister_self()` and from the NES sleep path in `nes_driver.rs`.
+// Keeping the local copy would have made three implementations of one DELETE.
 
 /// Close SBI server
 ///
@@ -399,10 +387,17 @@ pub async fn udm_sbi_send_request(
         request.header.method
     );
 
-    client
-        .send_request(request)
-        .await
-        .map_err(|e| format!("SBI request to {nf_instance_id} failed: {e}"))
+    match client.send_request(request).await {
+        Ok(response) => Ok(response),
+        Err(e) => {
+            // #235: a TRANSPORT failure is evidence the cached profile is wrong,
+            // so drop it and let the next call re-discover. Deliberately not done
+            // for an error STATUS: a 4xx/5xx means the peer answered, i.e. the
+            // endpoint is live and the profile is fine.
+            sbi_ctx.evict_nf_instance_on_failure(nf_instance_id).await;
+            Err(format!("SBI request to {nf_instance_id} failed: {e}"))
+        }
+    }
 }
 
 /// Discover UDR and send a NUDR-DR request
@@ -421,8 +416,15 @@ pub async fn udm_sbi_discover_and_send_nudr_dr(
     // Find UDR instances (from discovery cache or env var fallback)
     let udr_instances = sbi_ctx.find_nf_instances_by_type(NfType::Udr).await;
 
+    // #235: remember WHICH cached profile was selected, so a transport failure
+    // can evict that entry rather than leaving the consumer retrying a dead
+    // endpoint. `None` on the env-var fallback path — there is no cache entry to
+    // blame for a misconfigured environment variable.
+    let selected_instance_id: Option<String>;
+
     let (host_str, port);
     if let Some(udr) = udr_instances.first() {
+        selected_instance_id = Some(udr.id.clone());
         host_str = udr
             .ipv4_addresses
             .first()
@@ -433,6 +435,7 @@ pub async fn udm_sbi_discover_and_send_nudr_dr(
             .map(|s| s.port)
             .unwrap_or(80);
     } else {
+        selected_instance_id = None;
         // Fallback: use UDR_SBI_ADDR/UDR_SBI_PORT env vars
         host_str = std::env::var("UDR_SBI_ADDR")
             .map_err(|_| "No UDR instance discovered and UDR_SBI_ADDR not set".to_string())?;
@@ -451,10 +454,17 @@ pub async fn udm_sbi_discover_and_send_nudr_dr(
         "Sending NUDR-DR request for UE [{udm_ue_id}] stream [{stream_id}] to UDR at {host_str}:{port}"
     );
 
-    client
-        .send_request(request)
-        .await
-        .map_err(|e| format!("NUDR-DR request to UDR failed: {e}"))
+    match client.send_request(request).await {
+        Ok(response) => Ok(response),
+        Err(e) => {
+            // #235: transport failure only — an error status means the UDR
+            // answered, so its cached profile is still correct.
+            if let Some(id) = selected_instance_id {
+                sbi_ctx.evict_nf_instance_on_failure(&id).await;
+            }
+            Err(format!("NUDR-DR request to UDR failed: {e}"))
+        }
+    }
 }
 
 /// Build and send authentication subscription GET to UDR
@@ -994,6 +1004,188 @@ pub fn send_sbi_response(stream_id: u64, response: SbiResponse) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #235: a TRANSPORT failure to a cached NF must evict that cached profile,
+    /// so the next call re-discovers instead of retrying an endpoint the NRF may
+    /// already have replaced. This is the WIRING, not the library helper — the
+    /// helper has its own tests in `nextgcore-sbi`, and a passing helper test says
+    /// nothing about whether any caller invokes it.
+    ///
+    /// Port 1 on loopback is used rather than an allocated-then-dropped port:
+    /// binding it needs root, so nothing can be listening and the refusal is
+    /// deterministic with no port allocation to contend on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn transport_failure_evicts_the_cached_instance_by_id() {
+        // The discovery cache is process-global and all three #235 tests below
+        // seed `NfType::Udr` entries, so `.first()` in the by-type test could pick
+        // up a sibling's profile. `CONTEXT_GUARD` is udmd's existing process-wide
+        // test lock; poison-tolerant so one failing test does not turn its
+        // siblings into misleading second failures.
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // The SBI profile defaults to Production, so `get_client` would build a
+        // TLS client and fail loading /etc/nextgcore/tls/client.crt instead of
+        // being refused by the port. That is still a transport failure, so the
+        // eviction assertion would pass -- for the wrong reason, and only when
+        // another test had not already forced Dev. Force it here so the failure
+        // the test documents is the failure the test gets.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+
+        let sbi_ctx = global_context();
+        let instance_id = "udmd-235-evict-by-id";
+
+        let mut instance = NfInstance::new(instance_id, NfType::Udr);
+        instance.ipv4_addresses.push("127.0.0.1".to_string());
+        let mut svc = NfService::new("nudr-dr", SbiServiceType::NudrDr);
+        svc.port = 1;
+        instance.add_service(svc);
+        sbi_ctx
+            .add_nf_instance_with_validity(instance, std::time::Duration::from_secs(3600))
+            .await;
+        assert!(
+            sbi_ctx.get_nf_instance(instance_id).await.is_some(),
+            "precondition: the profile is cached and live"
+        );
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            udm_sbi_send_request(instance_id, SbiRequest::get("/nudr-dr/v2/ping")),
+        )
+        .await
+        .expect("the refused connection must not hang");
+        assert!(result.is_err(), "connecting to a closed port must fail");
+
+        assert!(
+            sbi_ctx.get_nf_instance(instance_id).await.is_none(),
+            "a transport failure must evict the cached profile"
+        );
+    }
+
+    /// The same wiring on the by-type selection path (`find_nf_instances_by_type`
+    /// then send), which resolves the UDR without being handed an ID. Kept as its
+    /// own test because the two paths evict from different places: this one has to
+    /// remember which instance it selected.
+    ///
+    /// `.first()` over a process-global map is order-dependent, and the two
+    /// sibling tests here also seed `NfType::Udr` entries — this test DID pick up
+    /// the by-id test's profile and evict that instead, intermittently, before the
+    /// guard below was added. Do not remove the guard on the grounds that the IDs
+    /// are distinct: distinctness was never the problem, the shared view was.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn transport_failure_evicts_the_selected_udr() {
+        // The discovery cache is process-global and all three #235 tests below
+        // seed `NfType::Udr` entries, so `.first()` in the by-type test could pick
+        // up a sibling's profile. `CONTEXT_GUARD` is udmd's existing process-wide
+        // test lock; poison-tolerant so one failing test does not turn its
+        // siblings into misleading second failures.
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // See the sibling test: Dev profile so the failure is the refused
+        // connection this test is about, not a missing TLS certificate.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+
+        let sbi_ctx = global_context();
+        let instance_id = "udmd-235-evict-selected-udr";
+
+        let mut instance = NfInstance::new(instance_id, NfType::Udr);
+        instance.ipv4_addresses.push("127.0.0.1".to_string());
+        let mut svc = NfService::new("nudr-dr", SbiServiceType::NudrDr);
+        svc.port = 1;
+        instance.add_service(svc);
+        sbi_ctx
+            .add_nf_instance_with_validity(instance, std::time::Duration::from_secs(3600))
+            .await;
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            udm_sbi_discover_and_send_nudr_dr(1, 1, SbiRequest::get("/nudr-dr/v2/ping")),
+        )
+        .await
+        .expect("the refused connection must not hang");
+        assert!(result.is_err(), "connecting to a closed port must fail");
+
+        assert!(
+            sbi_ctx.get_nf_instance(instance_id).await.is_none(),
+            "a transport failure must evict the UDR profile that was selected"
+        );
+    }
+
+    /// #235: the discovery WIRING — a profile learned from the NRF must carry the
+    /// SearchResult's `validityPeriod` into the cache, not be cached forever.
+    ///
+    /// Driven through the real `udm_nrf_discover` against a stub NRF, because the
+    /// interesting failure is a discovery path that calls `add_nf_instance`
+    /// (permanent) instead of `add_nf_instance_with_validity`. A library-level
+    /// test cannot see that: the plain method still works, it is just the wrong
+    /// one to call. `validityPeriod: 0` makes the assertion immediate and
+    /// sleep-free.
+    ///
+    /// The other three discovery writers (`amfd`, `ausfd`, `nssfd`) have the same
+    /// three lines and no equivalent test — see the spec's Ceilings section.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn discovery_honours_the_search_result_validity_period() {
+        // The discovery cache is process-global and all three #235 tests below
+        // seed `NfType::Udr` entries, so `.first()` in the by-type test could pick
+        // up a sibling's profile. `CONTEXT_GUARD` is udmd's existing process-wide
+        // test lock; poison-tolerant so one failing test does not turn its
+        // siblings into misleading second failures.
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Dev profile: the stub NRF below is plain HTTP, and the default
+        // Production profile would make the client attempt TLS against it.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+
+        let addr = nextgcore_sbi::test_support::ephemeral_addr();
+        let server = nextgcore_sbi::server::SbiServer::new(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+        );
+        server
+            .start(|_req: SbiRequest| async move {
+                let body = serde_json::json!({
+                    // The NRF says "do not cache this". Honouring it is the point.
+                    "validityPeriod": 0,
+                    "nfInstances": [{
+                        "nfInstanceId": "udmd-235-validity-udr",
+                        "nfType": "UDR",
+                        "nfStatus": "REGISTERED",
+                        "ipv4Addresses": ["127.0.0.1"],
+                    }]
+                });
+                SbiResponse::ok().with_json_body(&body).unwrap()
+            })
+            .await
+            .expect("stub NRF starts");
+
+        let sbi_ctx = global_context();
+        // `udm_nrf_discover` refuses to run without a self instance.
+        sbi_ctx
+            .set_self_instance(NfInstance::new("udmd-235-self", NfType::Udm))
+            .await;
+
+        let discovered = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            udm_nrf_discover("127.0.0.1", addr.port(), NfType::Udr),
+        )
+        .await
+        .expect("discovery must not hang")
+        .expect("discovery succeeds");
+        assert_eq!(discovered.len(), 1, "the stub returned one profile");
+
+        // Returned to the caller, but NOT selectable from the cache: a zero
+        // validityPeriod means this answer was good for this call only.
+        assert!(
+            sbi_ctx
+                .get_nf_instance("udmd-235-validity-udr")
+                .await
+                .is_none(),
+            "a zero validityPeriod must not leave a selectable cache entry"
+        );
+
+        server.stop().await.expect("stub NRF stops");
+    }
 
     #[test]
     fn test_sbi_server_config_default() {

--- a/src/bins/nextgcore-udrd/src/main.rs
+++ b/src/bins/nextgcore-udrd/src/main.rs
@@ -511,6 +511,12 @@ async fn main() -> Result<()> {
     // Graceful shutdown
     log::info!("Shutting down...");
 
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     // Stop SBI server
     sbi_server
         .stop()

--- a/src/bins/nextgcore-upfd/src/main.rs
+++ b/src/bins/nextgcore-upfd/src/main.rs
@@ -436,6 +436,12 @@ async fn main() -> Result<()> {
     // Graceful shutdown
     log::info!("Shutting down...");
 
+    // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
+    // away, so the NRF stops handing this profile to consumers instead of
+    // waiting out its supervision timer. Stopping the server first would
+    // open the bad window: not serving, but still advertised.
+    nextgcore_sbi::heartbeat::deregister_self().await;
+
     // Close GTP-U path
     upf_gtp_close().map_err(|e| anyhow::anyhow!("Failed to close GTP path: {e}"))?;
     log::info!("GTP-U path closed");

--- a/src/libs/nextgcore-sbi/src/context.rs
+++ b/src/libs/nextgcore-sbi/src/context.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 use crate::client::SbiClient;
@@ -130,12 +131,60 @@ pub struct NfSubscription {
     pub validity_time: Option<u64>,
 }
 
+/// A discovered NF instance plus the deadline after which it must not be
+/// selected again (#235).
+///
+/// The deadline is a monotonic [`Instant`], not a wall-clock time, so a clock
+/// step cannot make a live entry look expired or vice versa.
+#[derive(Debug, Clone)]
+struct CachedNfInstance {
+    instance: NfInstance,
+    /// `None` means "never expires" — the state every entry was in before #235,
+    /// and still what [`SbiContext::add_nf_instance`] produces.
+    expires_at: Option<Instant>,
+}
+
+impl CachedNfInstance {
+    /// Whether this entry is past its validity deadline.
+    ///
+    /// A zero validity expires immediately and deterministically, which is what
+    /// lets the expiry tests run without sleeping.
+    fn is_expired(&self) -> bool {
+        self.expires_at
+            .is_some_and(|deadline| Instant::now() >= deadline)
+    }
+}
+
+/// Cache validity applied to a discovered NF profile when the NRF's
+/// `SearchResult` omits `validityPeriod` (#235).
+///
+/// 3600s, matching `nrfd`'s own `NRF_DISC_VALIDITY_PERIOD` default. The point of
+/// having a fallback at all is that a *foreign* NRF which omits the member must
+/// not mean "cache this peer forever" — an hour is a bound, not a guess at what
+/// that NRF intended.
+pub const DEFAULT_NF_DISCOVERY_VALIDITY_SECS: u64 = 3600;
+
+/// Read a discovery `SearchResult`'s `validityPeriod` (seconds, TS 29.510
+/// §6.1.6.2.x) as a cache TTL, falling back to
+/// [`DEFAULT_NF_DISCOVERY_VALIDITY_SECS`].
+///
+/// A `validityPeriod` of `0` is honoured as zero rather than coerced to the
+/// default: an NRF saying "do not cache this" is a legitimate instruction, and
+/// silently replacing it with an hour would be the lower-layer-can-never-win
+/// mistake.
+pub fn search_result_validity(search_result: &serde_json::Value) -> Duration {
+    match search_result.get("validityPeriod").and_then(|v| v.as_u64()) {
+        Some(secs) => Duration::from_secs(secs),
+        None => Duration::from_secs(DEFAULT_NF_DISCOVERY_VALIDITY_SECS),
+    }
+}
+
 /// SBI Context - manages NF instances and clients
 pub struct SbiContext {
     /// Self NF instance
     self_instance: RwLock<Option<NfInstance>>,
-    /// Discovered NF instances by ID
-    nf_instances: RwLock<HashMap<String, NfInstance>>,
+    /// Discovered NF instances by ID, each with its validity deadline (#235)
+    nf_instances: RwLock<HashMap<String, CachedNfInstance>>,
     /// Clients by endpoint
     clients: RwLock<HashMap<String, Arc<SbiClient>>>,
     /// Subscriptions
@@ -180,35 +229,102 @@ impl SbiContext {
         nrf_uri.clone()
     }
 
-    /// Add an NF instance
+    /// Add an NF instance that **never expires**.
+    ///
+    /// This is the pre-#235 behaviour, kept for callers that seed the registry
+    /// by hand (tests, and the strict-peer harnesses that stand in for a real
+    /// NRF). A production discovery path should use
+    /// [`Self::add_nf_instance_with_validity`] instead: an entry added here is
+    /// selected for the whole process lifetime, which is exactly the permanent
+    /// staleness #235 was filed about.
     pub async fn add_nf_instance(&self, instance: NfInstance) {
         let mut instances = self.nf_instances.write().await;
-        instances.insert(instance.id.clone(), instance);
+        instances.insert(
+            instance.id.clone(),
+            CachedNfInstance {
+                instance,
+                expires_at: None,
+            },
+        );
+    }
+
+    /// Add a discovered NF instance that stops being selectable after
+    /// `validity` (#235, TS 29.510 §6.1.6.2.x `validityPeriod`).
+    ///
+    /// Once the deadline passes, the reads below behave as if the entry were
+    /// absent, so the caller's "not in cache -> discover" branch runs again and
+    /// picks up whatever the NRF says now. A `validity` of zero expires the
+    /// entry immediately, which is the lever the tests use.
+    pub async fn add_nf_instance_with_validity(&self, instance: NfInstance, validity: Duration) {
+        let mut instances = self.nf_instances.write().await;
+        instances.insert(
+            instance.id.clone(),
+            CachedNfInstance {
+                instance,
+                expires_at: Some(Instant::now() + validity),
+            },
+        );
     }
 
     /// Remove an NF instance
     pub async fn remove_nf_instance(&self, id: &str) -> Option<NfInstance> {
         let mut instances = self.nf_instances.write().await;
-        instances.remove(id)
+        instances.remove(id).map(|cached| cached.instance)
     }
 
-    /// Get an NF instance by ID
+    /// Evict a cached NF instance because sending to it failed (#235).
+    ///
+    /// Returns whether an entry was actually removed, so a caller can log the
+    /// difference between "we dropped the stale peer" and "someone else already
+    /// had". Separate from [`Self::remove_nf_instance`] so the *reason* is
+    /// legible at the call site: a delivery failure is evidence the profile is
+    /// wrong, and the next request should re-discover rather than retry an
+    /// endpoint the NRF may already have replaced.
+    pub async fn evict_nf_instance_on_failure(&self, id: &str) -> bool {
+        let removed = {
+            let mut instances = self.nf_instances.write().await;
+            instances.remove(id).is_some()
+        };
+        if removed {
+            log::info!(
+                "Evicted NF instance {id} from the discovery cache after a delivery failure"
+            );
+        }
+        removed
+    }
+
+    /// Drop every entry past its validity deadline, returning how many went.
+    ///
+    /// The reads below already ignore expired entries, so this is bookkeeping
+    /// rather than correctness — it stops a long-lived consumer accumulating
+    /// dead profiles it will never look at.
+    pub async fn purge_expired_nf_instances(&self) -> usize {
+        let mut instances = self.nf_instances.write().await;
+        let before = instances.len();
+        instances.retain(|_, cached| !cached.is_expired());
+        before - instances.len()
+    }
+
+    /// Get an NF instance by ID, or `None` if it is absent **or expired**.
     pub async fn get_nf_instance(&self, id: &str) -> Option<NfInstance> {
         let instances = self.nf_instances.read().await;
-        instances.get(id).cloned()
+        instances
+            .get(id)
+            .filter(|cached| !cached.is_expired())
+            .map(|cached| cached.instance.clone())
     }
 
-    /// Find NF instances by type
+    /// Find non-expired NF instances by type
     pub async fn find_nf_instances_by_type(&self, nf_type: NfType) -> Vec<NfInstance> {
         let instances = self.nf_instances.read().await;
         instances
             .values()
-            .filter(|i| i.nf_type == nf_type)
-            .cloned()
+            .filter(|cached| !cached.is_expired() && cached.instance.nf_type == nf_type)
+            .map(|cached| cached.instance.clone())
             .collect()
     }
 
-    /// Find NF instances by service type
+    /// Find non-expired NF instances by service type
     pub async fn find_nf_instances_by_service(
         &self,
         service_type: SbiServiceType,
@@ -216,8 +332,15 @@ impl SbiContext {
         let instances = self.nf_instances.read().await;
         instances
             .values()
-            .filter(|i| i.services.iter().any(|s| s.service_type == service_type))
-            .cloned()
+            .filter(|cached| {
+                !cached.is_expired()
+                    && cached
+                        .instance
+                        .services
+                        .iter()
+                        .any(|s| s.service_type == service_type)
+            })
+            .map(|cached| cached.instance.clone())
             .collect()
     }
 
@@ -276,10 +399,16 @@ impl SbiContext {
         clients.clear();
     }
 
-    /// Get the number of NF instances
+    /// Get the number of **selectable** NF instances.
+    ///
+    /// Counts what the reads above would return, so it cannot report a peer that
+    /// `find_nf_instances_by_type` has already stopped handing out.
     pub async fn nf_instance_count(&self) -> usize {
         let instances = self.nf_instances.read().await;
-        instances.len()
+        instances
+            .values()
+            .filter(|cached| !cached.is_expired())
+            .count()
     }
 }
 
@@ -388,5 +517,159 @@ mod tests {
 
         let amfs = ctx.find_nf_instances_by_type(NfType::Amf).await;
         assert_eq!(amfs.len(), 2);
+    }
+
+    // ─── #235: discovery-cache validity ──────────────────────────────────────
+
+    /// An entry past its validity must read as ABSENT on every path, not merely
+    /// be flagged — the caller's "not in cache -> discover" branch is what
+    /// re-discovery hangs off, so anything that still returns the instance keeps
+    /// the consumer pointed at a dead endpoint.
+    ///
+    /// `Duration::ZERO` expires immediately, so this is deterministic without
+    /// sleeping.
+    #[tokio::test]
+    async fn expired_instance_reads_as_a_cache_miss_on_every_path() {
+        let ctx = SbiContext::new();
+
+        let mut instance = NfInstance::new("udr-stale", NfType::Udr);
+        instance.add_service(NfService::new("nudr-dr", SbiServiceType::NudrDr));
+        ctx.add_nf_instance_with_validity(instance, Duration::ZERO)
+            .await;
+
+        assert!(
+            ctx.get_nf_instance("udr-stale").await.is_none(),
+            "get_nf_instance must not return an expired profile"
+        );
+        assert!(
+            ctx.find_nf_instances_by_type(NfType::Udr).await.is_empty(),
+            "find_nf_instances_by_type must not return an expired profile"
+        );
+        assert!(
+            ctx.find_nf_instances_by_service(SbiServiceType::NudrDr)
+                .await
+                .is_empty(),
+            "find_nf_instances_by_service must not return an expired profile"
+        );
+        assert_eq!(
+            ctx.nf_instance_count().await,
+            0,
+            "the count must agree with what the reads hand out"
+        );
+    }
+
+    /// The complement: a validity that has not elapsed leaves the entry usable,
+    /// so the expiry check cannot be passing the test above by rejecting
+    /// everything.
+    #[tokio::test]
+    async fn instance_within_its_validity_stays_selectable() {
+        let ctx = SbiContext::new();
+
+        let mut instance = NfInstance::new("udr-live", NfType::Udr);
+        instance.add_service(NfService::new("nudr-dr", SbiServiceType::NudrDr));
+        ctx.add_nf_instance_with_validity(instance, Duration::from_secs(3600))
+            .await;
+
+        assert!(ctx.get_nf_instance("udr-live").await.is_some());
+        assert_eq!(ctx.find_nf_instances_by_type(NfType::Udr).await.len(), 1);
+        assert_eq!(
+            ctx.find_nf_instances_by_service(SbiServiceType::NudrDr)
+                .await
+                .len(),
+            1
+        );
+        assert_eq!(ctx.nf_instance_count().await, 1);
+    }
+
+    /// `add_nf_instance` deliberately opts out of expiry, so the strict-peer
+    /// harnesses that seed the registry by hand keep working. Pinned as a test
+    /// because it is a behaviour difference between two adjacent methods, and the
+    /// kind of thing a later reader would "tidy" into consistency.
+    #[tokio::test]
+    async fn add_without_validity_never_expires() {
+        let ctx = SbiContext::new();
+        ctx.add_nf_instance(NfInstance::new("udr-forever", NfType::Udr))
+            .await;
+
+        assert!(ctx.get_nf_instance("udr-forever").await.is_some());
+        assert_eq!(
+            ctx.purge_expired_nf_instances().await,
+            0,
+            "an entry with no deadline is never purged"
+        );
+        assert!(ctx.get_nf_instance("udr-forever").await.is_some());
+    }
+
+    /// Purging drops expired entries and leaves live ones, and reports the count
+    /// it dropped.
+    #[tokio::test]
+    async fn purge_expired_drops_only_the_expired() {
+        let ctx = SbiContext::new();
+
+        ctx.add_nf_instance_with_validity(NfInstance::new("gone-1", NfType::Udr), Duration::ZERO)
+            .await;
+        ctx.add_nf_instance_with_validity(NfInstance::new("gone-2", NfType::Ausf), Duration::ZERO)
+            .await;
+        ctx.add_nf_instance_with_validity(
+            NfInstance::new("kept", NfType::Udm),
+            Duration::from_secs(3600),
+        )
+        .await;
+
+        assert_eq!(ctx.purge_expired_nf_instances().await, 2);
+        assert!(ctx.get_nf_instance("kept").await.is_some());
+        assert_eq!(ctx.purge_expired_nf_instances().await, 0);
+    }
+
+    /// A delivery failure evicts the entry, and the return value distinguishes
+    /// "we dropped it" from "it was already gone" — which is what lets a caller
+    /// log the difference instead of claiming an eviction it did not perform.
+    #[tokio::test]
+    async fn eviction_on_failure_removes_the_entry_and_reports_whether_it_did() {
+        let ctx = SbiContext::new();
+        ctx.add_nf_instance_with_validity(
+            NfInstance::new("udr-dead", NfType::Udr),
+            Duration::from_secs(3600),
+        )
+        .await;
+
+        assert!(
+            ctx.evict_nf_instance_on_failure("udr-dead").await,
+            "the first eviction removed a live entry"
+        );
+        assert!(ctx.get_nf_instance("udr-dead").await.is_none());
+        assert!(
+            !ctx.evict_nf_instance_on_failure("udr-dead").await,
+            "a second eviction must report that there was nothing to remove"
+        );
+        assert!(
+            !ctx.evict_nf_instance_on_failure("never-cached").await,
+            "evicting an unknown id must not claim a removal"
+        );
+    }
+
+    /// `validityPeriod` drives the TTL; a MISSING member falls back to the
+    /// bounded default; and an explicit `0` is honoured as zero rather than
+    /// coerced to the default, because an NRF saying "do not cache this" is an
+    /// instruction, not an omission.
+    #[test]
+    fn search_result_validity_reads_the_member_and_honours_zero() {
+        assert_eq!(
+            search_result_validity(&serde_json::json!({"validityPeriod": 120})),
+            Duration::from_secs(120)
+        );
+        assert_eq!(
+            search_result_validity(&serde_json::json!({"validityPeriod": 0})),
+            Duration::ZERO
+        );
+        assert_eq!(
+            search_result_validity(&serde_json::json!({"nfInstances": []})),
+            Duration::from_secs(DEFAULT_NF_DISCOVERY_VALIDITY_SECS)
+        );
+        // A non-numeric value is not a validity; fall back rather than panic.
+        assert_eq!(
+            search_result_validity(&serde_json::json!({"validityPeriod": "3600"})),
+            Duration::from_secs(DEFAULT_NF_DISCOVERY_VALIDITY_SECS)
+        );
     }
 }

--- a/src/libs/nextgcore-sbi/src/heartbeat.rs
+++ b/src/libs/nextgcore-sbi/src/heartbeat.rs
@@ -480,6 +480,125 @@ pub fn heartbeat_paused() -> bool {
     HEARTBEAT_PAUSED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+// ─── NF deregistration on shutdown (#235) ────────────────────────────────────
+//
+// Every NF in this workspace that registers an NFProfile also spawns a
+// heartbeat worker — verified by grep: the 17 crates matching
+// `spawn_heartbeat_worker` are exactly the 17 that PUT
+// `/nnrf-nfm/v1/nf-instances/{id}`. `pind` deliberately does not register
+// (PIND-01), and `scpd` / `seppd` only consume `nnrf-disc`. So recording the ID
+// here catches every registering NF, and `deregister_self()` needs no argument
+// — which matters, because an ID passed by hand at 17 shutdown sites is exactly
+// where a copy-paste error would live.
+
+static REGISTERED_NF_INSTANCE_ID: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// Record the NF instance ID this process registered under, so
+/// [`deregister_self`] can DELETE the right profile without being told.
+///
+/// Called automatically by [`spawn_heartbeat_worker_with_load`]; public so an NF
+/// that registers without a heartbeat worker can opt in (none does today).
+pub fn set_registered_nf_instance_id(nf_instance_id: impl Into<String>) {
+    let id = nf_instance_id.into();
+    match REGISTERED_NF_INSTANCE_ID.lock() {
+        Ok(mut slot) => *slot = Some(id),
+        // A poisoned lock here must not take the process down on a path whose
+        // only job is bookkeeping; the cost is that deregistration is skipped,
+        // which is the pre-#235 behaviour and is logged.
+        Err(e) => log::warn!("could not record registered NF instance ID: {e}"),
+    }
+}
+
+/// The NF instance ID this process registered under, if it registered.
+pub fn registered_nf_instance_id() -> Option<String> {
+    REGISTERED_NF_INSTANCE_ID
+        .lock()
+        .ok()
+        .and_then(|slot| slot.clone())
+}
+
+/// Forget the recorded NF instance ID.
+///
+/// **Only for use in tests**, so a test that records an ID leaves the
+/// process-global back as it found it.
+///
+/// NOT gated behind `cfg(test)`: `nextgcore-sbi` compiles as a *dependency* of
+/// every NF crate, and `cfg(test)` is false in that build — the recorded trap
+/// that `udmd`'s ungated `test_support` module exists for. A test in `nrfd` needs
+/// this, so gating it would make the symbol invisible exactly where it is used.
+pub fn clear_registered_nf_instance_id() {
+    if let Ok(mut slot) = REGISTERED_NF_INSTANCE_ID.lock() {
+        *slot = None;
+    }
+}
+
+/// `DELETE /nnrf-nfm/v1/nf-instances/{nfInstanceId}` — NFDeregister,
+/// TS 29.510 §5.2.2.2.3.
+///
+/// The single client for this operation. Before #235 there were two hand-rolled
+/// copies (`udmd`'s `udm_nrf_deregister` and the inline DELETE in `udmd`'s NES
+/// driver) and sixteen NFs with none at all.
+pub async fn deregister_nf(nf_instance_id: &str) -> Result<(), String> {
+    let ctx = crate::context::global_context();
+    let nrf_uri = ctx
+        .get_nrf_uri()
+        .await
+        .ok_or_else(|| "no NRF URI configured".to_string())?;
+    let (nrf_host, nrf_port) =
+        parse_nrf_host_port(&nrf_uri).ok_or_else(|| format!("invalid NRF URI '{nrf_uri}'"))?;
+    let client = SbiClient::with_host_port(&nrf_host, nrf_port);
+    let path = format!("/nnrf-nfm/v1/nf-instances/{nf_instance_id}");
+
+    match client.send_request(SbiRequest::delete(&path)).await {
+        // TS 29.510 §5.2.2.2.3 specifies 204; 200 is accepted too rather than
+        // reported as a failure, since either means the profile is gone.
+        Ok(resp) if resp.status == 204 || resp.status == 200 => Ok(()),
+        // A profile the NRF does not hold is the state we wanted: treat 404 as
+        // success so a shutdown after the supervision timer already expired does
+        // not log an alarming warning.
+        Ok(resp) if resp.status == 404 => {
+            log::debug!("NRF had already dropped NF instance {nf_instance_id}");
+            Ok(())
+        }
+        Ok(resp) => Err(format!("NRF returned status {}", resp.status)),
+        Err(e) => Err(format!("NFDeregister failed: {e}")),
+    }
+}
+
+/// Deregister this process's own NFProfile from the NRF, for the shutdown path.
+///
+/// Pauses the heartbeat worker **first**: a tick that lands after the DELETE
+/// would PATCH a profile that no longer exists, which reads to an operator as
+/// the NRF losing registrations rather than as an ordering bug here. The NES
+/// deregister action established the same ordering.
+///
+/// Never returns an error the caller has to handle at shutdown — a failure is
+/// logged and swallowed, because refusing to exit because the NRF is unreachable
+/// would be worse than the stale profile this is trying to avoid. Returns
+/// whether a DELETE was actually issued so a test can assert it.
+pub async fn deregister_self() -> bool {
+    let Some(nf_instance_id) = registered_nf_instance_id() else {
+        log::debug!("No registered NF instance ID: skipping NRF deregistration");
+        return false;
+    };
+
+    set_heartbeat_paused(true);
+
+    match deregister_nf(&nf_instance_id).await {
+        Ok(()) => {
+            log::info!("Deregistered NF instance {nf_instance_id} from the NRF");
+            true
+        }
+        Err(e) => {
+            // Deliberately a warning, not an error return: the process is
+            // exiting either way, and the NRF's supervision timer is the
+            // backstop this is merely trying to pre-empt.
+            log::warn!("NRF deregistration for {nf_instance_id} failed: {e}");
+            true
+        }
+    }
+}
+
 /// One-off `nfStatus` PATCH toward the NRF (issue #22 NES transitions),
 /// using the exact wire shape of the heartbeat worker (RFC 6902 array,
 /// `application/json-patch+json`).
@@ -538,6 +657,11 @@ pub fn spawn_heartbeat_worker_with_load<F>(nf_instance_id: String, interval_secs
 where
     F: Fn() -> u8 + Send + 'static,
 {
+    // #235: remember the ID so the shutdown path can deregister without being
+    // handed it again. Done here rather than at each NF's registration site
+    // because every registering NF reaches this function.
+    set_registered_nf_instance_id(nf_instance_id.clone());
+
     tokio::spawn(async move {
         log::info!(
             "Heartbeat worker started for NF instance {nf_instance_id} (interval={interval_secs}s)"
@@ -620,6 +744,58 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #235: the registered-NF-instance-ID plumbing that lets `deregister_self`
+    /// DELETE the right profile without being handed the ID at 17 shutdown sites.
+    ///
+    /// One test, not several, and it restores the static — same reason the NES
+    /// test below gives: the slot is process-global, so mutation and restoration
+    /// belong together. Deliberately does NOT call `deregister_self()`: that
+    /// pauses the heartbeat, which is another process-global the NES test
+    /// asserts on. The end-to-end path is covered in `nrfd`, whose binary
+    /// touches neither global.
+    #[tokio::test]
+    async fn test_registered_nf_instance_id_plumbing() {
+        // Nothing has registered in this test binary.
+        clear_registered_nf_instance_id();
+        assert_eq!(registered_nf_instance_id(), None);
+
+        set_registered_nf_instance_id("5e9b1c0a-2222-4f6a-8888-0123456789ab");
+        assert_eq!(
+            registered_nf_instance_id().as_deref(),
+            Some("5e9b1c0a-2222-4f6a-8888-0123456789ab")
+        );
+
+        // A re-registration (the NES resume path re-registers under a new ID)
+        // must replace, not accumulate — deregistering the previous ID would
+        // delete a profile that is no longer this process's.
+        set_registered_nf_instance_id("5e9b1c0a-3333-4f6a-8888-0123456789ab");
+        assert_eq!(
+            registered_nf_instance_id().as_deref(),
+            Some("5e9b1c0a-3333-4f6a-8888-0123456789ab")
+        );
+
+        // Spawning the heartbeat worker is what records the ID in production —
+        // no NF calls the setter itself. Asserted here because otherwise the
+        // recording is the untested half and every other test seeds the slot by
+        // hand, which would pass with the recording deleted. No NRF URI is
+        // configured, so the worker's first tick logs "no NRF URI" and skips;
+        // the task dies with this test's runtime.
+        clear_registered_nf_instance_id();
+        spawn_heartbeat_worker_with_load(
+            "5e9b1c0a-5555-4f6a-8888-0123456789ab".to_string(),
+            3600,
+            || 0,
+        );
+        assert_eq!(
+            registered_nf_instance_id().as_deref(),
+            Some("5e9b1c0a-5555-4f6a-8888-0123456789ab"),
+            "spawning the heartbeat worker must record the ID the shutdown path deregisters"
+        );
+
+        clear_registered_nf_instance_id();
+        assert_eq!(registered_nf_instance_id(), None);
+    }
 
     /// Issue #22 NES: the default heartbeat body is byte-identical to the
     /// historical hardcoded-REGISTERED patch, the status builder emits the


### PR DESCRIPTION
`Closes #235`.

Spec: [`specs/fix-nrf-deregister-on-shutdown-and-discovery-cache-validity.md`](specs/fix-nrf-deregister-on-shutdown-and-discovery-cache-validity.md).

## Gap 1 — nothing deregistered, and the one client that existed had no caller

`udmd` owned the workspace's only `NFDeregister` client (`udm_nrf_deregister`, `sbi_path.rs:321`) and
**never called it**. Sixteen other registering NFs had no client at all.

**Where the instance ID lives is the design.** Every NF that registers an `NFProfile` also spawns the
shared heartbeat worker — an *exact* coincidence, not an approximation:

| | registers `nnrf-nfm` | spawns heartbeat worker |
|---|---|---|
| amfd, ausfd, bsfd, dccfd, easdfd, lmfd, mbsmfd, nefd, nsacfd, nssfd, nwdafd, pcfd, smfd, tsctsf, udmd, udrd, upfd | yes (17) | yes (17) |
| pind | no — `PIND-01` removed it deliberately | no |
| scpd, seppd | no — `nnrf-disc` consumers only | no |

So `spawn_heartbeat_worker_with_load` records the ID and **`deregister_self()` takes no argument**. An ID
threaded by hand through 17 shutdown sites is exactly where a copy-paste error lives, and
`DELETE /nf-instances/{someone-else's-id}` is worse than no deregistration.

Ordering, all deliberate:

- **Deregister before stopping the listener** — the reverse opens the bad window (not serving, still
  advertised); this opens the harmless one.
- **Pause the heartbeat before the DELETE** — a later tick would `PATCH` a profile that no longer exists,
  which reads to an operator as the NRF losing registrations. The #22 NES action set this precedent.
- **404 is success** — a profile the NRF does not hold is the state we wanted.
- **Failures are logged, never returned** — refusing to exit because the NRF is unreachable is worse than
  the stale profile; the supervision timer is still the backstop.

`amfd` needed a call: it has `shutdown()` and `shutdown_async()`, only the async one can await — and only
the async one has a caller (`lib.rs:954`), the sync twin being dead.

Two hand-rolled DELETEs migrated onto the one client: `udmd`'s uncalled `udm_nrf_deregister` (deleted, with
a note at the site) and the inline copy in `udmd`'s NES sleep path, which gains the 404 handling it lacked.

## Gap 2 — a cached NF profile was selectable for the whole process lifetime

`nf_instances` was a bare map: no expiry, no eviction, no re-discovery. Now each entry carries an
`Option<Instant>` deadline from the `SearchResult`'s `validityPeriod`, and **expired entries read as absent
on every path** rather than being flagged — which makes re-discovery free, since every consumer already has
a not-in-cache→discover branch (e.g. `amfd`'s resolver, which re-discovers on a miss precisely because a
late-registering NSACF was invisible). `Instant`, not wall-clock, so a clock step cannot make a live entry
look dead. **Eviction fires on a transport failure only** — a 4xx/5xx means the peer answered, so its
profile is fine.

Three deliberate asymmetries, each pinned by a test:

- `add_nf_instance` still means **never expires** — the strict-peer harnesses seed the registry by hand and
  a TTL would make them flake on timing. Pinned so nobody tidies the two methods into consistency.
- a **missing** `validityPeriod` falls back to 3600s (matching `nrfd`'s own default) — a foreign NRF
  omitting it must not mean forever.
- an **explicit `0`** is honoured as zero — an NRF saying "do not cache this" is an instruction; coercing it
  would be the lower-layer-can-never-win mistake.

Wired at all four production discovery writers, each reading `validityPeriod` once for the whole
`SearchResult` (which is where TS 29.510 puts it — a property of the answer, not of a profile). Eviction is
wired at `udmd`'s two send shapes: resolve-by-ID, and select-by-type-then-send (which now remembers *which*
profile it selected).

## What the issue understated

1. **Four production cache writers, not two** — plus `ausfd/app.rs:1960` and `nssfd/main.rs:3008`. All four wired.
2. **`udmd` had two hand-rolled DELETEs, not one** — the NES sleep path had its own inline copy.
3. **The registering set is exactly the heartbeat-worker set** — unremarked in the issue, and the whole
   reason no per-NF ID plumbing was needed.

## Verification

- **Workspace 5949 passed / 0 failed over three consecutive runs** (baseline 5938 / 0; the difference is
  the eleven tests added here). Three runs rather than two because this adds port-binding tests and touches
  process-global state.
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
- **Fifteen behavioural claims individually revert-verified.** The harness checked itself against all four
  ways a revert lies: the anchor asserted **unique** in its file, a compile failure treated as inconclusive
  rather than a bite, the named test required to be **seen to run**, and each substitution read for semantic
  equivalence. All fifteen bit.

| # | claim | test that bit |
|---|---|---|
| 1–4 | all four cache reads skip expired entries | `expired_instance_reads_as_a_cache_miss_on_every_path` |
| 5 | purge drops expired | `purge_expired_drops_only_the_expired` |
| 6 | `add_nf_instance` never expires | `add_without_validity_never_expires` |
| 7 | eviction actually removes | `eviction_on_failure_removes_the_entry_and_reports_whether_it_did` |
| 8 | `validityPeriod` drives the TTL, `0` honoured | `search_result_validity_reads_the_member_and_honours_zero` |
| 9 | spawning the worker records the ID | `test_registered_nf_instance_id_plumbing` |
| 10–12 | DELETE issued / heartbeat paused first / 404 is success | `test_shared_deregister_self_removes_the_profile_from_the_real_nrf` |
| 13–14 | `udmd` evicts on transport failure, both send shapes | `transport_failure_evicts_the_cached_instance_by_id`, `..._the_selected_udr` |
| 15 | discovery passes the validity into the cache | `discovery_honours_the_search_result_validity_period` |

Claim 10 is proved **against the real NRF handler, not a mock**: `nrfd`'s test module starts a real
`SbiServer` on `nrf_sbi_request_handler`, registers over HTTP, calls `deregister_self()`, then asserts the
profile is gone from `nf_manager()` — `nrfd`'s actual registry — and a subsequent GET is 404. The existing
lifecycle test already proved the DELETE *handler*; what is newly proved is that the shared client added to
17 shutdown paths reaches it.

### Two authoring traps hit and fixed in-session

**The SBI profile defaults to Production, so a test dialling loopback gets a TLS error, not a refused
connection.** The first eviction tests passed — at the wrong layer: a missing
`/etc/nextgcore/tls/client.crt` rather than the closed port the comment described, and which one you got
depended on whether a sibling test had already forced Dev. All three new `udmd` tests now set
`set_sbi_profile_override(SbiProfile::Dev)` explicitly, matching the eleven existing sites.

**A `.first()` over the process-global cache picked a sibling test's profile.** The by-type eviction test
intermittently evicted the by-ID test's UDR. Distinct IDs did not help — distinctness was never the
problem, the shared view was. Fixed with `udmd`'s existing `test_support::CONTEXT_GUARD` (poison-tolerant)
plus 6 consecutive clean runs; the test comment records that it *did* race so nobody removes the guard.

## Ceilings

- **No test drives any NF's `main()` shutdown**, so the 17 one-line insertions are compile-checked and
  reviewed but not observed firing — there is no shutdown harness in this repo. What *is* observed is the
  function they all call, end-to-end against the real NRF.
- **Only `udmd`'s discovery writer has a validity test**; `amfd`/`ausfd`/`nssfd` carry the same three lines,
  type-checked only. The recorded "helper tested, wiring not" pattern, reduced 4→3 rather than eliminated.
- **Eviction is wired in `udmd` only** — `amfd`'s resolver returns `(host, port)` and discards the instance
  ID, so evicting there means threading it out to every send site. `amfd` still gets the TTL half.
- **`purge_expired_nf_instances` has no production caller**, by design: the reads are already bounded, so it
  is bookkeeping. Wiring it to a timer in every NF is a separate decision.

## GitNexus

`nextgcore/CLAUDE.md` mandates `gitnexus_impact` / `gitnexus_detect_changes`. No GitNexus MCP server is
connected here, so the mandate is unsatisfiable — 24th consecutive PR in this state. Blast radius was
established by exhaustive `grep` plus `cargo check --workspace --all-targets`.