### PR TITLE
docs(bsfd): decide the durability question — memory-only, stated and guarded

### DIFF
--- a/docs-book/src/configuration/bsf.md
+++ b/docs-book/src/configuration/bsf.md
@@ -4,7 +4,7 @@ The BSF (Binding Support Function, `nextgcore-bsfd`) stores and serves PCF bindi
 
 Configuration is split between a YAML file (default path `/etc/nextgcore/bsf.yaml`, overridable with `-c/--config`; the docker deployment passes `-c /etc/nextgcore/bsf.yaml`) and command-line flags. Unusually for this codebase, the YAML SBI `server` entry **overrides** the CLI `--sbi-addr`/`--sbi-port` (so the NRF NFProfile advertises a routable endpoint instead of `0.0.0.0`, per the code comment); everything else — TLS flags, session capacity, log level — is CLI-only. The only environment variable the binary reads is `OTEL_EXPORTER_OTLP_ENDPOINT`.
 
-> **Honesty note:** BSF behavior is validated by this project's own unit tests and matched-simulator Docker E2E runs (84/84 as of 2026-07-02), not by third-party conformance certification. Known gaps visible in the source: the `--tls` flag does **not** enable TLS on the actual HTTP/2 listener (it only flips the advertised URI scheme in the legacy NF-instance metadata built in `sbi_path.rs`); the MongoDB persistence layer (`bsf_bindings` collection) is best-effort and the daemon never initializes a MongoDB connection itself — no `nextgcore_mongoc_init`/`nextgcore_dbi_init` call exists in this crate, so in the standalone binary bindings live in memory only; and `sbi_path.rs` still contains legacy placeholder helpers (`bsf_sbi_send_request`/`bsf_sbi_discover_and_send` return a hardcoded transaction ID).
+> **Honesty note:** BSF behavior is validated by this project's own unit tests and matched-simulator Docker E2E runs (84/84 as of 2026-07-02), not by third-party conformance certification. Known gaps visible in the source: the `--tls` flag does **not** enable TLS on the actual HTTP/2 listener (it only flips the advertised URI scheme in the legacy NF-instance metadata built in `sbi_path.rs`); the daemon is **memory-only** by decision — bindings and subscriptions do not survive a restart, see [Durability](#durability-bsfd-is-a-memory-only-nf); and `sbi_path.rs` still contains legacy placeholder helpers (`bsf_sbi_send_request`/`bsf_sbi_discover_and_send` return a hardcoded transaction ID).
 
 ## Example configuration
 
@@ -103,3 +103,55 @@ Runtime knobs with real defaults from the clap `Args` struct in `src/bins/nextgc
 - **Binding TTL**: every PDU-session binding arms an expiry timer — from the RFC 3339 `expiry` attribute when supplied (invalid values are rejected 400), otherwise the default TTL of **3600 s** (`timer::defaults::BINDING_EXPIRY` in `src/bins/nextgcore-bsfd/src/timer.rs`). The event loop removes expired bindings, and expired-but-unswept bindings are excluded from GET/discovery.
 - **NRF registration and load reporting**: the BSF PUTs an NFProfile (`nfType: BSF`, service `nbsf-management`, `allowedNfTypes: PCF/SMF/SCP`, `heartBeatTimer: 10`) to `/nnrf-nfm/v1/nf-instances/{id}` and, on success, spawns a heartbeat worker every **5 s** that PATCHes a live `/load` gauge computed as bindings vs. `--max-sess` capacity (TS 29.510 §5.2.2.3.2 per code comment). Registration failure is non-fatal ("will operate without NRF"). Quirk: passing `--nrf-uri` on the CLI additionally triggers a second, legacy registration with a separate random NF instance ID from `bsf_sbi_open` (`sbi_path.rs`); the YAML-configured URI only drives the main registration path.
 - **Environment variables**: the only one read is `OTEL_EXPORTER_OTLP_ENDPOINT` (default `http://jaeger:4317`) for the OpenTelemetry OTLP exporter. `RUST_LOG` is not honored, and MongoDB persistence has no URI source in this binary at all — the `bsf_bindings` upsert/delete/load calls are best-effort no-ops (failures logged at debug) unless some in-process embedder initializes the shared DBI layer first.
