### PR TITLE
fix(scpd): select the producer endpoint by service name and API version, not nfServices[0] (#207)

### DIFF
--- a/specs/fix-scpd-model-d-service-and-version-endpoint-selection.md
+++ b/specs/fix-scpd-model-d-service-and-version-endpoint-selection.md
@@ -1,0 +1,164 @@
+# nextgcore #207 (scpd Model D): select the producer endpoint by service name and API version
+
+Verified against `main` @ `645dcc7`. The issue's cites are from `562b4a1`; all three were
+re-verified and all three still hold, at the same line numbers.
+
+## Verified against current main
+
+| claim in the issue | site on `645dcc7` | still true? |
+|---|---|---|
+| `select_nf_instance` filters by **health only**, then priority/capacity/load | `bins/nextgcore-scpd/src/sbi_path.rs:145-174` | yes |
+| the endpoint is taken from the first service unconditionally | `sbi_path.rs:439-478` (`first_service`), consumed at `proxy.rs:1232-1237` | yes |
+| `grep -c 'INVALID_API\|apiVersionInUri\|api_version' bins/nextgcore-scpd/src/sbi_path.rs` → `0` | — | yes, `0` |
+
+The suggested approach's preconditions were checked too, per the
+verify-the-approach-not-just-the-cites rule: `UriComponents` (`libs/nextgcore-sbi/src/message.rs:20`)
+does already expose `api_name` and `api_version`, so the "thread the API major version from
+`UriComponents`" step is followable as written. That is the one part of the suggestion that
+survived unchanged.
+
+## Decision 1: per-service endpoints on the candidate, not a second parse
+
+`NfInstanceCandidate` collapsed the whole profile to one `(scheme, port, prefix)` triple taken
+from `nfServices[0]`, so there was nothing to match against. The fix keeps every service:
+
+```rust
+pub struct NfServiceEndpoint {
+    pub service_name: String,
+    pub versions: Vec<String>,   // versions[].apiVersionInUri
+    pub scheme: UriScheme,
+    pub port: u16,
+    pub prefix: String,
+}
+```
+
+and `NfInstanceCandidate` gains `services: Vec<NfServiceEndpoint>`. The existing
+`scheme`/`port`/`prefix` fields are **kept** as the profile-level fallback rather than removed:
+a profile that registers no `nfServices` at all still has to be routable, and those fields are
+already what `parse_search_result` synthesises for it (port 7777, `http`, no prefix). Removing
+them would have made a serviceless profile unroutable — a regression the issue does not ask for
+and that no acceptance criterion covers.
+
+The alternative was to re-parse the SearchResult JSON at selection time. Rejected: the
+candidates are **cached** (`DiscoveryCache`, per-entry `validityPeriod` TTL), the raw JSON is
+not, so a cache hit would have had nothing to re-parse and would have silently kept the old
+first-service behaviour. That is the same cache-state-dependent divergence #208 exists to fix,
+and reproducing it here would have been self-defeating.
+
+## Decision 2: silence in the profile means "any", not "none"
+
+`versions` is optional in TS 29.510, and **every** NF profile fixture in this tree omits it.
+So:
+
+* a service with an empty `versions` list matches any requested version;
+* a candidate with no `services` list matches any request and keeps its profile-level endpoint;
+* a `None` requested service name or version matches everything.
+
+Reading a missing optional field as "supports no version" would have turned this change into a
+fleet-wide outage: every existing producer would have started answering `400 INVALID_API`. The
+strictness has to attach to what the profile actually *says*, which is the same reasoning
+recorded for the RFC 3339 offset decision — refuse only what is genuinely undecidable.
+
+`apiFullVersion` is deliberately **not** consulted to synthesise a major version. Deriving `v1`
+from `1.R15.1.1` is a guess about a string this codebase has no other reader for, and a wrong
+guess produces an `INVALID_API` for a conformant producer. An entry with no `apiVersionInUri`
+is skipped, which folds into the "declares none" case above.
+
+## Decision 3: two filter stages, because the consumer is owed two different answers
+
+```
+stage 1  candidates offering the requested serviceName   -> else ServiceNotOffered
+stage 2  ...of those, those serving the requested version -> else UnsupportedApiVersion
+stage 3  existing health/priority/capacity ordering WITHIN the stage-2 set
+```
+
+Collapsing the stages would have been shorter and wrong: "no producer serves `nudm-ueau`" and
+"`nudm-uecm` exists but only at `v1`" are different facts, and only the second is
+`INVALID_API` (TS 29.500 Table 5.2.7.2-1). The first is a discovery failure — the NRF returned
+nothing usable for the service — and stays `502 NF_DISCOVERY_FAILURE`. Telling a consumer
+`NF_DISCOVERY_FAILURE` when its own requested version is the problem sends it to retry
+something that cannot succeed; telling it `INVALID_API` when the NRF is simply empty sends it
+to change a URI that is correct.
+
+Stage 3 runs *inside* the matched set, so a single-service producer selects exactly as before.
+
+Note the two stages are **not** independent: stage 2's predicate re-applies the name match, so
+deleting stage 1 alone changes no routing outcome — only the error variant. That was found by
+reverting stage 1 and watching only the error-taxonomy test fail (see Verification).
+
+## Decision 4: the request URI is authoritative for the service name
+
+`3gpp-Sbi-Discovery-service-names` is a *list*, and the issue names it first. It is used only
+as a fallback, and only when it names exactly one service. The URI is what will actually be
+sent to the producer, so `/nudm-uecm/v1/registrations` names the service being invoked with no
+ambiguity; picking an element out of a multi-valued header would reinstate exactly the
+arbitrary choice this change removes.
+
+## Decision 5: cache the SearchResult before selecting from it
+
+`discovery_cache.put` moved to *before* selection. The cache holds what the NRF answered, which
+stays valid for other requests even when it cannot serve this one's API version. And a cache
+hit that cannot serve the request falls through to a fresh NRF query rather than erroring from
+possibly-stale data: the TTL is the SearchResult's own `validityPeriod` (up to an hour), so a
+producer offering the requested version may well have registered since. The error, when it
+comes, is raised against current data.
+
+## Acceptance criteria
+
+- [x] `select_nf_service_endpoint` matches `serviceName` and API major version, and takes the
+      endpoint from the matching `NFService`.
+- [x] A test with a two-service producer on differing ports/prefixes asserts the requested
+      service's endpoint is used — `test_model_d_addresses_the_requested_services_endpoint`
+      (end to end, two live producers) and
+      `test_select_endpoint_uses_the_requested_services_endpoint` (unit, both directions).
+- [x] An unsupported API version yields `400 INVALID_API` rather than a forwarded request —
+      `test_model_d_unsupported_api_version_is_400_invalid_api`, which asserts a **zero hit
+      count on a live producer**, so the 400 cannot be a forward that happened to fail.
+- [x] Single-service producers are byte-unchanged; all pre-existing selection tests pass
+      untouched (the two scpd-01 tests were re-pointed at the new function, same assertions).
+- [x] Workspace lint and the scpd suite pass.
+
+## Verification
+
+Workspace `5958 passed / 0 failed / 6 ignored` (baseline `5950`; +8 tests). `cargo clippy
+--workspace` and `cargo fmt --all -- --check` clean — including the one `needless_lifetimes`
+warning this change introduced and then removed, since CI gates on errors only and a warning
+left behind is a broken window.
+
+Three claims revert-verified:
+
+| revert | expected to break | result |
+|---|---|---|
+| endpoint taken from `services.first()` instead of the matched entry | the two endpoint tests | **2 failed** |
+| `service_version_matches` always `true` | the two version tests | **2 failed** |
+| `service_name_matches` always `true` | endpoint + taxonomy + ordering tests | **4 failed** |
+
+**The revert caught a false guard in my own test.** `test_select_endpoint_uses_the_requested_services_endpoint`
+first used a fixture where the two services declared *different* versions (`v1` and `v2`), and
+it **passed** with service-name matching disabled — the version filter alone resolved the
+endpoint, so the test proved nothing about the thing it is named for. The fixture now gives
+both services the same `v1`, making the name the only discriminator, and the same revert then
+fails it. This is the recorded hazard exactly: a green test that looks like a guard and is not.
+The reason is written at the fixture so it is not "simplified" back.
+
+A fourth revert (deleting filter stage 1) was **inconclusive as a routing test and conclusive
+as a taxonomy one**: only `test_select_endpoint_distinguishes_version_from_service_mismatch`
+failed, because stage 2 re-applies the name predicate. Recorded in Decision 3 rather than
+reported as a pass.
+
+## Ceilings
+
+* No test drives a producer that registers the same service **twice** with different endpoints
+  (legal in TS 29.510 as separate `serviceInstanceId`s). The code takes the first matching
+  entry; nothing pins that choice.
+* `apiFullVersion` is unread, so a producer declaring only `apiFullVersion` and no
+  `apiVersionInUri` is treated as version-agnostic rather than matched precisely.
+* `select_nf_instance_round_robin` was **not** made service-aware. It has no caller on the
+  proxy path (`grep` finds only the `main.rs` re-export), so making it match would have been
+  untested code; flagged rather than half-done.
+* GitNexus impact analysis unrunnable — no MCP server connected, so `nextgcore/CLAUDE.md`'s
+  mandate to run `gitnexus_impact` before editing `select_nf_instance` and
+  `gitnexus_detect_changes` before committing could not be satisfied. Blast radius was
+  established by grep instead: `NfInstanceCandidate` has no constructor outside
+  `sbi_path.rs`, and `select_nf_instance`'s only non-test callers were `proxy.rs::discover`
+  and the two re-exports in `main.rs`.

--- a/src/bins/nextgcore-scpd/src/proxy.rs
+++ b/src/bins/nextgcore-scpd/src/proxy.rs
@@ -37,7 +37,9 @@ use nextgcore_sbi::SbiError;
 
 use crate::cache::BoundedCache;
 use crate::circuit_breaker::CircuitBreaker;
-use crate::sbi_path::{parse_search_result, select_nf_instance, DiscoveryCache};
+use crate::sbi_path::{
+    parse_search_result, select_nf_service_endpoint, DiscoveryCache, EndpointSelectionError,
+};
 
 /// Default upstream connect timeout (bounded per TS 29.500 §6.11 guidance).
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -573,6 +575,69 @@ fn upstream_error_response(target: &str, err: &SbiError) -> SbiResponse {
             "Bad Gateway",
             &format!("Failed to forward request to {target}: {other}"),
             "TARGET_NF_NOT_REACHABLE",
+        ),
+    }
+}
+
+/// The service name and API major version the request is *for*, used to select
+/// the producer's matching `NFService` endpoint (TS 29.510 §6.2.6.2).
+///
+/// **The request URI is authoritative**, because it is what the producer will be
+/// asked for: `/nudm-uecm/v1/registrations` names service `nudm-uecm` at version
+/// `v1`. `3gpp-Sbi-Discovery-service-names` is only a fallback for a URI with no
+/// `{apiName}/{apiVersion}` pair, and only when it names exactly **one** service
+/// — a list leaves the endpoint ambiguous, and picking an element of it would
+/// reinstate the arbitrary choice this selection exists to remove.
+fn requested_service_and_version(request: &SbiRequest) -> (Option<String>, Option<String>) {
+    let parsed = UriComponents::parse(&request.header.uri);
+    let single_named_service = || {
+        request
+            .http
+            .get_header(discovery_header::SERVICE_NAMES)
+            .and_then(|value| {
+                let mut names = value.split(',').map(str::trim).filter(|s| !s.is_empty());
+                let first = names.next()?;
+                names.next().is_none().then(|| first.to_string())
+            })
+    };
+    let service = parsed.api_name.clone().or_else(single_named_service);
+    (service, parsed.api_version)
+}
+
+/// Map an endpoint-selection failure to the answer the consumer is owed
+/// (TS 29.510 §6.2.6.2, TS 29.500 Table 5.2.7.2-1).
+///
+/// The version case is `400 INVALID_API` and not a discovery failure: the NRF
+/// did its job and returned the producer, and it is the consumer's requested API
+/// version that cannot be served — retrying will not help, so telling it
+/// `NF_DISCOVERY_FAILURE` would send it looking in the wrong place.
+fn endpoint_selection_error_response(
+    err: EndpointSelectionError,
+    service: Option<&str>,
+    version: Option<&str>,
+) -> SbiResponse {
+    let service = service.unwrap_or("(unnamed)");
+    match err {
+        EndpointSelectionError::UnsupportedApiVersion => problem_response(
+            400,
+            "Bad Request",
+            &format!(
+                "No discovered producer serves service {service} at API version {}",
+                version.unwrap_or("(unnamed)")
+            ),
+            "INVALID_API",
+        ),
+        EndpointSelectionError::ServiceNotOffered => problem_response(
+            502,
+            "Bad Gateway",
+            &format!("NRF discovery returned no NF instance offering service {service}"),
+            "NF_DISCOVERY_FAILURE",
+        ),
+        EndpointSelectionError::NoCandidate => problem_response(
+            502,
+            "Bad Gateway",
+            "NRF discovery returned no usable NF instance",
+            "NF_DISCOVERY_FAILURE",
         ),
     }
 }
