### PR TITLE
test(pcfd,bsfd,nsacfd): observe the three notification producers arriving, closing the #90/#96/#98 verification ceilings

### DIFF
--- a/specs/fix-close-three-notification-verification-ceilings.md
+++ b/specs/fix-close-three-notification-verification-ceilings.md
@@ -1,0 +1,122 @@
+# Close the three notification verification ceilings from the 2026-09-08 five-PR run
+
+Verified against `main` @ `4ec257a`. No issue number: this is the tracked follow-up the #90 / #96 / #98 specs
+each recorded as a ceiling rather than papering over.
+
+All three had the same shape — **a producer that is wired and type-checked while nothing observes its output
+arriving** — which is the recorded "the helper is tested and the wiring is not, and the better the helper's
+test the more convincing the illusion" pattern. They are closed in one change because the fix for each is the
+same move (drive the real handler, read a stub consumer, then delete the call line and confirm the test
+fails) and doing them together means writing the stub-consumer shape once.
+
+## (a) `pcfd` #90 — the UE-policy delivery events
+
+`handle_ue_policy_n1_notify` fires `SUCCESS_UE_POL_DEL_SP` / `UNSUCCESS_UE_POL_DEL_SP` on the terminal
+outcomes. `tests/strict_peer_updp_result.rs` already drove that handler through amfd's **real**
+`N1MessageNotify` builder, but only asserted the delivery *state* — the Npcf_EventExposure feed was invisible.
+
+Three tests added to that file. Each creates the subscription through pcfd's **real SBI router**
+(`POST /npcf-eventexposure/v1/subscriptions`), so the create path is part of what is proved, then drives the
+same real handler and reads a stub consumer:
+
+* a matching-PTI COMPLETE puts exactly one `SUCCESS_UE_POL_DEL_SP` report on the feed, carrying the
+  association's SUPI and an RFC 3339 UTC `timeStamp`;
+* a matching-PTI REJECT reports `UNSUCCESS_UE_POL_DEL_SP` — and **must not** carry `delivFailure`, because
+  TS 29.522 `Failure` enumerates northbound delivery failures and a D.6.3 UE-side rejection is not one of
+  them, so mapping it would misreport the reason;
+* **the negative**, which is what makes the other two mean something: a wrong-PTI COMPLETE is a stale or
+  duplicate command (TS 24.501 D.2.1.6) with the delivery still in flight, so it must report **nothing**.
+
+### A race found and fixed while writing these
+
+The first run failed with **four** notifications where one was expected, including the wrong event token. The
+pcfd context is process-global and the delivery events fire from this very handler, so each test's firing was
+POSTed to every test's subscription — including the three *pre-existing* tests in the file, one of which
+fires `SUCCESS_UE_POL_DEL_SP` itself.
+
+Fixed by taking `nextgcore_pcfd::test_support::CONTEXT_GUARD` in **all six** tests in the file — the three
+new ones and the three that were already there, because they are producers too — and by deleting each new
+subscription before releasing the guard so a later firing cannot be POSTed at a stub that has already
+stopped. Confirmed with 8 consecutive clean runs of the file. The guard is poison-tolerant so one failing
+test does not turn its siblings into misleading second failures.
+
+## (b) `bsfd` #98 — the UE-binding notifications
+
+`subscribe_register_deregister_delivers_notifications` proved the **PDU-session** pair end-to-end against a
+stub callback. The **UE-binding** pair was wired and its SUPI/event matching covered, but no test saw a
+`PCF_UE_BINDING_REGISTRATION` or `_DEREGISTRATION` arrive.
+
+Mirrored for `/nbsf-management/v1/pcf-ue-bindings`. The load-bearing assertion is not that a notification
+arrives — it is that it carries **`pcfForUeInfo` and not `pcfForPduSessInfos`**. `BsfEventNotification`
+models the two binding kinds with different members, so using one for the other would tell a consumer the
+wrong resource changed, and a test that only counted notifications would pass either way. The deregistration
+half asserts the identity member is present too, so a consumer can tell *which* PCF binding went away.
+
+A SUPI distinct from the PDU-session test's is used, so the two cannot cross-report through the
+process-global context even when run concurrently.
+
+## (c) `nsacfd` #96 — the two subscribe-time dispatches
+
+The task named "the `immediateFlag` report and the immediate EAC notification". Re-checking what was already
+covered mattered here, because the picture was better than the task recorded and the gap was narrower and
+more specific:
+
+| already covered | by |
+|---|---|
+| an EAC notification following a mode **transition** | `test_http_slice_ee_subscription_and_eac_notification` (observes a real receiver) |
+| the mode-list construction and the first/repeat decision | `eac_mode_list_and_first_subscription_detection` (pure logic) |
+
+What nothing observed was the two dispatches that happen **at subscribe time**, both via `tokio::spawn` and
+so invisible to a test that checks only the `201`/`204`:
+
+1. **the `immediateFlag` report** (TS 29.536 §5.3.2.2.2). The new test subscribes with
+   `eventTrigger: REACHING_THRESHOLD`, `notifThreshold: 90` and **zero occupancy** — so the trigger gate
+   would suppress the report. It arrives only because `immediateFlag` bypasses the gate, which is the whole
+   point of §5.3.2.2.2 and cannot be seen from the 201. The `SACEventReport` shape is asserted
+   (`eventFilter.sst`, `sliceStautsInfo.reachedNumUes`) so it cannot pass on a bare POST.
+2. **the immediate EAC notification on a FIRST subscription** (§5.2.2.2.2), with the §6.1.6.2.4
+   `eacModeList` map shape asserted — not the old `eacMode` scalar.
+
+Both negatives are included: a subscription **without** `immediateFlag` reports nothing at subscribe time,
+and a **repeat** EAC subscription from the same `nfId` is not re-notified (an AMF re-sends its
+`eacNotificationUri` on every `NumOfUEsUpdate`, so re-notifying each time would flood it).
+
+## Verification
+
+Workspace: **5943 passed / 0 failed** across three consecutive runs (baseline 5938). The five added tests are
+three in `pcfd` and one each in `bsfd` and `nsacfd` — the `nsacfd` one covers four claims (two positives and
+their two negatives) in a single test because they share one receiver and the ordering between them is part of
+what is asserted. `cargo clippy --workspace` and `cargo fmt --all -- --check` clean. Three runs because the
+new tests bind ports and touch process-global state.
+
+**Nine claims revert-verified — and for this change the reverts *are* the deliverable**, since the whole point
+is that the observers can fail. Each producer was deleted or inverted and the observing test confirmed to fail:
+
+| # | producer reverted | test that bit |
+|---|---|---|
+| 1 | `pcf_report_pc_event` call deleted | `a_delivered_ue_policy_reports_success_to_a_real_subscriber` |
+| 2 | the `Rejected` arm mapped to `None` | `a_rejected_ue_policy_reports_unsuccess_to_a_real_subscriber` |
+| 3 | the non-terminal arm made to report `SUCCESS` | `a_non_terminal_outcome_reports_nothing` |
+| 4 | `spawn_bsf_notifications` for UE-binding registration deleted | `ue_binding_register_deregister_delivers_notifications` |
+| 5 | `pcfForUeInfo` swapped for `pcfForPduSessInfos` | same |
+| 6 | the `if immediate { … }` block deleted | `subscribe_time_dispatches_actually_arrive_at_the_consumer` |
+| 7 | `immediate` forced to `true` | same (the negative half) |
+| 8 | the first-subscription EAC dispatch deleted | same |
+| 9 | `first` forced to `true` | same (the repeat negative) |
+
+Each revert was checked for a unique anchor, for compiling, and for the named test actually running before
+its result was trusted. Reverts 3, 7 and 9 are the *inverted* kind — they make the producer fire when it
+should not — which is what proves the three negative assertions are load-bearing rather than satisfied by a
+path that never arrives.
+
+## Ceilings
+
+* **The un-driveable middle is still elided in (a).** The NGAP uplink NAS path needs live SCTP, so the test
+  builds the exact `N1MessageNotify` amfd's `forward_ul_updp_to_pcf` emits and feeds it to pcfd's real
+  router. That was already true of the three pre-existing tests in the file; these three inherit it.
+* **No test drives a real PCF/BSF/NSACF process**, only their real handlers in-process. A misconfigured
+  listener or a callback URI that is wrong only in deployment stays out of reach.
+* **`nsacfd`'s repeat-subscription negative is time-bounded** (a 600 ms drain) rather than proven for all
+  time. A re-notification arriving later than that would be missed. Bounded windows are the only option for a
+  "nothing happens" assertion about a spawned task; the window is generous relative to the loopback delivery
+  the positive assertions measure in the same test.

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -4776,6 +4776,147 @@ mod tests {
         server.stop().await.expect("server stops");
     }
 