+
+## Durability: bsfd is a memory-only NF
+
+**Decided deliberately, not by omission.** Every resource this BSF holds — PDU-session bindings, UE
+bindings, MBS bindings and event subscriptions — lives in process memory and is **lost when the daemon
+restarts**. There is no state file and no database connection: the `bsf_bindings` MongoDB helpers exist in
+`context.rs` but the daemon never calls `nextgcore_mongoc_init` / `nextgcore_dbi_init`, so every
+upsert/delete/load is a best-effort no-op that logs at debug. A source guard
+(`bsfd_is_declared_memory_only` in `context.rs`) fails the build's test suite if a future change initialises
+the DBI layer without updating this section, so this statement cannot quietly stop being true.
+
+### What a consumer must do
+
+After a BSF restart, a consumer must:
+
+1. **re-register its bindings.** A `GET /pcfBindings?ipv4Addr=…` for a session registered before the restart
+   returns **204** (no match), which is the same answer as "never registered" — deliberately, because it is
+   the truth. The PCF or SMF that owns the binding is the only party that can restore it.
+2. **re-subscribe.** A `POST /nbsf-management/v1/subscriptions` from before the restart is gone, and no
+   notification will be delivered for it. `DELETE` on its `{subId}` answers 404.
+
+Nothing is silently degraded: there is no path that returns a stale binding or accepts a notification
+subscription it will not honour.
+
+### Why restoring bindings would be *worse* than losing them
+
+This is the reason the memory-only posture is a decision rather than a gap to be filled later.
+
+A TS 29.521 binding is a **live** association between a UE's PDU session and the PCF currently serving it.
+While the BSF is down, that association can change: the session can be released, or a different PCF can take
+it over. A restored binding therefore asserts a fact that may no longer hold — and a consumer that reads it
+is told **the wrong PCF**, which is worse than being told nothing, because "nothing" makes it re-discover
+while a wrong answer makes it send policy traffic to a PCF that does not serve the session.
+
+Restoring subscriptions **alone** would be worse still, and is specifically not done: a subscriber that
+survived a restart while its bindings did not would either be notified about nothing at all, or — if the
+sweep treated absent bindings as removed — be told bindings "deregistered" that were simply never restored.
+That is a fabricated event, which is the failure this project treats as most serious.
+
+### What would have to change to make it durable
+
+Recorded so the option stays open and costed, rather than being rediscovered:
+
+1. **bindings first, subscriptions with them** — never subscriptions alone, for the reason above.
+2. a URI source for the DBI layer (there is none in this binary today: no config key, no environment
+   variable) plus a `nextgcore_dbi_init` call on the startup path, and a decision about whether a database
+   that is unreachable at boot is fatal or degrades to memory-only;
+3. a **recovery-time** answer for the staleness above — most plausibly writing `recoveryTime` on each
+   binding and refusing to serve a restored binding whose owning PCF has not reconfirmed it, which is a
+   protocol addition rather than a storage change;
+4. the durable-snapshot hazards this project has already paid for elsewhere: restore **before** the SBI
+   listener accepts, persist removals as well as inserts, and never resurrect a deleted record.

