### PR TITLE
refactor(nrfd): migrate onto nextgcore_sbi::datetime (RFC 3339 migration 1 of 5)

### DIFF
--- a/specs/fix-nrfd-migrate-onto-shared-datetime.md
+++ b/specs/fix-nrfd-migrate-onto-shared-datetime.md
@@ -1,0 +1,73 @@
+# RFC 3339 migration 1 of 5: `nrfd` onto `nextgcore_sbi::datetime`
+
+Verified against `main` @ `4ec257a`. First of the five per-daemon migrations the shared-module task
+enumerates. `nrfd` is taken first because it held **both** functions and because the shared module was
+derived from its copies, so this is the one migration with no behavioural question at all.
+
+No issue number: this is the tracked follow-up from PR #239 (#94), which created
+`libs/nextgcore-sbi/src/datetime.rs` as the canonical home and deliberately left the six pre-existing
+copies in place.
+
+## The two copies removed
+
+| copy | signature | verdict |
+|---|---|---|
+| `main.rs:2001` `epoch_to_rfc3339` | `fn(u64) -> String` | semantically identical to the shared one |
+| `main.rs:2070` `rfc3339_to_epoch` | `fn(&str) -> Option<u64>` | **character-for-character** the shared one's algorithm |
+
+`rfc3339_to_epoch` needs no argument: the shared module's body is this function, moved. The doc comment in
+`datetime.rs` even says so ("the same reasoning nrfd's copy records").
+
+`epoch_to_rfc3339` differs in exactly one way, and it is not a behavioural one: `nrfd` typed the
+civil-days intermediates (`doe`, `yoe`, `doy`, `mp`, `d`) as `i64` where the shared module casts to `u64`.
+Since the input is `u64`, `days = secs / 86400 >= 0`, so `z = days + 719468 > 0`, `era >= 0` and
+`doe ∈ [0, 146096]` — every intermediate is non-negative and the two typings compute the same values. The
+migration is therefore behaviour-preserving, and that is asserted rather than assumed: `nrfd`'s existing
+golden-literal tests (`epoch_to_rfc3339(0) == "1970-01-01T00:00:00Z"`,
+`epoch_to_rfc3339(1_700_000_000) == "2023-11-14T22:13:20Z"`) pass unchanged against the shared
+implementation.
+
+## Why this matters rather than being tidiness
+
+These are **wire** timestamps: `validityTime` on an `Nnrf_NFManagement` subscription (`main.rs:1936`,
+`:1897`, `:2120`). A leap-year or offset bug fixed in one copy stays broken in the other five. `nrfd` was
+also the only daemon holding *both* directions, so it was the only place where a format/parse asymmetry
+could be introduced and still round-trip locally.
+
+## Verification
+
+Workspace: **5938 passed / 0 failed** over two consecutive runs — unchanged from the `main` baseline, which
+is the point: no test was added or removed and none changed behaviour. `cargo clippy --workspace` and
+`cargo fmt --all -- --check` clean.
+
+**Revert-verification for a migration is a different question**, and the task flags exactly why: "a
+timestamp change cannot be caught by a round-trip test that formats and parses with the same code". A
+round-trip through both shared functions would pass even if both were wrong in mirrored ways. So the claim
+tested here is not "the arithmetic is right" (`datetime.rs`'s own golden-instant tests cover that) but
+**"nrfd's call sites now reach the shared code"** — because the failure mode of a botched migration is a
+leftover private copy still being used, which every test would pass over silently.
+
+Both directions were reverted **inside the shared module** and `nrfd`'s tests were confirmed to bite:
+
+| claim | revert applied to `datetime.rs` | result |
+|---|---|---|
+| `nrfd`'s formatting comes from the shared module | `days = secs / 86_400 + 1` (off by one day) | `test_nrfd_08_epoch_to_rfc3339` **FAILED** |
+| `nrfd`'s parsing comes from the shared module | make the zone-strip always fail | `nrfd`'s parse tests **FAILED** |
+
+Each revert was checked for a unique anchor, for compiling, and for the named test actually running before
+its result was trusted.
+
+## Note for the migration that follows
+
+`nrfd`'s tests at `main.rs:5801` and `:5805` assert that `rfc3339_to_epoch` **rejects** `+02:00` and
+`-05:00`. That matches the shared module's current, deliberately strict behaviour. The **`bsfd` migration
+(5 of 5) changes it**: `bsfd`'s copy does not merely fail to reject a non-UTC offset, it correctly
+*applies* it — so the shared module gains offset handling and these two assertions will need inverting,
+with a comment recording the flip. Flagged here so the change is not a surprise when it lands, and so
+nobody "fixes" those assertions in isolation.
+
+## Ceiling
+
+Nothing new is tested. The claim is "behaviour is unchanged and the shared code is now the one that runs",
+and both halves are established by existing golden-literal tests plus the two reverts above — not by a new
+test, which for a pure redirect would only restate what the reverts already prove.

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -15,6 +15,9 @@ use nextgcore_nrfd::{
     ChangeItem, DiscoveryQuery, NfProfile, NotificationEventType, NrfSmContext, PatchError,
     SbiServerConfig,
 };
+// The canonical TS 29.571 `DateTime` conversion. nrfd's own copies of these two
+// were the ones this module was derived from; see the note where they used to live.
+use nextgcore_sbi::datetime::{epoch_to_rfc3339, rfc3339_to_epoch};
 use nextgcore_sbi::message::{SbiRequest, SbiResponse};
 use nextgcore_sbi::oauth::{AccessTokenResponse, OAuth2Client};
 use nextgcore_sbi::server::{
@@ -1995,27 +1998,6 @@ fn subscription_response_json(
     obj
 }
 
-/// nrfd-08: format epoch seconds (UTC) as an RFC 3339 `YYYY-MM-DDTHH:MM:SSZ`
-/// timestamp without pulling in a date/time crate. Uses Howard Hinnant's
-/// `civil_from_days` algorithm for the calendar conversion.
-fn epoch_to_rfc3339(secs: u64) -> String {
-    let days = (secs / 86400) as i64;
-    let rem = secs % 86400;
-    let (h, mi, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
-    // civil_from_days: days since 1970-01-01 -> (year, month, day).
-    let z = days + 719468;
-    let era = if z >= 0 { z } else { z - 146096 } / 146097;
-    let doe = z - era * 146097; // [0, 146096]
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
-    let mp = (5 * doy + 2) / 153; // [0, 11]
-    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
-    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
-    let year = if m <= 2 { y + 1 } else { y };
-    format!("{year:04}-{m:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
-}
-
 /// Re-arm supervision timers for records restored from the state file.
 ///
 /// Restored NFs get a no-heartbeat timer so a stale registration is eventually
@@ -2060,54 +2042,16 @@ fn rearm_restored_timers() {
     }
 }
 
-/// Parse an RFC 3339 UTC date-time into seconds since the epoch, the inverse of
-/// [`epoch_to_rfc3339`].
-///
-/// Deliberately strict: only the `YYYY-MM-DDThh:mm:ss` form this NRF emits, with
-/// an optional fractional part and a `Z`/`+00:00` offset. A non-UTC offset is
-/// REJECTED rather than silently read as UTC, because misreading an offset
-/// shifts a subscription's expiry by hours.
-fn rfc3339_to_epoch(text: &str) -> Option<u64> {
-    let t = text.trim();
-    let (date, rest) = t.split_once('T').or_else(|| t.split_once(' '))?;
-    let mut parts = date.split('-');
-    let year: i64 = parts.next()?.parse().ok()?;
-    let month: i64 = parts.next()?.parse().ok()?;
-    let day: i64 = parts.next()?.parse().ok()?;
-    if parts.next().is_some() || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
-        return None;
-    }
-
-    // Strip the zone, accepting only UTC.
-    let time = rest
-        .strip_suffix('Z')
-        .or_else(|| rest.strip_suffix('z'))
-        .or_else(|| rest.strip_suffix("+00:00"))
-        .or_else(|| rest.strip_suffix("+0000"))?;
-    // Drop any fractional seconds.
-    let time = time.split('.').next()?;
-
-    let mut tparts = time.split(':');
-    let hour: u64 = tparts.next()?.parse().ok()?;
-    let minute: u64 = tparts.next()?.parse().ok()?;
-    let second: u64 = tparts.next().unwrap_or("0").parse().ok()?;
-    if tparts.next().is_some() || hour > 23 || minute > 59 || second > 60 {
-        return None;
-    }
-
-    // days_from_civil, the inverse of the civil_from_days above.
-    let y = if month <= 2 { year - 1 } else { year };
-    let era = if y >= 0 { y } else { y - 399 } / 400;
-    let yoe = y - era * 400;
-    let mp = if month > 2 { month - 3 } else { month + 9 };
-    let doy = (153 * mp + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146097 + doe - 719468;
-    if days < 0 {
-        return None;
-    }
-    Some(days as u64 * 86400 + hour * 3600 + minute * 60 + second)
-}
+// #235-adjacent (the RFC 3339 migration): nrfd's private `epoch_to_rfc3339` and
+// `rfc3339_to_epoch` used to live here. They are now
+// `nextgcore_sbi::datetime::{epoch_to_rfc3339, rfc3339_to_epoch}`, imported at the
+// top of this file. The shared module was DERIVED from these two, so the migration
+// is behaviour-preserving: both bodies were character-for-character the same
+// algorithm, differing only in whether the civil-days intermediates were typed
+// `i64` or `u64` -- and since `secs: u64` makes every intermediate non-negative,
+// the two are semantically identical. Wire timestamps belong in one place: a
+// leap-year or offset fix applied here would otherwise stay unapplied in the other
+// five copies.
 
 /// Handle Subscription Delete request
 async fn handle_subscription_delete(subscription_id: &str) -> SbiResponse {


### PR DESCRIPTION
Spec: [`specs/fix-nrfd-migrate-onto-shared-datetime.md`](specs/fix-nrfd-migrate-onto-shared-datetime.md).

First of the five per-daemon migrations onto the canonical TS 29.571 `DateTime` module that PR #239 (#94)
created and deliberately left unmigrated. No issue number — this is that PR's tracked follow-up.

`nrfd` goes first because it held **both** functions and because the shared module was *derived from its
copies*, so this is the one migration with no behavioural question.

## The two copies removed

| copy | signature | verdict |
|---|---|---|
| `main.rs:2001` `epoch_to_rfc3339` | `fn(u64) -> String` | semantically identical |
| `main.rs:2070` `rfc3339_to_epoch` | `fn(&str) -> Option<u64>` | **character-for-character** the shared algorithm |

`rfc3339_to_epoch` needs no argument: the shared module's body *is* this function, moved — `datetime.rs`'s
doc comment even says so ("the same reasoning nrfd's copy records").

`epoch_to_rfc3339` differs in exactly one non-behavioural way: `nrfd` typed the civil-days intermediates
`i64` where the shared module casts to `u64`. With a `u64` input every intermediate is non-negative
(`days >= 0` so `z > 0`, `era >= 0`, `doe ∈ [0, 146096]`), so the two typings compute identical values.
Asserted rather than assumed: `nrfd`'s existing golden literals — `epoch_to_rfc3339(0)` ==
`"1970-01-01T00:00:00Z"`, `1_700_000_000` == `"2023-11-14T22:13:20Z"` — pass unchanged against the shared
implementation.

## Why this matters rather than being tidiness

These are **wire** timestamps: `validityTime` on an `Nnrf_NFManagement` subscription (`main.rs:1936`,
`:1897`, `:2120`). A leap-year or offset bug fixed in one copy stays broken in the other five. `nrfd` was
also the only daemon holding *both* directions — the only place a format/parse asymmetry could be
introduced and still round-trip locally.

## Verification

- **Workspace 5938 passed / 0 failed** over two consecutive runs — *unchanged* from baseline, which is the
  point: no test added, none removed, none changed behaviour.
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.

**Revert-verification for a migration is a different question**, and the task flags exactly why: a
round-trip test that formats and parses with the same code passes even if both halves are wrong in mirrored
ways. So the claim tested is not "the arithmetic is right" (`datetime.rs`'s golden instants cover that) but
**"nrfd's call sites now reach the shared code"** — because the failure mode of a botched migration is a
leftover private copy still in use, which every test passes over silently.

Both directions were reverted **inside the shared module** and `nrfd`'s tests were confirmed to bite:

| claim | revert applied to `datetime.rs` | result |
|---|---|---|
| `nrfd` formats via the shared module | `days = secs / 86_400 + 1` | `test_nrfd_08_epoch_to_rfc3339` **FAILED** |
| `nrfd` parses via the shared module | force the zone-strip to fail | `nrfd`'s parse tests **FAILED** |

Each revert was checked for a unique anchor, for compiling, and for the named test actually running before
its result was trusted.

## Note for migration 5 of 5

`nrfd`'s tests at `main.rs:5801` and `:5805` assert that `rfc3339_to_epoch` **rejects** `+02:00` and
`-05:00`, matching the shared module's current strictness. **The `bsfd` migration changes that**: `bsfd`'s
copy does not merely fail to reject a non-UTC offset, it correctly *applies* it, so the shared module gains
offset handling and those two assertions will need inverting with a comment recording the flip. Flagged here
so it is not a surprise, and so nobody "fixes" them in isolation.

## Ceiling

Nothing new is tested. The claim is "behaviour unchanged, and the shared code is now what runs" — both
halves established by existing golden-literal tests plus the two reverts, not by a new test which for a pure
redirect would only restate what the reverts prove.

## GitNexus

No GitNexus MCP server is connected, so `nextgcore/CLAUDE.md`'s mandate is unsatisfiable — 26th consecutive
PR in this state. Blast radius established by `grep` plus `cargo check -p nextgcore-nrfd --all-targets`.