### PR TITLE
fix(amfd): retrieve the GPSI from am-data and convey it on N11 (#205)

### DIFF
--- a/specs/fix-amfd-gpsi-from-am-data.md
+++ b/specs/fix-amfd-gpsi-from-am-data.md
@@ -1,0 +1,130 @@
+# nextgcore #205 (amfd): retrieve the GPSI from `am-data` and convey it on N11
+
+Verified against `main` @ `4e5771d`. The issue was written at `d9aea74`; every cite was
+re-located and one part of its suggested approach is **stale** — see below.
+
+## Verified against current main
+
+| claim in the issue | site on `4e5771d` | still true? |
+|---|---|---|
+| the N11 builder documents `gpsi` as deliberately absent | `bins/nextgcore-amfd/src/sbi_path.rs:883` | yes |
+| `AmfUe` has no `gpsi` field | `grep -n gpsi bins/nextgcore-amfd/src/context.rs` → nothing | yes |
+| the AMF's only SDM retrieval is `GET /nudm-sdm/v2/{supi}/am-data` | `sbi_path.rs:1582` (`call_udm_sdm_get_am_data`) | yes |
+| the response parse does not read `gpsis` | it read `subscribedUeAmbr` and `nssai.defaultSingleNssais` only | yes |
+| `udrd` populates `gpsis` in `am-data` | `bins/nextgcore-udrd/src/nudr_handler.rs:474` `build_am_data`, `msisdn-{bcd}` | yes |
+
+**Stale in the suggested approach.** It says to "populate the existing (already-wired) `gpsi`
+member of the N11 identity struct". There is no such member: `SmContextIdentity`
+(`sbi_path.rs:818`) carries `supi`, `pei`, `guami`, `serving_plmn`, `serving_nf_id`, `ue_location`
+and stops. The comment at `:883` is the *only* trace of `gpsi` in the crate. So the field had to be
+added to the struct as well as to `AmfUe` — a larger diff than the issue implies, though in the
+same shape.
+
+## Decision 1: `Gpsi` is accepted only in its two NAMED forms, which is stricter than TS 29.571's own pattern
+
+TS 29.571's `Gpsi` pattern is `^(msisdn-[0-9]{5,15}|extid-[^@]+@[^@]+|.+)$`. **That trailing `.+`
+alternative matches any non-empty string**, so validating against the pattern *literally* would
+validate nothing — a UDR bug that put a bare SUPI, a stray whitespace or an empty placeholder into
+`gpsis` would pass, and the AMF would convey it to the SMF as an external identity.
+
+`validated_gpsi` therefore accepts `msisdn-<5..15 digits>` and `extid-<local>@<domain>` and
+rejects everything else. The reasoning: a GPSI exists to be the identifier a CHF or AF correlates
+on (TS 23.501 §5.9.8), so a value of unknown form is worth no more than no value at all — and
+`None` is the honest one, because every consumer then omits the member instead of conveying
+something a billing system cannot join on. This is the same omit-never-placehold rule #73
+established for `supi` and `servingNetwork`, applied one step earlier: at ingest rather than at
+serialisation.
+
+The deliberate cost, stated because it is a real conformance trade: a subscription carrying a
+FUTURE GPSI type added by 3GPP under the `.+` escape is dropped rather than forwarded. The caller
+logs that at `warn` with the entry count, so it is diagnosable instead of silent, and the fix is to
+add the new form to `validated_gpsi`.
+
+## Decision 2: the first well-formed entry wins, and a malformed leading entry is skipped
+
+`gpsis` is an array; the N11 `gpsi` member is singular. The first entry that validates is taken —
+not the first entry outright, so one malformed record does not cost a subscriber their usable
+second identity. When nothing in the array validates, nothing is stored.
+
+## Decision 3: the store is unconditional, so a withdrawn GPSI is cleared
+
+`state.amf_ue.gpsi = am_data.gpsi.clone()` assigns even when the response carries none, rather than
+`if let Some(..)`. A subscription that STOPS carrying a GPSI must clear the stale one on
+re-registration; keeping the old value would have the AMF conveying an identity the subscription no
+longer asserts, which is the same class of defect as conveying a derived one.
+
+## Decision 4: two refactors were made to close a false-guard shape, not for tidiness
+
+Neither is asked for by the issue. Both exist because without them the tests would have been
+guards that prove nothing:
+
+1. **`parse_am_data` extracted from `call_udm_sdm_get_am_data`.** The decode was inline in an async
+   function that needs a live UDM, so the interesting `gpsis` inputs — several entries, a malformed
+   leading entry, an empty array, an all-malformed array — were not expressible from a test at all.
+2. **`build_sm_context_identity` extracted from the inline block at the CreateSMContext call site**
+   (`ngap_path.rs:3600`). `sbi_path`'s serialiser tests build a `SmContextIdentity` **by hand**, so
+   they assert that the serialiser emits what it is handed. They would keep passing if the mapping
+   from the UE context were `gpsi: None` — the exact shape of false guard recorded from the #210
+   session. The new test asserts the mapping itself.
+
+The second extraction is a behaviour-preserving move of ~50 lines; its revert (`gpsi: None`) is one
+of the five below.
+
+## Acceptance criteria
+
+- [x] `AmfUe` carries an optional GPSI parsed from the `am-data` response the AMF already retrieves
+      — `context.rs` `gpsi: Option<String>`, assigned from `AmDataResponse.gpsi` in the
+      registration path.
+- [x] A malformed or absent `gpsis` yields no stored GPSI (no blank, no derived value) —
+      `am_data_takes_the_first_well_formed_gpsi` covers empty array, empty string, a SUPI, a
+      non-string, and an absent member; `validated_gpsi_accepts_only_the_named_forms` covers 13
+      malformed spellings including both `msisdn-` digit bounds.
+- [x] `build_create_sm_context_request` emits `gpsi` when held; a test asserts both the present and
+      absent cases, and that the emitted value matches the `Gpsi` pattern —
+      `n11_create_carries_the_gpsi_when_the_subscription_supplies_one` (present, pattern-checked,
+      and asserted *not equal* to the SUPI) and `n11_omits_identity_the_amf_does_not_have` (absent,
+      `gpsi` added to its omit list).
+- [x] Workspace lint and the amfd suite pass.
+
+## Verification
+
+Workspace `5985 passed / 0 failed / 6 ignored` (baseline `5981` on `4e5771d`; +4 tests). `cargo
+clippy --workspace --all-targets` and `cargo fmt --all -- --check` clean, zero new warnings.
+
+Five reverts, each run against the named test:
+
+| revert | expected to break | result |
+|---|---|---|
+| the N11 `gpsi` insert removed | `n11_create_carries_the_gpsi_when_the_subscription_supplies_one` | **1 failed** |
+| `gpsi` emitted unconditionally (`null` when absent) | `n11_omits_identity_the_amf_does_not_have` | **1 failed** (`got {"gpsi":null,...}`) |
+| `validated_gpsi` accepts any non-empty string (the letter of the TS 29.571 pattern) | `validated_gpsi_accepts_only_the_named_forms`, `am_data_takes_the_first_well_formed_gpsi` | **2 failed** |
+| `parse_am_data` stops reading `gpsis` | `am_data_takes_the_first_well_formed_gpsi` | **1 failed** |
+| `build_sm_context_identity` returns `gpsi: None` | `sm_context_identity_is_built_from_the_ue_context` | **1 failed** |
+
+No false guards found this time. The fifth revert is the one that would have caught one: it is the
+link the hand-built-identity tests cannot see.
+
+## Ceilings
+
+* **One link in the chain is still untested**: the single assignment
+  `state.amf_ue.gpsi = am_data.gpsi.clone()` inside `handle_registration_complete`'s SBI sequence.
+  The decode either side of it is tested (`parse_am_data`) and so is the mapping after it
+  (`build_sm_context_identity`), but that statement sits in a ~400-line async method whose
+  preconditions are a live UDM, a live PCF and an authenticated UE state machine. Driving it needs
+  a registration-flow harness that does not exist in this crate; noted rather than faked with a
+  test that would assert only that a field can be assigned.
+* `AmfUe` already carries `msisdn: Vec<String>` / `num_of_msisdn`, populated by nothing in the
+  crate. They are the EPS-shaped spelling of the same subscriber datum and are left alone: nothing
+  in #205 asks about them, and merging them into `gpsi` would change what `msisdn` means for any
+  future reader. Worth an issue if the duplication matters.
+* Only the N11 `SmContextCreateData` consumer is wired. The GPSI is also conveyable on
+  Namf_EventExposure and in Namf communication contexts (`namf_server.rs:557` already comments that
+  a subscription may target a `gpsi`); those are untouched, because #205 scopes to the N11 member
+  #73 criterion 1 named.
+* `extid-` GPSIs are accepted and conveyed but no in-tree producer emits one: `udrd`'s
+  `build_am_data` only ever writes `msisdn-{bcd}`. So the `extid-` half of the validator is
+  exercised by unit tests only, never end to end.
+* GitNexus impact analysis unrunnable (no MCP server connected — 40th consecutive PR). Blast radius
+  by grep: `SmContextIdentity` has one production construction site (now
+  `build_sm_context_identity`) and one consumer (`build_create_sm_context_request`);
+  `AmDataResponse` has one producer and one consumer; `AmfUe.gpsi` has one writer and one reader.

--- a/src/bins/nextgcore-amfd/src/context.rs
+++ b/src/bins/nextgcore-amfd/src/context.rs
@@ -2101,6 +2101,14 @@ pub struct AmfUe {
     pub home_plmn_id: PlmnId,
     /// PEI (Permanent Equipment Identifier)
     pub pei: Option<String>,
+    /// GPSI — the UE's EXTERNAL identity, taken from the `gpsis` array of the
+    /// `am-data` the AMF retrieves from UDM SDM (TS 29.503 §5.2.2.2.1).
+    ///
+    /// Held as an `Option` and never synthesised: the SUPI is the internal
+    /// identity and cannot be converted into a GPSI, so when the subscription
+    /// carries no usable `gpsis` entry this stays `None` and every consumer
+    /// omits the member rather than conveying a derived one (issue #205).
+    pub gpsi: Option<String>,
     /// Masked IMEISV
     pub masked_imeisv: [u8; NEXTGCORE_MAX_IMEISV_LEN],
     /// Masked IMEISV length
@@ -2661,6 +2669,7 @@ impl AmfUe {
             supi: None,
             home_plmn_id: PlmnId::default(),
             pei: None,
+            gpsi: None,
             masked_imeisv: [0u8; NEXTGCORE_MAX_IMEISV_LEN],
             masked_imeisv_len: 0,
             imeisv_bcd: String::new(),

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -2896,6 +2896,14 @@ impl NgapServer {
             state.amf_ue.ue_ambr.uplink = ul;
         }
 
+        // GPSI (UDM am-data `gpsis`, TS 29.503 §5.2.2.2.1) — the UE's external
+        // identity, conveyed onward on N11 (issue #205). Assigned unconditionally
+        // from the response so that a subscription which STOPS carrying a GPSI
+        // clears the stale one on re-registration rather than keeping it; the
+        // parser has already dropped any entry that is not a well-formed
+        // TS 29.571 `Gpsi`, so this is never a placeholder.
+        state.amf_ue.gpsi = am_data.gpsi.clone();
+
         // New 5G-GUTI: GUAMI of this AMF + CSPRNG 5G-TMSI (TS 23.003 2.10.1)
         state.amf_ue.generate_new_guti();
         state.amf_ue.next_guti.plmn_id = guami_plmn;
@@ -3592,52 +3600,10 @@ impl NgapServer {
                 let identity = {
                     let ctx = crate::context::amf_self();
                     let guard = ctx.read().ok();
-                    let state = self.ue_auth_state.get(&amf_ue_ngap_id);
-                    // The serving PLMN: prefer the TAI the UE is actually in,
-                    // then the AMF's own served GUAMI. Never a literal.
-                    let serving_plmn = state
-                        .map(|s| &s.amf_ue.nr_tai.plmn_id)
-                        .map(|p| (p.mcc(), p.mnc()))
-                        .or_else(|| {
-                            guard
-                                .as_ref()
-                                .and_then(|c| c.served_guami.first())
-                                .map(|g| (g.plmn_id.mcc(), g.plmn_id.mnc()))
-                        });
-                    let guami = guard
-                        .as_ref()
-                        .and_then(|c| c.served_guami.first())
-                        .map(|g| {
-                            serde_json::json!({
-                                "plmnId": { "mcc": g.plmn_id.mcc(), "mnc": g.plmn_id.mnc() },
-                                "amfId": format!(
-                                    "{:02x}{:03x}{:02x}",
-                                    g.amf_id.region, g.amf_id.set, g.amf_id.pointer
-                                ),
-                            })
-                        });
-                    // TS 29.571 UserLocation: the serving NR TAI.
-                    let ue_location = state.map(|s| &s.amf_ue.nr_tai).map(|tai| {
-                        serde_json::json!({
-                            "nrLocation": {
-                                "tai": {
-                                    "plmnId": {
-                                        "mcc": tai.plmn_id.mcc(),
-                                        "mnc": tai.plmn_id.mnc(),
-                                    },
-                                    "tac": format!("{:06x}", tai.tac),
-                                }
-                            }
-                        })
-                    });
-                    crate::sbi_path::SmContextIdentity {
-                        supi: state.and_then(|s| s.amf_ue.supi.clone()),
-                        pei: state.and_then(|s| s.amf_ue.pei.clone()),
-                        guami,
-                        serving_plmn,
-                        serving_nf_id: None,
-                        ue_location,
-                    }
+                    build_sm_context_identity(
+                        self.ue_auth_state.get(&amf_ue_ngap_id),
+                        guard.as_ref().and_then(|c| c.served_guami.first()),
+                    )
                 };
 
                 match crate::sbi_path::call_smf_create_sm_context(
@@ -6019,6 +5985,65 @@ fn validate_initial_registration_cleartext(
     None
 }
 
+/// Assemble the UE and serving-network identity the AMF conveys on N11
+/// (TS 29.502 §6.1.6.2.2 `SmContextCreateData`) from the UE's NAS context and the
+/// AMF's own served GUAMI.
+///
+/// Every member is `Option`: an identity the AMF does not hold is OMITTED by
+/// `build_create_sm_context_request` rather than placeheld, because a wrong
+/// identity is worse than an absent one (issue #73).
+///
+/// Extracted from the inline block at the CreateSMContext call site so that this
+/// mapping is reachable from a test. It is the half of the identity path that was
+/// unguarded: a test that hands `build_create_sm_context_request` an identity it
+/// built itself proves the SERIALISER emits what it is given, and would keep
+/// passing if this function returned `None` for every member.
+fn build_sm_context_identity(
+    state: Option<&UeNasContext>,
+    served_guami: Option<&crate::context::Guami>,
+) -> crate::sbi_path::SmContextIdentity {
+    // The serving PLMN: prefer the TAI the UE is actually in, then the AMF's own
+    // served GUAMI. Never a literal.
+    let serving_plmn = state
+        .map(|s| &s.amf_ue.nr_tai.plmn_id)
+        .map(|p| (p.mcc(), p.mnc()))
+        .or_else(|| served_guami.map(|g| (g.plmn_id.mcc(), g.plmn_id.mnc())));
+    let guami = served_guami.map(|g| {
+        serde_json::json!({
+            "plmnId": { "mcc": g.plmn_id.mcc(), "mnc": g.plmn_id.mnc() },
+            "amfId": format!(
+                "{:02x}{:03x}{:02x}",
+                g.amf_id.region, g.amf_id.set, g.amf_id.pointer
+            ),
+        })
+    });
+    // TS 29.571 UserLocation: the serving NR TAI.
+    let ue_location = state.map(|s| &s.amf_ue.nr_tai).map(|tai| {
+        serde_json::json!({
+            "nrLocation": {
+                "tai": {
+                    "plmnId": {
+                        "mcc": tai.plmn_id.mcc(),
+                        "mnc": tai.plmn_id.mnc(),
+                    },
+                    "tac": format!("{:06x}", tai.tac),
+                }
+            }
+        })
+    });
+    crate::sbi_path::SmContextIdentity {
+        supi: state.and_then(|s| s.amf_ue.supi.clone()),
+        pei: state.and_then(|s| s.amf_ue.pei.clone()),
+        guami,
+        serving_plmn,
+        serving_nf_id: None,
+        ue_location,
+        // Issue #205: the UE's EXTERNAL identity, stored on the UE context from
+        // the `gpsis` array of the `am-data` the AMF retrieves at registration.
+        gpsi: state.and_then(|s| s.amf_ue.gpsi.clone()),
+    }
+}
+
 /// amfd-06: choose the authorized Allowed-NSSAI for a Registration Accept
 /// (TS 23.502 §4.2.2.2.3, TS 24.501 §9.11.3.37).
 ///
@@ -6979,6 +7004,46 @@ mod tests {
         assert!(handle.is_ok());
         let handle = handle.unwrap();
         assert_eq!(handle.num_gnbs().await, 0);
+    }
+
+    /// **Issue #205.** The N11 identity is assembled FROM the UE context, so a
+    /// GPSI the AMF stored at registration reaches `SmContextCreateData`.
+    ///
+    /// `sbi_path`'s serialiser tests build an identity by hand, which cannot tell
+    /// a working `gpsi: state.amf_ue.gpsi.clone()` from a hardcoded `None`. This
+    /// asserts the mapping itself, for the GPSI and for the members beside it.
+    #[test]
+    fn sm_context_identity_is_built_from_the_ue_context() {
+        let mut state = UeNasContext::new(1, 2, 3, false);
+        state.amf_ue.supi = Some("imsi-262011234567890".to_string());
+        state.amf_ue.pei = Some("imeisv-1234567890123456".to_string());
+        state.amf_ue.gpsi = Some("msisdn-491234567890".to_string());
+        state.amf_ue.nr_tai.plmn_id = PlmnId::new("262", "01");
+        state.amf_ue.nr_tai.tac = 1;
+
+        let identity = build_sm_context_identity(Some(&state), None);
+        assert_eq!(identity.supi.as_deref(), Some("imsi-262011234567890"));
+        assert_eq!(identity.pei.as_deref(), Some("imeisv-1234567890123456"));
+        assert_eq!(identity.gpsi.as_deref(), Some("msisdn-491234567890"));
+        assert_eq!(
+            identity.serving_plmn,
+            Some(("262".to_string(), "01".to_string()))
+        );
+        assert_eq!(
+            identity.ue_location.as_ref().unwrap()["nrLocation"]["tai"]["tac"].as_str(),
+            Some("000001")
+        );
+
+        // A UE the AMF holds no GPSI for yields none — not a SUPI-derived one.
+        state.amf_ue.gpsi = None;
+        let without = build_sm_context_identity(Some(&state), None);
+        assert_eq!(without.gpsi, None);
+        assert_eq!(without.supi.as_deref(), Some("imsi-262011234567890"));
+
+        // No UE context at all: every UE-sourced member is absent.
+        let none = build_sm_context_identity(None, None);
+        assert!(none.supi.is_none() && none.pei.is_none() && none.gpsi.is_none());
+        assert!(none.serving_plmn.is_none() && none.ue_location.is_none());
     }
 
     #[test]

--- a/src/bins/nextgcore-amfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-amfd/src/sbi_path.rs
@@ -828,6 +828,11 @@ pub struct SmContextIdentity {
     pub serving_nf_id: Option<String>,
     /// `ueLocation` — TS 29.571 `UserLocation`, built from the serving TAI.
     pub ue_location: Option<serde_json::Value>,
+    /// `gpsi` — the UE's external identity, from the `gpsis` array of the
+    /// `am-data` the AMF already retrieves (TS 29.503 §5.2.2.2.1). `None` when
+    /// the subscription carries none, in which case the member is omitted
+    /// (issue #205).
+    pub gpsi: Option<String>,
 }
 
 fn build_create_sm_context_request(
@@ -880,9 +885,15 @@ fn build_create_sm_context_request(
     if let Some(loc) = &identity.ue_location {
         obj.insert("ueLocation".to_string(), loc.clone());
     }
-    // `gpsi` is deliberately absent: amfd's UE context has no GPSI field at all
-    // (it never retrieves one from UDM), so there is nothing to convey. Emitting
-    // a derived or blank GPSI would be a fabrication. Tracked as a follow-up.
+    // `gpsi` — the UE's EXTERNAL identity, so that the SMF (and through it the
+    // CHF and any AF-facing exposure) has something to correlate on other than
+    // the SUPI, which is internal and is not what a billing system keys on
+    // (issue #205, TS 23.501 §5.9.8). It follows the same omit-never-placehold
+    // rule as the members above: it is emitted only when the `am-data`
+    // subscription actually supplied a well-formed one.
+    if let Some(gpsi) = &identity.gpsi {
+        obj.insert("gpsi".to_string(), serde_json::json!(gpsi));
+    }
     SbiRequest::post("/nsmf-pdusession/v1/sm-contexts")
         .with_body(body.to_string(), content_type::APPLICATION_JSON)
         .with_part(SbiPart::with_content(
@@ -1573,6 +1584,48 @@ pub struct AmDataResponse {
     pub ue_ambr_downlink: Option<String>,
     /// Subscribed S-NSSAIs (SST, optional SD)
     pub nssai: Vec<(u8, Option<u32>)>,
+    /// GPSI — first well-formed entry of the `gpsis` array
+    /// (TS 29.503 §5.2.2.2.1), or `None` when the subscription carries none.
+    pub gpsi: Option<String>,
+}
+
+/// Accept a TS 29.571 `Gpsi` only in one of its two NAMED forms —
+/// `msisdn-<5..15 digits>` or `extid-<local>@<domain>` — and reject everything
+/// else.
+///
+/// TS 29.571's own `Gpsi` pattern is
+/// `^(msisdn-[0-9]{5,15}|extid-[^@]+@[^@]+|.+)$`. That trailing `.+` alternative
+/// makes the pattern match ANY non-empty string, so validating against it
+/// literally would validate nothing: a UDR bug that put a bare SUPI or an empty
+/// placeholder in `gpsis` would sail through and the AMF would convey it to the
+/// SMF as an external identity. Since a GPSI's whole purpose is to be the
+/// identifier a CHF or AF correlates on (TS 23.501 §5.9.8), a value of unknown
+/// form is worth no more than no value at all — and `None` is the honest one,
+/// because every consumer omits the member for it.
+///
+/// The deliberate cost: a subscription carrying a FUTURE GPSI type that 3GPP
+/// adds under the `.+` escape is dropped rather than forwarded. That is logged
+/// at `warn` by the caller so it is diagnosable instead of silent, and the fix
+/// is to add the new form here.
+fn validated_gpsi(raw: &str) -> Option<String> {
+    if let Some(digits) = raw.strip_prefix("msisdn-") {
+        let len = digits.len();
+        if (5..=15).contains(&len) && digits.bytes().all(|b| b.is_ascii_digit()) {
+            return Some(raw.to_string());
+        }
+        return None;
+    }
+    if let Some(ext_id) = raw.strip_prefix("extid-") {
+        // `[^@]+@[^@]+`: exactly one `@`, non-empty on both sides.
+        let mut parts = ext_id.split('@');
+        let local = parts.next().unwrap_or_default();
+        let domain = parts.next().unwrap_or_default();
+        if parts.next().is_none() && !local.is_empty() && !domain.is_empty() {
+            return Some(raw.to_string());
+        }
+        return None;
+    }
+    None
 }
 
 /// Nudm_SDM_Get (am-data): GET /nudm-sdm/v2/{supi}/am-data (TS 29.503 5.2.2.2.1)
@@ -1602,32 +1655,70 @@ pub async fn call_udm_sdm_get_am_data(
         )));
     }
 
+    let out = response
+        .http
+        .content
+        .as_deref()
+        .and_then(|c| serde_json::from_str::<serde_json::Value>(c).ok())
+        .map(|json| parse_am_data(&json, supi))
+        .unwrap_or_default();
+
+    log::info!(
+        "[{supi}] Nudm_SDM_Get am-data OK ({} S-NSSAI, gpsi {})",
+        out.nssai.len(),
+        if out.gpsi.is_some() {
+            "present"
+        } else {
+            "absent"
+        }
+    );
+    Ok(out)
+}
+
+/// Decode an `AccessAndMobilitySubscriptionData` body into the subset of it the
+/// AMF keeps (TS 29.503 §5.2.2.2.1).
+///
+/// Split out of `call_udm_sdm_get_am_data` so the decode is reachable from a test
+/// without standing up a UDM: `gpsis` selection in particular has more than one
+/// interesting input (several entries, a malformed entry, an empty array) and
+/// none of them are expressible through the async caller.
+fn parse_am_data(json: &serde_json::Value, supi: &str) -> AmDataResponse {
     let mut out = AmDataResponse::default();
-    if let Some(content) = &response.http.content {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(content) {
-            out.ue_ambr_uplink = json["subscribedUeAmbr"]["uplink"]
-                .as_str()
-                .map(String::from);
-            out.ue_ambr_downlink = json["subscribedUeAmbr"]["downlink"]
-                .as_str()
-                .map(String::from);
-            if let Some(list) = json["nssai"]["defaultSingleNssais"].as_array() {
-                for s in list {
-                    if let Some(sst) = s["sst"].as_u64() {
-                        let sd = s["sd"]
-                            .as_str()
-                            .and_then(|h| u32::from_str_radix(h, 16).ok());
-                        out.nssai.push((sst as u8, sd));
-                    }
-                }
+    out.ue_ambr_uplink = json["subscribedUeAmbr"]["uplink"]
+        .as_str()
+        .map(String::from);
+    out.ue_ambr_downlink = json["subscribedUeAmbr"]["downlink"]
+        .as_str()
+        .map(String::from);
+    if let Some(list) = json["nssai"]["defaultSingleNssais"].as_array() {
+        for s in list {
+            if let Some(sst) = s["sst"].as_u64() {
+                let sd = s["sd"]
+                    .as_str()
+                    .and_then(|h| u32::from_str_radix(h, 16).ok());
+                out.nssai.push((sst as u8, sd));
             }
         }
     }
-    log::info!(
-        "[{supi}] Nudm_SDM_Get am-data OK ({} S-NSSAI)",
-        out.nssai.len()
-    );
-    Ok(out)
+    // `gpsis` is an ARRAY (TS 29.503 §5.2.2.2.1) and a subscriber may hold
+    // several external identities; the N11 `gpsi` member is singular, so the
+    // first well-formed entry is taken. Entries that are not one of the two
+    // named `Gpsi` forms are skipped rather than stored -- see `validated_gpsi`.
+    if let Some(list) = json["gpsis"].as_array() {
+        out.gpsi = list
+            .iter()
+            .filter_map(|g| g.as_str())
+            .find_map(validated_gpsi);
+        if out.gpsi.is_none() && !list.is_empty() {
+            log::warn!(
+                "[{supi}] am-data carried {} gpsis entr{}, none in a recognised \
+                 TS 29.571 Gpsi form (msisdn-/extid-); no GPSI stored",
+                list.len(),
+                if list.len() == 1 { "y" } else { "ies" }
+            );
+        }
+    }
+    out
 }
 
 /// Nudm_SDM_Subscribe: POST /nudm-sdm/v2/{supi}/sdm-subscriptions (TS 29.503 5.2.2.3.2)
@@ -2221,6 +2312,7 @@ mod tests {
                     "tai": { "plmnId": { "mcc": "262", "mnc": "01" }, "tac": "000001" }
                 }
             })),
+            gpsi: Some("msisdn-491234567890".to_string()),
         }
     }
 
@@ -2265,6 +2357,128 @@ mod tests {
         );
     }
 
+    /// **Issue #205.** The N11 body carries the `gpsi` — the UE's EXTERNAL
+    /// identity — when the `am-data` subscription supplied one.
+    ///
+    /// Before this the member was unconditionally absent (the AMF had no GPSI
+    /// field at all), so the SMF, and through it the CHF, had nothing but the
+    /// SUPI to key on and no CDR could be joined to an operator's subscriber
+    /// records by MSISDN.
+    #[test]
+    fn n11_create_carries_the_gpsi_when_the_subscription_supplies_one() {
+        let body = n11_body(&test_identity());
+
+        assert_eq!(body["gpsi"].as_str(), Some("msisdn-491234567890"));
+        // The emitted value must be a TS 29.571 `Gpsi`, not an arbitrary string
+        // that happened to be in the subscription.
+        assert_eq!(
+            validated_gpsi(body["gpsi"].as_str().unwrap()).as_deref(),
+            body["gpsi"].as_str(),
+            "the emitted gpsi must itself pass Gpsi validation"
+        );
+        // The SUPI is the INTERNAL identity and must not be reused as the GPSI:
+        // deriving one from the other is the fabrication issue #205 forbids.
+        assert_ne!(body["gpsi"].as_str(), body["supi"].as_str());
+    }
+
+    /// The GPSI the AMF conveys comes from `am-data`'s `gpsis` array, and only a
+    /// well-formed entry is taken.
+    ///
+    /// Each case here is a real decode input the async caller cannot express:
+    /// several entries (take the first usable), a leading malformed entry (skip
+    /// to the usable one), and an all-malformed array (store nothing at all
+    /// rather than the least-bad candidate).
+    #[test]
+    fn am_data_takes_the_first_well_formed_gpsi() {
+        let supi = "imsi-262011234567890";
+
+        let one = parse_am_data(
+            &serde_json::json!({ "gpsis": ["msisdn-491234567890"] }),
+            supi,
+        );
+        assert_eq!(one.gpsi.as_deref(), Some("msisdn-491234567890"));
+
+        // Several: the N11 member is singular, so the FIRST is conveyed.
+        let many = parse_am_data(
+            &serde_json::json!({ "gpsis": ["msisdn-491111111111", "extid-alice@example.com"] }),
+            supi,
+        );
+        assert_eq!(many.gpsi.as_deref(), Some("msisdn-491111111111"));
+
+        // A malformed leading entry is SKIPPED, not conveyed and not fatal.
+        let skip = parse_am_data(
+            &serde_json::json!({ "gpsis": ["msisdn-abc", "extid-bob@example.com"] }),
+            supi,
+        );
+        assert_eq!(skip.gpsi.as_deref(), Some("extid-bob@example.com"));
+
+        // Nothing usable => nothing stored. Not a blank, not the SUPI.
+        for hopeless in [
+            serde_json::json!({ "gpsis": [] }),
+            serde_json::json!({ "gpsis": [""] }),
+            serde_json::json!({ "gpsis": ["imsi-262011234567890"] }),
+            serde_json::json!({ "gpsis": [42] }),
+            serde_json::json!({}),
+        ] {
+            assert_eq!(
+                parse_am_data(&hopeless, supi).gpsi,
+                None,
+                "no GPSI may be stored for {hopeless}"
+            );
+        }
+
+        // The rest of the decode is unaffected by the gpsis handling.
+        let full = parse_am_data(
+            &serde_json::json!({
+                "gpsis": ["msisdn-491234567890"],
+                "subscribedUeAmbr": { "uplink": "1 Gbps", "downlink": "2 Gbps" },
+                "nssai": { "defaultSingleNssais": [{ "sst": 1, "sd": "000001" }] },
+            }),
+            supi,
+        );
+        assert_eq!(full.ue_ambr_uplink.as_deref(), Some("1 Gbps"));
+        assert_eq!(full.nssai, vec![(1u8, Some(1u32))]);
+    }
+
+    /// `Gpsi` is accepted only in one of its two NAMED TS 29.571 forms.
+    ///
+    /// TS 29.571's published pattern ends in a `.+` alternative that matches any
+    /// non-empty string, so this is deliberately stricter than the letter of the
+    /// pattern — see `validated_gpsi` for why, and for what it costs.
+    #[test]
+    fn validated_gpsi_accepts_only_the_named_forms() {
+        for ok in [
+            "msisdn-12345",            // 5 digits: the low bound
+            "msisdn-491234567890",     // a realistic MSISDN
+            "msisdn-123456789012345",  // 15 digits: the high bound
+            "extid-alice@example.com", // an external identifier
+            "extid-a@b",               // minimal both sides
+        ] {
+            assert_eq!(
+                validated_gpsi(ok).as_deref(),
+                Some(ok),
+                "{ok} is a valid Gpsi"
+            );
+        }
+        for bad in [
+            "",                        // empty
+            "msisdn-",                 // no digits
+            "msisdn-1234",             // 4 digits: below the bound
+            "msisdn-1234567890123456", // 16 digits: above the bound
+            "msisdn-49123456789a",     // not all digits
+            "msisdn-+491234567890",    // leading + is not a digit
+            "extid-",                  // no local part, no domain
+            "extid-alice",             // no @
+            "extid-@example.com",      // empty local part
+            "extid-alice@",            // empty domain
+            "extid-a@b@c",             // two @
+            "imsi-262011234567890",    // a SUPI is NOT a GPSI
+            "491234567890",            // bare digits, no scheme prefix
+        ] {
+            assert_eq!(validated_gpsi(bad), None, "{bad} must be rejected");
+        }
+    }
+
     /// **Criterion 2.** `servingNetwork` reflects the real serving PLMN, not the
     /// hardcoded `001/01` every SM context used to claim.
     #[test]
@@ -2295,6 +2509,7 @@ mod tests {
             "servingNfId",
             "ueLocation",
             "servingNetwork",
+            "gpsi",
         ] {
             assert!(
                 body.get(absent).is_none(),


### PR DESCRIPTION
Closes #205.

## What was wrong

The GPSI was sitting in a response the AMF **already fetches** and was thrown away.
`call_udm_sdm_get_am_data` read `subscribedUeAmbr` and `nssai.defaultSingleNssais` and ignored
`gpsis`; `AmfUe` had no `gpsi` field at all; and the N11 builder carried a comment saying so. The
SMF — and through it the CHF and any AF-facing exposure — had nothing but the SUPI to key on, so no
CDR could be joined to an operator's subscriber records by MSISDN.

## Stale in the issue's suggested approach

Stated so a reviewer comparing issue to diff is not left guessing: the issue says to populate the
*"existing (already-wired) `gpsi` member of the N11 identity struct"*. **There is no such member.**
`SmContextIdentity` carries `supi`, `pei`, `guami`, `serving_plmn`, `serving_nf_id`, `ue_location`
and stops; the deliberately-absent comment at `sbi_path.rs:883` was the only trace of `gpsi` in the
crate. The field had to be added to the struct as well as to `AmfUe`.

## Validation is deliberately stricter than TS 29.571's own pattern

TS 29.571's `Gpsi` pattern is `^(msisdn-[0-9]{5,15}|extid-[^@]+@[^@]+|.+)$`. **That trailing `.+`
alternative matches any non-empty string**, so validating against it literally validates nothing: a
UDR bug that put a bare SUPI or an empty placeholder into `gpsis` would sail through and the AMF
would convey it as an external identity.

`validated_gpsi` accepts the two **named** forms and rejects everything else, because a GPSI exists
to be what a CHF or AF correlates on (TS 23.501 §5.9.8) and a value of unknown form is worth no
more than no value — and `None` is the honest one, since every consumer then omits the member. The
cost, which is real: a future GPSI type added by 3GPP under the `.+` escape is dropped rather than
forwarded. Logged at `warn` with the entry count so it is diagnosable, not silent.

## Three smaller calls

- `gpsis` is an array and the N11 member is singular, so the first entry that **validates** wins
  rather than the first entry outright — one malformed record must not cost a subscriber their
  usable second identity.
- The store is unconditional, so a subscription that stops carrying a GPSI **clears** the stale one
  on re-registration instead of conveying an identity it no longer asserts.
- The member is omitted, never placeheld, per #73.

## Two refactors the issue does not ask for

Both exist to close a false-guard shape, not for tidiness:

1. **`parse_am_data`** split out of `call_udm_sdm_get_am_data` — the decode was inline in an async
   function needing a live UDM, so none of the interesting `gpsis` inputs (several entries, a
   malformed leading entry, an empty array) were expressible from a test.
2. **`build_sm_context_identity`** split out of the inline block at the CreateSMContext call site —
   `sbi_path`'s serialiser tests build a `SmContextIdentity` **by hand**, so they assert the
   serialiser emits what it is handed and would keep passing if the mapping from the UE context were
   `gpsi: None`. That is exactly the false guard the #210 session recorded. Its revert is one of the
   five below.

## Verification

Workspace **5985 passed / 0 failed / 6 ignored** (baseline 5981 on `4e5771d`, +4 tests). `cargo
clippy` and `cargo fmt --all -- --check` clean, zero new warnings.

| revert | expected to break | result |
|---|---|---|
| the N11 `gpsi` insert removed | `n11_create_carries_the_gpsi_when_the_subscription_supplies_one` | **1 failed** |
| `gpsi` emitted unconditionally (`null` when absent) | `n11_omits_identity_the_amf_does_not_have` | **1 failed** (`got {"gpsi":null,...}`) |
| `validated_gpsi` accepts any non-empty string | `validated_gpsi_accepts_only_the_named_forms`, `am_data_takes_the_first_well_formed_gpsi` | **2 failed** |
| `parse_am_data` stops reading `gpsis` | `am_data_takes_the_first_well_formed_gpsi` | **1 failed** |
| the identity builder returns `gpsi: None` | `sm_context_identity_is_built_from_the_ue_context` | **1 failed** |

No false guards found this time. The fifth revert is the one that would have caught one.

## Ceilings

- **One link in the chain is still untested**: the single assignment
  `state.amf_ue.gpsi = am_data.gpsi.clone()` sits in a ~400-line async method whose preconditions
  are a live UDM, a live PCF and an authenticated UE state machine. The decode before it and the
  mapping after it are both tested; driving the statement itself needs a registration-flow harness
  this crate does not have, so it is noted rather than faked.
- `AmfUe` already carries `msisdn` / `num_of_msisdn`, populated by nothing — the EPS-shaped spelling
  of the same datum, left alone. Worth an issue if the duplication matters.
- Only the N11 consumer is wired, not Namf_EventExposure.
- `extid-` GPSIs are accepted but no in-tree producer emits one (`udrd` writes only
  `msisdn-{bcd}`), so that half is unit-tested only.
- GitNexus impact analysis unrunnable (no MCP server connected).

Spec: `specs/fix-amfd-gpsi-from-am-data.md`