@@ -1129,23 +1194,37 @@ impl ScpProxy {
             .cloned()
             .unwrap_or_default();
         let cache_discriminator = discovery_cache_discriminator(&request.http);
+
+        // scpd-#207: the endpoint is selected by matching the requested service
+        // name AND the API major version in the URI, and taken from the matching
+        // `NFService` (TS 29.510 §6.2.6.2) — not from `nfServices[0]`.
+        let (requested_service, requested_version) = requested_service_and_version(request);
         if let Some(cached) =
             self.discovery_cache
                 .get(&target_nf_type, &service_key, &cache_discriminator)
         {
-            if let Some(selected) = select_nf_instance(&cached) {
+            if let Ok(selected) = select_nf_service_endpoint(
+                &cached,
+                requested_service.as_deref(),
+                requested_version.as_deref(),
+            ) {
                 return Ok(DiscoveredProducer {
                     target: ApiRoot {
                         scheme: selected.scheme,
-                        host: selected.host.clone(),
+                        host: selected.candidate.host.clone(),
                         port: selected.port,
-                        prefix: selected.prefix.clone(),
+                        prefix: selected.prefix,
                     },
-                    nf_instance_id: selected.nf_instance_id.clone(),
+                    nf_instance_id: selected.candidate.nf_instance_id.clone(),
                     nf_set_id: None,
                     nf_group_id: None,
                 });
             }
+            // A cached set that cannot serve THIS request falls through to a
+            // fresh NRF query rather than erroring from stale data: the cache TTL
+            // is the SearchResult's `validityPeriod` (up to an hour), and a
+            // producer offering the requested service/version may have registered
+            // since. The error, if any, is then raised against current data.
         }
 
         let nrf_uri = self.config.nrf_uri.as_deref().ok_or_else(|| {
@@ -1196,17 +1275,12 @@ impl ScpProxy {
         let value: serde_json::Value =
             serde_json::from_slice(body.as_bytes()).unwrap_or(serde_json::Value::Null);
         let candidates = parse_search_result(body.as_bytes());
-        let selected = select_nf_instance(&candidates).ok_or_else(|| {
-            problem_response(
-                502,
-                "Bad Gateway",
-                "NRF discovery returned no usable NF instance",
-                "NF_DISCOVERY_FAILURE",
-            )
-        })?;
 
         // scpd-08: cache the parsed candidates with the SearchResult
-        // `validityPeriod` (seconds) as TTL (default 3600 when absent).
+        // `validityPeriod` (seconds) as TTL (default 3600 when absent). Cached
+        // BEFORE selection (scpd-#207): the cache holds what the NRF answered,
+        // which is still valid for other requests even when it cannot serve this
+        // one's API version.
         if !candidates.is_empty() {
             let validity = value
                 .get("validityPeriod")
@@ -1221,23 +1295,37 @@ impl ScpProxy {
             );
         }
 
+        let selected = select_nf_service_endpoint(
+            &candidates,
+            requested_service.as_deref(),
+            requested_version.as_deref(),
+        )
+        .map_err(|e| {
+            endpoint_selection_error_response(
+                e,
+                requested_service.as_deref(),
+                requested_version.as_deref(),
+            )
+        })?;
+
         // scpd-02/scpd-12: surface the producer's set id / group id when present.
-        let (nf_set_id, nf_group_id) = extract_set_and_group(&value, &selected.nf_instance_id);
+        let (nf_set_id, nf_group_id) =
+            extract_set_and_group(&value, &selected.candidate.nf_instance_id);
 
         // Build the producer ApiRoot from the NF profile fields parsed out of
-        // the SearchResult: scheme and prefix come from nfServices[].scheme /
-        // nfServices[].apiPrefix; host is ipv4→fqdn→ipv6(bracketed).
+        // the SearchResult: scheme, port and prefix come from the MATCHED
+        // `nfServices` entry (scpd-#207); host is ipv4→fqdn→ipv6(bracketed).
         // `client_for`/`oauth_client_for` already honour the scheme field, so
         // an `https` producer is now contacted over TLS automatically.
         let target = ApiRoot {
             scheme: selected.scheme,
-            host: selected.host.clone(),
+            host: selected.candidate.host.clone(),
             port: selected.port,
-            prefix: selected.prefix.clone(),
+            prefix: selected.prefix,
         };
         Ok(DiscoveredProducer {
             target,
-            nf_instance_id: selected.nf_instance_id.clone(),
+            nf_instance_id: selected.candidate.nf_instance_id.clone(),
             nf_set_id,
             nf_group_id,
         })
@@ -2756,12 +2844,13 @@ mod tests {
         });
         let body = serde_json::to_vec(&https_ipv6_result).unwrap();
         let candidates = parse_search_result(&body);
-        let selected = select_nf_instance(&candidates).expect("candidate selected");
+        let selected = select_nf_service_endpoint(&candidates, Some("nudm-sdm"), Some("v1"))
+            .expect("candidate selected");
 
         // Simulate what discover() now does.
         let target = ApiRoot {
             scheme: selected.scheme,
-            host: selected.host.clone(),
+            host: selected.candidate.host.clone(),
             port: selected.port,
             prefix: selected.prefix.clone(),
         };
@@ -2797,11 +2886,12 @@ mod tests {
         });
         let body = serde_json::to_vec(&http_ipv4_result).unwrap();
         let candidates = parse_search_result(&body);
-        let selected = select_nf_instance(&candidates).expect("candidate selected");
+        let selected = select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v1"))
+            .expect("candidate selected");
 
         let target = ApiRoot {
             scheme: selected.scheme,
-            host: selected.host.clone(),
+            host: selected.candidate.host.clone(),
             port: selected.port,
             prefix: selected.prefix.clone(),
         };
@@ -2811,6 +2901,219 @@ mod tests {
         assert_eq!(target.port, 7777);
         assert_eq!(target.prefix, "");
         assert_eq!(target.to_uri(), "http://10.0.0.1:7777");
+    }
+
+    // ------------------------------------------------------------------
+    // scpd-#207: Model D endpoint selection matches serviceName + API version
+    // (TS 29.510 §6.2.6.2)
+    // ------------------------------------------------------------------
+
+    /// A producer that answers 200 with `{"servedBy":"<name>"}` and counts its
+    /// hits, so a test can assert **which** endpoint served a request — and that
+    /// a live producer was *not* contacted.
+    async fn start_named_producer(
+        port: u16,
+        name: &'static str,
+        hits: Arc<AtomicU64>,
+    ) -> nextgcore_sbi::server::SbiServer {
+        let server = nextgcore_sbi::server::SbiServer::new(
+            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        );
+        server
+            .start(move |request: SbiRequest| {
+                let hits = hits.clone();
+                async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    SbiResponse::ok().with_body(
+                        serde_json::json!({"servedBy": name, "uri": request.header.uri})
+                            .to_string(),
+                        "application/json",
+                    )
+                }
+            })
+            .await
+            .expect("producer start");
+        server
+    }
+
+    /// A mock NRF that answers every `nnrf-disc` query with `search_result`, and
+    /// serves the token endpoint the Model D path needs.
+    async fn start_nrf_serving(
+        port: u16,
+        search_result: serde_json::Value,
+    ) -> nextgcore_sbi::server::SbiServer {
+        let server = nextgcore_sbi::server::SbiServer::new(
+            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        );
+        server
+            .start(move |request: SbiRequest| {
+                let search_result = search_result.clone();
+                async move {
+                    if request.header.uri == "/nnrf-oauth2/v1/access-token" {
+                        return SbiResponse::ok().with_body(
+                            r#"{"access_token":"scp-test-token","token_type":"Bearer","expires_in":3600}"#.to_string(),
+                            "application/json",
+                        );
+                    }
+                    SbiResponse::ok().with_body(search_result.to_string(), "application/json")
+                }
+            })
+            .await
+            .expect("nrf start");
+        server
+    }
+
+    /// scpd-#207 acceptance: a two-service producer on differing ports is
+    /// addressed on the **requested** service's port.
+    ///
+    /// `nudm-sdm` is deliberately `nfServices[0]`, so the pre-fix code — which
+    /// took the endpoint from the first service unconditionally — would send this
+    /// `nudm-uecm` request to the sdm port and the assertion would name the wrong
+    /// producer. Asserting on `servedBy` rather than on a 200 is what makes that
+    /// visible: the sdm producer is live and would have answered 200 too.
+    #[tokio::test]
+    async fn test_model_d_addresses_the_requested_services_endpoint() {
+        let sdm_port = ephemeral_port();
+        let uecm_port = ephemeral_port();
+        let nrf_port = ephemeral_port();
+        let scp_port = ephemeral_port();
+        let sdm_hits = Arc::new(AtomicU64::new(0));
+        let uecm_hits = Arc::new(AtomicU64::new(0));
+
+        let sdm = start_named_producer(sdm_port, "sdm", sdm_hits.clone()).await;
+        let uecm = start_named_producer(uecm_port, "uecm", uecm_hits.clone()).await;
+        let nrf = start_nrf_serving(
+            nrf_port,
+            serde_json::json!({
+                "validityPeriod": 3600,
+                "nfInstances": [{
+                    "nfInstanceId": "udm-multi-service",
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["127.0.0.1"],
+                    "priority": 1,
+                    "nfServices": [
+                        {
+                            "serviceName": "nudm-sdm",
+                            "versions": [{"apiVersionInUri": "v1"}],
+                            "ipEndPoints": [{"transport": "TCP", "port": sdm_port}]
+                        },
+                        {
+                            "serviceName": "nudm-uecm",
+                            "versions": [{"apiVersionInUri": "v1"}],
+                            "ipEndPoints": [{"transport": "TCP", "port": uecm_port}]
+                        }
+                    ]
+                }]
+            }),
+        )
+        .await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let request = SbiRequest::post("/nudm-uecm/v1/registrations")
+            .with_header(discovery_header::TARGET_NF_TYPE, "UDM")
+            .with_header(discovery_header::REQUESTER_NF_TYPE, "AMF")
+            .with_header(discovery_header::SERVICE_NAMES, "nudm-uecm");
+        let response = fast_client(scp_port)
+            .send_request(request)
+            .await
+            .expect("roundtrip");
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = response.json_body().unwrap();
+        assert_eq!(
+            body["servedBy"], "uecm",
+            "the requested service's endpoint must serve the request, not nfServices[0]'s"
+        );
+        assert_eq!(uecm_hits.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            sdm_hits.load(Ordering::SeqCst),
+            0,
+            "the unrequested service's endpoint must not be contacted"
+        );
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        uecm.stop().await.expect("uecm stop");
+        sdm.stop().await.expect("sdm stop");
+    }
+
+    /// scpd-#207 acceptance: an API version no discovered producer serves is
+    /// `400 INVALID_API` (TS 29.500 Table 5.2.7.2-1) and the request is **not**
+    /// forwarded — asserted against a live producer, so a zero hit count means
+    /// the SCP declined rather than that the forward happened to fail.
+    #[tokio::test]
+    async fn test_model_d_unsupported_api_version_is_400_invalid_api() {
+        let producer_port = ephemeral_port();
+        let nrf_port = ephemeral_port();
+        let scp_port = ephemeral_port();
+        let hits = Arc::new(AtomicU64::new(0));
+
+        let producer = start_named_producer(producer_port, "uecm-v1", hits.clone()).await;
+        let nrf = start_nrf_serving(
+            nrf_port,
+            serde_json::json!({
+                "validityPeriod": 3600,
+                "nfInstances": [{
+                    "nfInstanceId": "udm-v1-only",
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["127.0.0.1"],
+                    "priority": 1,
+                    "nfServices": [{
+                        "serviceName": "nudm-uecm",
+                        "versions": [{"apiVersionInUri": "v1"}],
+                        "ipEndPoints": [{"transport": "TCP", "port": producer_port}]
+                    }]
+                }]
+            }),
+        )
+        .await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let client = fast_client(scp_port);
+
+        // v2 is not registered: 400 INVALID_API, nothing forwarded.
+        let v2 = SbiRequest::post("/nudm-uecm/v2/registrations")
+            .with_header(discovery_header::TARGET_NF_TYPE, "UDM")
+            .with_header(discovery_header::REQUESTER_NF_TYPE, "AMF")
+            .with_header(discovery_header::SERVICE_NAMES, "nudm-uecm");
+        let response = client.send_request(v2).await.expect("roundtrip");
+        assert_eq!(response.status, 400);
+        let problem: ProblemDetails = response.json_body().unwrap();
+        assert_eq!(problem.cause.as_deref(), Some("INVALID_API"));
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            0,
+            "an unsupported API version must not be forwarded"
+        );
+
+        // The same producer still serves v1, so the rejection is version-specific
+        // rather than the SCP having broken this profile outright.
+        let v1 = SbiRequest::post("/nudm-uecm/v1/registrations")
+            .with_header(discovery_header::TARGET_NF_TYPE, "UDM")
+            .with_header(discovery_header::REQUESTER_NF_TYPE, "AMF")
+            .with_header(discovery_header::SERVICE_NAMES, "nudm-uecm");
+        let response = client.send_request(v1).await.expect("roundtrip");
+        assert_eq!(response.status, 200);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        producer.stop().await.expect("producer stop");
     }
 
     /// When no NRF (and thus no OAuth2 client) is configured, a Model C forward

--- a/src/bins/nextgcore-scpd/src/sbi_path.rs
+++ b/src/bins/nextgcore-scpd/src/sbi_path.rs
@@ -113,6 +113,32 @@ pub fn scp_sbi_is_running() -> bool {
 // NF Instance Selection & Request Routing
 // ============================================================================
 
+/// One `nfServices` entry of an NF profile, reduced to what endpoint selection
+/// needs (TS 29.510 §6.1.6.2.x).
+///
+/// An NF may register several services with **different** schemes, `apiPrefix`
+/// values and ports — a UDM registering `nudm-sdm`, `nudm-uecm` and `nudm-ueau`
+/// is the ordinary case. TS 29.510 §6.2.6.2 selects the endpoint from the
+/// service matching the requested service name and the API version in the URI,
+/// so those three fields must be kept *per service* rather than collapsed to
+/// the profile's first entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NfServiceEndpoint {
+    /// `serviceName`, e.g. `nudm-sdm`.
+    pub service_name: String,
+    /// `versions[].apiVersionInUri` values, e.g. `["v1"]`. **Empty means the
+    /// profile declared none**, which is treated as "serves any version" rather
+    /// than "serves no version": a great many profiles omit `versions`, and
+    /// refusing them would turn a missing optional field into an outage.
+    pub versions: Vec<String>,
+    /// `scheme` (`https` → TLS), defaulting to `Http` when absent.
+    pub scheme: UriScheme,
+    /// Port from this service's `ipEndPoints` (TCP entry preferred).
+    pub port: u16,
+    /// `apiPrefix` for this service (empty when absent).
+    pub prefix: String,
+}
+
 /// NF instance candidate for load-balanced routing
 #[derive(Debug, Clone)]
 pub struct NfInstanceCandidate {
@@ -131,6 +157,39 @@ pub struct NfInstanceCandidate {
     /// Optional deployment-specific API prefix from `nfServices[].apiPrefix`
     /// (TS 29.501 §4.4.1 / TS 29.500 §6.10.2.5).
     pub prefix: String,
+    /// Every `nfServices` entry of the profile, so the endpoint can be taken
+    /// from the *matching* service (TS 29.510 §6.2.6.2) instead of the first.
+    /// The `scheme`/`port`/`prefix` fields above remain the profile-level
+    /// fallback used when the profile declares no services at all.
+    pub services: Vec<NfServiceEndpoint>,
+}
+
+/// Why no producer endpoint could be selected for a requested service and API
+/// version (TS 29.510 §6.2.6.2). The variants are kept distinct because the
+/// SCP owes the consumer three *different* answers: nothing to choose from,
+/// nobody offers the service, and the service exists in another version only —
+/// the last of which is `INVALID_API` rather than a discovery failure
+/// (TS 29.500 Table 5.2.7.2-1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointSelectionError {
+    /// The candidate list is empty, or holds nothing selectable.
+    NoCandidate,
+    /// Candidates exist but none registers the requested `serviceName`.
+    ServiceNotOffered,
+    /// The requested `serviceName` is registered, but no candidate declares the
+    /// requested API major version for it.
+    UnsupportedApiVersion,
+}
+
+/// A producer endpoint resolved from the *matching* `NFService` of the selected
+/// candidate. `scheme`/`port`/`prefix` are the matched service's, not the
+/// profile's first service's.
+#[derive(Debug, Clone)]
+pub struct SelectedEndpoint<'a> {
+    pub candidate: &'a NfInstanceCandidate,
+    pub scheme: UriScheme,
+    pub port: u16,
+    pub prefix: String,
 }
 
 /// Select the best NF instance from a list of candidates using weighted round-robin.
