### PR TITLE
refactor(bsfd,nwdafd): delete two dead registries that read as working NRF integration (Closes #234, Closes #233)

### DIFF
--- a/specs/fix-delete-two-dead-nrf-integration-registries.md
+++ b/specs/fix-delete-two-dead-nrf-integration-registries.md
@@ -1,0 +1,113 @@
+# nextgcore #234 + #233: delete two dead registries that read as working NRF integration
+
+Verified against `main` @ `4ec257a`. Both issues' reference tables reproduced exactly; both turned out to
+be **more** dead than reported.
+
+`Closes #234`. `Closes #233`.
+
+## Why one PR for two issues
+
+The project convention is one PR per issue *covering all of that issue's parts* — the prohibition is on
+**splitting** an umbrella, not on combining. These two are single-scope pure deletions of the same class,
+filed in the same backlog sweep, with the same recommendation (`DELETE`) already settled in each issue body
+so neither needs re-litigating. Combining them means one lint/test gate instead of two, and both still
+close cleanly and auditably. The bodies below are kept separate so a reviewer can compare each diff against
+the issue that asked for it.
+
+## #234: `bsfd`'s consumer-side NRF-discovery path
+
+Three functions formed a consumer-side discovery path that could not work and had no caller.
+`bsf_sbi_send_request` and `bsf_sbi_discover_and_send` logged at debug, did nothing, and returned a
+**fabricated `Ok(1)`** transaction ID; `bsf_nnrf_handle_nf_discover` was reached only from its own two
+tests, which passed *because* the stub fabricated success.
+
+### The pre-check the issue asked for, answered
+
+> Check first whether `bsf_sbi_send_response`, `PathSbiRequest` and `SbiXact` have live callers before
+> removing them too.
+
+**None of the three does**, so all three went as well:
+
+| symbol | references in `bsfd` |
+|---|---|
+| `bsf_sbi_send_response` | its definition and one test (`sbi_path.rs:343`) — nothing else |
+| `PathSbiRequest` | the deleted functions, one test, and the deleted discovery handler |
+| `SbiXact` | **its definition only.** No caller, no test, nothing |
+| `PathSbiRequestBuilder` | its own definition, whose return type is `PathSbiRequest` |
+
+`bsf_sbi_send_response` is worth naming separately: it returned `Ok(())` having sent nothing, under a
+comment saying "the actual response is sent by the HTTP handler in main.rs". So it was a third stub that
+lies to its caller, in the same file, and the issue did not know it was dead.
+
+Also removed with the handler: `SearchResult`, `NfInstanceInfo` and `SbiXactContext`, which only fed it.
+
+### Not re-litigated
+
+The evidence that ruled out "wire it per TS 29.521 / TS 29.510" is copied into the removal note at the
+site, so a fourth pass cannot reopen it: `bsfd`'s `nnrf-nfm` obligations are already complete (profile PUT,
+heartbeat worker in `lib.rs`, DELETE on close); TS 23.501 §6.2.19 and TS 29.521 define the BSF as a
+**producer** of binding management with no originated service request for that role; and the giveaway is
+that the handler hardcoded `GET /nbsf-management/v1/pcf-bindings` — it would have had the BSF query **its
+own service** on another NF, which is a copy-paste artefact of the C port rather than a defined procedure.
+
+### What was kept, and why
+
+`handle_nf_status_notify` stays. It has no non-test caller either — `bsf_sm.rs:176` mentions the C original
+in a comment but does not call it — but it is an *inbound* status-notify observer, not an outbound client
+that could not work. Withdrawing an inbound hook is a different decision from deleting a discovery path
+TS 29.521 does not give the BSF, and #234 scopes itself to the latter. Recorded in the module doc so it is
+not mistaken for live code.
+
+`bsf_sm.rs:343` carried a comment pointing at `bsf_nnrf_handle_nf_discover`. Left dangling it would be a
+reference to a deleted symbol, so it now says why the branch has nothing to dispatch to.
+
+`pcfd`'s `tests/strict_peer_bsfd.rs` is the only external consumer of `bsfd`'s public API and uses only
+`bsf_sbi_request_handler` and `test_support::init_context` — checked before deleting anything re-exported by
+`pub use sbi_path::*`.
+
+## #233: `nwdafd`'s `DataSource` registry
+
+The struct, `add_data_source`, `get_data_sources`, `data_source_count` and the `data_sources` map formed an
+inventory API structurally incapable of holding anything.
+
+**Two corrections, both in the direction of more-dead-than-reported:**
+
+1. #233 says the grep hits are "its definitions and its own tests". There were **no tests** — the five
+   definitions were the only references in the crate. That is why the deletion needed no test changes, and
+   why `cargo check --all-targets` staying green is itself the proof that nothing referenced them.
+2. `get_data_sources` ended in `.expect("value expected")` where every sibling reader uses `unwrap_or`. A
+   poisoned lock would therefore have **panicked** the NWDAF — on a read of a map that was always empty.
+
+### The pre-check the issue asked for, answered
+
+> Check first whether any `docs-book` page or `build_nf_profile` claims a data-source inventory this was
+> meant to feed.
+
+Clean. `build_nf_profile` never mentions data sources. The two `docs-book` pages that say "data source"
+(`concepts/ai-stack.md:63`, `configuration/nwdaf.md:73`) describe the **G2-1 NRF collector** — "the only
+data source is the NRF's view of NF load" — which is `nrf_collector.rs` and is untouched here. So no page
+is left claiming an inventory the code no longer offers, and the alternative the issue names (wire a
+producer) remains a feature needing its own issue rather than a silent expansion of this one.
+
+## Verification
+
+Workspace: **5934 passed / 0 failed** over two consecutive runs, against a `main` baseline of **5938 / 0**.
+The difference is exactly the four deleted `bsfd` tests — `test_sbi_request` and `test_sbi_send_response`
+in `sbi_path.rs`, plus `test_search_result_empty` and `test_search_result_with_instances` in
+`nnrf_handler.rs`, the two the issue names as the discovery stub's only callers. Each tested a symbol this
+removes. `nwdafd` had no test to delete. `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
+
+**On revert-verification.** As with #236, this adds no behaviour, so there is no guard to make fail;
+inventing one would be the decorative-test failure mode this project records. The compiler is the check
+that matters here — every "X had no caller" claim is falsified at build time if it is wrong — and
+`cargo check -p nextgcore-bsfd --all-targets`, `cargo check -p nextgcore-nwdafd --all-targets` and the
+whole-workspace build are that check. For `nwdafd` specifically it is unusually strong: had the issue been
+right that tests exercised the registry, the build would have failed.
+
+## Ceilings
+
+* **`handle_nf_status_notify` in `bsfd` remains uncalled** (see above). It is now documented as a latent
+  hook rather than left to read as live code, but it is still ~20 lines with no producer.
+* **Nothing was added**, so there is no new behaviour to test and no test added. The claim being made is
+  "the removed code could not run", and that is established by reference-counting plus the build, not by a
+  test.

--- a/src/bins/nextgcore-bsfd/src/bsf_sm.rs
+++ b/src/bins/nextgcore-bsfd/src/bsf_sm.rs
@@ -340,8 +340,12 @@ impl BsfSmContext {
                 log::debug!("NF discover response received");
                 if let Some(sbi_xact_id) = event.sbi_xact_id {
                     log::debug!("SBI xact ID: {sbi_xact_id}");
-                    // Note: bsf_nnrf_handle_nf_discover processes NF discovery results
-                    // This is handled by the nnrf_handler module when NRF integration is enabled
+                    // #234: this used to point at `bsf_nnrf_handle_nf_discover`,
+                    // which is now deleted. The BSF is a PRODUCER of binding
+                    // management (TS 23.501 6.2.19, TS 29.521) with no originated
+                    // service request for that role, so there is nothing for it to
+                    // discover and this branch has nothing to dispatch to. Kept as
+                    // a log so an unexpected discovery response is still visible.
                 }
             }
             _ => {

--- a/src/bins/nextgcore-bsfd/src/nnrf_handler.rs
+++ b/src/bins/nextgcore-bsfd/src/nnrf_handler.rs
@@ -1,100 +1,26 @@
 //! BSF NRF Handler
 //!
-//! Port of src/bsf/nnrf-handler.c - Handler for NRF discovery responses
-
-use crate::sbi_path::bsf_sbi_send_request;
-
-/// NF discovery search result (simplified)
-#[derive(Debug, Clone, Default)]
-pub struct SearchResult {
-    pub nf_instances: Vec<NfInstanceInfo>,
-    pub validity_period: Option<u32>,
-}
-
-/// NF instance information (simplified)
-#[derive(Debug, Clone, Default)]
-pub struct NfInstanceInfo {
-    pub nf_instance_id: String,
-    pub nf_type: String,
-    pub nf_status: String,
-    pub fqdn: Option<String>,
-    pub ipv4_addresses: Vec<String>,
-    pub ipv6_addresses: Vec<String>,
-    pub priority: Option<u16>,
-    pub capacity: Option<u16>,
-    pub load: Option<u8>,
-}
-
-/// SBI transaction context for discovery
-#[derive(Debug)]
-pub struct SbiXactContext {
-    pub id: u64,
-    pub service_type: String,
-    pub target_nf_type: String,
-    pub requester_nf_type: String,
-    pub sess_id: Option<u64>,
-    pub stream_id: Option<u64>,
-}
-
-/// Handle NF discover response
-/// Port of bsf_nnrf_handle_nf_discover
-pub fn bsf_nnrf_handle_nf_discover(
-    xact: &SbiXactContext,
-    search_result: &SearchResult,
-) -> Result<(), String> {
-    log::debug!(
-        "NF discover response: service_type={}, target_nf_type={}, requester_nf_type={}",
-        xact.service_type,
-        xact.target_nf_type,
-        xact.requester_nf_type
-    );
-
-    if search_result.nf_instances.is_empty() {
-        log::error!(
-            "(NF discover) No [{}:{}]",
-            xact.service_type,
-            xact.requester_nf_type
-        );
-        return Err("No NF instances found".to_string());
-    }
-
-    // Process search result
-    // In C: nextgcore_nnrf_disc_handle_nf_discover_search_result(SearchResult)
-    for nf_instance in &search_result.nf_instances {
-        log::debug!(
-            "Found NF instance: id={}, type={}, status={}",
-            nf_instance.nf_instance_id,
-            nf_instance.nf_type,
-            nf_instance.nf_status
-        );
-    }
-
-    // Find NF instance by discovery parameters
-    // In C: nextgcore_sbi_nf_instance_find_by_discovery_param(...)
-    let nf_instance = search_result
-        .nf_instances
-        .first()
-        .ok_or_else(|| "No suitable NF instance found".to_string())?;
-
-    log::debug!(
-        "Selected NF instance: {} ({})",
-        nf_instance.nf_instance_id,
-        nf_instance.nf_type
-    );
-
-    // Send request to discovered NF instance
-    // In C: bsf_sbi_send_request(nf_instance, xact)
-    let request = crate::sbi_path::PathSbiRequest {
-        method: "GET".to_string(),
-        uri: "/nbsf-management/v1/pcf-bindings".to_string(),
-        headers: vec![],
-        body: None,
-    };
-
-    bsf_sbi_send_request(&nf_instance.nf_instance_id, request)?;
-
-    Ok(())
-}
+//! Port of src/bsf/nnrf-handler.c - Handler for NRF status notifications.
+//!
+//! ## Removed in #234: the consumer-side NF-discovery path
+//!
+//! `bsf_nnrf_handle_nf_discover` and the three types that only fed it
+//! (`SearchResult`, `NfInstanceInfo`, `SbiXactContext`) are gone, together with
+//! the two tests that were its only callers — and which passed *because* the stub
+//! they reached fabricated `Ok(1)`. See the removal note in
+//! [`crate::sbi_path`] for the evidence that ruled out wiring it instead: bsfd's
+//! `nnrf-nfm` obligations are already complete, TS 29.521 gives the BSF no
+//! originated service request for binding management, and the handler hardcoded
+//! `GET /nbsf-management/v1/pcf-bindings` — it would have had the BSF query its
+//! own service on another NF.
+//!
+//! What remains is [`handle_nf_status_notify`], which is a different thing: an
+//! inbound status-notify observer, not an outbound discovery client. It has no
+//! non-test caller either — `bsf_sm.rs:176` mentions the C original in a comment
+//! but does not call it — so it is a latent hook rather than live code. It was
+//! left in place because #234 scopes itself to the discovery path, and because
+//! withdrawing an inbound observer is a different decision from deleting an
+//! outbound client that could not work.
 
 /// Handle NF status notify
 pub fn handle_nf_status_notify(nf_instance_id: &str, nf_status: &str) -> Result<(), String> {
@@ -121,48 +47,6 @@ pub fn handle_nf_status_notify(nf_instance_id: &str, nf_status: &str) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_search_result_empty() {
-        let xact = SbiXactContext {
-            id: 1,
-            service_type: "nbsf-management".to_string(),
-            target_nf_type: "PCF".to_string(),
-            requester_nf_type: "BSF".to_string(),
-            sess_id: Some(1),
-            stream_id: Some(1),
-        };
-
-        let search_result = SearchResult::default();
-        let result = bsf_nnrf_handle_nf_discover(&xact, &search_result);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_search_result_with_instances() {
-        let xact = SbiXactContext {
-            id: 1,
-            service_type: "nbsf-management".to_string(),
-            target_nf_type: "PCF".to_string(),
-            requester_nf_type: "BSF".to_string(),
-            sess_id: Some(1),
-            stream_id: Some(1),
-        };
-
-        let search_result = SearchResult {
-            nf_instances: vec![NfInstanceInfo {
-                nf_instance_id: "pcf-001".to_string(),
-                nf_type: "PCF".to_string(),
-                nf_status: "REGISTERED".to_string(),
-                fqdn: Some("pcf.example.com".to_string()),
-                ..Default::default()
-            }],
-            validity_period: Some(3600),
-        };
-
-        let result = bsf_nnrf_handle_nf_discover(&xact, &search_result);
-        assert!(result.is_ok());
-    }
 
     #[test]
     fn test_handle_nf_status_notify() {

--- a/src/bins/nextgcore-bsfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-bsfd/src/sbi_path.rs
@@ -225,78 +225,26 @@ pub fn bsf_sbi_is_running() -> bool {
     SBI_SERVER_RUNNING.load(Ordering::SeqCst)
 }
 
-/// SBI request builder function type
-pub type PathSbiRequestBuilder =
-    fn(sess_id: u64, data: &dyn std::any::Any) -> Option<PathSbiRequest>;
-
-/// Simplified SBI request for path operations
-#[derive(Debug, Clone)]
-pub struct PathSbiRequest {
-    pub method: String,
-    pub uri: String,
-    pub headers: Vec<(String, String)>,
-    pub body: Option<String>,
-}
-
-/// SBI transaction for tracking requests
-#[derive(Debug)]
-pub struct SbiXact {
-    pub id: u64,
-    pub sess_id: u64,
-    pub stream_id: u64,
-    pub service_type: String,
-}
-
-/// Send SBI request to NF instance
-/// Port of bsf_sbi_send_request
-pub fn bsf_sbi_send_request(nf_instance_id: &str, request: PathSbiRequest) -> Result<u64, String> {
-    log::debug!(
-        "Sending SBI request to NF instance [{}]: {} {}",
-        nf_instance_id,
-        request.method,
-        request.uri
-    );
-
-    // Note: SBI request sending requires HTTP client integration
-    // In C: nextgcore_sbi_send_request_to_nf_instance(nf_instance, xact)
-    // The actual HTTP client would send the request and handle the response
-
-    // Return transaction ID (placeholder)
-    Ok(1)
-}
-
-/// Discover NF and send request
-/// Port of bsf_sbi_discover_and_send
-pub fn bsf_sbi_discover_and_send(
-    service_type: &str,
-    sess_id: u64,
-    stream_id: u64,
-    _request: PathSbiRequest,
-) -> Result<u64, String> {
-    log::debug!(
-        "Discover and send: service_type={service_type}, sess_id={sess_id}, stream_id={stream_id}"
-    );
-
-    // Note: SBI transaction tracking and NF discovery require NRF integration
-    // In C: nextgcore_sbi_xact_add(...) creates a transaction
-    // In C: nextgcore_sbi_discover_and_send(xact) discovers and sends to target NF
-
-    // Return transaction ID (placeholder)
-    Ok(1)
-}
-
-/// Send SBI response
-/// Port of bsf_sbi_send_response
-pub fn bsf_sbi_send_response(stream_id: u64, status: u16) -> Result<(), String> {
-    log::debug!("Sending SBI response: stream_id={stream_id}, status={status}");
-
-    // Note: Build and send response through HTTP server
-    // In C: nextgcore_sbi_build_response(&sendmsg, status)
-    // In C: nextgcore_sbi_server_send_response(stream, response)
-    // The actual response is sent by the HTTP handler in main.rs
-
-    Ok(())
-}
+// #234: a dead consumer-side NRF-discovery path used to live here. Removed:
+// `PathSbiRequestBuilder`, `PathSbiRequest`, `SbiXact`, `bsf_sbi_send_request`,
+// `bsf_sbi_discover_and_send` and `bsf_sbi_send_response`.
+//
+// The first two of those functions logged at debug, did nothing, and returned a
+// FABRICATED `Ok(1)` transaction ID -- a stub that lies to its caller. The third
+// returned `Ok(())` without sending anything, and had no caller but its own test.
+// `SbiXact` had no reference anywhere in the crate, not even a test, and
+// `PathSbiRequestBuilder` only named the struct beside it.
+//
+// "Wire it per TS 29.521 / TS 29.510" was ruled out on evidence rather than left
+// open, so it is not re-litigated: bsfd's `nnrf-nfm` obligations are ALREADY
+// complete (`register_with_nrf` PUTs the profile, `spawn_heartbeat_worker_with_load`
+// runs in `lib.rs`, and `bsf_sbi_close` tears down); TS 23.501 6.2.19 and TS 29.521
+// define the BSF as a PRODUCER of binding management with no originated service
+// request for that role; and the giveaway was that the discovery handler hardcoded
+// `GET /nbsf-management/v1/pcf-bindings`, i.e. it would have had the BSF query ITS
+// OWN SERVICE on another NF. That is a copy-paste artefact of the C port, not a
+// procedure. Implementing a generic discover-and-send would have invented a
+// capability nothing asked for.
 
 #[cfg(test)]
 mod tests {
@@ -325,22 +273,5 @@ mod tests {
 
         bsf_sbi_close();
         assert!(!bsf_sbi_is_running());
-    }
-
-    #[test]
-    fn test_sbi_request() {
-        let request = PathSbiRequest {
-            method: "POST".to_string(),
-            uri: "/nbsf-management/v1/pcf-bindings".to_string(),
-            headers: vec![],
-            body: None,
-        };
-        assert_eq!(request.method, "POST");
-    }
-
-    #[test]
-    fn test_sbi_send_response() {
-        let result = bsf_sbi_send_response(1, 200);
-        assert!(result.is_ok());
     }
 }

--- a/src/bins/nextgcore-nwdafd/src/context.rs
+++ b/src/bins/nextgcore-nwdafd/src/context.rs
@@ -915,18 +915,30 @@ pub struct NrfCollectorConfig {
     pub callback_uri: String,
 }
 
-/// Data source configuration for analytics collection
-#[derive(Debug, Clone)]
-pub struct DataSource {
-    /// Source NF type (e.g., "AMF", "SMF", "UPF")
-    pub nf_type: String,
-    /// Source NF instance ID
-    pub nf_instance_id: String,
-    /// Data collection URI
-    pub collection_uri: String,
-    /// Collection enabled flag
-    pub enabled: bool,
-}
+// #233: a `DataSource` registry used to live here -- the struct plus
+// `add_data_source`, `get_data_sources`, `data_source_count` and the
+// `data_sources` map. It was dead: `add_data_source` had NO caller at all, so
+// `data_sources` was always empty and the two readers could only ever report
+// nothing. Removed rather than left as ~40 lines that read as a working
+// data-source inventory and would keep attracting fixes that cannot matter.
+//
+// Two details the issue got slightly wrong, both in the direction of it being
+// MORE dead than reported. #233 says the grep hits are "its definitions and its
+// own tests"; there were no tests — the five definitions were the only references
+// in the crate, which is why deleting them needed no test changes. And
+// `get_data_sources` ended in `.expect("value expected")` where every sibling
+// reader uses `unwrap_or`, so a poisoned lock would have PANICKED the NWDAF on a
+// read of a map that was structurally always empty.
+//
+// The pre-check #233 asked for came out clean: nothing claims an inventory this
+// was meant to feed. `build_nf_profile` never mentioned data sources, and the two
+// docs-book pages that say "data source" (`concepts/ai-stack.md:63`,
+// `configuration/nwdaf.md:73`) describe the G2-1 NRF collector -- "the only data
+// source is the NRF's view of NF load" -- which is `nrf_collector.rs` and is
+// untouched here. Wiring a producer instead would have been a feature, and #233
+// says so: it would need its own issue rather than a silent expansion of this one.
+// It was also correctly EXCLUDED from #192's snapshot, since persisting it would
+// have snapshotted nothing.
 
 /// Why durable state could not be loaded (issue #66/#192).
 #[derive(Debug, thiserror::Error)]
@@ -968,7 +980,6 @@ pub struct NwdafContext {
     /// previous value rather than re-firing on every cycle.
     event_levels: RwLock<HashMap<String, f64>>,
     /// Data sources (nf_instance_id -> source)
-    data_sources: RwLock<HashMap<String, DataSource>>,
     /// The analytics engine (G2-1): sample store + computation, shared by the
     /// Nnwdaf_AnalyticsInfo handler, the notification dispatcher and the NRF
     /// NFStatusNotify ingestion path so samples actually accumulate.
@@ -1028,7 +1039,6 @@ impl NwdafContext {
             analytics_subscriptions: RwLock::new(HashMap::new()),
             ml_prov_subscriptions: RwLock::new(HashMap::new()),
             event_levels: RwLock::new(HashMap::new()),
-            data_sources: RwLock::new(HashMap::new()),
             engine: Mutex::new(AnalyticsEngine::new()),
             nrf_status_subscription: RwLock::new(None),
             nrf_collector_config: RwLock::new(None),
@@ -1152,9 +1162,6 @@ impl NwdafContext {
         }
         if let Ok(mut levels) = self.event_levels.write() {
             levels.clear();
-        }
-        if let Ok(mut sources) = self.data_sources.write() {
-            sources.clear();
         }
         if let Ok(engine) = self.engine.get_mut() {
             *engine = AnalyticsEngine::new();
@@ -1716,23 +1723,6 @@ impl NwdafContext {
         }
     }
 
-    /// Add a data source
-    pub fn add_data_source(&self, source: DataSource) -> bool {
-        if let Ok(mut sources) = self.data_sources.write() {
-            sources.insert(source.nf_instance_id.clone(), source);
-            return true;
-        }
-        false
-    }
-
-    /// Get all enabled data sources
-    pub fn get_data_sources(&self) -> Vec<DataSource> {
-        self.data_sources
-            .read()
-            .map(|sources| sources.values().filter(|s| s.enabled).cloned().collect())
-            .expect("value expected")
-    }
-
     /// Get all active, non-expired subscriptions (for the notification dispatcher)
     pub fn get_all_active_subscriptions(&self) -> Vec<AnalyticsSubscription> {
         self.analytics_subscriptions
@@ -1811,10 +1801,6 @@ impl NwdafContext {
             .read()
             .map(|s| s.len())
             .unwrap_or(0)
-    }
-
-    pub fn data_source_count(&self) -> usize {
-        self.data_sources.read().map(|d| d.len()).unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
`Closes #234`. `Closes #233`.

