### PR TITLE
fix(sbi,bsfd): apply the RFC 3339 offset, fixing the fail-open expiry it caused in bsfd and nsacfd (RFC 3339 migration 5 of 5)

### DIFF
--- a/specs/fix-bsfd-datetime-offset-handling-and-two-parser-split.md
+++ b/specs/fix-bsfd-datetime-offset-handling-and-two-parser-split.md
@@ -1,0 +1,147 @@
+# RFC 3339 migration 5 of 5: apply the offset, and fix the fail-open expiry it was causing in `bsfd` and `nsacfd`
+
+Verified against `main` @ `4ec257a`. Last of the five per-daemon migrations, and the only one that is a
+**defect fix** rather than a consolidation. Follow-up to PR #239 (#94).
+
+## The task's premise was wrong, and that is the whole change
+
+The task says:
+
+> the shared module is the only one that REJECTS a non-UTC offset instead of reading it as UTC — a copy
+> that does not reject shifts a deadline by hours
+
+That conflates two different things. `bsfd`'s copy does **not** read a non-UTC offset as UTC; it **applies**
+it. So the premise "the copies are the lax ones" is inverted here: `bsfd`'s parser was the *correct* one and
+the shared module was the strict-and-wrong one.
+
+The strictness was not merely pedantic. **Every consumer of the shared parser treats `None` as "no
+deadline"**, so refusing a conformant offset did not shift a deadline — it *deleted* one:
+
+| daemon | site | what a `+02:00` expiry did before this change |
+|---|---|---|
+| `bsfd` | `context.rs` `BsfSubscription::wants` (#98) | parser returned `None` → deadline check skipped → **a lapsed subscription kept matching**, so notifications went on being delivered to an expired subscriber |
+| `nsacfd` | `context.rs:425` `report_decision` (#96) | same shape → never `Exhausted` → **kept reporting past its own expiry** |
+| `nssfd` | `main.rs:2390` | `unwrap_or(nssf_deadline)` → a conformant consumer's requested expiry silently replaced by the NSSF default |
+
+Both `bsfd` (`lib.rs:1147`) and `nsacfd` (`main.rs:1571`) store a consumer's `expiry` **verbatim with no
+validation**, so the bad input is reachable from the wire in both. A refused deadline is strictly worse than
+a shifted one, which is what makes this a fix.
+
+And TS 29.571's `DateTime` is RFC 3339, which permits any offset — so honouring it is what the spec says
+anyway.
+
+## `bsfd` was using both parsers, on two resources, in one daemon
+
+The sharpest evidence that this needed settling rather than mechanically migrating:
+
+* the **binding**'s `expiry` (`BsfSess::set_expiry`, and the ingress validation in `lib.rs:720`) went
+  through `bsfd`'s own offset-applying parser;
+* the **subscription**'s `expiry` (`BsfSubscription::wants`, added by #98) went through the shared
+  offset-rejecting one.
+
+Same field name, same wire type, two resources, two answers. Migrating `bsfd` down to the shared parser
+would have made the binding side start rejecting timestamps it accepts today — a regression at a wire field,
+introduced by the consolidation meant to prevent exactly that.
+
+## What changed
+
+**`nextgcore_sbi::datetime`:**
+
+* `split_zone` — a new helper that peels a trailing `Z`/`z` or numeric `±HH:MM` / `±HHMM` and returns the
+  offset in seconds. **No zone at all is still refused**, because a naive local time names no instant and
+  guessing UTC for it is the hazard the old strictness was actually worried about. A malformed zone
+  (`+2:00`, `+xx:00`, `+25:00`, `+02:60`) is refused rather than read as UTC.
+* `rfc3339_to_epoch_signed(&str) -> Option<i64>` — the full parse, applying the offset. Signed because a
+  positive-offset instant just after the epoch resolves to *before* it, which `u64` cannot hold; `bsfd`'s
+  call sites are `i64` anyway.
+* `rfc3339_to_epoch(&str) -> Option<u64>` — now a narrowing of the signed one via `u64::try_from`, so a
+  pre-epoch result is `None`. That is the same answer the pre-migration implementation gave through its
+  `days < 0` guard, so `nssfd`/`nsacfd` see no change other than offsets now working.
+
+Accepting the no-colon `±HHMM` spelling is a deliberate uniformity call: the shared parser already accepted
+`+0000`, and `eesd`'s parser accepts `±HHMM` generally, so accepting both spellings is easier to explain
+than accepting `+0000` while refusing `+0200`. It is not strictly RFC 3339 (`time-numoffset` requires the
+colon) and that is stated at the site.
+
+**`bsfd`:** its parser is deleted and re-exported from the shared module under the same name, so all call
+sites read unchanged. The `wants()` matcher now uses that one parser, and its unparseable branch **fails
+closed** — an expiry we cannot read must not be treated as permission to keep notifying, which is the same
+fail-open this change is about.
+
+**`nsacfd`:** no code change. The shared parser fix is what repairs it; a regression test pins that.
+
+## Three pinned-behaviour tests inverted, each with the flip recorded
+
+The project's signal that behaviour widened deliberately:
+
+1. `datetime.rs`'s `rejects_a_non_utc_offset_rather_than_reading_it_as_utc` → `applies_a_non_utc_offset_rather_than_refusing_it`. It pinned the defect, not the guard.
+2. `bsfd`'s `rfc3339_to_epoch("2026-06-12 00:00:00Z") == None` → now `Some(...)`. RFC 3339 §5.6 permits the space separator and the shared parser always accepted it; `bsfd`'s copy did not.
+3. `bsfd`'s `rfc3339_to_epoch("2026-06-12T00:00:00+0200") == None` → now `Some(...)`, per the uniformity call above.
+
+Each inversion is commented at the site with why, rather than the old assertion being deleted.
+
+## Verification
+
+Workspace: **5941 passed / 0 failed** across three consecutive runs (baseline 5938; two tests added, one
+`bsfd` regression and the shared parser's split into three tests where there were two). `cargo clippy
+--workspace` and `cargo fmt --all -- --check` clean. Three runs because the change touches a shared library
+every NF links.
+
+**Nine claims revert-verified:**
+
+| # | claim | test that bit |
+|---|---|---|
+| 1 | the offset is applied, not ignored | `applies_a_non_utc_offset_rather_than_refusing_it` |
+| 2 | the offset's sign is honoured | same |
+| 3 | a zoneless time is still refused | `refuses_input_with_no_defined_instant` |
+| 4 | out-of-range zone fields are refused, not read as UTC | same |
+| 5 | the `u64` entry point still rejects a pre-epoch instant | `pre_epoch_instants_are_none_for_u64_and_kept_when_signed` |
+| 6 | `bsfd`'s subscription matcher honours an offset expiry | `an_expired_subscription_does_not_match_whatever_zone_its_expiry_uses` |
+| 7 | an unreadable `bsfd` expiry fails **closed** | same |
+| 8 | `nsacfd`'s report decision honours an offset expiry | `report_triggers_gate_emission` |
+| 9 | `bsfd`'s own parse test reaches the shared parser | `test_rfc3339_to_epoch` |
+
+### The harness lied twice, and both are the recorded failure modes
+
+Worth writing down because they are exactly the two the project's revert lesson warns are indistinguishable
+from a decorative test:
+
+* **Claim 6 first came back GREEN because the revert was a SEMANTIC NO-OP.** The revert pointed `bsfd`'s
+  matcher back at `nextgcore_sbi::datetime::rfc3339_to_epoch` — but that function *also* applies offsets
+  now, so both sides of the substitution behaved identically. Reading the substitution for equivalence, as
+  the lesson says to, is what caught it. The real revert restores the *old strictness inside `split_zone`*,
+  and then claim 6 bites — and so do 8 and 9, which is the stronger result: one revert of the shared parser
+  fails tests in three different crates.
+* **Claim 8 first came back NOT-RUN** because the test name was wrong (`report_decision_honours_every_trigger`
+  does not exist; the real one is `report_triggers_gate_emission`). Treated as inconclusive rather than as a
+  pass, per the same lesson.
+
+## Merge-order dependency, and it is not optional
+
+These five migration PRs are **not** independent:
+
+* migrations 1–3 (`nrfd`, `udmd`, `pcfd`) do not touch `datetime.rs` and can land in any order;
+* migration 4 (`eesd`) adds `epoch_to_rfc3339_signed` to `datetime.rs` and this one rewrites the parser in
+  the same file, so **the two will conflict textually**. Land 4 first, then rebase this one.
+* migration 1 (`nrfd`) makes `nrfd` a consumer of the shared parser, and `nrfd`'s tests at `main.rs:5801`
+  and `:5805` assert that `+02:00` and `-05:00` are **rejected**. Once both this and migration 1 are in,
+  **those two assertions must be inverted** the same way `bsfd`'s were. On this branch `nrfd` still has its
+  private copy, so its tests pass here and CI cannot see the interaction — whichever of the two lands
+  second is where CI will surface it.
+
+Recommended order: **1, 2, 3 → 4 → 5 (this one, rebased, inverting `nrfd`'s two assertions)**.
+
+## Ceilings
+
+* **A garbage `expiry` is still unvalidated at ingress** in both `bsfd` (subscriptions; the binding side
+  *is* validated) and `nsacfd`. This change makes `bsfd`'s matcher fail closed on one, but `nsacfd`'s
+  `report_decision` still skips the check for an unparseable expiry, i.e. it stays fail-open for genuine
+  garbage. Validating at creation is the real fix and belongs with #96, not in a datetime migration —
+  flagged rather than silently half-done.
+* **`nssfd`'s improvement is untested here.** A conformant consumer's `+02:00` requested expiry is now
+  honoured instead of being replaced by the NSSF default, but no test covers that path; `nssfd` normalises
+  what it stores, so the change is only observable at the create boundary.
+* **`eesd`'s `parse_rfc3339_to_epoch` is still a seventh parser.** It honours offsets like the new shared
+  one, so it is no longer *divergent*, but it is still a copy — along with the `civil_from_days` /
+  `days_from_civil` pair that serves it. Now that the shared parser has the same semantics, deleting it is
+  finally a mechanical change; it was not before, which is why migration 4 deferred it.

--- a/src/bins/nextgcore-bsfd/src/context.rs
+++ b/src/bins/nextgcore-bsfd/src/context.rs
@@ -222,83 +222,27 @@ impl fmt::Display for Ipv6Prefix {
     }
 }
 
-/// Parse an RFC 3339 date-time (e.g. `2026-06-12T10:00:00Z`,
-/// `2026-06-12T10:00:00.5+02:00`) into Unix epoch seconds.
-///
-/// Implements the subset required by the TS 29.571 DateTime type without an
-/// external date crate. Returns `None` on any malformed input.
-pub fn rfc3339_to_epoch(s: &str) -> Option<i64> {
-    let b = s.as_bytes();
-    if b.len() < 20 {
-        return None;
-    }
-    let year: i64 = s.get(0..4)?.parse().ok()?;
-    let month: i64 = s.get(5..7)?.parse().ok()?;
-    let day: i64 = s.get(8..10)?.parse().ok()?;
-    let hour: i64 = s.get(11..13)?.parse().ok()?;
-    let min: i64 = s.get(14..16)?.parse().ok()?;
-    let sec: i64 = s.get(17..19)?.parse().ok()?;
-    if b[4] != b'-'
-        || b[7] != b'-'
-        || (b[10] != b'T' && b[10] != b't')
-        || b[13] != b':'
-        || b[16] != b':'
-        || !(1..=12).contains(&month)
-        || !(1..=31).contains(&day)
-        || hour > 23
-        || min > 59
-        || sec > 60
-    {
-        return None;
-    }
-    // Optional fractional seconds (ignored)
-    let mut idx = 19;
-    if b.get(idx) == Some(&b'.') {
-        idx += 1;
-        let frac_start = idx;
-        while idx < b.len() && b[idx].is_ascii_digit() {
-            idx += 1;
-        }
-        if idx == frac_start {
-            return None;
-        }
-    }
-    // Offset: Z or +HH:MM / -HH:MM
-    let offset_secs: i64 = match b.get(idx)? {
-        b'Z' | b'z' => {
-            if idx + 1 != b.len() {
-                return None;
-            }
-            0
-        }
-        sign @ (b'+' | b'-') => {
-            if idx + 6 != b.len() || b[idx + 3] != b':' {
-                return None;
-            }
-            let oh: i64 = s.get(idx + 1..idx + 3)?.parse().ok()?;
-            let om: i64 = s.get(idx + 4..idx + 6)?.parse().ok()?;
-            if oh > 23 || om > 59 {
-                return None;
-            }
-            let total = oh * 3600 + om * 60;
-            if *sign == b'+' {
-                total
-            } else {
-                -total
-            }
-        }
-        _ => return None,
-    };
-    // Days-from-civil (Howard Hinnant's algorithm)
-    let y = year - i64::from(month <= 2);
-    let era = if y >= 0 { y } else { y - 399 } / 400;
-    let yoe = y - era * 400;
-    let mp = (month + 9) % 12;
-    let doy = (153 * mp + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146097 + doe - 719_468;
-    Some(days * 86_400 + hour * 3600 + min * 60 + sec - offset_secs)
-}
+// The RFC 3339 migration, copy 6 of 6: bsfd's own `rfc3339_to_epoch` used to live
+// here. It is now `nextgcore_sbi::datetime::rfc3339_to_epoch_signed`, re-exported
+// below under the old name so every call site reads unchanged.
+//
+// This copy was the one that could NOT simply be deleted, because it disagreed with
+// the shared module rather than duplicating it: bsfd's parser APPLIED a numeric
+// `±HH:MM` offset while the shared one refused any non-UTC offset outright. And bsfd
+// was using BOTH: its own for the BINDING's `expiry` (`BsfSess::set_expiry`, and the
+// ingress validation in `lib.rs`), and the shared one for the SUBSCRIPTION's
+// `expiry` in the #98 matcher below. So the same RFC 3339 field name on two
+// resources was parsed two ways in one daemon, and the disagreement was a live
+// FAIL-OPEN bug on the subscription side: `lib.rs` stores a subscription's `expiry`
+// verbatim with no validation, so a conformant `+02:00` value was accepted, the
+// matcher's shared parser returned `None`, and `None` was read as "no deadline" --
+// the subscription never expired and notifications kept being delivered to a lapsed
+// subscriber.
+//
+// Resolved by teaching the shared parser to apply the offset -- see the reasoning on
+// `rfc3339_to_epoch_signed` -- rather than by narrowing bsfd, which would have made
+// bsfd reject conformant timestamps it accepts today.
+pub use nextgcore_sbi::datetime::rfc3339_to_epoch_signed as rfc3339_to_epoch;
 
 /// Current Unix epoch seconds.
 pub fn now_epoch() -> i64 {
@@ -715,8 +659,28 @@ impl BsfSubscription {
             _ => return false,
         }
         if let Some(ref e) = self.expiry {
-            if let Some(deadline) = nextgcore_sbi::datetime::rfc3339_to_epoch(e) {
-                if now_secs >= deadline {
+            // #98 used the offset-REJECTING shared parser here while the binding
+            // side used bsfd's offset-applying one. `lib.rs` stores a subscription
+            // `expiry` verbatim without validating it, so a conformant `+02:00`
+            // value parsed to `None` here and `None` was read as "no deadline" --
+            // the subscription never expired. One parser now, and it applies the
+            // offset.
+            match rfc3339_to_epoch(e) {
+                Some(deadline) => {
+                    // Compare as i64: the shared parser is signed, so a
+                    // positive-offset instant just after the epoch can be negative,
+                    // and such a deadline is unambiguously already past. `now_secs`
+                    // is seconds since the epoch and cannot overflow i64.
+                    if now_secs as i64 >= deadline {
+                        return false;
+                    }
+                }
+                // Unparseable despite having passed ingress validation: only
+                // reachable for a record restored from an older snapshot. Fail
+                // CLOSED for matching -- an expiry we cannot read must not be
+                // treated as permission to keep notifying.
+                None => {
+                    log::warn!("binding expiry {e:?} is unparseable; not matching it");
                     return false;
                 }
             }
@@ -1925,10 +1889,97 @@ mod tests {
         );
         // Malformed inputs
         assert_eq!(rfc3339_to_epoch("3600"), None);
-        assert_eq!(rfc3339_to_epoch("2026-06-12 00:00:00Z"), None);
         assert_eq!(rfc3339_to_epoch("2026-13-12T00:00:00Z"), None);
+        // Still refused, and the important one: no zone names no instant.
         assert_eq!(rfc3339_to_epoch("2026-06-12T00:00:00"), None);
-        assert_eq!(rfc3339_to_epoch("2026-06-12T00:00:00+0200"), None);
+
+        // TWO ASSERTIONS INVERTED by the migration onto
+        // `nextgcore_sbi::datetime::rfc3339_to_epoch_signed`, both because the shared
+        // parser is the UNION of the three implementations' accepted spellings rather
+        // than the intersection. Recorded as flips rather than quietly changed:
+        //
+        // 1. A space instead of `T`. RFC 3339 5.6 permits it by mutual agreement and
+        //    the shared parser has always accepted it; bsfd's copy did not.
+        assert_eq!(
+            rfc3339_to_epoch("2026-06-12 00:00:00Z"),
+            Some(1781222400),
+            "the shared parser accepts the space separator RFC 3339 5.6 allows"
+        );
+        // 2. A no-colon `+HHMM` zone. bsfd's copy refused it while accepting
+        //    `+HH:MM`; the shared parser already accepted `+0000`, and eesd's parser
+        //    accepts `±HHMM` generally, so accepting both spellings uniformly is
+        //    easier to explain than accepting `+0000` and refusing `+0200`.
+        assert_eq!(
+            rfc3339_to_epoch("2026-06-12T02:00:00+0200"),
+            Some(1781222400),
+            "the shared parser accepts +HHMM as well as +HH:MM"
+        );
+        // A MALFORMED zone is still refused rather than read as UTC — the widening is
+        // about spellings that name a real offset, not about guessing.
+        assert_eq!(rfc3339_to_epoch("2026-06-12T00:00:00+2:00"), None);
+        assert_eq!(rfc3339_to_epoch("2026-06-12T00:00:00+25:00"), None);
+    }
+
+    fn subscription_with_expiry(expiry: Option<&str>) -> BsfSubscription {
+        BsfSubscription {
+            sub_id: "sub-1".to_string(),
+            notif_uri: "http://pcf.example.com/notify".to_string(),
+            notif_corre_id: "corr-1".to_string(),
+            supi: "imsi-001010000000001".to_string(),
+            events: vec!["PCF_UE_BINDING_REGISTRATION".to_string()],
+            expiry: expiry.map(String::from),
+            raw: serde_json::json!({}),
+        }
+    }
+
+    /// REGRESSION, the reason this migration is a fix and not a tidy-up.
+    ///
+    /// `lib.rs` stores a subscription's `expiry` verbatim without validating it, and
+    /// `wants()` used the offset-REJECTING shared parser. So a conformant
+    /// `+02:00` expiry parsed to `None`, `None` was read as "no deadline", and a
+    /// LAPSED subscription kept matching — notifications were delivered to a
+    /// subscriber whose subscription had expired hours earlier.
+    ///
+    /// The three cases together are the point: the UTC spelling always worked, the
+    /// offset spelling did not, and both must now agree on the same instant.
+    #[test]
+    fn an_expired_subscription_does_not_match_whatever_zone_its_expiry_uses() {
+        // 1781222400 == 2026-06-12T00:00:00Z. "now" is one second later, so every
+        // subscription below has expired.
+        let now = 1781222401u64;
+        let event = "PCF_UE_BINDING_REGISTRATION";
+        let supi = Some("imsi-001010000000001");
+
+        for expiry in [
+            "2026-06-12T00:00:00Z",
+            "2026-06-12T02:00:00+02:00",
+            "2026-06-11T22:00:00-02:00",
+            "2026-06-12T02:00:00+0200",
+        ] {
+            assert!(
+                !subscription_with_expiry(Some(expiry)).wants(event, supi, now),
+                "an expired subscription must not match, expiry={expiry}"
+            );
+        }
+
+        // The complement, so the test cannot pass by rejecting everything: the same
+        // instants one second EARLIER are still live.
+        for expiry in ["2026-06-12T00:00:00Z", "2026-06-12T02:00:00+02:00"] {
+            assert!(
+                subscription_with_expiry(Some(expiry)).wants(event, supi, 1781222399),
+                "a subscription that has not expired must match, expiry={expiry}"
+            );
+        }
+
+        // No expiry at all is unbounded, unchanged.
+        assert!(subscription_with_expiry(None).wants(event, supi, now));
+
+        // An expiry that cannot be parsed at all now fails CLOSED: it used to be
+        // read as "no deadline", which is the same fail-open this test exists for.
+        assert!(
+            !subscription_with_expiry(Some("garbage")).wants(event, supi, now),
+            "an unreadable expiry must not be treated as permission to keep notifying"
+        );
     }
 
     #[test]

--- a/src/bins/nextgcore-nsacfd/src/main.rs
+++ b/src/bins/nextgcore-nsacfd/src/main.rs
@@ -3707,6 +3707,36 @@ nsacf:
             expired.report_decision(0, 0, 0, 0, 1_000),
             ReportDecision::Emit
         );
+
+        // REGRESSION (RFC 3339 migration 5 of 5): a consumer's `expiry` is stored
+        // VERBATIM by the create path, and the shared parser used to REFUSE any
+        // non-UTC offset. An unparsed expiry skipped the check below, so a
+        // conformant `+02:00` expiry meant the subscription never became Exhausted
+        // and kept reporting past its own deadline. The offset is now applied, so
+        // these three spellings of the same instant agree.
+        //
+        // 1970-01-01T00:16:40Z is epoch 1000, so an expiry of epoch 500 in any zone
+        // must be Exhausted at now=1000.
+        for expiry in [
+            "1970-01-01T00:08:20Z",
+            "1970-01-01T02:08:20+02:00",
+            "1970-01-01T02:08:20+0200",
+        ] {
+            let mut s = base.clone();
+            s.expiry = Some(expiry.to_string());
+            assert_eq!(
+                s.report_decision(0, 0, 0, 0, 1_000),
+                ReportDecision::Exhausted,
+                "an expired subscription is spent whatever zone its expiry uses: {expiry}"
+            );
+        }
+        // The complement, so this cannot pass by treating everything as expired.
+        let mut live = base.clone();
+        live.expiry = Some("1970-01-01T02:33:20+02:00".to_string()); // epoch 2000
+        assert_eq!(
+            live.report_decision(0, 0, 0, 0, 1_000),
+            ReportDecision::Emit
+        );
     }
 
     /// Every trigger field is parsed, and from the RIGHT object: `eventTrigger`,

--- a/src/libs/nextgcore-sbi/src/datetime.rs
+++ b/src/libs/nextgcore-sbi/src/datetime.rs
@@ -46,14 +46,90 @@ pub fn epoch_to_rfc3339(secs: u64) -> String {
     )
 }
 
-/// Parse an RFC 3339 UTC date-time into seconds since the epoch, the inverse of
-/// [`epoch_to_rfc3339`].
+/// Split a trailing RFC 3339 zone designator off a time string, returning the
+/// time without it and the zone's offset from UTC in seconds.
 ///
-/// Deliberately strict: only the `YYYY-MM-DDThh:mm:ss` form, with an optional
-/// fractional part and a `Z`/`+00:00` offset. **A non-UTC offset is REJECTED**
-/// rather than silently read as UTC, because misreading an offset shifts a
-/// deadline by hours — the same reasoning nrfd's copy records.
-pub fn rfc3339_to_epoch(text: &str) -> Option<u64> {
+/// Accepted: `Z` / `z`, and a numeric `±HH:MM` or `±HHMM`. Anything else — most
+/// importantly *no zone at all* — is refused, because a naive local time has no
+/// defined instant and guessing UTC for it is how a deadline moves by hours.
+///
+/// The no-colon `±HHMM` form is not strictly RFC 3339 (its `time-numoffset`
+/// requires the colon), but the shared parser already accepted `+0000` and
+/// `eesd`'s parser accepts `±HHMM` generally. Accepting both spellings uniformly
+/// is easier to explain than accepting `+0000` while refusing `+0200`.
+fn split_zone(rest: &str) -> Option<(&str, i64)> {
+    if let Some(time) = rest.strip_suffix('Z').or_else(|| rest.strip_suffix('z')) {
+        return Some((time, 0));
+    }
+    // Find the sign that starts the offset. Scanning from the end keeps the date's
+    // own '-' separators out of it, since only the last 5 or 6 bytes can be a zone.
+    for width in [6usize, 5] {
+        if rest.len() < width + 1 {
+            continue;
+        }
+        let (time, zone) = rest.split_at(rest.len() - width);
+        let bytes = zone.as_bytes();
+        let sign = match bytes[0] {
+            b'+' => 1i64,
+            b'-' => -1i64,
+            _ => continue,
+        };
+        let (hh, mm) = if width == 6 {
+            if bytes[3] != b':' {
+                continue;
+            }
+            (&zone[1..3], &zone[4..6])
+        } else {
+            (&zone[1..3], &zone[3..5])
+        };
+        let hours: i64 = match hh.parse() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let minutes: i64 = match mm.parse() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if hours > 23 || minutes > 59 {
+            return None;
+        }
+        return Some((time, sign * (hours * 3600 + minutes * 60)));
+    }
+    None
+}
+
+/// Parse an RFC 3339 date-time into **signed** seconds since the epoch, the
+/// inverse of [`epoch_to_rfc3339_signed`].
+///
+/// Accepts the `YYYY-MM-DDThh:mm:ss` form with an optional fractional part and a
+/// `Z` or numeric `±HH:MM` / `±HHMM` zone.
+///
+/// # A non-UTC offset is APPLIED, not rejected
+///
+/// This module originally **refused** any offset other than UTC, on the reasoning
+/// that "misreading an offset shifts a deadline by hours". The reasoning was
+/// right about the hazard and wrong about the remedy: the hazard is *ignoring* the
+/// offset, and honouring it avoids that hazard without refusing conformant input.
+/// Refusing turned out to be actively worse, because every consumer of this
+/// function treats `None` as "no deadline":
+///
+/// * `bsfd` accepted a `+02:00` binding `expiry` at ingress and stored it verbatim,
+///   then its subscription matcher parsed it with this function, got `None`, skipped
+///   the deadline check and reported the binding as **live past its expiry**.
+/// * `nsacfd` stores a consumer's `expiry` verbatim too, with the same fail-open
+///   result in its report-decision path.
+/// * `nssfd` silently substituted its own default for a conformant consumer's
+///   requested expiry.
+///
+/// So the strict version converted a valid request into a *missing deadline*, which
+/// is a worse failure than the shifted one it was guarding against. TS 29.571's
+/// `DateTime` is RFC 3339, which permits any offset, so honouring it is also what
+/// the spec says.
+///
+/// Still refused, because these are genuinely undecidable rather than merely
+/// inconvenient: a time with **no zone**, a malformed zone, and out-of-range
+/// fields.
+pub fn rfc3339_to_epoch_signed(text: &str) -> Option<i64> {
     let t = text.trim();
     let (date, rest) = t.split_once('T').or_else(|| t.split_once(' '))?;
     let mut parts = date.split('-');
@@ -64,19 +140,14 @@ pub fn rfc3339_to_epoch(text: &str) -> Option<u64> {
         return None;
     }
 
-    // Strip the zone, accepting only UTC.
-    let time = rest
-        .strip_suffix('Z')
-        .or_else(|| rest.strip_suffix('z'))
-        .or_else(|| rest.strip_suffix("+00:00"))
-        .or_else(|| rest.strip_suffix("+0000"))?;
+    let (time, offset_secs) = split_zone(rest)?;
     // Drop any fractional seconds.
     let time = time.split('.').next()?;
 
     let mut tparts = time.split(':');
-    let hour: u64 = tparts.next()?.parse().ok()?;
-    let minute: u64 = tparts.next()?.parse().ok()?;
-    let second: u64 = tparts.next().unwrap_or("0").parse().ok()?;
+    let hour: i64 = tparts.next()?.parse().ok()?;
+    let minute: i64 = tparts.next()?.parse().ok()?;
+    let second: i64 = tparts.next().unwrap_or("0").parse().ok()?;
     if tparts.next().is_some() || hour > 23 || minute > 59 || second > 60 {
         return None;
     }
@@ -89,10 +160,17 @@ pub fn rfc3339_to_epoch(text: &str) -> Option<u64> {
     let doy = (153 * mp + 2) / 5 + day - 1;
     let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
     let days = era * 146_097 + doe - 719_468;
-    if days < 0 {
-        return None;
-    }
-    Some(days as u64 * 86_400 + hour * 3600 + minute * 60 + second)
+    Some(days * 86_400 + hour * 3600 + minute * 60 + second - offset_secs)
+}
+
+/// Parse an RFC 3339 date-time into seconds since the epoch, the inverse of
+/// [`epoch_to_rfc3339`].
+///
+/// Returns `None` for an instant **before** the epoch, which no `u64` can hold —
+/// the same answer the pre-offset implementation gave via its `days < 0` guard.
+/// Call [`rfc3339_to_epoch_signed`] where a pre-epoch instant must survive.
+pub fn rfc3339_to_epoch(text: &str) -> Option<u64> {
+    rfc3339_to_epoch_signed(text).and_then(|secs| u64::try_from(secs).ok())
 }
 
 /// Seconds since the Unix epoch, or 0 if the clock is before it.
@@ -132,19 +210,75 @@ mod tests {
         assert_eq!(rfc3339_to_epoch("  2000-01-01T00:00:00Z  "), base);
     }
 
+    /// INVERTED from `rejects_a_non_utc_offset_rather_than_reading_it_as_utc`.
+    ///
+    /// That test asserted `+02:00` parsed to `None`. It pinned behaviour that
+    /// turned out to be the defect rather than the guard: every consumer reads
+    /// `None` as "no deadline", so refusing a conformant offset made `bsfd` and
+    /// `nsacfd` treat an EXPIRED subscription as live, and made `nssfd` discard a
+    /// consumer's requested expiry. The offset is now applied. The flip is
+    /// recorded here rather than the old test being deleted, so the widening is
+    /// visible to anyone reading the history.
     #[test]
-    fn rejects_a_non_utc_offset_rather_than_reading_it_as_utc() {
-        // The whole point of the strictness: silently treating +02:00 as UTC
-        // shifts a deadline by two hours.
-        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00+02:00"), None);
-        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00-05:00"), None);
-        // Malformed input is refused, not guessed at.
+    fn applies_a_non_utc_offset_rather_than_refusing_it() {
+        // 02:00 in a +02:00 zone is 00:00 UTC. Subtracting the offset, not
+        // ignoring it, is what makes these equal.
+        let utc = rfc3339_to_epoch("2000-01-01T00:00:00Z").expect("UTC parses");
+        assert_eq!(rfc3339_to_epoch("2000-01-01T02:00:00+02:00"), Some(utc));
+        assert_eq!(rfc3339_to_epoch("1999-12-31T19:00:00-05:00"), Some(utc));
+        // Both spellings of the zone, and the zero offset that was already accepted.
+        assert_eq!(rfc3339_to_epoch("2000-01-01T02:00:00+0200"), Some(utc));
+        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00+00:00"), Some(utc));
+        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00+0000"), Some(utc));
+        // The sign matters: reading -05:00 as +05:00 would be a ten-hour error.
+        assert_ne!(
+            rfc3339_to_epoch("2000-01-01T00:00:00-05:00"),
+            rfc3339_to_epoch("2000-01-01T00:00:00+05:00")
+        );
+    }
+
+    /// What is still refused, and why each is undecidable rather than merely
+    /// inconvenient.
+    #[test]
+    fn refuses_input_with_no_defined_instant() {
+        // No zone at all: a naive local time names no instant, and guessing UTC
+        // for it is the hazard the old strictness was actually worried about.
+        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00"), None);
+        // Malformed rather than guessed at.
         assert_eq!(rfc3339_to_epoch(""), None);
         assert_eq!(rfc3339_to_epoch("not a date"), None);
         assert_eq!(rfc3339_to_epoch("2000-13-01T00:00:00Z"), None);
         assert_eq!(rfc3339_to_epoch("2000-01-01T24:00:00Z"), None);
         assert_eq!(rfc3339_to_epoch("2000-01-01T00:60:00Z"), None);
-        // No zone at all.
-        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00"), None);
+        // A malformed zone is refused rather than read as UTC.
+        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00+2:00"), None);
+        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00+xx:00"), None);
+        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00+25:00"), None);
+        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00+02:60"), None);
+    }
+
+    /// The `u64` entry point cannot hold a pre-epoch instant and says so with
+    /// `None`, which is the answer the pre-offset implementation gave via its
+    /// `days < 0` guard. The signed one keeps the value.
+    ///
+    /// Reachable now that offsets are applied: a positive-offset timestamp just
+    /// after the epoch resolves to before it.
+    #[test]
+    fn pre_epoch_instants_are_none_for_u64_and_kept_when_signed() {
+        assert_eq!(rfc3339_to_epoch("1970-01-01T00:00:00+02:00"), None);
+        assert_eq!(
+            rfc3339_to_epoch_signed("1970-01-01T00:00:00+02:00"),
+            Some(-7200)
+        );
+        assert_eq!(rfc3339_to_epoch_signed("1969-12-31T23:59:59Z"), Some(-1));
+        // The signed parser agrees with the unsigned one wherever both are defined,
+        // so the u64 entry point is a narrowing and not a second implementation.
+        for text in ["1970-01-01T00:00:00Z", "2000-01-01T00:00:00Z"] {
+            assert_eq!(
+                rfc3339_to_epoch_signed(text).map(|s| s as u64),
+                rfc3339_to_epoch(text),
+                "signed and unsigned must agree for {text}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Spec: [`specs/fix-bsfd-datetime-offset-handling-and-two-parser-split.md`](specs/fix-bsfd-datetime-offset-handling-and-two-parser-split.md).

Last of the five per-daemon migrations, and the only one that is a **defect fix** rather than a
consolidation. Follow-up to PR #239 (#94).

## ⚠️ Merge order is not optional — see the bottom of this description

## The task's premise was wrong, and that is the whole change

The task says the shared module *"is the only one that REJECTS a non-UTC offset instead of reading it as UTC —
a copy that does not reject shifts a deadline by hours"*. That conflates two things: `bsfd`'s copy does **not**
read a non-UTC offset as UTC, it **applies** it. So `bsfd`'s parser was the correct one and the shared module
was the strict-and-wrong one.

The strictness was not pedantic — it was a live fail-open bug, because **every consumer of the shared parser
reads `None` as "no deadline"**. Refusing a conformant offset did not shift a deadline; it *deleted* one:

| daemon | site | what a `+02:00` expiry did |
|---|---|---|
| `bsfd` | `BsfSubscription::wants` (#98) | `None` → check skipped → **a lapsed subscription kept matching**, so notifications went on to an expired subscriber |
| `nsacfd` | `report_decision` (#96) | same shape → never `Exhausted` → **kept reporting past its own expiry** |
| `nssfd` | `main.rs:2390` | a conformant consumer's requested expiry silently replaced by the NSSF default |

Both `bsfd` (`lib.rs:1147`) and `nsacfd` (`main.rs:1571`) store the consumer's `expiry` **verbatim with no
validation**, so the input is reachable from the wire in both. TS 29.571's `DateTime` is RFC 3339, which
permits any offset, so honouring it is also what the spec says.

## `bsfd` was using both parsers, on two resources, in one daemon

- the **binding**'s `expiry` (`set_expiry`, plus ingress validation at `lib.rs:720`) → `bsfd`'s own
  offset-applying parser;
- the **subscription**'s `expiry` (`wants`, added by #98) → the shared offset-rejecting one.

Same field name, same wire type, two answers. Migrating `bsfd` *down* to the shared parser would have made the
binding side start rejecting timestamps it accepts today — a regression at a wire field, introduced by the
consolidation meant to prevent exactly that.

## What changed

**`nextgcore_sbi::datetime`**
- `split_zone` peels a trailing `Z`/`z` or numeric `±HH:MM`/`±HHMM` and returns the offset. **No zone at all
  is still refused** — a naive local time names no instant, and guessing UTC for it is the hazard the old
  strictness was actually worried about. A malformed zone (`+2:00`, `+xx:00`, `+25:00`, `+02:60`) is refused
  rather than read as UTC.
- `rfc3339_to_epoch_signed(&str) -> Option<i64>` applies the offset. Signed because a positive-offset instant
  just after the epoch resolves to *before* it, which `u64` cannot hold — and `bsfd`'s call sites are `i64`.
- `rfc3339_to_epoch(&str) -> Option<u64>` is now a narrowing via `u64::try_from`, so a pre-epoch result is
  `None` — the same answer the old code gave through its `days < 0` guard. `nssfd`/`nsacfd` therefore see no
  change other than offsets working.

Accepting the no-colon `±HHMM` spelling is a deliberate uniformity call, stated at the site: the shared parser
already accepted `+0000` and `eesd`'s accepts `±HHMM` generally, so accepting both is easier to explain than
accepting `+0000` while refusing `+0200`.

**`bsfd`** — its parser is deleted and re-exported under the same name, so all call sites read unchanged. The
matcher now uses that one parser and its unparseable branch **fails closed**.

**`nsacfd`** — no code change; the parser fix repairs it, and a regression test pins that.

## Three pinned-behaviour tests inverted, each flip recorded at the site

1. `rejects_a_non_utc_offset_rather_than_reading_it_as_utc` → `applies_a_non_utc_offset_rather_than_refusing_it`. It pinned the defect, not the guard.
2. `bsfd`: a space separator was asserted malformed → now accepted (RFC 3339 §5.6 permits it; the shared parser always did).
3. `bsfd`: `+0200` was asserted malformed → now accepted, per the uniformity call.

## Verification

- **Workspace 5941 passed / 0 failed across three consecutive runs** (baseline 5938). Three runs because this
  touches a library every NF links.
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
- **Nine claims revert-verified.** The strongest: one revert of the shared parser fails tests in **three
  different crates** (`nextgcore-sbi`, `nextgcore-bsfd`, `nextgcore-nsacfd`), which is the claim that the fix
  reaches all three.

| # | claim | test that bit |
|---|---|---|
| 1–2 | the offset is applied, and its sign honoured | `applies_a_non_utc_offset_rather_than_refusing_it` |
| 3–4 | a zoneless time and an out-of-range zone are still refused | `refuses_input_with_no_defined_instant` |
| 5 | the `u64` entry point still rejects a pre-epoch instant | `pre_epoch_instants_are_none_for_u64_and_kept_when_signed` |
| 6–7 | `bsfd`'s matcher honours an offset expiry; an unreadable one fails **closed** | `an_expired_subscription_does_not_match_whatever_zone_its_expiry_uses` |
| 8 | `nsacfd`'s report decision honours an offset expiry | `report_triggers_gate_emission` |
| 9 | `bsfd`'s own parse test reaches the shared parser | `test_rfc3339_to_epoch` |

### The harness lied twice, both the recorded failure modes

- **Claim 6 first came back GREEN because the revert was a semantic no-op**: it pointed `bsfd`'s matcher back
  at the shared `u64` parser — which *also* applies offsets now, so both sides behaved identically. Reading
  the substitution for equivalence is what caught it; the real revert restores the old strictness inside
  `split_zone`.
- **Claim 8 first came back NOT-RUN** because the test name was wrong. Treated as inconclusive, not as a pass.

## ⚠️ Merge-order dependency

These five PRs are **not** independent:

- migrations **1–3** (`nrfd` #246, `udmd` #247, `pcfd` #248) do not touch `datetime.rs` — any order;
- migration **4** (`eesd` #249) adds `epoch_to_rfc3339_signed` to `datetime.rs` and **this one rewrites the
  parser in the same file** → they will **conflict textually**. Land #249 first, then rebase this;
- migration **1** makes `nrfd` a consumer of the shared parser, and `nrfd`'s tests at `main.rs:5801`/`:5805`
  assert `+02:00` and `-05:00` are **rejected**. Once both #246 and this are in, **those two assertions must be
  inverted** as `bsfd`'s were. On this branch `nrfd` still has its private copy, so CI here cannot see the
  interaction — whichever lands second is where it surfaces.

**Recommended order: #246, #247, #248 → #249 → this one (rebased, inverting `nrfd`'s two assertions).**

## Ceilings

- **A garbage `expiry` is still unvalidated at ingress** in `bsfd` subscriptions and in `nsacfd`. This makes
  `bsfd`'s matcher fail closed on one, but `nsacfd`'s `report_decision` still skips the check for an
  unparseable expiry — still fail-open for genuine garbage. Validating at creation belongs with #96.
- **`nssfd`'s improvement is untested here** — a `+02:00` requested expiry is now honoured, but no test covers
  that path.
- **`eesd`'s `parse_rfc3339_to_epoch` is still a seventh parser.** It now has the *same* semantics as the
  shared one, so deleting it is finally mechanical — which it was not before, and is why #249 deferred it.

## GitNexus

No GitNexus MCP server connected (30th consecutive PR). Blast radius established by `grep` over every
consumer of both entry points plus `cargo check --workspace --all-targets`.