--- a/specs/fix-bsfd-declare-memory-only-durability.md
+++ b/specs/fix-bsfd-declare-memory-only-durability.md
@@ -1,0 +1,106 @@
+# bsfd durability: decide memory-only, say so, and guard the statement
+
+Verified against `main` @ `4ec257a`. No issue number — this is the decision the #98 spec deferred and
+TASKS.md carried: *"Either make bindings durable first and subscriptions with them, or state explicitly that
+bsfd is a memory-only NF and that consumers must re-subscribe after a restart."*
+
+**The decision is memory-only.** Recorded below with the reasoning, so it is a posture rather than a gap.
+
+## The premises, re-verified
+
+Both hold exactly as the task states:
+
+* `grep -rn 'nextgcore_mongoc_init\|nextgcore_dbi_init' src/bins/nextgcore-bsfd/` returns **nothing**. The
+  daemon never initialises the shared DBI layer.
+* The `bsf_bindings` helpers exist (`context.rs`: `bsf_db_upsert_binding`, `bsf_db_delete_binding`,
+  `bsf_db_load_all_bindings`, each with exactly one caller) and every call is best-effort — failures logged at
+  debug — so in the standalone binary bindings live in memory only.
+
+And the follow-on: `lib.rs` stores a subscription verbatim in memory, so subscriptions were never durable
+either.
+
+## Why memory-only, rather than "durable, later"
+
+The task frames this as a choice between two honest options. It is more than that: **restoring bindings would
+be worse than losing them**, which turns the choice into a decision with a reason.
+
+A TS 29.521 binding is a **live** association between a UE's PDU session and the PCF *currently* serving it.
+While the BSF is down that association can change — the session can be released, or another PCF can take it
+over. A restored binding therefore asserts a fact that may no longer hold, and a consumer reading it is told
+**the wrong PCF**. That is worse than being told nothing: "nothing" (a `204` from
+`GET /pcfBindings?ipv4Addr=…`) makes the consumer re-discover, whereas a wrong answer makes it send policy
+traffic to a PCF that does not serve the session.
+
+Restoring **subscriptions alone** — the thing the task explicitly forbids — would be worse still, and now
+there is a sharper way to say why: a subscriber that survived a restart while its bindings did not would
+either be notified about nothing at all, or, if the expiry/removal sweep read absent bindings as removed, be
+told bindings *"deregistered"* that were simply never restored. That is a **fabricated event**, which this
+project treats as the most serious class of defect — the same reason a stub returning `Ok` is treated as a
+lie rather than a placeholder.
+
+So durability here is not a missing feature to be added when convenient. It requires a *recovery-time answer*
+first, which is a protocol addition rather than a storage change.
+
+## What was written
+
+1. **A first-class `## Durability: bsfd is a memory-only NF` section** in
+   `docs-book/src/configuration/bsf.md`, placed after the behaviour notes. It states what is lost, what a
+   consumer must do (re-register bindings, re-subscribe), why restoring bindings would be worse, and — so the
+   option stays costed rather than rediscovered — the four things that would have to change to make it
+   durable: bindings first and subscriptions with them; a URI source plus an init call and a decision about
+   an unreachable database at boot; a recovery-time answer for the staleness above; and the durable-snapshot
+   hazards this project has already paid for (restore before the listener accepts, persist removals, never
+   resurrect a deleted record).
+   The pre-existing "Honesty note" bullet that half-said this now points at the section instead of restating
+   it, so there is one statement rather than two that can drift.
+2. **The same statement in the code**, as a module doc comment on `context.rs`. A claim that lives only in a
+   book is easy to contradict from the source; a reader of `bsf_db_upsert_binding` now finds the posture
+   where the dormant helper is.
+3. **A source guard that keeps it true** — `tests::bsfd_is_declared_memory_only`. It reads bsfd's own
+   sources and fails if any of them calls `nextgcore_mongoc_init` or `nextgcore_dbi_init`, naming the doc
+   page and the module comment in the failure message. Modelled on `nextgcore_core::signal`'s `--kill` guard,
+   including its self-check: it asserts the persistence helpers are still **present**, so it cannot pass by
+   having nothing left to look at.
+
+The Mongo helpers are deliberately **kept**. Deleting them would remove the option and lose the schema work
+in `sess_to_doc`; documenting them as the dormant half of a stated posture is what the task asked for.
+
+## Verification
+
+Workspace: **5939 passed / 0 failed** over two consecutive runs (baseline 5938; the added test is the guard).
+`cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
+
+**The guard was revert-verified**, which for a guard is the only thing that distinguishes it from decoration.
+Injecting `nextgcore_dbi::mongoc::nextgcore_dbi_init("mongodb://localhost/nextgcore")` into `bsfd/src/lib.rs`
+makes it **FAIL**, with the offending line quoted in the message.
+
+### The guard's first version had a false negative, and the revert is what exposed it
+
+Worth recording because it is the failure mode a passing test hides. The first version skipped any line
+containing a `"` character, in order not to match the guard's own string literals — which would have
+**silently skipped a real `nextgcore_dbi_init("mongodb://…")` call**, i.e. the most likely form of the exact
+thing being guarded against. A guard that cannot see the realistic case is worse than no guard, because it
+reports safety.
+
+Fixed by building both markers with `concat!("nextgcore_", "dbi_init")` so this file never contains either as
+a contiguous string, which removes the need for the heuristic entirely. The revert above uses the
+string-argument form deliberately, so it proves the fix and not just the guard.
+
+The first revert attempt also failed for a *harness* reason and was treated as inconclusive rather than as a
+pass: the injection was prepended to `lib.rs`, which does not compile because inner (`//!`) doc comments must
+be the first thing in a file. Appending it compiled, and then it bit.
+
+## Ceilings
+
+* **No test proves a restart loses state**, because nothing in this repo drives a bsfd process through a
+  restart. The claim rests on there being no persistence call path at all, which the guard checks
+  structurally — a stronger check than a test that restarted a process and observed an empty store, since
+  that would pass on a database that merely happened to be unreachable.
+* **The docs-book statement is prose**, and prose can still drift from behaviour in ways a grep cannot see —
+  for example if a future in-process embedder initialises the DBI layer from *outside* bsfd, which the guard
+  cannot detect because it only reads bsfd's sources. That path is named in the existing env-vars bullet and
+  is unchanged by this decision.
+* **The "Honesty note" also mentions `bsf_sbi_send_request` / `bsf_sbi_discover_and_send`**, which the #234
+  change deletes. That sentence is still accurate on this branch; whichever change lands second should drop
+  that clause. Flagged rather than fixed here, because editing it on this branch would conflict with nothing
+  and mislead a reviewer comparing against `main`.

