### PR TITLE
fix(scpd): fail over to an alternate producer, and 504 once the candidate set is exhausted (#209)

### DIFF
--- a/docker/rust/configs/scp.yaml
+++ b/docker/rust/configs/scp.yaml
@@ -46,3 +46,12 @@ scp:
   # peer-influenced binding / discovery / client caches (TS 33.522 §4.2.3.3).
   # max_cache_entries: 4096
   # cache_ttl: 3600
+  #
+  # How many discovered producers ONE Model D request may be forwarded to before
+  # the SCP gives up (default 3: the selected producer plus two alternates), per
+  # TS 29.500 §6.10.8.2 alternate-producer reselection. Only reached when a
+  # forward provably never left the SCP (connection refused / TLS failure, or the
+  # producer's circuit breaker is open) -- never for a producer that answered, and
+  # never after a timeout, which could have been delivered already. Set to 1 to
+  # disable reselection entirely.
+  # max_producer_attempts: 3

--- a/docs-book/src/configuration/scp.md
+++ b/docs-book/src/configuration/scp.md
@@ -2,9 +2,11 @@
 
 The SCP (Service Communication Proxy, `nextgcore-scpd`) is the 5GC indirect-communication proxy: an HTTP/2 forwarding engine implementing TS 29.500 §6.10 (as cited in the daemon's source comments) with both **Model C** (consumer supplies `3gpp-Sbi-Target-apiRoot`) and **Model D** (delegated discovery driven by `3gpp-Sbi-Discovery-*` headers, resolved against the NRF's `nnrf-disc` service per TS 29.500 §6.10.3 / TS 29.510 §5.3.2 per code comments). It exposes no NF-specific API routes of its own — a single catch-all handler (`ScpProxy::handle` in `src/bins/nextgcore-scpd/src/proxy.rs`) proxies every inbound SBI request, adding binding stickiness (TS 29.500 §6.12), Via/Server loop detection (§6.10.10), and delegated OAuth2 token acquisition (TS 33.501 §13, per code comments).
 
-Configuration is **CLI flags and environment variables only**. There is a YAML file path (default `/etc/nextgcore/scp.yaml`, overridable with `-c/--config`), but the daemon does not parse it — see the honesty note below. The NRF URI, the SCP's NF Instance ID, and its FQDN each have an environment-variable fallback (`NRF_URI`, `NF_INSTANCE_ID`, `SCP_FQDN`) used when the corresponding flag is absent; the flag always wins over the env var.
+Configuration comes from **CLI flags, environment variables and the YAML file**, in that precedence order (CLI > env > file > built-in default). The file path defaults to `/etc/nextgcore/scp.yaml` and is overridable with `-c/--config`. The NRF URI, the SCP's NF Instance ID, and its FQDN each have an environment-variable fallback (`NRF_URI`, `NF_INSTANCE_ID`, `SCP_FQDN`) used when the corresponding flag is absent; the flag always wins over the env var, and the file is consulted after both.
 
-> **Honesty note:** SCP behavior is validated by this project's own unit tests (including an in-process mock NRF in `proxy.rs`) and the matched-simulator Docker E2E, not by third-party conformance certification. Three things an operator should know up front: (1) the daemon **reads the YAML config file only to log its byte count** — `main.rs` contains a placeholder (`// In C: scp_context_parse_config()`) and no `#[derive(Deserialize)]` config structs exist anywhere in the crate, so every field in the shipped `scp.yaml` is decorative; (2) the `-k/--kill` flag is a stub that logs "would send SIGTERM" and exits without killing anything; (3) `-l/--log-file` is accepted by clap but never used by `init_logging` — logs always go to the `env_logger` default sink.
+> **Honesty note:** SCP behavior is validated by this project's own unit tests (including an in-process mock NRF in `proxy.rs`) and the matched-simulator Docker E2E, not by third-party conformance certification. Two things an operator should know up front: (1) the `-k/--kill` flag is a stub that logs "would send SIGTERM" and exits without killing anything; (2) `-l/--log-file` is accepted by clap but never used by `init_logging` — logs always go to the `env_logger` default sink.
+>
+> This note previously stated that the daemon read the YAML file only to log its byte count and that every field in it was decorative. **That is no longer true** and is corrected below: `config.rs` carries `#[derive(Deserialize)]` structs and `main.rs` reads the `scp` section for the SBI address/port, the NRF URI, `fqdn`, `nf_instance_id`, both timeouts, the cache bounds, `max_producer_attempts`, and `sbi.tls.enabled`/`cert`/`key`.
 
 ## Example configuration
 
@@ -41,21 +43,36 @@ scp:
       min_version: "1.2"
 ```
 
-Note that the shipped `docker-compose.yml` service (`scp:`, lines 491–503) does not even mount this file into the container — it runs the daemon purely on CLI flags: `command: ["--sbi-addr", "172.23.0.37", "--sbi-port", "7777"]`. The YAML's addresses (`172.22.0.x`) do not match the compose network (`172.23.0.x`), which is further evidence the file is not load-bearing.
+The commented-out optional `scp`-level keys are omitted from the excerpt above; see the live-fields table below.
+
+Note that the shipped `docker-compose.yml` service (`scp:`, lines 491–503) does not mount this file into the container — it runs the daemon purely on CLI flags: `command: ["--sbi-addr", "172.23.0.37", "--sbi-port", "7777"]`. The YAML's addresses (`172.22.0.x`) do not match the compose network (`172.23.0.x`) either. So the file **is** parsed when present, but in *that* deployment it is never mounted and the flags supply everything.
 
 ## YAML parameters
 
-**None.** Unlike the other NF daemons, `nextgcore-scpd` deserializes no YAML fields at all. `main.rs` checks whether the `--config` path exists, reads the file to a string, and logs `"Configuration file loaded (N bytes)"` — nothing more. There are no serde `Deserialize` structs in `src/bins/nextgcore-scpd/`. All runtime knobs are CLI flags (below) with three env-var fallbacks, plumbed into `ScpProxyConfig` (`proxy.rs`) and `SbiServerConfig` (`sbi_path.rs`).
+`nextgcore-scpd` deserializes its `scp` section in `src/bins/nextgcore-scpd/src/config.rs` (serde `Deserialize` structs) and `main.rs` resolves each value as CLI flag > env var > file > built-in default via `config::resolve`. The resolved values are plumbed into `ScpProxyConfig` (`proxy.rs`) and `SbiServerConfig` (`sbi_path.rs`).
 
-### Parsed-but-inert / decorative YAML fields
+### Which YAML fields are live, and which are inert
 
-Every field in the shipped example file is inert. Where the real knob lives:
+**Live** — read by `config.rs` / `main.rs`, and used when no CLI flag or environment variable supplies the value:
 
-- **`logger.file.path` and `logger.level` are inert.** The log level comes from the CLI flag `-e/--log-level` (default `info`); `init_logging` builds `env_logger` with an explicit filter level, so even `RUST_LOG` (set to `info` by the compose file's common environment) is not consulted. There is no working log-file output (`-l/--log-file` is accepted but unused).
-- **`global.max.ue` / `global.max.peer` are inert.** The only pool sizing the daemon applies is `--max-assoc` (default `8192`), passed to `scp_context_init`.
-- **`scp.sbi.server[]` (address/port) is inert.** The SBI bind address and port come from `--sbi-addr`/`--sbi-port`.
-- **`scp.sbi.client.nrf[].uri` is inert.** The NRF URI for Model D delegated discovery comes from `--nrf-uri`, falling back to the `NRF_URI` environment variable; when neither is set, delegated discovery is disabled.
-- **`scp.sbi.tls.*` (enabled/cert/key/ca/min_version) is inert.** TLS is controlled by the `--tls`, `--tls-cert`, and `--tls-key` flags; there is no CA-bundle or minimum-version knob in the code.
+| key | effect |
+|---|---|
+| `scp.sbi.server[0].address` / `.port` | SBI bind address / port (after `--sbi-addr` / `--sbi-port`) |
+| `scp.sbi.client.nrf[0].uri` | NRF URI for Model D (after `--nrf-uri`, then `NRF_URI`) |
+| `scp.sbi.tls.enabled` / `.cert` / `.key` | TLS on the SBI server; `--tls` forces it on regardless |
+| `scp.fqdn` | SCP identity for `Via` / `Server` / loop detection (after `--scp-fqdn`, then `SCP_FQDN`) |
+| `scp.nf_instance_id` | own `nfInstanceId` for delegated tokens (after `--nf-instance-id`, then `NF_INSTANCE_ID`) |
+| `scp.connect_timeout` / `scp.request_timeout` | upstream timeouts, whole seconds |
+| `scp.max_cache_entries` / `scp.cache_ttl` | proxy cache bounds |
+| `scp.max_producer_attempts` | Model D alternate-producer reselection bound |
+
+All of the `scp`-level keys are shipped **commented out**, so the built-in defaults apply unless an operator uncomments them.
+
+**Inert** — present in the shipped file and not read anywhere:
+
+- **`logger.file.path` and `logger.level`.** The log level comes from the CLI flag `-e/--log-level` (default `info`); `init_logging` builds `env_logger` with an explicit filter level, so even `RUST_LOG` (set to `info` by the compose file's common environment) is not consulted. There is no working log-file output (`-l/--log-file` is accepted but unused).
+- **`global.max.ue` / `global.max.peer`.** The only pool sizing the daemon applies is `--max-assoc` (default `8192`), passed to `scp_context_init`.
+- **`scp.sbi.tls.ca` and `scp.sbi.tls.min_version`.** There is no CA-bundle or minimum-version knob in the code; the rest of the `tls` block *is* read.
 
 ## Command-line flags
 
@@ -63,7 +80,7 @@ From the clap `Args` struct in `src/bins/nextgcore-scpd/src/main.rs`:
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `-c, --config` | path | `/etc/nextgcore/scp.yaml` | Configuration file path (read but **not parsed** — see honesty note). |
+| `-c, --config` | path | `/etc/nextgcore/scp.yaml` | Configuration file path. Parsed; see the live-fields table above. |
 | `-l, --log-file` | path | unset | Log file path — **accepted but unused** by `init_logging`. |
 | `-e, --log-level` | string | `info` | Log level (`trace`/`debug`/`info`/`warn`/`error`); unrecognized values fall back to `info`. |
 | `-m, --no-color` | flag | off | Disable color output. |
@@ -94,8 +111,15 @@ From the clap `Args` struct in `src/bins/nextgcore-scpd/src/main.rs`:
   | NRF answered, non-200 | **502** | `NF_DISCOVERY_FAILURE` |
   | empty `SearchResult`, or no instance offering the requested service | **404** | `NF_DISCOVERY_FAILURE` |
   | requested API major version served by no discovered producer | **400** | `INVALID_API` |
+  | every discovered producer unreachable (candidate set exhausted) | **504** | `TARGET_NF_NOT_REACHABLE` |
 
   `TARGET_NF_NOT_REACHABLE` is reserved for **producer**-side unreachability and is never used for an NRF failure.
+- **Model D alternate-producer reselection** (TS 29.500 §6.10.8.2 per code comment): the whole ranked candidate set is kept, and a forward that **provably never reached** the selected producer is retried against the next-best one. Bounded by `scp.max_producer_attempts` (default **3** — the selected producer plus two alternates; `1` disables reselection), and the bound is logged at `warn` when it leaves discovered candidates untried. Three rules govern when it fires:
+  - **Only pre-send failures.** A connection refused or a TLS handshake failure proves the request bytes were never written, so replaying them cannot duplicate work even for a `POST`. A **timeout** does *not* qualify — the same error covers "never connected" and "sent, producer still working" — and neither does any post-send transport error, so a possibly-delivered request is never replayed.
+  - **An open circuit breaker reselects rather than shedding.** Previously the breaker protected a dead producer but still failed the request; now the request goes to a sibling while the dead producer stays protected. If *every* candidate is shed by its own breaker, the answer is **503** `TARGET_NF_NOT_REACHABLE` (load shedding, retry shortly) rather than 504.
+  - **A producer that answered is never reselected.** Any status the producer returns — including 4xx and 5xx — is relayed verbatim; a sibling has no business overriding it.
+
+  A reselected producer reports **its own** `3gpp-Sbi-Producer-Id`, not the originally selected one's. Model C and binding-stickiness forwarding have no alternates, so a single pinned target keeps its previous mapping (**502** refused / **504** timeout).
 - **Delegated OAuth2**: when an NRF URI is known, the SCP acts as an OAuth2 client of NF type `SCP` and attaches producer-scoped access tokens on the Model D path; a token the NRF refuses yields **403** `ACCESS_TOKEN_DENIED`, and a producer `401` with a Bearer `WWW-Authenticate` challenge triggers one token-retry (TS 29.500 §6.10.11.2.3 per code comment). Model C requests are forwarded with the consumer's own `Authorization` untouched.
 - **No NRF registration**: the SCP never registers or heartbeats itself with the NRF — its only NRF traffic is `GET /nnrf-disc/v1/nf-instances` and token requests. Note the shipped `docker-compose.yml` sets no `NRF_URI` for the `scp` service, so Model D is disabled in that deployment (discovery requests get 503). Error identity: SCP-originated errors carry `Server: SCP-<fqdn>` (§6.10.8.2 per code comment); relayed producer 4xx/5xx keep their body/status verbatim but gain this SCP's `Via` (§6.10.8.3).
 - **Environment variables** (all read in `main.rs`; flags take precedence): `NRF_URI`, `NF_INSTANCE_ID`, `SCP_FQDN` (fallbacks as in the flags table) and `OTEL_EXPORTER_OTLP_ENDPOINT` (OpenTelemetry OTLP trace exporter endpoint, default `http://jaeger:4317`). Upstream timeouts are compile-time constants — 2 s connect, 10 s request (`proxy.rs`, bounded per TS 29.500 §6.11 guidance per code comment) — with no CLI or YAML override.

--- a/specs/fix-scpd-alternate-producer-reselection.md
+++ b/specs/fix-scpd-alternate-producer-reselection.md
@@ -1,0 +1,196 @@
+# nextgcore #209 (scpd): fail over to an alternate producer, and 504 when the set is exhausted
+
+Verified against `main` @ `cb26714` (i.e. after #207 and #211, which are the same file). The
+issue's cites are from `562b4a1`; all three still hold, at new line numbers, and the third
+changed shape.
+
+## Verified against current main
+
+| claim in the issue | site on `cb26714` | still true? |
+|---|---|---|
+| `forward()` issues one `client.send_request(fwd)` and returns on `Err` | `proxy.rs:1600`, error arm `:1601-1607` | yes |
+| the rest of the candidate list is parsed and discarded | `discover` took only the ranked head (`:1423`) | yes |
+| connection-refused maps to `502 TARGET_NF_NOT_REACHABLE` | `upstream_error_response` `:568-582` | yes |
+
+**Approach precondition that had changed:** the issue says to "keep the ordered candidate list on
+the discovery result". After #207 there *is* no ordered list — `select_nf_service_endpoint`
+returned one `SelectedEndpoint` and dropped the rest. So the first step was building the ranked
+list (`rank_nf_service_endpoints`), which the issue assumes already exists.
+
+## Decision 1: `ForwardOutcome`, because a single `SbiResponse` cannot express "try elsewhere"
+
+`forward` returned `SbiResponse` for every case — a producer 500, a refused connection and a
+token failure all came back as *an answer*. Reselection is impossible on top of that, which is
+why the split is the first change rather than a refactor bolted on afterwards:
+
+```rust
+enum ForwardOutcome {
+    Answered(SbiResponse),          // the producer answered, at any status
+    Undeliverable(Undeliverable),   // provably never arrived; another candidate may serve it
+    Final(SbiResponse),             // no other candidate could improve on this
+}
+```
+
+`forward_once` returns it; `forward` (Model C / sticky, no alternates) collapses it back to the
+**pre-existing** mapping so those paths are unchanged; `forward_with_reselection` (Model D)
+loops.
+
+`Final` is not a synonym for "error". A delegated token the NRF refused is `Final` because the
+token is minted for `(consumer, target NF **type**, scope)` — every instance of that type would
+be refused identically, so reselecting would only repeat the NRF round-trip.
+
+## Decision 2: reselect only on a provably pre-send failure
+
+The issue offers a choice: "restrict reselection to failures that provably occurred before the
+request was sent (connect refused), **or** document the exposure." Taking the first option, so
+there is no exposure to document:
+
+| `SbiError` | replayable | why |
+|---|---|---|
+| `ConnectionError` | **yes** | produced only by TCP connect (`client.rs:452`) and the HTTP/2 handshake (`:514`, `:529`) |
+| `TlsError` | **yes** | server-name validation and TLS handshake (`:457`, `:465`) |
+| `Timeout` | no | produced by the connect phase (`:451`, `:464`) **and** the send/response phase (`:892`) — cannot tell "never sent" from "sent, still working" |
+| `HyperError` | no | `:893`, after `send_request` began |
+| everything else | no | request-shape errors; another producer would reject identically |
+
+`Timeout` is the load-bearing exclusion. It *looks* like a transport failure, and replaying a
+`POST` on one could duplicate a registration or a charging record. `test_a_timeout_does_not_reselect`
+pins that a live sibling stays untouched when the first candidate times out.
+
+## Decision 3: an open circuit reselects instead of shedding
+
+This is the interaction the issue names: "the breaker stops *repeatedly* hitting a dead
+producer, but it does not retry a different one, so the first request after the circuit opens
+still fails." An Open circuit therefore returns `Undeliverable` (nothing was sent, so it is
+trivially pre-send) and the Model D path tries the next candidate. The dead producer stays
+protected — `test_an_open_circuit_reselects_rather_than_shedding` asserts its hit count does
+**not** move while the sibling's does.
+
+If *every* candidate is shed by its own breaker, the answer stays **503** rather than becoming
+504: nothing was put on the wire, so that is load shedding and "retry shortly" is true — the
+breakers will half-open. Only an attempt list containing a real transport failure yields 504.
+
+## Decision 4: 504 on exhaustion in Model D, 502 still in Model C
+
+The issue asks for 504 on exhaustion. The asymmetry with Model C is deliberate and worth
+stating, since it is the same underlying `ConnectionError`:
+
+* **Model D** — the SCP owns selection. Exhausting the whole candidate set means the SCP's
+  upstream is not answering, which is what 504 says.
+* **Model C / sticky** — the *consumer* pinned the target. There is no set to exhaust, so the
+  failure is that one hop and keeps its 502.
+
+`(504, TARGET_NF_NOT_REACHABLE)` does not collide with #211's `(504, NRF_NOT_REACHABLE)`: the
+cause still names which node failed, which was #211's whole point. Asserted in
+`test_model_d_exhausted_candidates_is_504_distinct_from_discovery_failure`.
+
+## Decision 5: rank by re-running the rule, not by sorting
+
+`rank_nf_service_endpoints` builds the order by calling `select_best` repeatedly and removing
+the winner, rather than sorting on `(priority, -available_capacity)`. `select_best` breaks a
+capacity tie with `max_by_key`, which yields the **last** maximum; a descending sort yields the
+first. Re-running the real rule makes "the ranked head IS the single pick" true by construction
+instead of by reproducing a tie-break that would drift.
+`test_ranked_endpoints_head_matches_the_single_pick` uses a fixture with a deliberate tie and
+pins the whole order, so the tie-break is documented rather than incidental.
+
+**The pool rule is applied once, up front, and that was found by a failing test.** The first
+version let the loop run until the pool emptied — and because `select_best` falls back to "all
+candidates" when none are healthy, that handed back every `SUSPENDED` instance as a last-resort
+alternate once the healthy ones were exhausted. A `SUSPENDED` NF must not be selected
+(TS 29.510 `nfStatus`), so that would have traded a reachability problem for a conformance one.
+The healthy-if-any pool is now computed before ranking, with the reasoning at the site;
+`test_ranked_endpoints_exclude_unhealthy_while_a_healthy_one_exists` pins it. The pre-existing
+leniency — use everything when the NRF reports nothing healthy at all — is untouched, because
+that is a different case.
+
+## Decision 6: the bound is operable, and it is logged when it bites
+
+`max_producer_attempts`, default **3** (selected producer plus two alternates), clamped to ≥ 1,
+and wired through the established YAML path (`scp.max_producer_attempts` → `config.rs` →
+`main.rs` → `ScpProxyConfig`) with a commented-out entry in the shipped `scp.yaml`. A tuning
+field reachable only from Rust would be close to a dead field; every sibling knob
+(`max_cache_entries`, `cache_ttl`, the timeouts) already follows this path.
+
+When the bound leaves candidates untried, that is logged at `warn` with both counts. Trying 3
+of 9 and then reporting "could not reach any producer" would overstate what the SCP did.
+
+## Acceptance criteria
+
+- [x] A forwarding transport failure triggers reselection before any error is returned.
+- [x] A test with two candidates, the first refusing connections, asserts the second served the
+      request — `test_model_d_reselects_the_next_candidate_when_the_first_refuses`, which also
+      asserts the relayed `Producer-Id` names the **second** instance.
+- [x] Connection-refused with no remaining candidates returns `504`, distinguished by a test
+      from a `502` discovery error — both driven in one test and asserted unequal.
+- [x] Reselection does not fire on a producer-generated 4xx/5xx —
+      `test_model_d_does_not_reselect_on_a_producer_error`, with a **live** second candidate at
+      hit count 0, so "did not reselect" is distinguished from "reselected and also failed".
+- [x] The idempotency decision is documented in code — `is_provably_undelivered`'s doc comment
+      cites the exact `client.rs` lines for each variant, and
+      `test_only_pre_send_failures_are_replayable` pins it.
+- [x] Workspace lint and the scpd suite pass.
+
+Beyond the criteria: the circuit-breaker interaction the issue flags in prose but does not list
+as a criterion is implemented and tested, and the attempt bound is operator-configurable.
+
+## Verification
+
+Workspace `5971 passed / 0 failed / 6 ignored` (baseline `5962` after #211; +9 tests). `cargo
+clippy --workspace` and `cargo fmt --all -- --check` clean, zero warnings.
+
+Five claims revert-verified:
+
+| revert | expected to break | result |
+|---|---|---|
+| stop after the first candidate (no reselection) | reselect + bound + circuit tests | **3 failed** |
+| exhaustion keeps the single-target mapping (502) | exhaustion + bound tests | **2 failed** |
+| treat a producer 5xx as `Undeliverable` | producer-error + circuit + 2 pre-existing | **4 failed** |
+| add `Timeout` to `is_provably_undelivered` | timeout + unit tests | **2 failed** |
+| open circuit returns `Final` 503 again | circuit test | **1 failed** |
+
+The third revert is worth noting: it also broke two **pre-existing** tests
+(`test_circuit_breaker_opens_sheds_load_then_probes`, `test_relayed_500_carries_no_producer_id`),
+which is independent evidence that "a producer that answered is relayed" was already load-bearing
+behaviour and not merely a new assertion of mine.
+
+#211's handoff note asked this branch to re-verify its five failure rows rather than assume them.
+Done: `test_three_discovery_failures_are_pairwise_distinct` and
+`test_unreachable_nrf_is_504_nrf_not_reachable` both still pass, and the new exhaustion pair is
+explicitly asserted distinct from the discovery-error pair.
+
+## Docs corrected — including a much older staleness found on the way
+
+`docs-book/src/configuration/scp.md` gains the reselection rules, the new failure row, and the
+`scp.max_producer_attempts` key. Adding that key exposed a **pre-existing** contradiction on the
+same page, which had to be resolved rather than shipped alongside:
+
+* the intro said configuration is "CLI flags and environment variables only" and "the daemon
+  does not parse" the YAML;
+* the honesty note said the daemon "reads the YAML config file only to log its byte count", that
+  `main.rs` holds a `// In C: scp_context_parse_config()` placeholder, and that "no
+  `#[derive(Deserialize)]` config structs exist anywhere in the crate";
+* a "YAML parameters" section read "**None.**";
+* and five keys were listed as inert.
+
+All of that is false as of `cb26714`: `config.rs` exists with serde structs, and `main.rs` reads
+the SBI address/port, NRF URI, `fqdn`, `nf_instance_id`, both timeouts, the cache bounds and
+`sbi.tls.enabled`/`cert`/`key`. Only `tls.ca` and `tls.min_version` remain unread. The page now
+carries a live-vs-inert table, the corrected precedence, and an explicit note that the previous
+claim no longer holds. This is scoped to the config-parsing claims — the `-k/--kill` and
+`-l/--log-file` stub claims are left alone, having not been re-verified here.
+
+## Ceilings
+
+* No test exercises a **TLS** handshake failure driving reselection; `TlsError` is covered by
+  the unit predicate only, because the mock producers are plaintext.
+* Reselection is not applied to the Model C or sticky-binding paths, by design (no candidate
+  set). An `nf-set` Routing-Binding *could* in principle reselect among learnt set members;
+  that is scpd-11's surface, not this one, and is left alone.
+* `select_nf_instance_round_robin` still has no caller and was not made rank-aware.
+* Ports 1 and 2 on loopback are used as "refuses immediately" in tests, following the
+  pre-existing `test_unreachable_target_is_502_problem`. Should something ever listen there the
+  tests would fail loudly rather than silently pass.
+* GitNexus impact analysis unrunnable (no MCP server connected). Blast radius by grep: `forward`
+  had three call sites (all in `handle`), and `DiscoveredProducer` was constructed only inside
+  `discover`.

--- a/src/bins/nextgcore-scpd/src/config.rs
+++ b/src/bins/nextgcore-scpd/src/config.rs
@@ -13,6 +13,7 @@
 //! - `scp.nf_instance_id` — the SCP's `nfInstanceId` for delegated OAuth2
 //! - `scp.connect_timeout` / `scp.request_timeout` — upstream timeouts (seconds)
 //! - `scp.max_cache_entries` / `scp.cache_ttl` — proxy cache bounds
+//! - `scp.max_producer_attempts` — Model D alternate-producer reselection bound
 //!
 //! Declaring only actionable keys is deliberate: parsing a key nothing reads
 //! is the very defect (#58, #102) being fixed.
@@ -72,6 +73,9 @@ pub struct ScpSection {
     pub max_cache_entries: Option<usize>,
     /// Cache entry lifetime, in whole seconds.
     pub cache_ttl: Option<u64>,
+    /// Maximum producers one Model D request may be forwarded to before the SCP
+    /// gives up (scpd-#209). `1` disables alternate-producer reselection.
+    pub max_producer_attempts: Option<usize>,
 }
 
 /// The top-level document: `scp: { ... }`.
@@ -92,6 +96,7 @@ impl ScpYaml {
             request_timeout: None,
             max_cache_entries: None,
             cache_ttl: None,
+            max_producer_attempts: None,
         };
         self.scp.as_ref().unwrap_or(&EMPTY)
     }
@@ -168,6 +173,7 @@ scp:
   request_timeout: 20
   max_cache_entries: 256
   cache_ttl: 120
+  max_producer_attempts: 5
 "#;
 
     #[test]
@@ -183,6 +189,7 @@ scp:
         assert_eq!(s.request_timeout, Some(20));
         assert_eq!(s.max_cache_entries, Some(256));
         assert_eq!(s.cache_ttl, Some(120));
+        assert_eq!(s.max_producer_attempts, Some(5));
         assert_eq!(
             s.sbi.as_ref().unwrap().tls.as_ref().unwrap().enabled,
             Some(false)
@@ -248,6 +255,7 @@ scp:
         assert!(cfg.section().fqdn.is_none());
         assert!(cfg.section().connect_timeout.is_none());
         assert!(cfg.section().max_cache_entries.is_none());
+        assert!(cfg.section().max_producer_attempts.is_none());
     }
 
     #[test]

--- a/src/bins/nextgcore-scpd/src/main.rs
+++ b/src/bins/nextgcore-scpd/src/main.rs
@@ -251,6 +251,14 @@ async fn main() -> Result<()> {
         .cache_ttl
         .map(Duration::from_secs)
         .unwrap_or(defaults.cache_ttl);
+    // scpd-#209: how many discovered producers one Model D request may be tried
+    // against. Clamped to >= 1 here as well as in the proxy so a `0` in the config
+    // cannot silently mean "never forward anything".
+    let max_producer_attempts = scp_yaml
+        .section()
+        .max_producer_attempts
+        .unwrap_or(defaults.max_producer_attempts)
+        .max(1);
 
     // TLS: --tls forces on; otherwise honour scp.sbi.tls.enabled. cert/key
     // come from the flag first, then the config.
@@ -267,7 +275,8 @@ async fn main() -> Result<()> {
 
     log::info!(
         "SCP identity: SCP-{own_fqdn}; SBI {sbi_addr}:{sbi_port} (tls={tls_enabled}); \
-         connect_timeout={}s request_timeout={}s; cache max={max_cache_entries} ttl={}s",
+         connect_timeout={}s request_timeout={}s; cache max={max_cache_entries} ttl={}s; \
+         max_producer_attempts={max_producer_attempts}",
         connect_timeout.as_secs(),
         request_timeout.as_secs(),
         cache_ttl.as_secs()
@@ -295,6 +304,7 @@ async fn main() -> Result<()> {
         next_hop_scp: args.next_hop_scp,
         max_cache_entries,
         cache_ttl,
+        max_producer_attempts,
         ..defaults
     }));
     let mut http_config =

--- a/src/bins/nextgcore-scpd/src/proxy.rs
+++ b/src/bins/nextgcore-scpd/src/proxy.rs
@@ -38,7 +38,7 @@ use nextgcore_sbi::SbiError;
 use crate::cache::BoundedCache;
 use crate::circuit_breaker::CircuitBreaker;
 use crate::sbi_path::{
-    parse_search_result, select_nf_service_endpoint, DiscoveryCache, EndpointSelectionError,
+    parse_search_result, rank_nf_service_endpoints, DiscoveryCache, EndpointSelectionError,
 };
 
 /// Default upstream connect timeout (bounded per TS 29.500 §6.11 guidance).
@@ -151,7 +151,17 @@ pub struct ScpProxyConfig {
     /// Set it only for such an NRF: with it on and no consumer CCA, the token
     /// request carries an unattested identity.
     pub trust_requester_identity: bool,
+    /// Maximum producers a single Model D request may be forwarded to before the
+    /// SCP gives up (scpd-#209). `1` disables reselection; the default `3` bounds
+    /// the fan-out so one consumer request cannot walk a large `SearchResult`.
+    /// Clamped to at least 1. Only reached on a *provably undelivered* forward, so
+    /// this is not a retry budget for a producer that answered.
+    pub max_producer_attempts: usize,
 }
+
+/// Default number of producers one Model D request may be forwarded to
+/// (scpd-#209): the selected one plus two alternates.
+const DEFAULT_MAX_PRODUCER_ATTEMPTS: usize = 3;
 
 impl Default for ScpProxyConfig {
     fn default() -> Self {
@@ -167,6 +177,7 @@ impl Default for ScpProxyConfig {
             circuit_failure_threshold: DEFAULT_CIRCUIT_FAILURE_THRESHOLD,
             circuit_open_timeout: DEFAULT_CIRCUIT_OPEN_TIMEOUT,
             trust_requester_identity: false,
+            max_producer_attempts: DEFAULT_MAX_PRODUCER_ATTEMPTS,
         }
     }
 }
@@ -500,11 +511,72 @@ impl ParsedBinding {
 
 /// A producer selected by Model D delegated discovery, with the identifiers the
 /// SCP surfaces to the consumer.
+#[derive(Debug, Clone)]
 struct DiscoveredProducer {
     target: ApiRoot,
     nf_instance_id: String,
     nf_set_id: Option<String>,
     nf_group_id: Option<String>,
+}
+
+/// The producer delegated discovery selected, plus the ordered alternates the SCP
+/// may fail over to (scpd-#209, TS 29.500 §6.10.8.2).
+///
+/// Before this, the remainder of the `SearchResult` was parsed and then thrown
+/// away, so a single restarting producer failed requests a registered, healthy
+/// sibling could have served: with N replicas behind the NRF, availability was
+/// that of one replica rather than of the set.
+struct DiscoveryOutcome {
+    primary: DiscoveredProducer,
+    alternates: Vec<DiscoveredProducer>,
+}
+
+/// A forward that provably never reached the producer, so another candidate may
+/// still serve it (scpd-#209).
+struct Undeliverable {
+    /// The producer apiRoot that could not be reached, for the error detail.
+    target: String,
+    /// The transport error, or `None` when the SCP's own circuit breaker for this
+    /// producer was Open and nothing was sent at all.
+    error: Option<SbiError>,
+}
+
+/// The result of forwarding to **one** producer (scpd-#209).
+///
+/// `Undeliverable` is separated from `Final` so the Model D path can tell "try
+/// the next candidate" from "this is the answer" — the distinction the old
+/// single-`SbiResponse` return could not express, which is why reselection was
+/// impossible without this split.
+enum ForwardOutcome {
+    /// The producer answered, at any status. Relay it.
+    Answered(SbiResponse),
+    /// The request never reached this producer.
+    Undeliverable(Undeliverable),
+    /// An SCP-originated answer no other candidate could improve on: a delegated
+    /// token the NRF refused (same for every instance of the target NF type), or
+    /// a transport failure that may have delivered the request already.
+    Final(SbiResponse),
+}
+
+/// True when `err` proves the request never left the SCP, so replaying it on
+/// another producer cannot duplicate work (scpd-#209 idempotency decision).
+///
+/// **This is the whole idempotency argument, and it is deliberately narrow.** In
+/// `nextgcore_sbi::client`, `ConnectionError` is produced only by the TCP connect
+/// (`client.rs:452`) and the HTTP/2 handshake (`:514`, `:529`), and `TlsError`
+/// only by server-name validation and the TLS handshake (`:457`, `:465`) — every
+/// one of them before a single request byte is written. So reselecting after one
+/// is safe even for a `POST`.
+///
+/// `Timeout` is excluded although it looks like a transport failure: the same
+/// variant is produced by the connect phase (`:451`, `:464`) **and** by the
+/// send/response phase (`:892`), so it cannot distinguish "never sent" from "sent
+/// and the producer is still working on it". Replaying a non-idempotent request
+/// on a timeout could duplicate a registration or a charging record.
+/// `HyperError` (`:893`) is likewise post-send. Taking the conservative reading
+/// means there is no exposure to document rather than an exposure documented.
+fn is_provably_undelivered(err: &SbiError) -> bool {
+    matches!(err, SbiError::ConnectionError(_) | SbiError::TlsError(_))
 }
 
 /// True for header names a proxy must not forward, in either direction:
@@ -1186,7 +1258,11 @@ impl ScpProxy {
     /// the `3gpp-Sbi-Discovery-*` request headers, parse the SearchResult,
     /// and select a producer. The requester identity comes from
     /// `3gpp-Sbi-Discovery-requester-nf-type` (NOT User-Agent).
-    async fn discover(&self, request: &SbiRequest) -> Result<DiscoveredProducer, SbiResponse> {
+    ///
+    /// Returns the selected producer **and the ordered alternates** (scpd-#209),
+    /// so a forward that never reached the selected one can fail over instead of
+    /// discarding a candidate set the SCP already holds.
+    async fn discover(&self, request: &SbiRequest) -> Result<DiscoveryOutcome, SbiResponse> {
         let target_nf_type = request
             .http
             .get_header(discovery_header::TARGET_NF_TYPE)
@@ -1233,12 +1309,19 @@ impl ScpProxy {
             self.discovery_cache
                 .get(&target_nf_type, &service_key, &cache_discriminator)
         {
-            if let Ok(selected) = select_nf_service_endpoint(
+            if let Ok(ranked) = rank_nf_service_endpoints(
                 &cached,
                 requested_service.as_deref(),
                 requested_version.as_deref(),
             ) {
-                return Ok(DiscoveredProducer {
+                // scpd-#209: the cached set supplies alternates too, so a producer
+                // that restarted since the SearchResult was cached is exactly the
+                // case failover exists for.
+                //
+                // nf_set_id / nf_group_id are None on a cache hit because the
+                // cache entry holds parsed candidates and not the raw profile —
+                // the cache-state divergence #208 fixes.
+                let mut producers = ranked.into_iter().map(|selected| DiscoveredProducer {
                     target: ApiRoot {
                         scheme: selected.scheme,
                         host: selected.candidate.host.clone(),
@@ -1249,6 +1332,12 @@ impl ScpProxy {
                     nf_set_id: None,
                     nf_group_id: None,
                 });
+                if let Some(primary) = producers.next() {
+                    return Ok(DiscoveryOutcome {
+                        primary,
+                        alternates: producers.collect(),
+                    });
+                }
             }
             // A cached set that cannot serve THIS request falls through to a
             // fresh NRF query rather than erroring from stale data: the cache TTL
@@ -1331,7 +1420,10 @@ impl ScpProxy {
             );
         }
 
-        let selected = select_nf_service_endpoint(
+        // scpd-#209: the whole ranked set, not just the head. Every entry is
+        // resolved here so the failover path holds no reference back into the
+        // SearchResult.
+        let ranked = rank_nf_service_endpoints(
             &candidates,
             requested_service.as_deref(),
             requested_version.as_deref(),
@@ -1344,26 +1436,39 @@ impl ScpProxy {
             )
         })?;
 
-        // scpd-02/scpd-12: surface the producer's set id / group id when present.
-        let (nf_set_id, nf_group_id) =
-            extract_set_and_group(&value, &selected.candidate.nf_instance_id);
-
-        // Build the producer ApiRoot from the NF profile fields parsed out of
-        // the SearchResult: scheme, port and prefix come from the MATCHED
-        // `nfServices` entry (scpd-#207); host is ipv4→fqdn→ipv6(bracketed).
-        // `client_for`/`oauth_client_for` already honour the scheme field, so
-        // an `https` producer is now contacted over TLS automatically.
-        let target = ApiRoot {
-            scheme: selected.scheme,
-            host: selected.candidate.host.clone(),
-            port: selected.port,
-            prefix: selected.prefix,
-        };
-        Ok(DiscoveredProducer {
-            target,
-            nf_instance_id: selected.candidate.nf_instance_id.clone(),
-            nf_set_id,
-            nf_group_id,
+        let mut producers = ranked.into_iter().map(|selected| {
+            // scpd-02/scpd-12: surface each producer's set id / group id when
+            // present — per candidate, so a reselected producer reports ITS own
+            // identifiers rather than the originally-selected one's.
+            let (nf_set_id, nf_group_id) =
+                extract_set_and_group(&value, &selected.candidate.nf_instance_id);
+            // Build the producer ApiRoot from the NF profile fields parsed out of
+            // the SearchResult: scheme, port and prefix come from the MATCHED
+            // `nfServices` entry (scpd-#207); host is ipv4→fqdn→ipv6(bracketed).
+            // `client_for`/`oauth_client_for` already honour the scheme field, so
+            // an `https` producer is now contacted over TLS automatically.
+            DiscoveredProducer {
+                target: ApiRoot {
+                    scheme: selected.scheme,
+                    host: selected.candidate.host.clone(),
+                    port: selected.port,
+                    prefix: selected.prefix,
+                },
+                nf_instance_id: selected.candidate.nf_instance_id.clone(),
+                nf_set_id,
+                nf_group_id,
+            }
+        });
+        let primary = producers.next().ok_or_else(|| {
+            endpoint_selection_error_response(
+                EndpointSelectionError::NoCandidate,
+                requested_service.as_deref(),
+                requested_version.as_deref(),
+            )
+        })?;
+        Ok(DiscoveryOutcome {
+            primary,
+            alternates: producers.collect(),
         })
     }
 
@@ -1387,20 +1492,62 @@ impl ScpProxy {
         group_id: Option<&str>,
         delegated: Option<DelegatedAuth>,
     ) -> SbiResponse {
-        // scpd-#102: consult this producer's circuit breaker before forwarding.
-        // An Open circuit short-circuits to 503 without contacting the producer,
-        // so a flapping/down backend cannot amplify latency across consumers.
-        let target_key = format!("{}://{}:{}", target.scheme, target.host, target.port);
-        if !self.circuit_allows(&target_key) {
-            return self.stamp_server(problem_response(
+        match self
+            .forward_once(request, target, producer_id, group_id, delegated)
+            .await
+        {
+            ForwardOutcome::Answered(response) | ForwardOutcome::Final(response) => response,
+            // A single pinned target has no alternates, so "undeliverable" is the
+            // final answer here and keeps its pre-#209 mapping exactly.
+            ForwardOutcome::Undeliverable(u) => self.stamp_server(self.undeliverable_response(&u)),
+        }
+    }
+
+    /// The single-target error response for an undelivered forward: the
+    /// pre-scpd-#209 mapping, unchanged — `503` when our own circuit breaker shed
+    /// the request, otherwise the `502`/`504` `TARGET_NF_NOT_REACHABLE` of
+    /// [`upstream_error_response`].
+    fn undeliverable_response(&self, u: &Undeliverable) -> SbiResponse {
+        match &u.error {
+            Some(err) => upstream_error_response(&u.target, err),
+            None => problem_response(
                 503,
                 "Service Unavailable",
                 &format!(
                     "SCP circuit breaker is open for {} (recent failures)",
-                    target.to_uri()
+                    u.target
                 ),
                 "TARGET_NF_NOT_REACHABLE",
-            ));
+            ),
+        }
+    }
+
+    /// Forward to exactly **one** producer, reporting whether the request was
+    /// delivered (scpd-#209). See [`ForwardOutcome`]; callers with alternates use
+    /// [`Self::forward_with_reselection`], callers without use [`Self::forward`].
+    async fn forward_once(
+        &self,
+        request: &SbiRequest,
+        target: &ApiRoot,
+        producer_id: Option<&str>,
+        group_id: Option<&str>,
+        delegated: Option<DelegatedAuth>,
+    ) -> ForwardOutcome {
+        // scpd-#102: consult this producer's circuit breaker before forwarding.
+        // An Open circuit short-circuits without contacting the producer, so a
+        // flapping/down backend cannot amplify latency across consumers.
+        //
+        // scpd-#209: this is reported as Undeliverable rather than as a finished
+        // 503, so the Model D path can try a DIFFERENT producer. That is the exact
+        // gap #209 names: the breaker stopped us hammering a dead producer but did
+        // not send us to a live one, so the first request after the circuit opened
+        // still failed.
+        let target_key = format!("{}://{}:{}", target.scheme, target.host, target.port);
+        if !self.circuit_allows(&target_key) {
+            return ForwardOutcome::Undeliverable(Undeliverable {
+                target: target.to_uri(),
+                error: None,
+            });
         }
 
         let mut fwd = SbiRequest::default();
@@ -1506,7 +1653,13 @@ impl ScpProxy {
                         }
                     }
                     Err(e) => {
-                        return self.stamp_server(token_acquisition_failure_response(&e));
+                        // scpd-#209: Final, not Undeliverable. The token is minted
+                        // for (consumer, target NF TYPE, scope), so every instance
+                        // of that type would get the same refusal — reselecting
+                        // would just repeat the NRF round-trip.
+                        return ForwardOutcome::Final(
+                            self.stamp_server(token_acquisition_failure_response(&e)),
+                        );
                     }
                 }
             }
@@ -1518,7 +1671,18 @@ impl ScpProxy {
                 // scpd-#102: a transport failure (connect refused / timeout) is
                 // a circuit failure.
                 self.circuit_record(&target_key, false);
-                return self.stamp_server(upstream_error_response(&target.to_uri(), &e));
+                // scpd-#209: only a provably-undelivered failure may be replayed
+                // on another producer; see `is_provably_undelivered`.
+                return if is_provably_undelivered(&e) {
+                    ForwardOutcome::Undeliverable(Undeliverable {
+                        target: target.to_uri(),
+                        error: Some(e),
+                    })
+                } else {
+                    ForwardOutcome::Final(
+                        self.stamp_server(upstream_error_response(&target.to_uri(), &e)),
+                    )
+                };
             }
         };
 
@@ -1596,7 +1760,113 @@ impl ScpProxy {
             self.append_via(&mut relayed.http);
         }
 
-        relayed
+        // scpd-#209: the producer ANSWERED, so this is the answer even at 4xx/5xx.
+        // Reselecting on a producer-generated error would be wrong twice: the
+        // producer is up (so the set is not the problem), and a 409 or a 404 is
+        // frequently the semantically correct answer that a sibling instance would
+        // have no business overriding.
+        ForwardOutcome::Answered(relayed)
+    }
+
+    /// Forward a Model D request, failing over to the next-best discovered
+    /// producer when one provably never received it (scpd-#209,
+    /// TS 29.500 §6.10.8.2).
+    ///
+    /// Bounded by `max_producer_attempts`, and the bound is **logged** when it
+    /// truncates the list: silently trying 3 of 9 candidates and then reporting
+    /// "no producer was reachable" would overstate what the SCP actually did.
+    async fn forward_with_reselection(
+        &self,
+        request: &SbiRequest,
+        outcome: DiscoveryOutcome,
+        delegated: Option<DelegatedAuth>,
+    ) -> SbiResponse {
+        let max_attempts = self.config.max_producer_attempts.max(1);
+        let total_candidates = 1 + outcome.alternates.len();
+        let producers = std::iter::once(outcome.primary).chain(outcome.alternates);
+
+        let mut attempted = 0usize;
+        let mut last_undeliverable: Option<Undeliverable> = None;
+        let mut any_transport_failure = false;
+
+        for producer in producers {
+            if attempted >= max_attempts {
+                break;
+            }
+            attempted += 1;
+            let producer_id =
+                build_producer_id(&producer.nf_instance_id, producer.nf_set_id.as_deref());
+            if attempted > 1 {
+                log::debug!(
+                    "SCP Model D reselection: attempt {attempted}/{max_attempts} -> {} \
+                     (producer {})",
+                    producer.target.to_uri(),
+                    producer.nf_instance_id
+                );
+            }
+            match self
+                .forward_once(
+                    request,
+                    &producer.target,
+                    producer_id.as_deref(),
+                    producer.nf_group_id.as_deref(),
+                    delegated.clone(),
+                )
+                .await
+            {
+                ForwardOutcome::Answered(response) | ForwardOutcome::Final(response) => {
+                    return response
+                }
+                ForwardOutcome::Undeliverable(u) => {
+                    any_transport_failure |= u.error.is_some();
+                    last_undeliverable = Some(u);
+                }
+            }
+        }
+
+        let untried = total_candidates.saturating_sub(attempted);
+        if untried > 0 {
+            log::warn!(
+                "SCP Model D: gave up after {attempted} producer(s); {untried} discovered \
+                 candidate(s) left untried because max_producer_attempts is {max_attempts}"
+            );
+        }
+
+        match last_undeliverable {
+            // At least one producer was actually unreachable on the wire. The SCP
+            // owns selection in Model D, so exhausting the whole candidate set
+            // means its upstream is not answering — 504, per TS 29.500 §6.10.8.2,
+            // rather than the 502 a single refused connection used to give. Model C
+            // keeps 502: there the CONSUMER pinned the target, so the failure is
+            // that one hop and not an exhausted set.
+            Some(u) if any_transport_failure => self.stamp_server(problem_response(
+                504,
+                "Gateway Timeout",
+                &format!(
+                    "SCP could not reach any of {attempted} discovered producer(s); \
+                     last was {} ({})",
+                    u.target,
+                    u.error
+                        .as_ref()
+                        .map(|e| e.to_string())
+                        .unwrap_or_else(|| "circuit open".to_string())
+                ),
+                "TARGET_NF_NOT_REACHABLE",
+            )),
+            // Every candidate was shed by its own circuit breaker, so nothing was
+            // ever put on the wire. That is load shedding, not unreachability, and
+            // 503 says "retry shortly" — which is exactly right, since the breakers
+            // will half-open.
+            Some(u) => self.stamp_server(self.undeliverable_response(&u)),
+            // Unreachable in practice: `attempted` is at least 1 and every arm
+            // either returns or sets `last_undeliverable`.
+            None => self.stamp_server(problem_response(
+                502,
+                "Bad Gateway",
+                "SCP selected no producer to forward to",
+                "TARGET_NF_NOT_REACHABLE",
+            )),
+        }
     }
 
     /// Handle one inbound SBI request end-to-end (the server handler entry
@@ -1636,7 +1906,7 @@ impl ScpProxy {
                     .await
             }
             RouteDecision::Discover => match self.discover(&request).await {
-                Ok(producer) => {
+                Ok(outcome) => {
                     // The producer NF type comes from the delegated-discovery
                     // header; used to scope the OAuth2 token the SCP attaches.
                     // #101 criterion 2: the token is minted for the requesting
@@ -1646,23 +1916,18 @@ impl ScpProxy {
                         .get_header(discovery_header::TARGET_NF_TYPE)
                         .and_then(|s| nf_type_from_str(s))
                         .map(|nf| self.delegated_auth(&request, nf));
-                    let producer_id =
-                        build_producer_id(&producer.nf_instance_id, producer.nf_set_id.as_deref());
                     log::debug!(
-                        "SCP Model D: {} {} -> {} (producer {})",
+                        "SCP Model D: {} {} -> {} (producer {}, {} alternate(s))",
                         request.header.method,
                         request.header.uri,
-                        producer.target.to_uri(),
-                        producer.nf_instance_id
+                        outcome.primary.target.to_uri(),
+                        outcome.primary.nf_instance_id,
+                        outcome.alternates.len()
                     );
-                    self.forward(
-                        &request,
-                        &producer.target,
-                        producer_id.as_deref(),
-                        producer.nf_group_id.as_deref(),
-                        delegated_auth,
-                    )
-                    .await
+                    // scpd-#209: fails over to the next-best discovered producer
+                    // when a forward provably never arrived.
+                    self.forward_with_reselection(&request, outcome, delegated_auth)
+                        .await
                 }
                 // scpd-03: SCP-originated discovery errors carry our `Server`.
                 Err(error_response) => self.stamp_server(error_response),
@@ -3045,8 +3310,9 @@ mod tests {
         });
         let body = serde_json::to_vec(&https_ipv6_result).unwrap();
         let candidates = parse_search_result(&body);
-        let selected = select_nf_service_endpoint(&candidates, Some("nudm-sdm"), Some("v1"))
-            .expect("candidate selected");
+        let selected =
+            crate::sbi_path::select_nf_service_endpoint(&candidates, Some("nudm-sdm"), Some("v1"))
+                .expect("candidate selected");
 
         // Simulate what discover() now does.
         let target = ApiRoot {
@@ -3087,8 +3353,9 @@ mod tests {
         });
         let body = serde_json::to_vec(&http_ipv4_result).unwrap();
         let candidates = parse_search_result(&body);
-        let selected = select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v1"))
-            .expect("candidate selected");
+        let selected =
+            crate::sbi_path::select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v1"))
+                .expect("candidate selected");
 
         let target = ApiRoot {
             scheme: selected.scheme,
@@ -3315,6 +3582,382 @@ mod tests {
         scp.stop().await.expect("scp stop");
         nrf.stop().await.expect("nrf stop");
         producer.stop().await.expect("producer stop");
+    }
+
+    // ------------------------------------------------------------------
+    // scpd-#209: alternate-producer reselection on an undelivered forward
+    // (TS 29.500 §6.10.8.2)
+    // ------------------------------------------------------------------
+
+    /// A `SearchResult` naming `ports` as separate UDM instances serving
+    /// `nudm-uecm`, in ascending `priority` — so the FIRST port listed is the one
+    /// selection picks first and reselection walks the rest in order.
+    fn uecm_instances(ports: &[u16]) -> serde_json::Value {
+        let instances: Vec<serde_json::Value> = ports
+            .iter()
+            .enumerate()
+            .map(|(i, port)| {
+                serde_json::json!({
+                    "nfInstanceId": format!("udm-{i}"),
+                    "nfType": "UDM",
+                    "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["127.0.0.1"],
+                    "priority": (i as u64) + 1,
+                    "capacity": 100,
+                    "load": 0,
+                    "nfServices": [{
+                        "serviceName": "nudm-uecm",
+                        "ipEndPoints": [{"transport": "TCP", "port": port}]
+                    }]
+                })
+            })
+            .collect();
+        serde_json::json!({"validityPeriod": 3600, "nfInstances": instances})
+    }
+
+    fn model_d_uecm_request() -> SbiRequest {
+        SbiRequest::post("/nudm-uecm/v1/registrations")
+            .with_header(discovery_header::TARGET_NF_TYPE, "UDM")
+            .with_header(discovery_header::REQUESTER_NF_TYPE, "AMF")
+            .with_header(discovery_header::SERVICE_NAMES, "nudm-uecm")
+    }
+
+    /// scpd-#209 acceptance: with two candidates where the first refuses
+    /// connections, the **second** serves the request.
+    ///
+    /// Two candidates is the minimum that can distinguish reselection from a
+    /// retry, which is why the issue asks for it: a single-candidate test would
+    /// pass against code that merely dialled the same dead producer twice.
+    #[tokio::test]
+    async fn test_model_d_reselects_the_next_candidate_when_the_first_refuses() {
+        // Port 1 on loopback refuses immediately (privileged, nothing listening).
+        const DEAD_PORT: u16 = 1;
+        let live_port = ephemeral_port();
+        let nrf_port = ephemeral_port();
+        let scp_port = ephemeral_port();
+        let live_hits = Arc::new(AtomicU64::new(0));
+
+        let live = start_named_producer(live_port, "second", live_hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[DEAD_PORT, live_port])).await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                connect_timeout: Duration::from_millis(500),
+                request_timeout: Duration::from_millis(500),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let response = fast_client(scp_port)
+            .send_request(model_d_uecm_request())
+            .await
+            .expect("roundtrip");
+        assert_eq!(
+            response.status, 200,
+            "a registered healthy sibling must serve a request the first candidate could not"
+        );
+        let body: serde_json::Value = response.json_body().unwrap();
+        assert_eq!(body["servedBy"], "second");
+        assert_eq!(live_hits.load(Ordering::SeqCst), 1);
+        // scpd-02/#209: the reselected producer reports ITS OWN instance id, not
+        // the one originally selected.
+        assert_eq!(
+            response.http.producer_id().map(String::as_str),
+            Some("nfinst=udm-1"),
+            "Producer-Id must name the producer that actually served the request"
+        );
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        live.stop().await.expect("live stop");
+    }
+
+    /// scpd-#209 acceptance: exhausting the candidate list on connection-refused
+    /// is `504`, and is distinguishable from the `502 NF_DISCOVERY_FAILURE` a
+    /// genuine discovery error gives.
+    ///
+    /// Both are driven here so the distinction is asserted rather than assumed —
+    /// and note the pair `(504, TARGET_NF_NOT_REACHABLE)` does not collide with
+    /// #211's `(504, NRF_NOT_REACHABLE)`: the cause still names which node failed.
+    #[tokio::test]
+    async fn test_model_d_exhausted_candidates_is_504_distinct_from_discovery_failure() {
+        let nrf_port = ephemeral_port();
+        // Two candidates, both refusing.
+        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[1, 2])).await;
+        let proxy = ScpProxy::new(ScpProxyConfig {
+            nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+            connect_timeout: Duration::from_millis(500),
+            request_timeout: Duration::from_millis(500),
+            ..Default::default()
+        });
+        let exhausted = proxy.handle(model_d_uecm_request()).await;
+        let problem: ProblemDetails = exhausted.json_body().unwrap();
+        let exhausted = (exhausted.status, problem.cause.unwrap_or_default());
+        assert_eq!(exhausted, (504, "TARGET_NF_NOT_REACHABLE".to_string()));
+
+        // A genuine discovery error: the NRF answers non-200.
+        let broken_port = ephemeral_port();
+        let broken =
+            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
+                SocketAddr::from(([127, 0, 0, 1], broken_port)),
+            ));
+        broken
+            .start(|_r: SbiRequest| async move { SbiResponse::with_status(500) })
+            .await
+            .expect("broken nrf start");
+        let proxy = ScpProxy::new(ScpProxyConfig {
+            nrf_uri: Some(format!("http://127.0.0.1:{broken_port}")),
+            connect_timeout: Duration::from_millis(500),
+            request_timeout: Duration::from_millis(500),
+            ..Default::default()
+        });
+        let discovery_error = proxy.handle(model_d_uecm_request()).await;
+        let problem: ProblemDetails = discovery_error.json_body().unwrap();
+        let discovery_error = (discovery_error.status, problem.cause.unwrap_or_default());
+        assert_eq!(discovery_error, (502, "NF_DISCOVERY_FAILURE".to_string()));
+
+        assert_ne!(
+            exhausted, discovery_error,
+            "an exhausted producer set and a discovery error must not read alike"
+        );
+
+        nrf.stop().await.expect("nrf stop");
+        broken.stop().await.expect("broken nrf stop");
+    }
+
+    /// scpd-#209 acceptance: a producer-generated 5xx is **relayed**, not
+    /// reselected. The producer answered, so the set is not the problem — and a
+    /// sibling has no business overriding a 409 or a 404 the first one returned.
+    ///
+    /// The second candidate is live and counted, so the assertion distinguishes
+    /// "did not reselect" from "reselected and the second also failed".
+    #[tokio::test]
+    async fn test_model_d_does_not_reselect_on_a_producer_error() {
+        let erroring_port = ephemeral_port();
+        let live_port = ephemeral_port();
+        let nrf_port = ephemeral_port();
+        let scp_port = ephemeral_port();
+        let erroring_hits = Arc::new(AtomicU64::new(0));
+        let live_hits = Arc::new(AtomicU64::new(0));
+
+        let erroring = start_counting_500_producer(erroring_port, erroring_hits.clone()).await;
+        let live = start_named_producer(live_port, "second", live_hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[erroring_port, live_port])).await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                connect_timeout: Duration::from_millis(500),
+                request_timeout: Duration::from_millis(500),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let response = fast_client(scp_port)
+            .send_request(model_d_uecm_request())
+            .await
+            .expect("roundtrip");
+        assert_eq!(response.status, 500, "the producer's answer is relayed");
+        assert_eq!(erroring_hits.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            live_hits.load(Ordering::SeqCst),
+            0,
+            "a producer that ANSWERED must not trigger failover to a sibling"
+        );
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        live.stop().await.expect("live stop");
+        erroring.stop().await.expect("erroring stop");
+    }
+
+    /// scpd-#209: `max_producer_attempts` really bounds the walk.
+    ///
+    /// Three candidates, the first two refusing and the third live, with the bound
+    /// set to 2: the request must FAIL even though a healthy producer was in the
+    /// set and one more attempt would have reached it. Asserting the failure is
+    /// how the bound is observed — counting connects to a dead port is not
+    /// possible.
+    #[tokio::test]
+    async fn test_max_producer_attempts_bounds_the_reselection_walk() {
+        let live_port = ephemeral_port();
+        let nrf_port = ephemeral_port();
+        let live_hits = Arc::new(AtomicU64::new(0));
+
+        let live = start_named_producer(live_port, "third", live_hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[1, 2, live_port])).await;
+
+        let bounded = ScpProxy::new(ScpProxyConfig {
+            nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+            connect_timeout: Duration::from_millis(500),
+            request_timeout: Duration::from_millis(500),
+            max_producer_attempts: 2,
+            ..Default::default()
+        });
+        let response = bounded.handle(model_d_uecm_request()).await;
+        assert_eq!(response.status, 504, "the bound stopped the walk short");
+        assert_eq!(
+            live_hits.load(Ordering::SeqCst),
+            0,
+            "the third candidate was never tried"
+        );
+
+        // Raising the bound reaches it, so the failure above is the bound and not
+        // a broken third candidate.
+        let unbounded = ScpProxy::new(ScpProxyConfig {
+            nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+            connect_timeout: Duration::from_millis(500),
+            request_timeout: Duration::from_millis(500),
+            max_producer_attempts: 3,
+            ..Default::default()
+        });
+        let response = unbounded.handle(model_d_uecm_request()).await;
+        assert_eq!(response.status, 200);
+        assert_eq!(live_hits.load(Ordering::SeqCst), 1);
+
+        nrf.stop().await.expect("nrf stop");
+        live.stop().await.expect("live stop");
+    }
+
+    /// scpd-#209 + scpd-#102: **an open circuit reselects instead of shedding.**
+    ///
+    /// This is the interaction the issue names in as many words: the breaker
+    /// stopped the SCP hammering a dead producer but never sent it to a live one,
+    /// so "the first request after the circuit opens still fails". Here the first
+    /// candidate answers 500 twice to trip its own breaker; the third request must
+    /// be served by the sibling rather than shed with a 503.
+    #[tokio::test]
+    async fn test_an_open_circuit_reselects_rather_than_shedding() {
+        let flapping_port = ephemeral_port();
+        let live_port = ephemeral_port();
+        let nrf_port = ephemeral_port();
+        let scp_port = ephemeral_port();
+        let flapping_hits = Arc::new(AtomicU64::new(0));
+        let live_hits = Arc::new(AtomicU64::new(0));
+
+        let flapping = start_counting_500_producer(flapping_port, flapping_hits.clone()).await;
+        let live = start_named_producer(live_port, "sibling", live_hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[flapping_port, live_port])).await;
+        let scp = start_scp(
+            scp_port,
+            ScpProxyConfig {
+                nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+                connect_timeout: Duration::from_millis(500),
+                request_timeout: Duration::from_millis(500),
+                circuit_failure_threshold: 2,
+                circuit_open_timeout: Duration::from_secs(30),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let client = fast_client(scp_port);
+
+        // Two 5xx answers trip the first candidate's breaker. Both are relayed —
+        // a producer that answers is not reselected.
+        for _ in 0..2 {
+            let response = client
+                .send_request(model_d_uecm_request())
+                .await
+                .expect("roundtrip");
+            assert_eq!(response.status, 500);
+        }
+        assert_eq!(flapping_hits.load(Ordering::SeqCst), 2);
+        assert_eq!(live_hits.load(Ordering::SeqCst), 0);
+
+        // The breaker for the first candidate is now Open. Pre-#209 this request
+        // was shed with 503; it must now be served by the sibling.
+        let response = client
+            .send_request(model_d_uecm_request())
+            .await
+            .expect("roundtrip");
+        assert_eq!(
+            response.status, 200,
+            "an open circuit must send the request to a sibling, not shed it"
+        );
+        let body: serde_json::Value = response.json_body().unwrap();
+        assert_eq!(body["servedBy"], "sibling");
+        assert_eq!(live_hits.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            flapping_hits.load(Ordering::SeqCst),
+            2,
+            "the open circuit still protects the failing producer from more traffic"
+        );
+
+        scp.stop().await.expect("scp stop");
+        nrf.stop().await.expect("nrf stop");
+        live.stop().await.expect("live stop");
+        flapping.stop().await.expect("flapping stop");
+    }
+
+    /// scpd-#209 unit: the idempotency rule. `ConnectionError` and `TlsError` are
+    /// produced only before any request byte is written, so replaying them is
+    /// safe; `Timeout` and `HyperError` can both occur *after* the request was
+    /// sent, so replaying a `POST` on one could duplicate work.
+    #[test]
+    fn test_only_pre_send_failures_are_replayable() {
+        assert!(is_provably_undelivered(&SbiError::ConnectionError(
+            "Connection refused (os error 111)".to_string()
+        )));
+        assert!(is_provably_undelivered(&SbiError::TlsError(
+            "TLS handshake failed".to_string()
+        )));
+        // The load-bearing negatives: a timeout may mean the producer received the
+        // request and is still working on it.
+        assert!(!is_provably_undelivered(&SbiError::Timeout));
+        assert!(!is_provably_undelivered(&SbiError::HyperError(
+            "stream closed".to_string()
+        )));
+        assert!(!is_provably_undelivered(&SbiError::InvalidResponse(
+            "garbage".to_string()
+        )));
+    }
+
+    /// scpd-#209: a timeout on the FIRST candidate is not replayed on the second,
+    /// because the request may already have been delivered. The live sibling stays
+    /// untouched and the consumer gets the 504 the slow producer earned.
+    #[tokio::test]
+    async fn test_a_timeout_does_not_reselect() {
+        let slow_port = ephemeral_port();
+        let live_port = ephemeral_port();
+        let nrf_port = ephemeral_port();
+        let live_hits = Arc::new(AtomicU64::new(0));
+
+        let slow =
+            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
+                SocketAddr::from(([127, 0, 0, 1], slow_port)),
+            ));
+        slow.start(|_r: SbiRequest| async move {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            SbiResponse::ok()
+        })
+        .await
+        .expect("slow producer start");
+        let live = start_named_producer(live_port, "second", live_hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[slow_port, live_port])).await;
+
+        let proxy = ScpProxy::new(ScpProxyConfig {
+            nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
+            connect_timeout: Duration::from_millis(500),
+            request_timeout: Duration::from_millis(300),
+            ..Default::default()
+        });
+        let response = proxy.handle(model_d_uecm_request()).await;
+        assert_eq!(response.status, 504);
+        let problem: ProblemDetails = response.json_body().unwrap();
+        assert_eq!(problem.cause.as_deref(), Some("TARGET_NF_NOT_REACHABLE"));
+        assert_eq!(
+            live_hits.load(Ordering::SeqCst),
+            0,
+            "a possibly-delivered request must not be replayed on a sibling"
+        );
+
+        nrf.stop().await.expect("nrf stop");
+        live.stop().await.expect("live stop");
+        slow.stop().await.expect("slow stop");
     }
 
     /// When no NRF (and thus no OAuth2 client) is configured, a Model C forward

--- a/src/bins/nextgcore-scpd/src/sbi_path.rs
+++ b/src/bins/nextgcore-scpd/src/sbi_path.rs
@@ -286,6 +286,72 @@ pub fn select_nf_service_endpoint<'a>(
     service_name: Option<&str>,
     api_version: Option<&str>,
 ) -> Result<SelectedEndpoint<'a>, EndpointSelectionError> {
+    rank_nf_service_endpoints(candidates, service_name, api_version)?
+        .into_iter()
+        .next()
+        .ok_or(EndpointSelectionError::NoCandidate)
+}
+
+/// Every producer endpoint matching the requested service and API version, in
+/// **selection order** — the head is exactly what [`select_nf_service_endpoint`]
+/// returns, and each subsequent entry is what it *would* return with all the
+/// preceding ones removed (scpd-#209).
+///
+/// The ranking is built by applying the same health / priority / capacity rule
+/// repeatedly rather than by sorting on a comparable key. That is deliberate:
+/// `select_best` breaks a capacity tie via `max_by_key`, which yields the **last**
+/// maximum, whereas a descending sort yields the first. Re-running the real rule
+/// makes head-equality true by construction instead of by reproducing a tie-break
+/// exactly — which is the sort of detail that drifts and then silently changes
+/// which producer every Model D request goes to.
+///
+/// The candidate lists here are a handful of entries, so the repeated pass is not
+/// a cost worth trading correctness for.
+pub fn rank_nf_service_endpoints<'a>(
+    candidates: &'a [NfInstanceCandidate],
+    service_name: Option<&str>,
+    api_version: Option<&str>,
+) -> Result<Vec<SelectedEndpoint<'a>>, EndpointSelectionError> {
+    let matching = match_candidates(candidates, service_name, api_version)?;
+
+    // The pool rule is applied ONCE, up front, rather than left to emerge from
+    // `select_best`'s own fallback. It has to be: `select_best` falls back to "all
+    // candidates" when none are healthy, so re-running it until the pool empties
+    // would hand back every SUSPENDED instance as a last-resort alternate once the
+    // healthy ones were exhausted. A SUSPENDED NF must not be selected
+    // (TS 29.510 `nfStatus`), so that would trade a reachability problem for a
+    // conformance one. The existing leniency — use everything when the NRF reports
+    // nothing healthy at all — is preserved, because that is a different case.
+    let healthy: Vec<&NfInstanceCandidate> =
+        matching.iter().copied().filter(|c| c.healthy).collect();
+    let mut remaining = if healthy.is_empty() {
+        matching
+    } else {
+        healthy
+    };
+    let mut ranked = Vec::with_capacity(remaining.len());
+    while !remaining.is_empty() {
+        let Some(best) = select_best(remaining.clone()) else {
+            break;
+        };
+        remaining.retain(|c| !std::ptr::eq(*c, best));
+        ranked.push(resolve_endpoint(best, service_name, api_version));
+    }
+    if ranked.is_empty() {
+        return Err(EndpointSelectionError::NoCandidate);
+    }
+    Ok(ranked)
+}
+
+/// The candidates that match the requested service name and API version, in
+/// SearchResult order and before any priority ordering. Splitting this out is
+/// what lets the error variants stay distinct while both the single-pick and the
+/// ranked-list entry points share one definition of "matching".
+fn match_candidates<'a>(
+    candidates: &'a [NfInstanceCandidate],
+    service_name: Option<&str>,
+    api_version: Option<&str>,
+) -> Result<Vec<&'a NfInstanceCandidate>, EndpointSelectionError> {
     if candidates.is_empty() {
         return Err(EndpointSelectionError::NoCandidate);
     }
