### PR TITLE
refactor(pcfd): migrate onto nextgcore_sbi::datetime (RFC 3339 migration 3 of 5)

### DIFF
--- a/specs/fix-pcfd-migrate-onto-shared-datetime.md
+++ b/specs/fix-pcfd-migrate-onto-shared-datetime.md
@@ -1,0 +1,44 @@
+# RFC 3339 migration 3 of 5: `pcfd` onto `nextgcore_sbi::datetime`
+
+Verified against `main` @ `4ec257a`. Third of the five per-daemon migrations; follow-up to PR #239 (#94).
+
+## What was removed
+
+Two functions from `bins/nextgcore-pcfd/src/npcf_eventexposure.rs`:
+
+| copy | verdict |
+|---|---|
+| `:34` `pub fn epoch_to_rfc3339(secs: u64) -> String` | byte-identical to the shared one |
+| `:59` `fn now_secs() -> u64` | the shared `now_epoch_secs` under a different name |
+
+`epoch_to_rfc3339` is the youngest of the six copies and the most avoidable: **#90 added it the day before
+the shared module existed**, and both it and the shared version descend from `udmd`'s, so the three were
+identical from the moment the second was written. Nothing about the emitted timestamp changes.
+
+`now_secs` is not in the task's inventory of six but belongs to the same duplication — same body, same
+`unwrap_or(0)` for a pre-epoch clock, same purpose. It is imported as
+`use nextgcore_sbi::datetime::now_epoch_secs as now_secs;` so the call site at `:388` reads unchanged; the
+alias keeps the diff to the definition rather than spreading a rename through the file.
+
+## Why this matters rather than being tidiness
+
+The timestamp is the `timeStamp` of an `Npcf_EventExposure` notification (`:388`) — a wire field a consumer
+compares against its own clock. Same argument as the other four: a leap-year or offset fix applied to one
+copy leaves the rest wrong.
+
+## Verification
+
+Workspace: **5938 passed / 0 failed** over two consecutive runs, unchanged from the `main` baseline. No test
+added or removed; `pcfd`'s existing `epoch_to_rfc3339_matches_known_instants` now exercises the shared
+implementation and still passes. `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
+
+**Revert-verified.** Reverting the shared formatter to `days = secs / 86_400 + 1` made
+`npcf_eventexposure::tests::epoch_to_rfc3339_matches_known_instants` **FAIL** — proving `pcfd`'s tests now
+reach the shared code rather than a leftover private copy, which is the failure mode a green suite would
+otherwise hide. Anchor confirmed unique, revert confirmed to compile, named test confirmed to have run.
+
+## Ceiling
+
+Nothing new is tested — a pure redirect. `now_secs` has no test either before or after, which is
+unremarkable for a wall-clock reader but worth stating: the claim about it is "same body, same name in the
+shared module", established by reading, not by a test.

--- a/src/bins/nextgcore-pcfd/src/npcf_eventexposure.rs
+++ b/src/bins/nextgcore-pcfd/src/npcf_eventexposure.rs
@@ -26,42 +26,16 @@ use nextgcore_sbi::server::{send_bad_request, send_method_not_allowed_with_allow
 /// `servers` entry plus the resource path.
 const SUBSCRIPTIONS_BASE: &str = "/npcf-eventexposure/v1/subscriptions";
 
-/// Format `secs` since the Unix epoch as an RFC 3339 UTC timestamp
-/// (TS 29.571 `DateTime`).
-///
-/// Hand-rolled rather than pulling in a date/time crate, matching what udmd and
-/// nrfd already do for the same reason.
-pub fn epoch_to_rfc3339(secs: u64) -> String {
-    let days = (secs / 86_400) as i64;
-    let rem = secs % 86_400;
-    // Howard Hinnant's civil_from_days.
-    let z = days + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = (z - era * 146_097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
-        y,
-        m,
-        d,
-        rem / 3600,
-        (rem % 3600) / 60,
-        rem % 60
-    )
-}
-
-fn now_secs() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
+// The RFC 3339 migration: pcfd's own `epoch_to_rfc3339` and `now_secs` used to live
+// here. Both are now `nextgcore_sbi::datetime::{epoch_to_rfc3339, now_epoch_secs}`.
+//
+// `epoch_to_rfc3339` was BYTE-IDENTICAL to the shared module's -- #90 added this
+// copy the day before the shared module existed, and both descend from udmd's -- so
+// nothing about the emitted timestamp changed. `now_secs` was likewise the shared
+// `now_epoch_secs` under a different name, including the same `unwrap_or(0)` for a
+// pre-epoch clock.
+pub use nextgcore_sbi::datetime::epoch_to_rfc3339;
+use nextgcore_sbi::datetime::now_epoch_secs as now_secs;
 
 /// The parsed, validated members of a `PcEventExposureSubsc`.
 struct ParsedSubsc {


### PR DESCRIPTION
Spec: [`specs/fix-pcfd-migrate-onto-shared-datetime.md`](specs/fix-pcfd-migrate-onto-shared-datetime.md).

Third of five per-daemon migrations onto the canonical TS 29.571 `DateTime` module. Follow-up to PR #239 (#94).

## What was removed

Two functions from `bins/nextgcore-pcfd/src/npcf_eventexposure.rs`:

| copy | verdict |
|---|---|
| `:34` `pub fn epoch_to_rfc3339(secs: u64) -> String` | byte-identical to the shared one |
| `:59` `fn now_secs() -> u64` | the shared `now_epoch_secs` under a different name |

`epoch_to_rfc3339` is the youngest of the six copies and the most avoidable: **#90 added it the day before
the shared module existed**, and both it and the shared version descend from `udmd`'s — so the three were
identical from the moment the second was written. Nothing about the emitted timestamp changes.

`now_secs` is not in the task's inventory of six but belongs to the same duplication: same body, same
`unwrap_or(0)` for a pre-epoch clock, same purpose. Imported as `now_epoch_secs as now_secs` so the call site
at `:388` reads unchanged and the diff stays at the definition rather than spreading a rename through the file.

## Why this matters rather than being tidiness

The timestamp is the `timeStamp` of an `Npcf_EventExposure` notification (`:388`) — a wire field a consumer
compares against its own clock. A leap-year or offset fix applied to one copy leaves the rest wrong.

## Verification

- **Workspace 5938 passed / 0 failed** over two consecutive runs, unchanged from baseline. No test added or
  removed; `pcfd`'s existing `epoch_to_rfc3339_matches_known_instants` now exercises the shared
  implementation and still passes.
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
- **Revert-verified.** Reverting the shared formatter to `days = secs / 86_400 + 1` made
  `npcf_eventexposure::tests::epoch_to_rfc3339_matches_known_instants` **FAIL** — proving `pcfd`'s tests now
  reach the shared code rather than a leftover private copy, the failure mode a green suite would otherwise
  hide. Anchor confirmed unique, revert confirmed to compile, named test confirmed to have run.

## Ceiling

Nothing new is tested — a pure redirect. `now_secs` has no test before or after, which is unremarkable for a
wall-clock reader but worth stating: the claim about it is "same body, same name in the shared module",
established by reading rather than by a test.

## GitNexus

No GitNexus MCP server connected (28th consecutive PR). Blast radius established by `grep` plus
`cargo check -p nextgcore-pcfd --all-targets`.