### PR TITLE
refactor(eesd,sbi): add the signed RFC 3339 entry point and migrate eesd onto it (RFC 3339 migration 4 of 5)

### DIFF
--- a/specs/fix-eesd-migrate-onto-shared-datetime.md
+++ b/specs/fix-eesd-migrate-onto-shared-datetime.md
@@ -1,0 +1,73 @@
+# RFC 3339 migration 4 of 5: `eesd`, and the signed entry point the shared module was missing
+
+Verified against `main` @ `4ec257a`. Fourth of the five per-daemon migrations; follow-up to PR #239 (#94).
+
+This is the one the task called out as the migration's real work: *"eesd's takes `i64`, the others `u64` —
+that signature split is the migration's real work"*.
+
+## Why `eesd`'s copy was not interchangeable
+
+`bins/nextgcore-eesd/src/types.rs:500`, `pub fn epoch_to_rfc3339(epoch: i64) -> String`, split the epoch with
+`div_euclid` / `rem_euclid` rather than `/` and `%`. That is not a stylistic difference:
+
+| epoch | `div_euclid`/`rem_euclid` (eesd) | `as u64` then `/`,`%` (the shared `u64` path) |
+|---|---|---|
+| `-1` | `1969-12-31T23:59:59Z` | a year around 584 billion (`-1 as u64` is 18446744073709551615) |
+| `-86401` | `1969-12-30T23:59:59Z` | likewise nonsense |
+
+So narrowing `eesd` to the `u64` entry point would have been a **silent behaviour regression at a wire
+field** — precisely the class of defect that having six copies is supposed to stop, introduced by the
+consolidation meant to prevent it.
+
+## The resolution: widen the shared module, do not narrow the caller
+
+`nextgcore_sbi::datetime` gains `epoch_to_rfc3339_signed(i64)`, which **is** `eesd`'s implementation
+promoted. `epoch_to_rfc3339(u64)` stays as the common case, so none of the other four daemons' call sites
+change. Both now share one extracted `civil_from_days(days: i64)` helper; they differ only in how they split
+an epoch into days and seconds-of-day, which is exactly where the signedness matters.
+
+`eesd` re-exports the shared signed function under the old name
+(`pub use ...::epoch_to_rfc3339_signed as epoch_to_rfc3339;`) so every call site in `main.rs` reads
+unchanged.
+
+Deliberately **not** done: making `epoch_to_rfc3339(u64)` a wrapper that casts to `i64`. For `secs`
+above `i64::MAX` the cast wraps negative, which would change the `u64` function's output for inputs it
+currently handles (absurdly, but differently). Sharing the calendar conversion and not the split keeps both
+entry points bit-for-bit as they were.
+
+## Out of scope, and why it is worth naming
+
+`eesd` also has `parse_rfc3339_to_epoch` (`types.rs:449`), which **honours** a numeric `±HH:MM` / `±HHMM`
+offset. The shared `rfc3339_to_epoch` currently **rejects** any non-UTC offset. That disagreement is not
+`eesd`'s problem to fix here — it is the subject of migration 5 (`bsfd`), whose copy has the same
+offset-honouring behaviour and whose two parsers currently disagree with each other inside one daemon. It is
+flagged here so the omission is visible: this PR migrates the inventory item (`epoch_to_rfc3339`) and leaves
+`eesd`'s parser for that change.
+
+## Verification
+
+Workspace: **5939 passed / 0 failed** over two consecutive runs, against the `main` baseline of 5938 — the
+one added test is the signed entry point's. `cargo clippy --workspace` and `cargo fmt --all -- --check`
+clean.
+
+**Three claims revert-verified:**
+
+| claim | revert | result |
+|---|---|---|
+| `eesd` formats via the shared signed entry point | `div_euclid(86_400) + 1` | `types::tests::test_epoch_to_rfc3339_roundtrip` FAILED |
+| the Euclidean split is load-bearing for pre-epoch instants | replace with truncating `/` and `%` | `signed_epochs_agree_with_unsigned_and_handle_pre_epoch_instants` FAILED |
+| the `u64` path still goes through the shared calendar conversion | `days + 719_469` in `civil_from_days` | `known_instants_round_trip` FAILED |
+
+**The harness caught its own bug on the first attempt**, which is worth recording because it is the exact
+failure mode the project's revert lesson names: claim 1 first came back `NOT_RUN`, not `GREEN`. The cause was
+a **wrong target flag** — `eesd` is `[[bin]]`-only with no `[lib]`, so `cargo test --lib` matched nothing and
+the run reported zero tests. Treating that as inconclusive rather than as "the test is decorative" is what
+stopped a pointless rewrite of a test that was fine; re-run with `--bin nextgcore-eesd`, it bit.
+
+## Ceiling
+
+`eesd`'s `parse_rfc3339_to_epoch`, `days_from_civil` and `civil_from_days` remain in `types.rs`: the parser
+is out of scope (above) and the two calendar helpers still serve it. So `eesd` still holds a second
+`civil_from_days`, identical to the one now in the shared module. Migration 5 is the right place to remove
+it, once the parser question is settled — deleting it now would leave the parser calling into the shared
+module for one half of its arithmetic and its own code for the other.