@@ -321,15 +387,22 @@ pub fn select_nf_service_endpoint<'a>(
         return Err(EndpointSelectionError::UnsupportedApiVersion);
     }
 
-    let candidate = select_best(serves_version).ok_or(EndpointSelectionError::NoCandidate)?;
+    Ok(serves_version)
+}
 
-    // Endpoint from the MATCHING service; the profile-level fields are only the
-    // fallback for a profile with no service list.
+/// Resolve `candidate` to its endpoint, taking scheme / port / `apiPrefix` from
+/// the **matching** service and falling back to the profile-level fields only
+/// when the profile declares no service list.
+fn resolve_endpoint<'a>(
+    candidate: &'a NfInstanceCandidate,
+    service_name: Option<&str>,
+    api_version: Option<&str>,
+) -> SelectedEndpoint<'a> {
     let matched = candidate
         .services
         .iter()
         .find(|s| service_name_matches(s, service_name) && service_version_matches(s, api_version));
-    Ok(match matched {
+    match matched {
         Some(service) => SelectedEndpoint {
             candidate,
             scheme: service.scheme,
@@ -342,7 +415,7 @@ pub fn select_nf_service_endpoint<'a>(
             port: candidate.port,
             prefix: candidate.prefix.clone(),
         },
-    })
+    }
 }
 
 /// Round-robin index for distributing requests across equal-weight instances.
