### PR TITLE
refactor(udmd): migrate onto nextgcore_sbi::datetime (RFC 3339 migration 2 of 5)

### DIFF
--- a/specs/fix-udmd-migrate-onto-shared-datetime.md
+++ b/specs/fix-udmd-migrate-onto-shared-datetime.md
@@ -1,0 +1,40 @@
+# RFC 3339 migration 2 of 5: `udmd` onto `nextgcore_sbi::datetime`
+
+Verified against `main` @ `4ec257a`. Second of the five per-daemon migrations; follow-up to PR #239 (#94),
+which created `libs/nextgcore-sbi/src/datetime.rs` and deliberately left the six pre-existing copies alone.
+
+## The copy removed
+
+`bins/nextgcore-udmd/src/notify.rs:133`, `pub fn epoch_to_rfc3339(secs: u64) -> String`.
+
+**Byte-identical** to the shared module's function — the shared module was derived from this one, down to
+the `Howard Hinnant's civil_from_days` comment and the multi-line `format!`. So there is no behavioural
+question and no signature question. `notify.rs` now carries
+`pub use nextgcore_sbi::datetime::epoch_to_rfc3339;` in its place, which keeps `udmd`'s public surface
+unchanged (the function was `pub` and is re-exported through `lib.rs`'s `pub mod notify`) while making the
+shared module the single implementation.
+
+## Why this matters rather than being tidiness
+
+The timestamp goes on the wire: it is the `timeStamp` of a `#83` Nudm_SDM Data Change Notification /
+Nudm_EE Event Occurrence report (`notify.rs:204`). A subscriber compares it against its own clock, so a
+leap-year error here is an interop defect — and fixing it in one of six copies would leave the other five
+wrong.
+
+## Verification
+
+Workspace: **5938 passed / 0 failed** over two consecutive runs, unchanged from the `main` baseline. No test
+added or removed; `udmd`'s existing golden literals (`epoch_to_rfc3339(0)`, `1_000_000_000`, and the
+`2024-02-29` leap day at `notify.rs:404`) now exercise the shared implementation and still pass.
+`cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
+
+**Revert-verified.** As in migration 1, the claim under test is not the arithmetic (`datetime.rs` has its
+own golden instants) but that `udmd`'s call sites and tests now *reach* the shared code — the failure mode of
+a botched migration being a leftover private copy that every test silently passes over. Reverting the shared
+formatter to `days = secs / 86_400 + 1` made `notify::tests::epoch_to_rfc3339_formats_utc` **FAIL**; the
+revert was confirmed to have a unique anchor, to compile, and to have actually run that named test.
+
+## Ceiling
+
+Nothing new is tested — this is a pure redirect, and a new test would only restate what the revert proves.
+`udmd`'s leap-day literal is the strongest existing assertion and it is now anchored to the shared code.

--- a/src/bins/nextgcore-udmd/src/notify.rs
+++ b/src/bins/nextgcore-udmd/src/notify.rs
@@ -126,34 +126,12 @@ pub fn build_monitoring_report(
     })
 }
 
-/// Format `secs` since the Unix epoch as an RFC 3339 UTC timestamp.
-///
-/// Hand-rolled rather than pulling in a date/time crate, matching what nrfd
-/// already does for the same reason (`epoch_to_rfc3339`).
-pub fn epoch_to_rfc3339(secs: u64) -> String {
-    let days = (secs / 86_400) as i64;
-    let rem = secs % 86_400;
-    // Howard Hinnant's civil_from_days.
-    let z = days + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = (z - era * 146_097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
-        y,
-        m,
-        d,
-        rem / 3600,
-        (rem % 3600) / 60,
-        rem % 60
-    )
-}
+// The RFC 3339 migration: udmd's own `epoch_to_rfc3339` used to live here. It is
+// now re-exported from `nextgcore_sbi::datetime` below, so a leap-year or offset fix
+// reaches every producer at once instead of one of six copies. The two bodies were
+// BYTE-IDENTICAL -- the shared module was derived from this one -- so nothing about
+// the emitted timestamp changed.
+pub use nextgcore_sbi::datetime::epoch_to_rfc3339;
 
 /// Deliver SDM and EE notifications for a UECM transition.
 ///


### PR DESCRIPTION
Spec: [`specs/fix-udmd-migrate-onto-shared-datetime.md`](specs/fix-udmd-migrate-onto-shared-datetime.md).

Second of five per-daemon migrations onto the canonical TS 29.571 `DateTime` module. Follow-up to PR #239
(#94), which created `libs/nextgcore-sbi/src/datetime.rs` and deliberately left the six copies alone.

## The copy removed

`bins/nextgcore-udmd/src/notify.rs:133`, `pub fn epoch_to_rfc3339(secs: u64) -> String`.

**Byte-identical** to the shared module's function — the shared module was derived from this one, down to the
`Howard Hinnant's civil_from_days` comment and the multi-line `format!`. No behavioural question, no
signature question. A `pub use nextgcore_sbi::datetime::epoch_to_rfc3339;` takes its place, keeping `udmd`'s
public surface unchanged (the function was `pub` and reaches consumers via `pub mod notify`) while making the
shared module the single implementation.

## Why this matters rather than being tidiness

The timestamp goes **on the wire**: it is the `timeStamp` of a #83 Nudm_SDM Data Change Notification /
Nudm_EE Event Occurrence report (`notify.rs:204`). A subscriber compares it against its own clock, so a
leap-year error here is an interop defect — and fixing it in one of six copies leaves the other five wrong.

## Verification

- **Workspace 5938 passed / 0 failed** over two consecutive runs, unchanged from baseline. No test added or
  removed; `udmd`'s existing golden literals — including the `2024-02-29` leap day at `notify.rs:404` — now
  exercise the shared implementation and still pass.
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
- **Revert-verified.** As in migration 1, the claim under test is not the arithmetic (`datetime.rs` has its
  own golden instants) but that `udmd`'s call sites and tests now *reach* the shared code — the failure mode
  of a botched migration being a leftover private copy every test silently passes over. Reverting the shared
  formatter to `days = secs / 86_400 + 1` made `notify::tests::epoch_to_rfc3339_formats_utc` **FAIL**, with
  the anchor confirmed unique, the revert confirmed to compile, and the named test confirmed to have run.

## Ceiling

Nothing new is tested — a pure redirect, where a new test would only restate what the revert proves.

## GitNexus

No GitNexus MCP server connected, so `nextgcore/CLAUDE.md`'s mandate is unsatisfiable (27th consecutive PR).
Blast radius established by `grep` plus `cargo check -p nextgcore-udmd --all-targets`.