Spec: [`specs/fix-delete-two-dead-nrf-integration-registries.md`](specs/fix-delete-two-dead-nrf-integration-registries.md).

## Why one PR for two issues

The convention forbids **splitting** an umbrella across PRs, not combining. These are two single-scope pure
deletions of the same class, filed in the same backlog sweep, each with `DELETE` already settled in its body
so neither needs re-litigating. One lint/test gate instead of two, both still close auditably, and the spec
keeps the bodies separate so each diff can be compared against the issue that asked for it.

## #234 — `bsfd`'s consumer-side NRF-discovery path

`bsf_sbi_send_request` and `bsf_sbi_discover_and_send` logged at debug, did nothing, and returned a
**fabricated `Ok(1)`** transaction ID. `bsf_nnrf_handle_nf_discover` was reached only from its own two
tests, which passed *because* the stub fabricated success.

**The pre-check the issue asked for came back "none are live", so all three named symbols went too:**

| symbol | references in `bsfd` |
|---|---|
| `bsf_sbi_send_response` | its definition and one test — nothing else |
| `PathSbiRequest` | only the removed functions and their tests |
| `SbiXact` | **its definition only.** No caller, no test, nothing |
| `PathSbiRequestBuilder` | only names the struct beside it |

`bsf_sbi_send_response` deserves its own line: it returned `Ok(())` having sent nothing, under a comment
saying the real response is sent elsewhere. So it was a **third** stub lying to its caller, in the same
file, and the issue did not know it was dead. `SearchResult`, `NfInstanceInfo` and `SbiXactContext` went
with the handler they fed.