--- a/src/bins/nextgcore-bsfd/src/context.rs
+++ b/src/bins/nextgcore-bsfd/src/context.rs
@@ -1,6 +1,37 @@
 //! BSF Context Management
 //!
 //! Port of src/bsf/context.c - BSF context with session management and IP address hashing
+//!
+//! # Durability: this is a MEMORY-ONLY NF, by decision
+//!
+//! Every resource held here — PDU-session bindings, UE bindings, MBS bindings and
+//! event subscriptions — lives in process memory and is lost on restart. The
+//! `bsf_bindings` MongoDB helpers below exist, but the daemon never calls
+//! `nextgcore_mongoc_init` / `nextgcore_dbi_init`, so every upsert, delete and load
+//! is a best-effort no-op logging at debug. There is no config key and no
+//! environment variable that would supply a database URI.
+//!
+//! **Restoring bindings would be worse than losing them**, which is why this is a
+//! decision and not a gap. A TS 29.521 binding is a LIVE association between a UE's
+//! PDU session and the PCF currently serving it. While the BSF is down that
+//! association can change — the session can be released, or another PCF can take it
+//! over — so a restored binding asserts a fact that may no longer hold, and a
+//! consumer reading it is told the WRONG PCF. "No binding" makes the consumer
+//! re-discover; a wrong binding makes it send policy traffic to a PCF that does not
+//! serve the session.
+//!
+//! Restoring subscriptions ALONE would be worse still, and is specifically not
+//! done: a subscriber that survived a restart while its bindings did not would
+//! either be notified about nothing, or — if the sweep read absent bindings as
+//! removed — be told bindings "deregistered" that were simply never restored, which
+//! is a fabricated event.
+//!
+//! Consumers must therefore re-register their bindings and re-subscribe after a
+//! restart. `docs-book/src/configuration/bsf.md` states this for interop partners,
+//! and [`tests::bsfd_is_declared_memory_only`] fails if a future change initialises
+//! the DBI layer without updating that page — so the posture cannot quietly stop
+//! being true. The same page records what would have to change to make it durable,
+//! bindings first and subscriptions with them.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -1757,6 +1788,68 @@ mod persistence_visibility_guards {
 
 #[cfg(test)]
 mod tests {
+    /// Guards the memory-only durability posture documented on this module and in
+    /// `docs-book/src/configuration/bsf.md`.
+    ///
+    /// A documented posture that nothing checks is a posture that stops being true
+    /// quietly. This reads bsfd's own sources: if a future change initialises the
+    /// shared DBI layer, the daemon is no longer memory-only and both the module doc
+    /// and the docs-book page are wrong — so the test fails and names them.
+    ///
+    /// Modelled on `nextgcore_core::signal`'s `--kill` guard, including its
+    /// self-check: it asserts the persistence helpers are still PRESENT, so the test
+    /// cannot pass by silently having nothing left to look at.
+    #[test]
+    fn bsfd_is_declared_memory_only() {
+        let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        assert!(src_dir.is_dir(), "expected {} to exist", src_dir.display());
+
+        let mut initialisers = Vec::new();
+        let mut saw_persistence_helpers = false;
+        for entry in std::fs::read_dir(&src_dir).expect("read bsfd src/") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).unwrap_or_default();
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            // The two calls that would give this daemon a real database.
+            //
+            // Built by concatenation so THIS FILE never contains either marker as a
+            // contiguous string. The first version skipped any line containing a
+            // quote, to avoid matching the guard's own literals -- which would have
+            // silently skipped a real `..._dbi_init("mongodb://...")` call, i.e. the
+            // most likely form of the very thing being guarded against. Removing the
+            // need for that heuristic removes the false negative.
+            for marker in [
+                concat!("nextgcore_", "mongoc_init"),
+                concat!("nextgcore_", "dbi_init"),
+            ] {
+                for line in text.lines() {
+                    if line.contains(marker) && !line.trim_start().starts_with("//") {
+                        initialisers.push(format!("{name}: {}", line.trim()));
+                    }
+                }
+            }
+            if text.contains("fn bsf_db_upsert_binding") {
+                saw_persistence_helpers = true;
+            }
+        }
+
+        assert!(
+            saw_persistence_helpers,
+            "the guard expected to find the bsf_bindings persistence helpers; it found none, so              it is no longer checking anything"
+        );
+        assert!(
+            initialisers.is_empty(),
+            "bsfd now initialises the DBI layer, so it is NOT memory-only: {initialisers:?}.              Update the durability section of docs-book/src/configuration/bsf.md and this              module's doc comment, and decide what a restored binding owes a consumer \
+             (see that section's 'Why restoring bindings would be worse')."
+        );
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
Spec: [`specs/fix-bsfd-declare-memory-only-durability.md`](specs/fix-bsfd-declare-memory-only-durability.md).