@@ -1403,6 +1476,117 @@ mod tests {
             .expect("the matching instance is selected despite worse priority");
         assert_eq!(selected.candidate.nf_instance_id, "udm-uecm-only");
         assert_eq!(selected.port, 2222);
+    }
+
+    // ------------------------------------------------------------------
+    // scpd-#209: the ranked candidate list reselection walks
+    // ------------------------------------------------------------------
+
+    /// scpd-#209: the ranked list's **head is exactly** what the single-pick entry
+    /// point returns, and each tail entry is the same rule with the preceding ones
+    /// removed. That equality is the whole reason `rank_nf_service_endpoints`
+    /// re-runs `select_best` instead of sorting on a key.
+    ///
+    /// The fixture contains a deliberate **capacity tie** between `udm-a` and
+    /// `udm-b`: `select_best` resolves it with `max_by_key`, which yields the LAST
+    /// maximum, so the head is `udm-b`. A descending sort would have produced
+    /// `udm-a` and silently changed which producer every Model D request goes to.
+    #[test]
+    fn test_ranked_endpoints_head_matches_the_single_pick() {
+        let tied = serde_json::to_vec(&serde_json::json!({
+            "nfInstances": [
+                {
+                    "nfInstanceId": "udm-a",
+                    "nfType": "UDM", "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["10.0.0.20"],
+                    "priority": 10, "capacity": 100, "load": 50,
+                    "nfServices": [{"serviceName": "nudm-uecm",
+                                    "ipEndPoints": [{"port": 1001}]}]
+                },
+                {
+                    "nfInstanceId": "udm-b",
+                    "nfType": "UDM", "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["10.0.0.21"],
+                    "priority": 10, "capacity": 100, "load": 50,
+                    "nfServices": [{"serviceName": "nudm-uecm",
+                                    "ipEndPoints": [{"port": 1002}]}]
+                },
+                {
+                    "nfInstanceId": "udm-c",
+                    "nfType": "UDM", "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["10.0.0.22"],
+                    "priority": 20, "capacity": 100, "load": 0,
+                    "nfServices": [{"serviceName": "nudm-uecm",
+                                    "ipEndPoints": [{"port": 1003}]}]
+                }
+            ]
+        }))
+        .unwrap();
+        let candidates = parse_search_result(&tied);
+
+        let single = select_nf_service_endpoint(&candidates, Some("nudm-uecm"), Some("v1"))
+            .expect("single pick");
+        let ranked =
+            rank_nf_service_endpoints(&candidates, Some("nudm-uecm"), Some("v1")).expect("ranked");
+
+        assert_eq!(
+            ranked.len(),
+            3,
+            "every matching candidate is available as an alternate"
+        );
+        assert_eq!(
+            ranked[0].candidate.nf_instance_id, single.candidate.nf_instance_id,
+            "the ranked head must BE the single pick, or reselection would start \
+             somewhere other than where selection did"
+        );
+        let order: Vec<&str> = ranked
+            .iter()
+            .map(|e| e.candidate.nf_instance_id.as_str())
+            .collect();
+        assert_eq!(order, vec!["udm-b", "udm-a", "udm-c"]);
+        // Each entry still carries its own matched endpoint.
+        assert_eq!(ranked[0].port, 1002);
+        assert_eq!(ranked[1].port, 1001);
+        assert_eq!(ranked[2].port, 1003);
+    }
+
+    /// scpd-#209: an unhealthy instance is **not** offered as an alternate while a
+    /// healthy one exists, mirroring `select_best`'s pool rule. A `SUSPENDED` NF
+    /// must not be selected (TS 29.510), so failing over onto one would trade a
+    /// reachability problem for a conformance one — the ranked list therefore
+    /// stops at the healthy set rather than appending the rest as a last resort.
+    #[test]
+    fn test_ranked_endpoints_exclude_unhealthy_while_a_healthy_one_exists() {
+        let mixed = serde_json::to_vec(&serde_json::json!({
+            "nfInstances": [
+                {
+                    "nfInstanceId": "udm-suspended",
+                    "nfType": "UDM", "nfStatus": "SUSPENDED",
+                    "ipv4Addresses": ["10.0.0.30"],
+                    "priority": 1,
+                    "nfServices": [{"serviceName": "nudm-uecm",
+                                    "ipEndPoints": [{"port": 2001}]}]
+                },
+                {
+                    "nfInstanceId": "udm-registered",
+                    "nfType": "UDM", "nfStatus": "REGISTERED",
+                    "ipv4Addresses": ["10.0.0.31"],
+                    "priority": 50,
+                    "nfServices": [{"serviceName": "nudm-uecm",
+                                    "ipEndPoints": [{"port": 2002}]}]
+                }
+            ]
+        }))
+        .unwrap();
+        let candidates = parse_search_result(&mixed);
+        let ranked =
+            rank_nf_service_endpoints(&candidates, Some("nudm-uecm"), Some("v1")).expect("ranked");
+        assert_eq!(
+            ranked.len(),
+            1,
+            "the SUSPENDED instance is not an alternate"
+        );
+        assert_eq!(ranked[0].candidate.nf_instance_id, "udm-registered");
     }
 
     /// scpd-#207: an unhealthy instance is still skipped inside the matching set,