@@ -143,19 +202,23 @@ pub struct NfInstanceCandidate {
 /// 2. Group by priority (lower = better)
 /// 3. Among same-priority, pick by available capacity (capacity - load)
 pub fn select_nf_instance(candidates: &[NfInstanceCandidate]) -> Option<&NfInstanceCandidate> {
-    if candidates.is_empty() {
+    select_best(candidates.iter().collect())
+}
+
+/// The health / priority / capacity ordering of [`select_nf_instance`], factored
+/// out so it can be applied *within* a service-and-version-matched subset
+/// (TS 29.510 §6.2.6.2) rather than only over a whole SearchResult. Behaviour is
+/// unchanged for the whole-list caller.
+fn select_best(pool: Vec<&NfInstanceCandidate>) -> Option<&NfInstanceCandidate> {
+    if pool.is_empty() {
         return None;
     }
 
     // Filter to healthy instances only
-    let healthy: Vec<&NfInstanceCandidate> = candidates.iter().filter(|c| c.healthy).collect();
+    let healthy: Vec<&NfInstanceCandidate> = pool.iter().copied().filter(|c| c.healthy).collect();
 
     // Fall back to all candidates if none are marked healthy
-    let pool = if healthy.is_empty() {
-        candidates.iter().collect()
-    } else {
-        healthy
-    };
+    let pool = if healthy.is_empty() { pool } else { healthy };
 
     // Group by priority (lower is better)
     let min_priority = pool.iter().map(|c| c.priority).min().unwrap_or(0);
@@ -171,6 +234,115 @@ pub fn select_nf_instance(candidates: &[NfInstanceCandidate]) -> Option<&NfInsta
         .iter()
         .max_by_key(|c| c.capacity.saturating_sub(c.load) as u32)
         .map(|c| **c)
+}
+
+/// True when `service` is the service the consumer asked for. A `None` request
+/// service name matches everything (the caller could not determine one).
+fn service_name_matches(service: &NfServiceEndpoint, requested: Option<&str>) -> bool {
+    match requested {
+        None => true,
+        Some(name) => service.service_name.eq_ignore_ascii_case(name),
+    }
+}
+
+/// True when `service` serves the requested API major version. A service that
+/// declares **no** `versions` matches any version: the field is optional in
+/// TS 29.510 and most profiles in this tree omit it, so treating "unstated" as
+/// "unsupported" would reject conformant producers. A `None` requested version
+/// likewise matches everything.
+fn service_version_matches(service: &NfServiceEndpoint, requested: Option<&str>) -> bool {
+    match requested {
+        None => true,
+        Some(version) => {
+            service.versions.is_empty()
+                || service
+                    .versions
+                    .iter()
+                    .any(|v| v.eq_ignore_ascii_case(version))
+        }
+    }
+}
+
+/// Select a producer endpoint by matching the requested **service name** and
+/// **API major version**, per TS 29.510 §6.2.6.2.
+///
+/// This is the selection TS 29.510 actually defines: an `NFService` is chosen by
+/// service name and by the API version in the URI, and the endpoint (scheme,
+/// `apiPrefix`, port) comes from *that* service. Taking the endpoint from
+/// `nfServices[0]` instead mis-addresses every multi-service producer — a UDM
+/// serving `nudm-uecm` on 8080 and `nudm-sdm` on 8443 resolves both to whichever
+/// entry the NRF happened to list first, and the failure then surfaces as a
+/// producer 404 that looks like a producer bug.
+///
+/// The existing priority / capacity / load ordering is applied **within** the
+/// matching set, so a single-service producer selects exactly as before.
+///
+/// A candidate whose profile declares no `nfServices` at all keeps the
+/// profile-level `scheme`/`port`/`prefix` and matches any request: there is no
+/// service list to contradict the request, and the alternative is refusing to
+/// route to a producer the NRF returned.
+pub fn select_nf_service_endpoint<'a>(
+    candidates: &'a [NfInstanceCandidate],
+    service_name: Option<&str>,
+    api_version: Option<&str>,
+) -> Result<SelectedEndpoint<'a>, EndpointSelectionError> {
+    if candidates.is_empty() {
+        return Err(EndpointSelectionError::NoCandidate);
+    }
+
+    // Stage 1: candidates that offer the requested service at all. Kept separate
+    // from the version stage so "offered in another version" is distinguishable
+    // from "not offered", which are different answers to the consumer.
+    let offers_service: Vec<&NfInstanceCandidate> = candidates
+        .iter()
+        .filter(|c| {
+            c.services.is_empty()
+                || c.services
+                    .iter()
+                    .any(|s| service_name_matches(s, service_name))
+        })
+        .collect();
+    if offers_service.is_empty() {
+        return Err(EndpointSelectionError::ServiceNotOffered);
+    }
+
+    // Stage 2: of those, the ones serving the requested API major version.
+    let serves_version: Vec<&NfInstanceCandidate> = offers_service
+        .iter()
+        .copied()
+        .filter(|c| {
+            c.services.is_empty()
+                || c.services.iter().any(|s| {
+                    service_name_matches(s, service_name) && service_version_matches(s, api_version)
+                })
+        })
+        .collect();
+    if serves_version.is_empty() {
+        return Err(EndpointSelectionError::UnsupportedApiVersion);
+    }
+
+    let candidate = select_best(serves_version).ok_or(EndpointSelectionError::NoCandidate)?;
+
+    // Endpoint from the MATCHING service; the profile-level fields are only the
+    // fallback for a profile with no service list.
+    let matched = candidate
+        .services
+        .iter()
+        .find(|s| service_name_matches(s, service_name) && service_version_matches(s, api_version));
+    Ok(match matched {
+        Some(service) => SelectedEndpoint {
+            candidate,
+            scheme: service.scheme,
+            port: service.port,
+            prefix: service.prefix.clone(),
+        },
+        None => SelectedEndpoint {
+            candidate,
+            scheme: candidate.scheme,
+            port: candidate.port,
+            prefix: candidate.prefix.clone(),
+        },
+    })
 }
 
 /// Round-robin index for distributing requests across equal-weight instances.