No issue number — this is the decision the #98 spec deferred and TASKS.md carried: *"Either make bindings
durable first and subscriptions with them, or state explicitly that bsfd is a memory-only NF and that consumers
must re-subscribe after a restart."*

**The decision is memory-only**, with a reason rather than by omission.

## Premises re-verified

- `grep -rn 'nextgcore_mongoc_init\|nextgcore_dbi_init' src/bins/nextgcore-bsfd/` returns **nothing** — the
  daemon never initialises the shared DBI layer.
- The `bsf_bindings` helpers exist with one caller each, and every call is best-effort with failures logged at
  debug.
- The follow-on the task implied: `lib.rs` stores a subscription **verbatim in memory**, so subscriptions were
  never durable either.

## Why memory-only, rather than "durable, later"

The task frames a choice between two honest options. It is more than that: **restoring bindings would be worse
than losing them**, which turns the choice into a decision with a reason.

A TS 29.521 binding is a **live** association between a UE's PDU session and the PCF *currently* serving it.
While the BSF is down that can change — the session can be released, or another PCF can take it over. A
restored binding therefore asserts a fact that may no longer hold, and a consumer reading it is told **the
wrong PCF** — worse than being told nothing, because a `204` makes it re-discover while a wrong answer makes it
send policy traffic to a PCF that does not serve the session.