### PR DESCRIPTION
The SCP forwarded to exactly one producer and gave up on the first transport
failure. The rest of the SearchResult -- addresses it already held, for instances
the NRF had just called REGISTERED -- was parsed and thrown away. With N replicas
behind the NRF, availability was that of ONE replica: any producer restart dropped
requests a healthy sibling could have served.

FORWARD_ONCE NOW RETURNS ForwardOutcome, and that split is the change rather than a
refactor bolted onto it. A single SbiResponse return cannot express "try elsewhere" --
a producer 500, a refused connection and a token failure all came back as an answer,
so reselection was not expressible on top of it. Answered / Undeliverable / Final.
forward() (Model C, sticky) collapses it back to the pre-existing mapping, so those
paths are byte-unchanged; forward_with_reselection() (Model D) loops.

Final is not a synonym for error: a delegated token the NRF refuses is Final because
the token is minted for (consumer, target NF TYPE, scope), so every instance of that
type would be refused identically and reselecting would only repeat the NRF
round-trip.

RESELECT ONLY ON A PROVABLY PRE-SEND FAILURE. The issue offers a choice -- restrict
to failures that provably occurred before the request was sent, or document the
exposure. Took the first, so there is no exposure to document. ConnectionError comes
only from TCP connect (client.rs:452) and the h2 handshake (:514, :529); TlsError only
from server-name validation and the TLS handshake (:457, :465) -- all before a single
request byte. TIMEOUT IS EXCLUDED although it looks like a transport failure: the same
variant is produced by the connect phase (:451, :464) AND the send/response phase
(:892), so it cannot distinguish "never sent" from "sent and the producer is still
working on it", and replaying a POST on one could duplicate a registration or a
charging record. HyperError (:893) likewise.