@@ -383,6 +555,13 @@ pub fn discovery_cache() -> &'static DiscoveryCache {
 ///   (case-insensitive), falling back to `ipEndPoints[0]` if none specifies
 ///   a transport.
 /// - **prefix**: from `nfServices[0].apiPrefix` (empty string when absent).
+///
+/// In addition **every** `nfServices` entry is retained in
+/// [`NfInstanceCandidate::services`] with its own scheme / port / `apiPrefix` and
+/// `versions[].apiVersionInUri`, so [`select_nf_service_endpoint`] can address
+/// the service the consumer actually asked for (TS 29.510 §6.2.6.2). The
+/// `nfServices[0]`-derived fields above are kept as the profile-level fallback
+/// for a profile that registers no services.
 pub fn parse_search_result(body: &[u8]) -> Vec<NfInstanceCandidate> {
     let value: serde_json::Value = match serde_json::from_slice(body) {
         Ok(v) => v,
@@ -436,46 +615,32 @@ pub fn parse_search_result(body: &[u8]) -> Vec<NfInstanceCandidate> {
             // Service-level fields: scheme, port, and apiPrefix come from
             // nfServices[0].  Port is taken from the first ipEndPoints entry
             // whose transport is TCP (case-insensitive); falls back to [0].
-            let first_service = inst
-                .get("nfServices")
-                .and_then(|v| v.as_array())
-                .and_then(|s| s.first());
+            let service_array = inst.get("nfServices").and_then(|v| v.as_array());
+            let first_service = service_array.and_then(|s| s.first());
 
-            let scheme = first_service
-                .and_then(|svc| svc.get("scheme"))
-                .and_then(|v| v.as_str())
-                .map(|s| {
-                    if s.eq_ignore_ascii_case("https") {
-                        UriScheme::Https
-                    } else {
-                        UriScheme::Http
-                    }
-                })
-                .unwrap_or(UriScheme::Http);
+            let scheme = service_scheme(first_service);
+            let prefix = service_prefix(first_service);
+            let port = service_port(first_service);
 
-            let prefix = first_service
-                .and_then(|svc| svc.get("apiPrefix"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-
-            let port = first_service
-                .and_then(|svc| svc.get("ipEndPoints"))
-                .and_then(|v| v.as_array())
-                .and_then(|eps| {
-                    // Prefer an endpoint explicitly marked as TCP.
-                    eps.iter()
-                        .find(|ep| {
-                            ep.get("transport")
-                                .and_then(|t| t.as_str())
-                                .map(|t| t.eq_ignore_ascii_case("TCP"))
-                                .unwrap_or(false)
+            // Every registered service, with ITS OWN endpoint, so the SCP can
+            // address the requested one (TS 29.510 §6.2.6.2).
+            let services: Vec<NfServiceEndpoint> = service_array
+                .map(|arr| {
+                    arr.iter()
+                        .map(|svc| NfServiceEndpoint {
+                            service_name: svc
+                                .get("serviceName")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            versions: service_versions(svc),
+                            scheme: service_scheme(Some(svc)),
+                            port: service_port(Some(svc)),
+                            prefix: service_prefix(Some(svc)),
                         })
-                        .or_else(|| eps.first())
+                        .collect()
                 })
-                .and_then(|ep| ep.get("port"))
-                .and_then(|v| v.as_u64())
-                .unwrap_or(7777) as u16;
+                .unwrap_or_default();
 
             let priority = inst.get("priority").and_then(|v| v.as_u64()).unwrap_or(50) as u16;
             let capacity = inst.get("capacity").and_then(|v| v.as_u64()).unwrap_or(100) as u16;
@@ -492,11 +657,77 @@ pub fn parse_search_result(body: &[u8]) -> Vec<NfInstanceCandidate> {
                 healthy: nf_status == "REGISTERED",
                 scheme,
                 prefix,
+                services,
             });
         }
     }
 
     candidates
+}
+
+/// `nfServices[].scheme` → [`UriScheme`]; `Http` when absent or unrecognised
+/// (backward-compat default, TS 29.510 §6.1.6.2.x).
+fn service_scheme(service: Option<&serde_json::Value>) -> UriScheme {
+    service
+        .and_then(|svc| svc.get("scheme"))
+        .and_then(|v| v.as_str())
+        .map(|s| {
+            if s.eq_ignore_ascii_case("https") {
+                UriScheme::Https
+            } else {
+                UriScheme::Http
+            }
+        })
+        .unwrap_or(UriScheme::Http)
+}
+
+/// `nfServices[].apiPrefix`, empty string when absent (TS 29.501 §4.4.1).
+fn service_prefix(service: Option<&serde_json::Value>) -> String {
+    service
+        .and_then(|svc| svc.get("apiPrefix"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Port from `nfServices[].ipEndPoints`, preferring an entry explicitly marked
+/// `transport: TCP` and falling back to the first entry, then to 7777.
+fn service_port(service: Option<&serde_json::Value>) -> u16 {
+    service
+        .and_then(|svc| svc.get("ipEndPoints"))
+        .and_then(|v| v.as_array())
+        .and_then(|eps| {
+            // Prefer an endpoint explicitly marked as TCP.
+            eps.iter()
+                .find(|ep| {
+                    ep.get("transport")
+                        .and_then(|t| t.as_str())
+                        .map(|t| t.eq_ignore_ascii_case("TCP"))
+                        .unwrap_or(false)
+                })
+                .or_else(|| eps.first())
+        })
+        .and_then(|ep| ep.get("port"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(7777) as u16
+}
+
+/// `nfServices[].versions[].apiVersionInUri` values (TS 29.510 §6.1.6.2.12).
+/// Entries without an `apiVersionInUri` are skipped rather than guessed at from
+/// `apiFullVersion`; a profile whose whole `versions` array yields nothing is
+/// therefore indistinguishable from one that declared none, which
+/// [`service_version_matches`] treats as "serves any version".
+fn service_versions(service: &serde_json::Value) -> Vec<String> {
+    service
+        .get("versions")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.get("apiVersionInUri").and_then(|x| x.as_str()))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -575,6 +806,7 @@ mod tests {
             healthy: true,
             scheme: UriScheme::Http,
             prefix: String::new(),
+            services: Vec::new(),
         }];
         let selected = select_nf_instance(&candidates);
         assert!(selected.is_some());
@@ -595,6 +827,7 @@ mod tests {
                 healthy: true,
                 scheme: UriScheme::Http,
                 prefix: String::new(),
+                services: Vec::new(),
             },
             NfInstanceCandidate {
                 nf_instance_id: "nf-high".to_string(),
@@ -607,6 +840,7 @@ mod tests {
                 healthy: true,
                 scheme: UriScheme::Http,
                 prefix: String::new(),
+                services: Vec::new(),
             },
         ];
         let selected = select_nf_instance(&candidates);
@@ -627,6 +861,7 @@ mod tests {
                 healthy: true,
                 scheme: UriScheme::Http,
                 prefix: String::new(),
+                services: Vec::new(),
             },
             NfInstanceCandidate {
                 nf_instance_id: "nf-idle".to_string(),
@@ -639,6 +874,7 @@ mod tests {
                 healthy: true,
                 scheme: UriScheme::Http,
                 prefix: String::new(),
+                services: Vec::new(),
             },
         ];
         let selected = select_nf_instance(&candidates);
@@ -659,6 +895,7 @@ mod tests {
                 healthy: false,
                 scheme: UriScheme::Http,
                 prefix: String::new(),
+                services: Vec::new(),
             },
             NfInstanceCandidate {
                 nf_instance_id: "nf-healthy".to_string(),
@@ -671,6 +908,7 @@ mod tests {
                 healthy: true,
                 scheme: UriScheme::Http,
                 prefix: String::new(),
+                services: Vec::new(),
             },
         ];
         let selected = select_nf_instance(&candidates);
@@ -691,6 +929,7 @@ mod tests {
                 healthy: true,
                 scheme: UriScheme::Http,
                 prefix: String::new(),
+                services: Vec::new(),
             },
             NfInstanceCandidate {
                 nf_instance_id: "nf-b".to_string(),
@@ -703,6 +942,7 @@ mod tests {
                 healthy: true,
                 scheme: UriScheme::Http,
                 prefix: String::new(),
+                services: Vec::new(),
             },
         ];
         // Call twice to see round-robin switching
@@ -735,6 +975,7 @@ mod tests {
             healthy: true,
             scheme: UriScheme::Http,
             prefix: String::new(),
+            services: Vec::new(),
         }];
 
         cache.put(
@@ -898,6 +1139,7 @@ mod tests {
             healthy: true,
             scheme: UriScheme::Http,
             prefix: String::new(),
+            services: Vec::new(),
         }]
     }
 
@@ -958,5 +1200,246 @@ mod tests {
         let body = serde_json::to_vec(&json).unwrap();
         let candidates = parse_search_result(&body);
         assert_eq!(candidates[0].host, "ausf.5gc.example.org");
+    }
+
+    // ------------------------------------------------------------------
+    // scpd-#207: endpoint selection matches serviceName AND API version
+    // (TS 29.510 §6.2.6.2)
+    // ------------------------------------------------------------------
+
+    /// A UDM registering two services on different ports / prefixes / schemes —
+    /// the ordinary shape TS 29.510 §6.2.6.2 exists for.
+    ///
+    /// Both services declare the SAME `v1`, deliberately: with different versions
+    /// the version filter alone would resolve the endpoint and
+    /// `test_select_endpoint_uses_the_requested_services_endpoint` would pass with
+    /// service-name matching disabled. It was written that way first and the
+    /// revert caught it. The name is now the only discriminator.
+    fn multi_service_udm() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "validityPeriod": 3600,
+            "nfInstances": [{
+                "nfInstanceId": "udm-multi",
+                "nfType": "UDM",
+                "nfStatus": "REGISTERED",
+                "ipv4Addresses": ["10.0.0.9"],
+                "priority": 1,
+                "capacity": 100,
+                "load": 0,
+                "nfServices": [
+                    {
+                        "serviceName": "nudm-uecm",
+                        "apiPrefix": "/uecm",
+                        "versions": [{"apiVersionInUri": "v1"}],
+                        "ipEndPoints": [{"transport": "TCP", "port": 8080}]
+                    },
+                    {
+                        "serviceName": "nudm-sdm",
+                        "scheme": "https",
+                        "apiPrefix": "/sdm",
+                        "versions": [{"apiVersionInUri": "v1"}],
+                        "ipEndPoints": [{"transport": "TCP", "port": 8443}]
+                    }
+                ]
+            }]
+        }))
+        .unwrap()
+    }
+
+    /// scpd-#207: `parse_search_result` retains EVERY service with its own
+    /// endpoint, not just `nfServices[0]`.
+    #[test]
+    fn test_parse_search_result_retains_every_service_endpoint() {
+        let candidates = parse_search_result(&multi_service_udm());
+        assert_eq!(candidates.len(), 1);
+        let services = &candidates[0].services;
+        assert_eq!(services.len(), 2, "both services retained");
+        assert_eq!(services[0].service_name, "nudm-uecm");
+        assert_eq!(services[0].port, 8080);
+        assert_eq!(services[0].prefix, "/uecm");
+        assert_eq!(services[0].scheme, UriScheme::Http);
+        assert_eq!(services[0].versions, vec!["v1".to_string()]);
+        assert_eq!(services[1].service_name, "nudm-sdm");
+        assert_eq!(services[1].port, 8443);
+        assert_eq!(services[1].prefix, "/sdm");
+        assert_eq!(services[1].scheme, UriScheme::Https);
+        assert_eq!(services[1].versions, vec!["v1".to_string()]);
+        // The profile-level fallback fields still mirror nfServices[0].
+        assert_eq!(candidates[0].port, 8080);
+        assert_eq!(candidates[0].prefix, "/uecm");
+    }
+
+    /// scpd-#207 acceptance: with a two-service producer on differing ports and
+    /// prefixes, the REQUESTED service's endpoint is used — for both services, so
+    /// the test cannot pass by always returning the first (or the last) entry.
+    #[test]
+    fn test_select_endpoint_uses_the_requested_services_endpoint() {
+        let candidates = parse_search_result(&multi_service_udm());
+
+        let uecm = select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v1"))
+            .expect("uecm selected");
+        assert_eq!(uecm.candidate.nf_instance_id, "udm-multi");
+        assert_eq!(uecm.port, 8080);
+        assert_eq!(uecm.prefix, "/uecm");
+        assert_eq!(uecm.scheme, UriScheme::Http);
+
+        let sdm = select_nf_service_endpoint(&candidates, Some("nudm-sdm"), Some("v1"))
+            .expect("sdm selected");
+        assert_eq!(sdm.port, 8443, "the second service's port, not the first's");
+        assert_eq!(sdm.prefix, "/sdm");
+        assert_eq!(sdm.scheme, UriScheme::Https);
+    }
+
+    /// scpd-#207 acceptance: an API version the producer does not declare for the
+    /// requested service is `UnsupportedApiVersion` — distinct from
+    /// `ServiceNotOffered`, because the two owe the consumer different answers.
+    #[test]
+    fn test_select_endpoint_distinguishes_version_from_service_mismatch() {
+        let candidates = parse_search_result(&multi_service_udm());
+
+        // nudm-uecm exists, but only at v1.
+        assert_eq!(
+            select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v2")).unwrap_err(),
+            EndpointSelectionError::UnsupportedApiVersion
+        );
+        // nudm-ueau is not registered at all.
+        assert_eq!(
+            select_nf_service_endpoint(&candidates, Some("nudm-ueau"), Some("v1")).unwrap_err(),
+            EndpointSelectionError::ServiceNotOffered
+        );
+        // An empty SearchResult is neither.
+        assert_eq!(
+            select_nf_service_endpoint(&[], Some("nudm-uecm"), Some("v1")).unwrap_err(),
+            EndpointSelectionError::NoCandidate
+        );
+    }
+
+    /// scpd-#207: a profile that declares NO `versions` serves any version, and a
+    /// profile with no `nfServices` at all keeps its profile-level endpoint. Both
+    /// are the backward-compatibility cases: refusing them would turn a missing
+    /// optional field into an outage.
+    #[test]
+    fn test_select_endpoint_is_lenient_where_the_profile_is_silent() {
+        let versionless = serde_json::to_vec(&serde_json::json!({
+            "nfInstances": [{
+                "nfInstanceId": "udm-versionless",
+                "nfType": "UDM",
+                "nfStatus": "REGISTERED",
+                "ipv4Addresses": ["10.0.0.10"],
+                "nfServices": [{
+                    "serviceName": "nudm-uecm",
+                    "ipEndPoints": [{"port": 7777}]
+                }]
+            }]
+        }))
+        .unwrap();
+        let candidates = parse_search_result(&versionless);
+        for version in ["v1", "v2", "v9"] {
+            let selected =
+                select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some(version))
+                    .unwrap_or_else(|e| panic!("versionless profile must serve {version}: {e:?}"));
+            assert_eq!(selected.port, 7777);
+        }
+
+        let serviceless = serde_json::to_vec(&serde_json::json!({
+            "nfInstances": [{
+                "nfInstanceId": "udm-serviceless",
+                "nfType": "UDM",
+                "nfStatus": "REGISTERED",
+                "ipv4Addresses": ["10.0.0.11"]
+            }]
+        }))
+        .unwrap();
+        let candidates = parse_search_result(&serviceless);
+        let selected = select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v1"))
+            .expect("a profile with no service list is still routable");
+        assert_eq!(selected.port, 7777, "profile-level fallback port");
+        assert_eq!(selected.scheme, UriScheme::Http);
+    }
+
+    /// scpd-#207: the priority / capacity ordering is applied WITHIN the matching
+    /// set. The best-priority instance here does not offer the requested service,
+    /// so the worse-priority one that does must win — a test that only ever had
+    /// matching candidates could not tell the filter from the ordering.
+    #[test]
+    fn test_select_endpoint_orders_within_the_matching_set_only() {
+        let mixed = serde_json::to_vec(&serde_json::json!({
+            "nfInstances": [
+                {
+                    "nfInstanceId": "udm-sdm-only",
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["10.0.0.12"],
+                    "priority": 1,
+                    "nfServices": [{
+                        "serviceName": "nudm-sdm",
+                        "ipEndPoints": [{"port": 1111}]
+                    }]
+                },
+                {
+                    "nfInstanceId": "udm-uecm-only",
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["10.0.0.13"],
+                    "priority": 90,
+                    "nfServices": [{
+                        "serviceName": "nudm-uecm",
+                        "ipEndPoints": [{"port": 2222}]
+                    }]
+                }
+            ]
+        }))
+        .unwrap();
+        let candidates = parse_search_result(&mixed);
+        // Whole-list selection still prefers priority 1 (unchanged behaviour).
+        assert_eq!(
+            select_nf_instance(&candidates)
+                .expect("selected")
+                .nf_instance_id,
+            "udm-sdm-only"
+        );
+        // Service-matched selection must skip it: it does not serve nudm-uecm.
+        let selected = select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v1"))
+            .expect("the matching instance is selected despite worse priority");
+        assert_eq!(selected.candidate.nf_instance_id, "udm-uecm-only");
+        assert_eq!(selected.port, 2222);
+    }
+
+    /// scpd-#207: an unhealthy instance is still skipped inside the matching set,
+    /// so the version/name filter does not defeat the health filter.
+    #[test]
+    fn test_select_endpoint_still_skips_unhealthy_within_the_match() {
+        let mixed = serde_json::to_vec(&serde_json::json!({
+            "nfInstances": [
+                {
+                    "nfInstanceId": "udm-down",
+                    "nfType": "UDM",
+                    "nfStatus": "SUSPENDED",
+                    "ipv4Addresses": ["10.0.0.14"],
+                    "priority": 1,
+                    "nfServices": [{
+                        "serviceName": "nudm-uecm",
+                        "ipEndPoints": [{"port": 3333}]
+                    }]
+                },
+                {
+                    "nfInstanceId": "udm-up",
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["10.0.0.15"],
+                    "priority": 50,
+                    "nfServices": [{
+                        "serviceName": "nudm-uecm",
+                        "ipEndPoints": [{"port": 4444}]
+                    }]
+                }
+            ]
+        }))
+        .unwrap();
+        let candidates = parse_search_result(&mixed);
+        let selected = select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v1"))
+            .expect("healthy");
+        assert_eq!(selected.candidate.nf_instance_id, "udm-up");
+        assert_eq!(selected.port, 4444);
     }
 }


### PR DESCRIPTION
TS 29.510 §6.2.6.2 defines endpoint selection over THREE keys -- service name, the
API version in the URI, and the instance -- and scpd was using one. select_nf_instance
filtered by health only (sbi_path.rs:145-174) and the endpoint came from
nfServices[0] unconditionally, so a UDM registering nudm-uecm on 8080 and nudm-sdm on
8443 resolved BOTH to whichever entry the NRF happened to list first. The request then
reached a real, healthy endpoint that does not serve it, and the failure surfaced as a
producer 404 -- which reads as a producer bug, not an SCP one. grep for
INVALID_API/apiVersionInUri/api_version over the crate returned 0: neither the version
nor the error existed anywhere in the selection path.

NfInstanceCandidate now keeps EVERY nfServices entry with its own scheme/port/apiPrefix
and versions[].apiVersionInUri, and select_nf_service_endpoint matches name then version
then runs the EXISTING health/priority/capacity ordering inside the matched set -- so a
single-service producer selects exactly as before. The profile-level scheme/port/prefix
fields are KEPT as the fallback for a profile that registers no services at all;
removing them would have made such a profile unroutable, which no criterion asked for.

Re-parsing the SearchResult at selection time was the obvious alternative and would have
been silently wrong: the candidates are cached and the raw JSON is not, so a cache hit
would have had nothing to re-parse and would have kept the old first-service behaviour
on exactly the path hardest to notice. That is the cache-state divergence #208 exists to
fix, so reproducing it here would have been self-defeating.

SILENCE IN THE PROFILE MEANS "ANY", NOT "NONE". versions is optional in TS 29.510 and
every profile fixture in this tree omits it, so an empty versions list serves any
version and a profile with no service list matches any request. Reading a missing
optional field as "supports no version" would have turned this into a fleet-wide outage
where every existing producer starts answering 400 INVALID_API. apiFullVersion is
deliberately not consulted to synthesise a major version: deriving v1 from 1.R15.1.1 is
a guess, and a wrong guess rejects a conformant producer.

TWO FILTER STAGES, because the consumer is owed two different answers. "No producer
serves nudm-ueau" is a discovery failure and stays 502 NF_DISCOVERY_FAILURE; "nudm-uecm
exists but only at v1" is 400 INVALID_API (TS 29.500 Table 5.2.7.2-1). Collapsing them
would tell a consumer to retry something that cannot succeed, or to fix a URI that is
already right.

The request URI is authoritative for the service name.
3gpp-Sbi-Discovery-service-names is a LIST, and picking an element of it would reinstate
the arbitrary choice being removed -- it is used only as a fallback, and only when it
names exactly one service.

Workspace 5958 passed / 0 failed / 6 ignored (baseline 5950; +8 tests). clippy and fmt
clean, including the one needless_lifetimes warning this change introduced and then
removed -- CI gates on errors only, so a warning left behind is a broken window.

THREE CLAIMS REVERT-VERIFIED: endpoint from services.first() fails the 2 endpoint tests;
version matching always-true fails the 2 version tests; name matching always-true fails
4 tests.

AND THE REVERT CAUGHT A FALSE GUARD IN MY OWN TEST.
test_select_endpoint_uses_the_requested_services_endpoint first used a fixture whose two
services declared DIFFERENT versions, and it PASSED with name matching disabled -- the
version filter alone resolved the endpoint, so the test proved nothing about the thing
it is named for. Both services now declare the same v1, making the name the only
discriminator, and the same revert then fails it. The reason is written at the fixture
so it is not simplified back.

A fourth revert (deleting filter stage 1) broke only the taxonomy test, because stage 2
re-applies the name predicate -- recorded in the spec as a design note rather than
reported as a pass.

Ceilings: no test pins which entry wins when one service is registered twice with
different endpoints; a producer declaring only apiFullVersion is treated as
version-agnostic; select_nf_instance_round_robin was NOT made service-aware because it
has no caller on the proxy path, so doing it would have been untested code. GitNexus
impact analysis unrunnable (no MCP server connected) -- blast radius established by grep
instead.

Closes #207

Spec: specs/fix-scpd-model-d-service-and-version-endpoint-selection.md