Restoring **subscriptions alone** (which the task forbids) would be worse still: a subscriber that survived
while its bindings did not would be notified about nothing, or — if the sweep read absent bindings as removed —
be told bindings *"deregistered"* that were simply never restored. That is a **fabricated event**, the class
this project treats as most serious.

So durability needs a **recovery-time answer** first, and that is a protocol addition rather than a storage
change.

## What was written — three ways, so the posture cannot drift

1. **A first-class `## Durability: bsfd is a memory-only NF` section** in `docs-book/src/configuration/bsf.md`:
   what is lost, what a consumer must do (re-register bindings, re-subscribe), why restoring would be worse,
   and the four things that would have to change to make it durable — so the option stays *costed* rather than
   rediscovered. The pre-existing "Honesty note" that half-said this now **points at** the section instead of
   restating it, so there is one statement rather than two that can diverge.
2. **The same statement as a module doc comment on `context.rs`** — a claim living only in a book is easy to
   contradict from the source, and a reader of `bsf_db_upsert_binding` should find the posture beside the
   dormant helper.
3. **A source guard**, `tests::bsfd_is_declared_memory_only`, which reads bsfd's own sources and fails if any
   initialises the DBI layer, naming the doc page and the module comment in its message. Modelled on
   `nextgcore_core::signal`'s `--kill` guard **including its self-check**: it asserts the persistence helpers
   are still *present*, so it cannot pass by having nothing left to look at.

The Mongo helpers are deliberately **kept** — deleting them would remove the option and lose the schema work in
`sess_to_doc`.

## Verification

- **Workspace 5939 passed / 0 failed** over two consecutive runs (baseline 5938; the addition is the guard).
- `cargo clippy --workspace` and `cargo fmt --all -- --check` clean.
- **The guard was revert-verified** — for a guard, the only thing separating it from decoration. Injecting
  `nextgcore_dbi_init("mongodb://localhost/nextgcore")` into `bsfd/src/lib.rs` makes it **FAIL**, with the
  offending line quoted.

### The guard's first version had a false negative, and the revert exposed it

It skipped any line containing a `"` so as not to match its own literals — which would have **silently skipped
a real `nextgcore_dbi_init("mongodb://…")` call**, the most likely form of the exact thing being guarded
against. A guard that cannot see the realistic case is worse than no guard, because it reports safety. Fixed by
building both markers with `concat!("nextgcore_", "dbi_init")` so this file never contains either as a
contiguous string, removing the need for the heuristic. The revert deliberately uses the string-argument form,
so it proves the fix and not just the guard.

The first revert attempt also failed for a **harness** reason and was treated as inconclusive rather than as a
pass: prepending the injection to `lib.rs` cannot compile, because inner (`//!`) doc comments must be the first
thing in a file.

## Ceilings

- **No test proves a restart loses state** — nothing drives a bsfd process through a restart. The claim rests
  on there being no persistence call path at all, which the guard checks *structurally* — a stronger check than
  restarting and observing an empty store, which would pass on a merely-unreachable database.
- **The guard cannot see an in-process embedder** initialising the DBI layer from *outside* bsfd; the existing
  env-vars bullet already names that path.
- **The "Honesty note" still mentions `bsf_sbi_send_request` / `bsf_sbi_discover_and_send`**, which the #234
  change (PR #245) deletes. Accurate on this branch, so whichever lands second should drop that clause.

## GitNexus

No GitNexus MCP server connected (32nd consecutive PR). Blast radius established by `grep` plus
`cargo check -p nextgcore-bsfd --all-targets`.