AN OPEN CIRCUIT NOW RESELECTS INSTEAD OF SHEDDING -- the interaction the issue names
in as many words: the breaker stopped us hammering a dead producer but never sent us
to a live one, so the first request after it opened still failed. The dead producer
stays protected; its hit count is asserted not to move while the sibling's does. If
EVERY candidate is shed by its own breaker the answer stays 503, not 504: nothing went
on the wire, so that is load shedding and "retry shortly" is true.

504 ON EXHAUSTION IN MODEL D, 502 STILL IN MODEL C, from the same underlying error --
deliberate. In Model D the SCP owns selection, so exhausting the set means its upstream
is not answering. In Model C the CONSUMER pinned the target: there is no set to
exhaust, so it is that one hop. And (504, TARGET_NF_NOT_REACHABLE) does not collide
with #211's (504, NRF_NOT_REACHABLE) -- the cause still names which node failed, which
was #211's whole point. Asserted, not assumed.

RANKED BY RE-RUNNING THE RULE, NOT BY SORTING. select_best breaks a capacity tie with
max_by_key, which yields the LAST maximum; a descending sort yields the first. Sorting
would have silently changed which producer every Model D request goes to. Re-running
the real rule makes "the ranked head IS the single pick" true by construction, and the
test uses a deliberate tie and pins the whole order so the tie-break is documented
rather than incidental.