**Not re-litigated.** The evidence ruling out "wire it per TS 29.521 / TS 29.510" is copied into the removal
note at the site so a fourth pass cannot reopen it: `bsfd`'s `nnrf-nfm` obligations are already complete
(profile PUT, heartbeat worker, DELETE on close); TS 23.501 §6.2.19 and TS 29.521 make the BSF a
**producer** of binding management with no originated service request for that role; and the handler
hardcoded `GET /nbsf-management/v1/pcf-bindings` — it would have had the BSF query **its own service** on
another NF, a copy-paste artefact of the C port.

**What was kept.** `handle_nf_status_notify` has no non-test caller either, but it is an *inbound* observer
rather than an outbound client that could not work — withdrawing an inbound hook is a different decision, and
#234 scopes itself to the discovery path. Now documented as a latent hook so it does not read as live code.
`bsf_sm.rs:343`'s comment pointed at the deleted handler and would have been left dangling; it now says why
the branch has nothing to dispatch to. `pcfd`'s `tests/strict_peer_bsfd.rs` is the only external consumer of
`bsfd`'s public API and touches none of this — checked before deleting anything behind `pub use sbi_path::*`.

## #233 — `nwdafd`'s `DataSource` registry

The struct plus `add_data_source`, `get_data_sources`, `data_source_count` and the `data_sources` map formed
an inventory API structurally incapable of holding anything.