--- a/src/bins/nextgcore-eesd/src/types.rs
+++ b/src/bins/nextgcore-eesd/src/types.rs
@@ -496,14 +496,19 @@ pub fn parse_rfc3339_to_epoch(s: &str) -> Option<i64> {
     Some(days * 86400 + hour * 3600 + minute * 60 + second - offset_secs)
 }
 
-/// Format Unix epoch seconds as an RFC 3339 UTC timestamp (`...Z`).
-pub fn epoch_to_rfc3339(epoch: i64) -> String {
-    let days = epoch.div_euclid(86400);
-    let secs = epoch.rem_euclid(86400);
-    let (y, m, d) = civil_from_days(days);
-    let (hh, mm, ss) = (secs / 3600, (secs % 3600) / 60, secs % 60);
-    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
-}
+// The RFC 3339 migration: eesd's `epoch_to_rfc3339(i64)` used to live here. It is
+// now `nextgcore_sbi::datetime::epoch_to_rfc3339_signed`, re-exported below under
+// the old name so every call site reads unchanged.
+//
+// This copy was the ONE of the six that was not interchangeable with the others:
+// it takes an `i64` and splits it with `div_euclid`/`rem_euclid`, so a pre-epoch
+// instant formats correctly instead of wrapping through `u64` into a year around
+// 584 billion. That is why the shared module gained a signed entry point rather
+// than eesd being narrowed to the `u64` one -- narrowing would have been a silent
+// behaviour regression at a wire field, which is exactly what having six copies is
+// supposed to stop. The `u64` entry point stays the common case, so no other
+// caller changes.
+pub use nextgcore_sbi::datetime::epoch_to_rfc3339_signed as epoch_to_rfc3339;
 
 #[cfg(test)]
 mod tests {

--- a/src/libs/nextgcore-sbi/src/datetime.rs
+++ b/src/libs/nextgcore-sbi/src/datetime.rs
@@ -19,22 +19,59 @@
 //! Hand-rolled rather than pulling in a date/time crate, matching what the
 //! existing copies already do.
 
+/// Howard Hinnant's `civil_from_days`: days since 1970-01-01 -> (year, month, day)
+/// in the proleptic Gregorian calendar.
+///
+/// Extracted so the `u64` and `i64` entry points below share one calendar
+/// conversion. The two differ only in how they split an epoch into days and
+/// seconds-of-day, which is where the signedness actually matters.
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
 /// Format `secs` since the Unix epoch as an RFC 3339 UTC timestamp
 /// (TS 29.571 `DateTime`).
 pub fn epoch_to_rfc3339(secs: u64) -> String {
     let days = (secs / 86_400) as i64;
     let rem = secs % 86_400;
-    // Howard Hinnant's civil_from_days.
-    let z = days + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = (z - era * 146_097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
+    let (y, m, d) = civil_from_days(days);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y,
+        m,
+        d,
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60
+    )
+}
+
+/// Format a **signed** epoch as an RFC 3339 UTC timestamp, for the call sites that
+/// hold an `i64`.
+///
+/// Not a convenience wrapper over [`epoch_to_rfc3339`]: a negative epoch cast to
+/// `u64` becomes an enormous positive number and formats as a year far in the
+/// future, so the split into days and seconds-of-day must be Euclidean.
+/// `(-1).div_euclid(86400) == -1` and `(-1).rem_euclid(86400) == 86399`, giving
+/// `1969-12-31T23:59:59Z`; `-1 / 86400 == 0` with a remainder of `-1` would not.
+///
+/// This is `eesd`'s implementation, promoted here during the RFC 3339 migration —
+/// it was the only one of the six copies that handled a pre-epoch instant, and
+/// keeping the `u64` entry point as the common case rather than widening it means
+/// no existing caller changes.
+pub fn epoch_to_rfc3339_signed(epoch: i64) -> String {
+    let days = epoch.div_euclid(86_400);
+    let rem = epoch.rem_euclid(86_400);
+    let (y, m, d) = civil_from_days(days);
     format!(
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
         y,
@@ -119,6 +156,29 @@ mod tests {
             assert_eq!(epoch_to_rfc3339(secs), text, "format {secs}");
             assert_eq!(rfc3339_to_epoch(text), Some(secs), "parse {text}");
         }
+    }
+
+    /// The signed entry point agrees with the `u64` one wherever both are defined,
+    /// and handles the pre-epoch instants the `u64` one cannot represent.
+    ///
+    /// The negative cases are the whole reason it exists: `-1` as a `u64` is
+    /// 18446744073709551615, which formats as a year around 584 billion. Getting
+    /// `1969-12-31T23:59:59Z` instead is what `div_euclid`/`rem_euclid` buy.
+    #[test]
+    fn signed_epochs_agree_with_unsigned_and_handle_pre_epoch_instants() {
+        for secs in [0u64, 946_684_800, 1_583_020_800, 1_709_164_800] {
+            assert_eq!(
+                epoch_to_rfc3339_signed(secs as i64),
+                epoch_to_rfc3339(secs),
+                "signed and unsigned must agree at {secs}"
+            );
+        }
+        assert_eq!(epoch_to_rfc3339_signed(-1), "1969-12-31T23:59:59Z");
+        assert_eq!(epoch_to_rfc3339_signed(-86_400), "1969-12-31T00:00:00Z");
+        assert_eq!(epoch_to_rfc3339_signed(-86_401), "1969-12-30T23:59:59Z");
+        // A truncating (non-Euclidean) split would give 1970-01-01T00:00:00Z here,
+        // i.e. it would silently round a pre-epoch instant up to the epoch.
+        assert_ne!(epoch_to_rfc3339_signed(-1), "1970-01-01T00:00:00Z");
     }
 
     #[test]


### PR DESCRIPTION
Spec: [`specs/fix-eesd-migrate-onto-shared-datetime.md`](specs/fix-eesd-migrate-onto-shared-datetime.md).

Fourth of five per-daemon migrations. Follow-up to PR #239 (#94). This is the one the task called out as the
migration's real work: *"eesd's takes `i64`, the others `u64` — that signature split is the migration's real
work"*.

## Why `eesd`'s copy was not interchangeable

`types.rs:500` split the epoch with `div_euclid`/`rem_euclid` rather than `/` and `%`. Not stylistic:

| epoch | `div_euclid`/`rem_euclid` (eesd) | cast to `u64` then `/`,`%` |
|---|---|---|
| `-1` | `1969-12-31T23:59:59Z` | a year around 584 billion (`-1 as u64` = 18446744073709551615) |
| `-86401` | `1969-12-30T23:59:59Z` | likewise nonsense |

Narrowing `eesd` to the `u64` entry point would therefore have been a **silent behaviour regression at a wire
field** — precisely the class of defect that having six copies is supposed to stop, introduced by the
consolidation meant to prevent it.

## The resolution: widen the shared module, do not narrow the caller

`nextgcore_sbi::datetime` gains `epoch_to_rfc3339_signed(i64)`, which **is** `eesd`'s implementation
promoted. `epoch_to_rfc3339(u64)` stays the common case, so none of the other four daemons' call sites change.
Both share one extracted `civil_from_days(days: i64)` helper and differ only in the split — exactly where
signedness matters. `eesd` re-exports the signed function under the old name so every call site reads
unchanged.

**Deliberately not done:** making `epoch_to_rfc3339(u64)` a wrapper that casts to `i64`. Above `i64::MAX` the
cast wraps negative, which would change the `u64` function's output for inputs it currently handles — absurdly,
but differently. Sharing the calendar conversion and not the split keeps both entry points bit-for-bit as they
were.

## Out of scope, named so the omission is visible

`eesd` also has `parse_rfc3339_to_epoch` (`types.rs:449`), which **honours** a numeric `±HH:MM`/`±HHMM`
offset, while the shared `rfc3339_to_epoch` **rejects** any non-UTC offset. That disagreement is migration 5's
subject: `bsfd`'s copy has the same offset-honouring behaviour, and `bsfd`'s two parsers currently disagree
with each other *inside one daemon*. This PR migrates the inventory item and leaves the parser for that change.

## Verification

- **Workspace 5939 passed / 0 failed** over two consecutive runs (baseline 5938 — the one addition is the
  signed entry point's test).
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.

**Three claims revert-verified:**

| claim | revert | result |
|---|---|---|
| `eesd` formats via the shared signed entry point | `div_euclid(86_400) + 1` | `test_epoch_to_rfc3339_roundtrip` **FAILED** |
| the Euclidean split is load-bearing for pre-epoch instants | truncating `/` and `%` | `signed_epochs_agree_with_unsigned_and_handle_pre_epoch_instants` **FAILED** |
| the `u64` path still goes through the shared calendar conversion | `days + 719_469` | `known_instants_round_trip` **FAILED** |

**The harness caught its own bug on the first attempt** — the exact failure mode the project's revert lesson
names. Claim 1 first came back `NOT_RUN`, not `GREEN`, because of a **wrong target flag**: `eesd` is
`[[bin]]`-only with no `[lib]`, so `cargo test --lib` matched nothing and reported zero tests. Treating that
as inconclusive rather than as "the test is decorative" is what stopped a pointless rewrite of a test that was
fine; re-run with `--bin nextgcore-eesd`, it bit.

## Ceiling

`eesd` keeps `parse_rfc3339_to_epoch`, `days_from_civil` and `civil_from_days` — the parser is out of scope
and the two helpers still serve it, so `eesd` still holds a second `civil_from_days` identical to the shared
one. Migration 5 is the right place to remove it, once the parser question is settled: deleting it now would
leave the parser calling the shared module for one half of its arithmetic and its own code for the other.

## GitNexus

No GitNexus MCP server connected (29th consecutive PR). Blast radius established by `grep` plus
`cargo check -p nextgcore-eesd --all-targets` and the whole-workspace build.