+    /// Closes the #98 verification ceiling for the UE-BINDING half of the event
+    /// surface.
+    ///
+    /// `subscribe_register_deregister_delivers_notifications` above proves the
+    /// PDU-session pair end-to-end against a stub consumer. The UE-binding pair was
+    /// wired and its SUPI/event matching covered, but NOTHING observed a
+    /// `PCF_UE_BINDING_REGISTRATION` or `_DEREGISTRATION` notification arriving —
+    /// the recorded "the helper is tested and the wiring is not" pattern, where the
+    /// better the helper's test the more convincing the illusion.
+    ///
+    /// The load-bearing assertion is not merely that a notification arrives: it is
+    /// that it carries `pcfForUeInfo` and NOT `pcfForPduSessInfos`.
+    /// `BsfEventNotification` models the two binding kinds with different members,
+    /// so using one for the other would tell a consumer the wrong resource changed
+    /// — and a test that only counted notifications would pass either way.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ue_binding_register_deregister_delivers_notifications() {
+        let (server, client) = start_bsf().await;
+
+        let recorded: Arc<std::sync::Mutex<Vec<serde_json::Value>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = Arc::clone(&recorded);
+        let cb_addr = ephemeral_addr();
+        let cb = SbiServer::new(NextgcoreSbiServerConfig::new(cb_addr));
+        cb.start(move |req: SbiRequest| {
+            let sink = Arc::clone(&sink);
+            async move {
+                if let Some(body) = req.http.content.as_deref() {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+                        sink.lock().unwrap_or_else(|e| e.into_inner()).push(v);
+                    }
+                }
+                SbiResponse::with_status(204)
+            }
+        })
+        .await
+        .expect("callback server starts");
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(cb_addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let notif_uri = format!("http://127.0.0.1:{}/bsf-notify", cb_addr.port());
+
+        // A SUPI distinct from the PDU-session test's, so the two cannot cross-report
+        // through the process-global context even if they run concurrently.
+        let supi = "imsi-001010000000097";
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/subscriptions",
+                &bsf_sub_doc(
+                    &notif_uri,
+                    supi,
+                    &[
+                        "PCF_UE_BINDING_REGISTRATION",
+                        "PCF_UE_BINDING_DEREGISTRATION",
+                    ],
+                ),
+            )
+            .await
+            .expect("POST subscription");
+        assert_eq!(resp.status, 201);
+
+        let resp = client
+            .post_json(
+                "/nbsf-management/v1/pcf-ue-bindings",
+                &json!({
+                    "supi": supi,
+                    "pcfForUeFqdn": "pcf97.example.com",
+                    "pcfId": "pcf-97",
+                }),
+            )
+            .await
+            .expect("POST ue-binding");
+        assert_eq!(resp.status, 201);
+        let binding_id = resp
+            .http
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("location"))
+            .and_then(|(_, v)| v.rsplit('/').next().map(str::to_string))
+            .expect("Location");
+
+        let mut got = Vec::new();
+        for _ in 0..150 {
+            got = recorded.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            if !got.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            got.len(),
+            1,
+            "a UE-binding registration must notify the subscriber once"
+        );
+        let n = &got[0];
+        // BsfNotification's oneOf: notifCorreId AND eventNotifs together.
+        assert_eq!(n["notifCorreId"], "corr-98");
+        let evs = n["eventNotifs"].as_array().expect("eventNotifs array");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(evs[0]["event"], "PCF_UE_BINDING_REGISTRATION");
+        // The UE-binding identity member, and NOT the PDU-session one.
+        assert_eq!(evs[0]["pcfForUeInfo"]["pcfFqdn"], "pcf97.example.com");
+        assert_eq!(evs[0]["pcfForUeInfo"]["pcfId"], "pcf-97");
+        assert!(
+            evs[0].get("pcfForPduSessInfos").is_none(),
+            "a UE-binding event must not carry the PDU-session member: {:?}",
+            evs[0]
+        );
+
+        // Deregister -> the second notification, with the same identity member.
+        let resp = client
+            .delete(&format!("/nbsf-management/v1/pcf-ue-bindings/{binding_id}"))
+            .await
+            .expect("DELETE ue-binding");
+        assert_eq!(resp.status, 204);
+        let mut got = Vec::new();
+        for _ in 0..150 {
+            got = recorded.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            if got.len() >= 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(got.len(), 2, "UE-binding deregistration must notify too");
+        assert_eq!(
+            got[1]["eventNotifs"][0]["event"],
+            "PCF_UE_BINDING_DEREGISTRATION"
+        );
+        assert!(
+            got[1]["eventNotifs"][0].get("pcfForUeInfo").is_some(),
+            "the deregistration also names WHICH PCF binding went away: {:?}",
+            got[1]
+        );
+
+        cb.stop().await.expect("callback stops");
+        server.stop().await.expect("server stops");
+    }
+
     /// A subscription is UE-scoped: a binding for a DIFFERENT SUPI must not be
     /// reported to it, or one UE's binding activity leaks to a consumer watching
     /// another.