**Two corrections, both toward more-dead-than-reported:**

1. #233 says the grep hits are "its definitions and its own tests". **There were no tests** — the five
   definitions were the only references in the crate. That is why the deletion needed no test changes, and
   why a green `--all-targets` build is itself the proof that nothing referenced them.
2. `get_data_sources` ended in `.expect("value expected")` where every sibling reader uses `unwrap_or`, so a
   poisoned lock would have **panicked** the NWDAF — on a read of a map that was always empty.

**The docs pre-check came back clean.** `build_nf_profile` never mentions data sources, and the two
`docs-book` pages that say "data source" (`concepts/ai-stack.md:63`, `configuration/nwdaf.md:73`) describe
the G2-1 NRF collector — "the only data source is the NRF's view of NF load" — which is `nrf_collector.rs`
and is untouched. No page is left claiming an inventory the code no longer offers, and wiring a producer
remains a feature needing its own issue rather than a silent expansion of this one.

## Verification

- **Workspace 5934 passed / 0 failed** over two consecutive runs (baseline 5938 / 0). The difference is
  exactly the four deleted `bsfd` tests — `test_sbi_request`, `test_sbi_send_response`,
  `test_search_result_empty`, `test_search_result_with_instances` — each of which tested a removed symbol.
  `nwdafd` had no test to delete.
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
- **No revert-verification, on purpose.** This adds no behaviour, so there is no guard to make fail;
  inventing one would be the decorative-test failure mode this project records. The compiler is the check
  that matters — every "X had no caller" claim is falsified at build time if wrong — and for `nwdafd` it is
  unusually strong: had the issue been right that tests exercised the registry, the build would have failed.

## Ceiling

`bsfd`'s `handle_nf_status_notify` remains uncalled — now documented rather than silently dead, but still
~20 lines with no producer.

## GitNexus

`nextgcore/CLAUDE.md` mandates `gitnexus_impact` / `gitnexus_detect_changes`. No GitNexus MCP server is
connected here, so the mandate is unsatisfiable — 25th consecutive PR in this state. Blast radius was
established by exhaustive `grep` plus per-crate and whole-workspace `--all-targets` builds.