AND A FAILING TEST CAUGHT A CONFORMANCE BUG IN MY FIRST VERSION. The rank loop ran
until the pool emptied -- and because select_best falls back to "all candidates" when
none are healthy, it handed back every SUSPENDED instance as a last-resort alternate
once the healthy ones were exhausted. A SUSPENDED NF must not be selected (TS 29.510
nfStatus), so that traded a reachability problem for a conformance one. The
healthy-if-any pool is now computed ONCE before ranking with the reasoning at the site.
The pre-existing leniency -- use everything when the NRF reports nothing healthy at all
-- is untouched, because that is a different case.

The bound is operable and it is logged when it bites. max_producer_attempts defaults to
3, is clamped to >=1, and is wired through the established YAML path with a
commented-out entry in the shipped scp.yaml -- a tuning field reachable only from Rust
is close to a dead field, and every sibling knob already follows that path. When the
bound leaves candidates untried it logs both counts at warn: trying 3 of 9 and then
reporting "could not reach any producer" would overstate what the SCP did.

Workspace 5971 passed / 0 failed / 6 ignored (baseline 5962 after #211; +9 tests).
clippy and fmt clean, zero warnings.

FIVE CLAIMS REVERT-VERIFIED: no reselection fails 3; exhaustion back to 502 fails 2;
producer 5xx treated as undeliverable fails 4; Timeout made replayable fails 2; open
circuit back to a final 503 fails 1. The third is worth noting -- it also broke TWO
PRE-EXISTING tests, which is independent evidence that "a producer that answered is
relayed" was already load-bearing and not just a new assertion of mine.

#211's handoff note asked this branch to re-verify its five failure rows rather than
assume them. Done: both #211 tests still pass and the new exhaustion pair is explicitly
asserted distinct from the discovery-error pair.

DOCS: adding the new config key exposed a MUCH OLDER staleness on the same page that
had to be resolved rather than shipped beside it. scp.md's intro said configuration is
"CLI flags and environment variables only", its honesty note said the daemon "reads the
YAML config file only to log its byte count" and that "no #[derive(Deserialize)] config
structs exist anywhere in the crate", and a whole section read "YAML parameters: None."
All false: config.rs has serde structs and main.rs reads the SBI address/port, NRF URI,
fqdn, nf_instance_id, both timeouts, the cache bounds and sbi.tls.enabled/cert/key.
Only tls.ca and tls.min_version are still unread. The page now carries a live-vs-inert
table, the corrected precedence, and an explicit note that the old claim no longer
holds. Scoped to the config-parsing claims -- the --kill and --log-file stub claims are
left alone, not having been re-verified here.

Ceilings: no test drives a TLS handshake failure into reselection (mock producers are
plaintext), so TlsError rests on the unit predicate; reselection is not applied to
Model C or sticky binding by design; select_nf_instance_round_robin still has no caller
and was not made rank-aware. GitNexus impact analysis unrunnable (no MCP server).

Closes #209

Spec: specs/fix-scpd-alternate-producer-reselection.md