--- a/src/bins/nextgcore-nsacfd/src/main.rs
+++ b/src/bins/nextgcore-nsacfd/src/main.rs
@@ -2763,6 +2763,218 @@ nsacf:
         server.stop().await.expect("stop");
     }
 
+    /// Closes the #96 verification ceiling: BOTH spawned dispatches are observed
+    /// arriving at a real receiver, not merely constructed.
+    ///
+    /// `test_http_slice_ee_subscription_and_eac_notification` below sees an EAC
+    /// notification that follows a mode TRANSITION, and
+    /// `eac_mode_list_and_first_subscription_detection` covers the mode-list
+    /// construction and the first/repeat decision as pure logic. Neither observes
+    /// the two dispatches that happen at SUBSCRIBE time, both of which go through
+    /// `tokio::spawn` and so are invisible to a test that only checks the 201:
+    ///
+    /// 1. the `immediateFlag` report (TS 29.536 5.3.2.2.2), and
+    /// 2. the immediate EAC notification on a FIRST subscription (5.2.2.2.2).
+    ///
+    /// The two negatives are what make the positives mean something: without the
+    /// flag nothing is reported at subscribe time, and a REPEAT EAC subscription
+    /// from the same `nfId` is not re-notified.
+    #[tokio::test]
+    async fn subscribe_time_dispatches_actually_arrive_at_the_consumer() {
+        let (server, port, _ctx_guard) = start_nsacf_server().await;
+        let client = SbiClient::with_host_port("127.0.0.1", port);
+
+        let recv_port = free_port();
+        let receiver = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+            [127, 0, 0, 1],
+            recv_port,
+        ))));
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        receiver
+            .start(move |req: SbiRequest| {
+                let tx = tx.clone();
+                async move {
+                    let _ = tx.send(req.http.content.unwrap_or_default());
+                    SbiResponse::with_status(204)
+                }
+            })
+            .await
+            .expect("receiver start");
+        let cb = format!("http://127.0.0.1:{recv_port}/cb");
+
+        // A quota so the slice has a mode to report at all. Without one,
+        // `eac_mode_list()` is empty and the immediate EAC notification is
+        // deliberately NOT sent (an empty eacModeList would assert "no slices"
+        // rather than "nothing configured yet").
+        create_quota(&client, 96, 10, 100).await;
+
+        // ── 1. immediateFlag: a report must arrive with no admission at all ──
+        //
+        // The trigger is REACHING_THRESHOLD with a threshold of 90%, and occupancy
+        // is 0%, so the trigger gate would SUPPRESS this report. It arrives only
+        // because `immediateFlag` bypasses the gate — which is the whole point of
+        // 5.3.2.2.2 and cannot be observed from the 201 alone.
+        let resp = client
+            .post_json(
+                "/nnsacf-slice-ee/v1/subscriptions",
+                &json!({
+                    "eventNotifyUri": cb,
+                    "nfId": "amf-96-immediate",
+                    "notifyCorrelationId": "corr-96-immediate",
+                    "event": {
+                        "eventType": "NUM_OF_REGD_UES",
+                        "eventFilter": [{"sst": 96}],
+                        "eventTrigger": "REACHING_THRESHOLD",
+                        "notifThreshold": 90,
+                        "immediateFlag": true
+                    }
+                }),
+            )
+            .await
+            .expect("response");
+        assert_eq!(resp.status, 201);
+
+        let mut immediate_report: Option<serde_json::Value> = None;
+        for _ in 0..8 {
+            let Ok(Some(text)) = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await
+            else {
+                break;
+            };
+            let v: serde_json::Value = serde_json::from_str(&text).expect("JSON body");
+            if v["notifyCorrelationId"] == "corr-96-immediate" {
+                immediate_report = Some(v);
+                break;
+            }
+        }
+        let report = immediate_report.expect(
+            "immediateFlag must produce a report AT SUBSCRIBE TIME, with no admission and              despite the trigger gate",
+        );
+        // The SACEventReport shape (TS 29.536 6.2.6.2.4), so this cannot pass on a
+        // bare POST that carries nothing useful.
+        assert_eq!(report["report"]["eventFilter"]["sst"], 96);
+        assert!(
+            report["report"]["sliceStautsInfo"]["reachedNumUes"]["numericValNumUes"].is_number(),
+            "the immediate report carries the CURRENT counts: {report}"
+        );
+
+        // ── 2. the negative: no immediateFlag means nothing at subscribe time ──
+        let resp = client
+            .post_json(
+                "/nnsacf-slice-ee/v1/subscriptions",
+                &json!({
+                    "eventNotifyUri": cb,
+                    "nfId": "amf-96-quiet",
+                    "notifyCorrelationId": "corr-96-quiet",
+                    "event": {
+                        "eventType": "NUM_OF_REGD_UES",
+                        "eventFilter": [{"sst": 96}],
+                        "eventTrigger": "REACHING_THRESHOLD",
+                        "notifThreshold": 90
+                    }
+                }),
+            )
+            .await
+            .expect("response");
+        assert_eq!(resp.status, 201);
+        // A short window is enough: the dispatch is a spawned task that would run
+        // immediately, and the previous report proves the receiver is live.
+        let quiet = tokio::time::timeout(Duration::from_millis(400), rx.recv()).await;
+        if let Ok(Some(text)) = quiet {
+            let v: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
+            assert_ne!(
+                v["notifyCorrelationId"], "corr-96-quiet",
+                "a subscription WITHOUT immediateFlag must not report at subscribe time: {v}"
+            );
+        }
+
+        // ── 3. the immediate EAC notification on a FIRST subscription ──
+        //
+        // A NumOfUEsUpdate carrying `eacNotificationUri` is the implicit EAC
+        // subscription. This nfId has not subscribed before, so 5.2.2.2.2 requires
+        // the current modes immediately — again a spawned dispatch.
+        let resp = client
+            .post_json(
+                "/nnsacf-nsac/v1/slices/ues",
+                &json!({
+                    "nfId": "amf-96-eac",
+                    "eacNotificationUri": cb,
+                    "ueACRequestInfo": [{
+                        "supi": "imsi-96-1",
+                        "anType": "3GPP_ACCESS",
+                        "acuOperationList": [{ "updateFlag": "INCREASE", "snssai": {"sst": 96} }]
+                    }]
+                }),
+            )
+            .await
+            .expect("response");
+        assert_eq!(resp.status, 204);
+
+        let mut saw_mode_list = false;
+        for _ in 0..8 {
+            let Ok(Some(text)) = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await
+            else {
+                break;
+            };
+            let v: serde_json::Value = serde_json::from_str(&text).expect("JSON body");
+            if v.get("eacModeList").is_some() {
+                // The 6.1.6.2.4 shape: a map keyed by S-NSSAI, not the old
+                // `eacMode` scalar.
+                assert!(
+                    v["eacModeList"].is_object(),
+                    "eacModeList is a map(EACMode): {v}"
+                );
+                assert!(
+                    v["eacModeList"]["96"].is_string(),
+                    "the immediate notification names the subscribed S-NSSAI's mode: {v}"
+                );
+                saw_mode_list = true;
+                break;
+            }
+        }
+        assert!(
+            saw_mode_list,
+            "a FIRST EAC subscription must immediately receive the current EAC modes"
+        );
+
+        // ── 4. the negative: a REPEAT subscription from the same nfId is silent ──
+        //
+        // An AMF re-sends its eacNotificationUri on every NumOfUEsUpdate, so
+        // re-notifying each time would flood it.
+        let resp = client
+            .post_json(
+                "/nnsacf-nsac/v1/slices/ues",
+                &json!({
+                    "nfId": "amf-96-eac",
+                    "eacNotificationUri": cb,
+                    "ueACRequestInfo": [{
+                        "supi": "imsi-96-2",
+                        "anType": "3GPP_ACCESS",
+                        "acuOperationList": [{ "updateFlag": "INCREASE", "snssai": {"sst": 96} }]
+                    }]
+                }),
+            )
+            .await
+            .expect("response");
+        assert_eq!(resp.status, 204);
+        // Drain briefly: an occupancy report may legitimately arrive for the
+        // immediateFlag subscription, but no second eacModeList may.
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(600);
+        while tokio::time::Instant::now() < deadline {
+            let Ok(Some(text)) = tokio::time::timeout(Duration::from_millis(150), rx.recv()).await
+            else {
+                continue;
+            };
+            let v: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
+            assert!(
+                v.get("eacModeList").is_none(),
+                "a repeat EAC subscription from the same nfId must not be re-notified: {v}"
+            );
+        }
+
+        receiver.stop().await.expect("receiver stops");
+        server.stop().await.expect("server stops");
+    }
+
     #[tokio::test]
     async fn test_http_slice_ee_subscription_and_eac_notification() {
         let (server, port, _ctx_guard) = start_nsacf_server().await;

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_updp_result.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_updp_result.rs
@@ -60,7 +60,15 @@ fn amfd_notify_request(pol_asso_id: &str, n1_payload: &[u8]) -> nextgcore_sbi::m
 /// COMPLETE with the matching PTI → real amfd notify → real pcfd callback flips
 /// the association Pending→Delivered (records the UPSC as installed UPSI).
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn complete_via_real_amfd_notify_delivers() {
+    // The PCF context is process-global and the UE-policy delivery events fire from
+    // this very handler, so a sibling test's firing would land on this test's stub
+    // consumer. `CONTEXT_GUARD` serialises every test in this file; poison-tolerant
+    // so one failure does not turn its siblings into misleading second failures.
+    let _guard = nextgcore_pcfd::test_support::CONTEXT_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
     // dev-profile deployment (issue #63). Declared rather than inherited from env.
     nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
@@ -84,7 +92,15 @@ async fn complete_via_real_amfd_notify_delivers() {
 /// REJECT with the matching PTI → association Failed, carrying the decoded
 /// D.6.3 per-instruction cause.
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn reject_via_real_amfd_notify_fails_with_cause() {
+    // The PCF context is process-global and the UE-policy delivery events fire from
+    // this very handler, so a sibling test's firing would land on this test's stub
+    // consumer. `CONTEXT_GUARD` serialises every test in this file; poison-tolerant
+    // so one failure does not turn its siblings into misleading second failures.
+    let _guard = nextgcore_pcfd::test_support::CONTEXT_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
     // dev-profile deployment (issue #63). Declared rather than inherited from env.
     nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
@@ -124,7 +140,15 @@ async fn reject_via_real_amfd_notify_fails_with_cause() {
 /// dropped: the callback still acks 204 (no crash) but the association stays
 /// Pending — Delivered is reached ONLY via a matching PTI.
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn wrong_pti_complete_is_dropped() {
+    // The PCF context is process-global and the UE-policy delivery events fire from
+    // this very handler, so a sibling test's firing would land on this test's stub
+    // consumer. `CONTEXT_GUARD` serialises every test in this file; poison-tolerant
+    // so one failure does not turn its siblings into misleading second failures.
+    let _guard = nextgcore_pcfd::test_support::CONTEXT_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
     // dev-profile deployment (issue #63). Declared rather than inherited from env.
     nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
@@ -143,4 +167,228 @@ async fn wrong_pti_complete_is_dropped() {
         DeliveryState::Pending,
         "a wrong-PTI COMPLETE must NOT deliver"
     );
+}
+
+// ─── Closing the #90 verification ceiling ────────────────────────────────────
+//
+// The three tests above prove the delivery-state correlation. What they do NOT
+// prove is the thing #90 actually added on top of it: that reaching a terminal
+// outcome puts a `SUCCESS_UE_POL_DEL_SP` / `UNSUCCESS_UE_POL_DEL_SP` report on the
+// Npcf_EventExposure feed. That producer was wired and type-checked, and nothing
+// observed its output arriving — the recorded "the helper is tested and the wiring
+// is not" pattern.
+//
+// These tests drive the SAME real handler and additionally read a STUB CONSUMER, so
+// the assertion is that the POST landed with the right event token and SUPI. The
+// subscription is created through pcfd's REAL SBI router rather than by seeding the
+// context, so the create path is part of what is proved.
+
+use std::sync::{Arc, Mutex};
+
+/// A stub Npcf_EventExposure consumer: records every notification body it is POSTed.
+/// Returns `(addr, recorded)`; the server is left running for the test's lifetime.
+async fn start_stub_consumer() -> (
+    std::net::SocketAddr,
+    Arc<Mutex<Vec<serde_json::Value>>>,
+    nextgcore_sbi::server::SbiServer,
+) {
+    let seen: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+    let addr = nextgcore_sbi::test_support::ephemeral_addr();
+    let server =
+        nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(addr));
+    server
+        .start(move |req: nextgcore_sbi::message::SbiRequest| {
+            let sink = Arc::clone(&sink);
+            async move {
+                if let Some(body) = req.http.content.as_deref() {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+                        sink.lock().expect("sink lock").push(v);
+                    }
+                }
+                nextgcore_sbi::message::SbiResponse::with_status(204)
+            }
+        })
+        .await
+        .expect("stub Npcf_EventExposure consumer starts");
+    (addr, seen, server)
+}
+
+/// Subscribe to both UE-policy delivery events through pcfd's REAL router, and
+/// return the created resource's URI so the test can remove it again.
+async fn subscribe_to_delivery_events(addr: std::net::SocketAddr, notif_id: &str) -> String {
+    let body = serde_json::json!({
+        "notifUri": format!("http://127.0.0.1:{}/pc-events", addr.port()),
+        "notifId": notif_id,
+        "eventSubs": ["SUCCESS_UE_POL_DEL_SP", "UNSUCCESS_UE_POL_DEL_SP"],
+    });
+    let req = nextgcore_sbi::message::SbiRequest::post("/npcf-eventexposure/v1/subscriptions")
+        .with_json_body(&body)
+        .expect("subscription body serialises");
+    let resp = pcf_sbi_request_handler(req).await;
+    assert_eq!(
+        resp.status, 201,
+        "the subscription must be created through the real router"
+    );
+    resp.http
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("location"))
+        .map(|(_, v)| v.clone())
+        .expect("create answers with a Location header")
+}
+
+/// Remove the subscription again, so a later test's firing cannot be POSTed at a
+/// stub consumer this test has already stopped.
+async fn delete_subscription(location: &str) {
+    let resp = pcf_sbi_request_handler(nextgcore_sbi::message::SbiRequest::delete(location)).await;
+    assert_eq!(resp.status, 204, "the subscription must be removable");
+}
+
+/// A matching-PTI COMPLETE must put a `SUCCESS_UE_POL_DEL_SP` report on the feed,
+/// carrying the association's SUPI so a consumer can correlate it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(clippy::await_holding_lock)]
+async fn a_delivered_ue_policy_reports_success_to_a_real_subscriber() {
+    // The PCF context is process-global and the UE-policy delivery events fire from
+    // this very handler, so a sibling test's firing would land on this test's stub
+    // consumer. `CONTEXT_GUARD` serialises every test in this file; poison-tolerant
+    // so one failure does not turn its siblings into misleading second failures.
+    let _guard = nextgcore_pcfd::test_support::CONTEXT_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+    let (addr, seen, server) = start_stub_consumer().await;
+    let location = subscribe_to_delivery_events(addr, "notif-e2e-success").await;
+
+    let id = seed_pending_association(0xA1);
+    let complete = nas_updp::ManageUePolicyComplete { pti: 0xA1 }
+        .encode()
+        .expect("COMPLETE encodes");
+    let resp = pcf_sbi_request_handler(amfd_notify_request(&id, &complete)).await;
+    assert_eq!(resp.status, 204);
+
+    let recorded = seen.lock().expect("sink lock").clone();
+    let ours: Vec<&serde_json::Value> = recorded
+        .iter()
+        .filter(|v| v["notifId"] == "notif-e2e-success")
+        .collect();
+    assert_eq!(
+        ours.len(),
+        1,
+        "exactly one report must have landed, got {recorded:?}"
+    );
+    let notif = &ours[0]["eventNotifs"][0];
+    assert_eq!(
+        notif["event"], "SUCCESS_UE_POL_DEL_SP",
+        "a Delivered outcome reports SUCCESS_UE_POL_DEL_SP"
+    );
+    assert_eq!(
+        notif["supi"], "imsi-001010000006e60",
+        "the report carries the SUPI a consumer correlates on"
+    );
+    assert!(
+        notif["timeStamp"]
+            .as_str()
+            .is_some_and(|t| t.ends_with('Z')),
+        "the report carries an RFC 3339 UTC timeStamp: {notif:?}"
+    );
+
+    delete_subscription(&location).await;
+    server.stop().await.expect("stub consumer stops");
+}
+
+/// A matching-PTI REJECT reports `UNSUCCESS_UE_POL_DEL_SP`, and deliberately does
+/// NOT carry `delivFailure`: TS 29.522 `Failure` enumerates NORTHBOUND delivery
+/// failures, and a D.6.3 UE-side rejection is not one of them, so mapping it to a
+/// token would misreport the reason.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(clippy::await_holding_lock)]
+async fn a_rejected_ue_policy_reports_unsuccess_to_a_real_subscriber() {
+    // The PCF context is process-global and the UE-policy delivery events fire from
+    // this very handler, so a sibling test's firing would land on this test's stub
+    // consumer. `CONTEXT_GUARD` serialises every test in this file; poison-tolerant
+    // so one failure does not turn its siblings into misleading second failures.
+    let _guard = nextgcore_pcfd::test_support::CONTEXT_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+    let (addr, seen, server) = start_stub_consumer().await;
+    let location = subscribe_to_delivery_events(addr, "notif-e2e-unsuccess").await;
+
+    let id = seed_pending_association(0xA2);
+    let reject = nas_updp::ManageUePolicyCommandReject {
+        pti: 0xA2,
+        result: nas_updp::UePolicySectionManagementResult {
+            subresults: vec![nas_updp::UePolicySectionManagementSubresult {
+                plmn_id: nextgcore_nas::common::types::PlmnId::new([0, 0, 1], [0, 1, 0xf], 2),
+                results: vec![nas_updp::UePolicyResult {
+                    upsc: 0x0001,
+                    failed_instruction_order: 1,
+                    cause: nas_updp::UE_POLICY_CAUSE_PROTOCOL_ERROR_UNSPECIFIED,
+                }],
+            }],
+        },
+    }
+    .encode()
+    .expect("REJECT encodes");
+    let resp = pcf_sbi_request_handler(amfd_notify_request(&id, &reject)).await;
+    assert_eq!(resp.status, 204);
+
+    let recorded = seen.lock().expect("sink lock").clone();
+    let ours: Vec<&serde_json::Value> = recorded
+        .iter()
+        .filter(|v| v["notifId"] == "notif-e2e-unsuccess")
+        .collect();
+    assert_eq!(ours.len(), 1, "exactly one report, got {recorded:?}");
+    let notif = &ours[0]["eventNotifs"][0];
+    assert_eq!(notif["event"], "UNSUCCESS_UE_POL_DEL_SP");
+    assert_eq!(notif["supi"], "imsi-001010000006e60");
+    assert!(
+        notif.get("delivFailure").is_none(),
+        "a UE-side D.6.3 rejection must not be reported as a TS 29.522 Failure: {notif:?}"
+    );
+
+    delete_subscription(&location).await;
+    server.stop().await.expect("stub consumer stops");
+}
+
+/// The NEGATIVE half, and the one that makes the two above mean something: a
+/// non-terminal outcome must put NOTHING on the feed. A wrong-PTI COMPLETE is a
+/// stale or duplicate command (TS 24.501 D.2.1.6) and the delivery is still in
+/// flight, so reporting it would tell a consumer the delivery concluded when it has
+/// not.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(clippy::await_holding_lock)]
+async fn a_non_terminal_outcome_reports_nothing() {
+    // The PCF context is process-global and the UE-policy delivery events fire from
+    // this very handler, so a sibling test's firing would land on this test's stub
+    // consumer. `CONTEXT_GUARD` serialises every test in this file; poison-tolerant
+    // so one failure does not turn its siblings into misleading second failures.
+    let _guard = nextgcore_pcfd::test_support::CONTEXT_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+    let (addr, seen, server) = start_stub_consumer().await;
+    let location = subscribe_to_delivery_events(addr, "notif-e2e-none").await;
+
+    let id = seed_pending_association(0xA3);
+    let stale = nas_updp::ManageUePolicyComplete { pti: 0xAF }
+        .encode()
+        .expect("COMPLETE encodes");
+    let resp = pcf_sbi_request_handler(amfd_notify_request(&id, &stale)).await;
+    assert_eq!(resp.status, 204);
+
+    let recorded = seen.lock().expect("sink lock").clone();
+    let ours: Vec<&serde_json::Value> = recorded
+        .iter()
+        .filter(|v| v["notifId"] == "notif-e2e-none")
+        .collect();
+    assert!(
+        ours.is_empty(),
+        "a stale answer must not be reported as a delivery result: {ours:?}"
+    );
+
+    delete_subscription(&location).await;
+    server.stop().await.expect("stub consumer stops");
 }


### PR DESCRIPTION
Spec: [`specs/fix-close-three-notification-verification-ceilings.md`](specs/fix-close-three-notification-verification-ceilings.md).

No issue number — this is the follow-up the #90 / #96 / #98 specs each recorded as a ceiling rather than
papering over. All three had the same shape: **a producer wired and type-checked while nothing observed its
output arriving** — the recorded *"the helper is tested and the wiring is not, and the better the helper's test
the more convincing the illusion"* pattern. Closed together because the fix for each is the same move, and
doing them together writes the stub-consumer shape once.

## (a) `pcfd` #90 — the UE-policy delivery events

`tests/strict_peer_updp_result.rs` already drove `handle_ue_policy_n1_notify` through amfd's **real**
`N1MessageNotify` builder — but asserted only the delivery *state*, so the Npcf_EventExposure feed was
invisible. Three tests added, each creating the subscription through pcfd's **real router** so the create path
is part of what is proved:

- a matching-PTI COMPLETE puts exactly one `SUCCESS_UE_POL_DEL_SP` on the feed, with the SUPI and an RFC 3339 UTC `timeStamp`;
- a REJECT reports `UNSUCCESS_UE_POL_DEL_SP` and **must not** carry `delivFailure` — TS 29.522 `Failure`
  enumerates *northbound* delivery failures, and a D.6.3 UE-side rejection is not one of them;
- **the negative**, which makes the other two mean something: a wrong-PTI COMPLETE is a stale command with the
  delivery still in flight, so it must report **nothing**.

### A race found and fixed while writing these

The first run saw **four** notifications where one was expected, including the wrong event token. pcfd's
context is process-global and the delivery events fire from this very handler, so each test's firing was POSTed
to every test's subscription — including the three **pre-existing** tests in the file, one of which fires
`SUCCESS_UE_POL_DEL_SP` itself. Fixed by taking `CONTEXT_GUARD` in **all six** tests (the three new *and* the
three already there, because they are producers too) and deleting each new subscription before releasing the
guard, so a later firing cannot be POSTed at a stopped stub. 8 consecutive clean runs.

## (b) `bsfd` #98 — the UE-binding notifications

The PDU-session pair was proved end-to-end; the UE-binding pair was wired with its matching covered, and
nothing saw a notification arrive. Mirrored for `/nbsf-management/v1/pcf-ue-bindings`.

The load-bearing assertion is **not** that a notification arrives — it is that it carries **`pcfForUeInfo` and
not `pcfForPduSessInfos`**. `BsfEventNotification` models the two binding kinds with different members, so
using one for the other tells a consumer the wrong resource changed, and a test that only counted
notifications would pass either way. A distinct SUPI keeps it from cross-reporting with the PDU-session test.

## (c) `nsacfd` #96 — the two subscribe-time dispatches

Re-checking what was already covered mattered: the picture was **better** than the task recorded and the gap
narrower. Already covered — an EAC notification following a mode *transition* (observed at a real receiver),
and the mode-list construction plus first/repeat decision (pure logic). What nothing observed was the two
dispatches at **subscribe time**, both via `tokio::spawn` and so invisible to a test that checks only the 201:

1. **the `immediateFlag` report** (§5.3.2.2.2) — subscribed with `REACHING_THRESHOLD` at 90% and **zero
   occupancy**, so the trigger gate would suppress it. It arrives only because `immediateFlag` bypasses the
   gate, which cannot be seen from the 201. The `SACEventReport` shape is asserted so it cannot pass on a bare POST.
2. **the immediate EAC notification on a FIRST subscription** (§5.2.2.2.2) — asserting the §6.1.6.2.4
   `eacModeList` **map** shape, not the old scalar.

Both negatives included: no flag → nothing at subscribe time; a **repeat** subscription from the same `nfId` is
not re-notified (an AMF re-sends its `eacNotificationUri` on every update, so re-notifying would flood it).

## Verification

- **Workspace 5943 passed / 0 failed across three consecutive runs** (baseline 5938). Three runs because the
  new tests bind ports and touch process-global state.
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
- **Nine claims revert-verified — and here the reverts *are* the deliverable**, since the whole point is that
  the observers can fail:

| # | producer reverted | test that bit |
|---|---|---|
| 1 | `pcf_report_pc_event` call deleted | `a_delivered_ue_policy_reports_success_to_a_real_subscriber` |
| 2 | the `Rejected` arm mapped to `None` | `a_rejected_ue_policy_reports_unsuccess_to_a_real_subscriber` |
| 3 | the non-terminal arm made to report SUCCESS | `a_non_terminal_outcome_reports_nothing` |
| 4 | `spawn_bsf_notifications` for UE-binding registration deleted | `ue_binding_register_deregister_delivers_notifications` |
| 5 | `pcfForUeInfo` swapped for `pcfForPduSessInfos` | same |
| 6 | the `if immediate { … }` block deleted | `subscribe_time_dispatches_actually_arrive_at_the_consumer` |
| 7 | `immediate` forced to `true` | same (negative half) |
| 8 | the first-subscription EAC dispatch deleted | same |
| 9 | `first` forced to `true` | same (repeat negative) |

Reverts 3, 7 and 9 are the **inverted** kind — they make the producer fire when it should not — which is what
proves the three negative assertions are load-bearing rather than satisfied by a path that never arrives. Each
revert was checked for a unique anchor, for compiling, and for the named test actually running.

## Ceilings

- **The un-driveable NGAP middle is still elided in (a)** — the uplink NAS path needs live SCTP, so the test
  builds the exact `N1MessageNotify` amfd emits. Inherited from the three pre-existing tests in the file.
- **No test drives a real process**, only real handlers in-process, so a misconfigured listener or a
  deployment-only callback URI stays out of reach.
- **`nsacfd`'s repeat-subscription negative is a 600 ms drain** rather than proven for all time — the only
  option for a "nothing happens" assertion about a spawned task; the window is generous relative to the
  loopback delivery the positives measure in the same test.

## GitNexus

No GitNexus MCP server connected (31st consecutive PR). Blast radius established by `grep` plus per-crate and
whole-workspace `--all-targets` builds.