### PR TITLE
fix(smfd/amfd): select the subscribed default DNN instead of the literal "internet" (#204)

### DIFF
--- a/docker/rust/docker-compose.yml
+++ b/docker/rust/docker-compose.yml
@@ -288,6 +288,13 @@ services:
       UPF_PFCP_ADDR: 172.23.0.7
       UPF_PFCP_PORT: "8805"
       SMF_PFCP_ADDR: 172.23.0.4
+      # Issue #204: the SMF resolves the SUBSCRIBED DEFAULT DNN from
+      # Nudm_SDM_Get(smf-select-data) when SmContextCreateData carries no `dnn`.
+      # NRF discovery is tried first; this is the fallback for a deployment with no
+      # NRF, and it is what makes a DNN-less PDU session establish here rather than
+      # be refused with SUBSCRIPTION_DATA_NOT_AVAILABLE.
+      UDM_SBI_ADDR: 172.23.0.12
+      UDM_SBI_PORT: "7777"
       TLS_CERT: /etc/nextgcore/certs/smf.crt
       TLS_KEY: /etc/nextgcore/certs/smf.key
       TLS_CA: /etc/nextgcore/certs/ca.crt

--- a/docs-book/src/configuration/smf.md
+++ b/docs-book/src/configuration/smf.md
@@ -92,6 +92,7 @@ The N4/PFCP endpoints are configured by environment variables, **not** by the `s
 | `SMF_PFCP_ADDR` / `SMF_PFCP_PORT` | `0.0.0.0` / `8805` | N4 PFCP bind address (single socket; sequence-number matching per TS 29.244 §7.2.1, per code comment). `SMF_PFCP_ADDR` also supplies the PFCP Node ID (falls back to `127.0.0.1` if not a dotted IPv4). |
 | `UPF_PFCP_ADDR` / `UPF_PFCP_PORT` | `127.0.0.1` / `8805` | UPF N4 peer address. |
 | `SMF_SBI_ADVERTISE_URI` | derived from SBI server address/port | Externally reachable base URI used in PCF callback (`notificationUri`) URIs. |
+| `UDM_SBI_ADDR` / `UDM_SBI_PORT` | unset / `7777` | UDM address for `Nudm_SDM_Get(smf-select-data)`, used only to resolve the **subscribed default DNN** (#204). Tried **after** NRF discovery, so it is the fallback for a deployment with no NRF. With neither available, a `SmContextCreateData` carrying no `dnn` is refused with `SUBSCRIPTION_DATA_NOT_AVAILABLE`. |
 | `NEXTGCORE_SBI_OAUTH2_REQUIRE` | unset | `1`/`true`/`yes` forces OAuth2 enforcement, taking precedence over the YAML knob. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://jaeger:4317` | OpenTelemetry OTLP trace exporter endpoint. |
 
@@ -105,6 +106,23 @@ The example file follows an Open5GS-style layout, but the typed deserializer ign
 - `smf.gtpc`, `smf.gtpu`, `smf.metrics` — not deserialized by the config structs.
 - `smf.session` (UE IP subnets/gateways), `smf.dns`, `smf.mtu` — not deserialized by the config structs.
 - `smf.tls` — not read by the SMF loader; the file comment ties TLS to `TLS_ENABLED`/`SBI_SCHEME` deployment variables.
+
+## Subscribed default DNN (#204)
+
+`dnn` is **optional** in `SmContextCreateData` (TS 29.502 §6.1.6.2.2). When the UE omits the DNN IE the AMF omits the member — it used to substitute the literal `"internet"`, so any deployment whose subscribers do not all default to a DNN of that name attached DNN-less sessions to the **wrong data network**, silently, because the session established fine against it. The SMF now selects the subscribed default itself, which is correct per TS 23.501 §6.2.2: the SMF is the NF that retrieves SM subscription data.
+
+Resolution, in order:
+
+1. `Nudm_SDM_Get` on **`smf-select-data`** (`SmfSelectionSubscriptionData`), because the default-DNN flag is `DnnInfo.defaultDnnIndicator` and lives there. `sm-data`'s `dnnConfigurations` has **no** default flag (TS 29.503 Table 5.5.2.4-1), so it cannot answer this question.
+2. The `dnnInfos` entry flagged `defaultDnnIndicator: true` wins.
+3. If exactly **one** DNN is subscribed for the S-NSSAI and none is flagged, that one is used — unambiguous.
+4. Otherwise the session is **refused** with `400 MANDATORY_IE_MISSING`, listing the candidate DNNs. Choosing among several unflagged DNNs would invent an answer the subscription does not give.
+
+Failure causes are distinct so an operator can tell a provisioning gap from an unreachable UDM: `MANDATORY_IE_MISSING` for "the subscription supplies no usable default", `SUBSCRIPTION_DATA_NOT_AVAILABLE` for "no UDM endpoint" or "the Nudm_SDM_Get failed".
+
+**Limit worth knowing:** nothing in this tree emits `defaultDnnIndicator` — the subscription DB has no such field and `udrd`'s `build_smf_selection_data` writes only the DNN name. So against this tree's own UDM/UDR, rule 3 is what makes it work, and a subscriber with **two or more DNNs on one S-NSSAI cannot establish a DNN-less PDU session** (it is refused, with the candidates named). Tracked as issue #264 (`decision`).
+
+No `single-nssai` query parameter is sent, even though TS 29.503 §5.2.2.2.1 allows scoping: the value is JSON and must be percent-encoded, but the shared SBI server stores query values verbatim without decoding them (issue #65), so a scoped query cannot round-trip to the in-tree UDM. The S-NSSAI's entry is selected locally by key instead.
 
 ## Honesty notes
 

--- a/specs/fix-smfd-subscribed-default-dnn.md
+++ b/specs/fix-smfd-subscribed-default-dnn.md
@@ -1,0 +1,183 @@
+# nextgcore #204 (smfd/amfd): select the subscribed default DNN instead of the literal `"internet"`
+
+Verified against `main` @ `35475d5` (after #205, #242, #95). The issue was written at `d9aea74`; every
+cite still holds, and the **suggested approach is unfollowable as written**.
+
+## Verified against current main
+
+| claim in the issue | cite | site on `35475d5` | still true? |
+|---|---|---|---|
+| `amfd` substitutes the literal | `ngap_path.rs:3470` | `ngap_path.rs:3585` `let dnn = dnn_override.unwrap_or("internet")` | yes |
+| `amfd` retrieves only `am-data` from UDM SDM | `sbi_path.rs:1582` | `sbi_path.rs:1636` `call_udm_sdm_get_am_data` | yes |
+| `smfd` never issues a `nudm-sdm` request | — | `grep -rn 'nudm-sdm' bins/nextgcore-smfd/src/` → **one** hit, the FSM arm | yes |
+| the dormant FSM arm | `gsm_sm.rs:302` | `gsm_sm.rs:302` | yes |
+| the producer side exists end to end | `udmd/app.rs:663` → `handle_get_sm_data` | `udmd/app.rs:839` routes `smf-select-data` → `:2125` → udrd `smf-selection-subscription-data` | yes |
+
+Also re-verified, and **not** in the issue: `smfd` had no way to reach a UDM at all. It knows only its
+NRF (for its own registration), performs no NF discovery, and the `smf` container in
+`docker/rust/docker-compose.yml` sets no `UDM_SBI_ADDR`. Both had to be added for the criterion-1 path
+to be reachable at all.
+
+## The suggested approach cannot be followed: there is no "flagged as default" entry in `sm-data`
+
+The issue says: *"select the `dnnConfigurations` entry **flagged as the subscribed default**"*. No such
+flag exists.
+
+- `sm-data` returns `SessionManagementSubscriptionData`, whose `dnnConfigurations` is a JSON **object
+  keyed by DNN name**. TS 29.503 Table 5.5.2.4-1's `DnnConfiguration` carries `pduSessionTypes`,
+  `sscModes`, `5gQosProfile`, `sessionAmbr` and friends — **no default indicator**. Selecting from it
+  would mean picking an arbitrary key out of a map, which is the fabrication #204 exists to remove.
+- The default-DNN flag is `DnnInfo.defaultDnnIndicator`, and `DnnInfo` lives in
+  `SmfSelectionSubscriptionData` — the `smf-select-data` resource.
+
+**So this reads `smf-select-data`, not `sm-data`.** Same service (Nudm_SDM), same producer chain, the
+resource that can actually answer the question. Stated prominently because a reviewer comparing the
+issue to the diff will otherwise think the wrong resource was used.
+
+## Decision 1: the selection order, and what it refuses
+
+`select_default_dnn`:
+
+1. the `dnnInfos` entry with `defaultDnnIndicator: true`;
+2. if exactly **one** DNN is subscribed for the S-NSSAI and none is flagged, that one — it is
+   unambiguous, there is nothing else the default could be;
+3. otherwise `AmbiguousDefault`, listing the candidates, and the session is **refused**.
+
+Rule 3 is the point of the change. Picking the first, or the alphabetically-first, or `"internet"`
+would all be deterministic and all be invented. A refused session is a visible operator problem; a
+session on the wrong data network is an invisible one, and that is the defect being fixed.
+
+The S-NSSAI key form is `{sst:02x}` or `{sst:02x}-{sd}` (matching udrd's `build_smf_selection_data`),
+and an unmatched `sst-sd` key widens to the no-SD entry — a subscription provisioned without an SD
+still applies to a request carrying one, the same widening `nsacfd`'s quota lookup does.
+
+## Decision 2: four distinct failure causes, not one
+
+`DefaultDnnError` has four variants and two ProblemDetails causes:
+
+| variant | cause | why separate |
+|---|---|---|
+| `NoSubscribedDnn` | `MANDATORY_IE_MISSING` | the consumer named no DNN and the subscription supplies none — a provisioning gap |
+| `AmbiguousDefault(Vec<String>)` | `MANDATORY_IE_MISSING` | same class, and the detail **names the candidates** so the operator knows what to flag |
+| `NoUdmEndpoint` | `SUBSCRIPTION_DATA_NOT_AVAILABLE` | not the consumer's fault — the SMF cannot reach the data |
+| `SdmRequestFailed(String)` | `SUBSCRIPTION_DATA_NOT_AVAILABLE` | same, with the transport/status detail |
+
+Collapsing them would leave an operator unable to tell a provisioning gap from an unreachable UDM,
+which have opposite remedies.
+
+## Decision 3: no `single-nssai` query parameter, and it is not an oversight
+
+TS 29.503 §5.2.2.2.1 lets the consumer scope the answer to one S-NSSAI, and the first draft did. It was
+removed after the end-to-end test showed why it cannot work here: the value is JSON, so on the wire it
+must be percent-encoded as an RFC 3986 query component — and **this tree's shared SBI server stores
+query values verbatim without decoding them** (`libs/nextgcore-sbi/src/server.rs:583`, which is exactly
+the gap issue #65 names). So a percent-encoded `single-nssai` reaches the in-tree UDM as the literal
+`%7B%22sst%22...` and cannot be parsed, while sending it unencoded would be invalid on the wire.
+Scoping is an optimisation, not a correctness requirement: `select_default_dnn` picks the S-NSSAI's
+entry by key regardless. The test asserts the parameter is **absent**, so re-adding it before #65 lands
+fails loudly rather than silently sending garbage.
+
+## Decision 4: the dormant `nudm-sdm` FSM arm is removed, not wired
+
+Criterion 2 offers either. Removed, because the request genuinely does not return there: the DNN is an
+**input to creating the session**, so the fetch must happen before the session's GSM FSM exists. The
+arm described a flow where the SMF fetched subscription data *during* the policy-association wait,
+which never existed — and dispatching the response into the FSM as well would put one decision in two
+places. (The sibling `npcf-smpolicycontrol` arm **is** live, via `fsm_dispatch_policy_response`, so
+this is a genuine asymmetry rather than the whole handler being dead.)
+
+## Decision 5: sequencing, which the issue calls load-bearing
+
+The issue insists the SMF must be able to apply a subscribed default *before* the AMF stops sending
+one. Both land in this PR, in one commit, so no intermediate state exists. Three things make the SMF
+side genuinely reachable rather than nominally present:
+
+1. `validate_sm_context_create_data` stops rejecting an absent `dnn` (it is optional per TS 29.502
+   Table 6.1.6.2.2-1). Leaving it mandatory would have made the whole resolution path unreachable —
+   the same class of defect as #242.
+2. `discover_udm_sdm_endpoint`: NRF discovery first, `UDM_SBI_ADDR`/`UDM_SBI_PORT` as the fallback.
+3. `UDM_SBI_ADDR` / `UDM_SBI_PORT` added to the `smf` container in
+   `docker/rust/docker-compose.yml`. Without it a DNN-less session in the E2E would be refused.
+
+Note what the *worst case* is: before this change, `smfd` refused any create with no `dnn`
+(`MANDATORY_IE_MISSING` at the validator). After it, an unresolvable default also refuses — with a
+better cause. So the failure mode for DNN-less requests is not a regression; the improvement is that a
+resolvable default now succeeds and a wrong one is never invented.
+
+`discover_udm_sdm_endpoint` deliberately does **not** populate the shared NF cache: `amfd` and `udmd`
+each carry a full cache-populating discovery routine, and a third copy is a maintenance cost this issue
+does not need. What the SMF wants is one address.
+
+## Acceptance criteria
+
+- [x] `smfd` retrieves subscription data and selects the subscribed default DNN when
+      `SmContextCreateData` carries no `dnn`; a test asserts the subscribed default (not `internet`) is
+      used — `select_default_dnn_uses_the_indicator_and_refuses_to_guess` (selection, including
+      explicitly `assert_ne!(..., "internet")`) and
+      `fetch_subscribed_default_dnn_queries_the_udm_and_returns_the_flagged_dnn` (the real HTTP request
+      against a stub UDM, returning the flagged DNN over `internet`). **Reads `smf-select-data`, not
+      `sm-data` — see above.**
+- [x] The `nudm-sdm` response arm in `gsm_sm.rs` is reachable, or is replaced by whatever path the
+      request actually returns on — **replaced**: removed, with the real path (a direct `await` in
+      `handle_sm_context_create`) named at the removal site.
+- [x] `amfd` omits `dnn` when the UE omitted it, and a test asserts the member is absent rather than
+      defaulted — `n11_omits_dnn_when_the_ue_did_not_supply_one`, which asserts absent (not `null`, not
+      `"internet"`) and that the unconditional members are still present.
+- [x] A test covers the no-subscription-data case: the session is refused, not a silent `internet` —
+      `dnn_less_create_with_no_udm_is_refused_not_defaulted` drives `handle_sm_context_create` over a
+      DNN-less body with no UDM reachable and asserts `400` + `SUBSCRIPTION_DATA_NOT_AVAILABLE`, and
+      that the response body does **not** contain the string `internet`.
+- [x] Workspace lint and the smfd + amfd suites pass.
+
+## Verification
+
+Workspace **5982 passed / 0 failed / 6 ignored** (baseline `5976` on `35475d5`; +6 tests — smfd 392 →
+397, amfd 427 → 428). `cargo clippy -p nextgcore-smfd -p nextgcore-amfd --all-targets` adds no
+warning, `cargo clippy --workspace` 0 errors, `cargo fmt --all -- --check` clean.
+
+Six reverts:
+
+| revert | expected to break | result |
+|---|---|---|
+| `amfd` substitutes `"internet"` again | `n11_omits_dnn_when_the_ue_did_not_supply_one` | **1 failed** (`got {"dnn":"internet",...}`) |
+| `smfd` falls back to the `"internet"` literal instead of refusing | `dnn_less_create_with_no_udm_is_refused_not_defaulted` | **1 failed** |
+| `select_default_dnn` ignores `defaultDnnIndicator` and takes the first entry | `select_default_dnn_uses_the_indicator_and_refuses_to_guess` | **1 failed** (`the flagged DNN wins over position`) |
+| several unflagged DNNs silently pick the first instead of refusing | same test | **1 failed** (`expected AmbiguousDefault, got Ok("internet")`) |
+| the fetch queries `am-data` instead of `smf-select-data` | `fetch_subscribed_default_dnn_queries_the_udm...` | **1 failed** |
+| the validator requires `dnn` again | `validate_sm_context_create_data_table`, `dnn_less_create...` | **2 failed** |
+
+No false guards found. Two other things the work surfaced, both recorded because they cost time:
+
+* **The first end-to-end test failed on TLS**, not on logic: the default `SbiProfile` is `Production`,
+  so a loopback plaintext stub needs `set_sbi_profile_override(SbiProfile::Dev)`. There is a
+  purpose-built helper and an in-crate precedent (`policy.rs:1733`).
+* **Calling `reset_sbi_profile_override()` at the end of the test broke a sibling test.** The override
+  is process-wide, and resetting it flipped `policy.rs`'s `sm_policy_lifecycle_http_round_trip` back to
+  Production mid-flight. Every loopback-plaintext test in this crate sets Dev and leaves it set;
+  matching that is what keeps them compatible. Tidying up global state was the wrong instinct.
+
+## Ceilings
+
+* **Nothing in this tree emits `defaultDnnIndicator`**, so against its own UDM/UDR the selection rests
+  on rule 2 (the single-subscribed-DNN case). A subscriber with two or more DNNs on one S-NSSAI
+  **cannot establish a DNN-less PDU session** — it is refused with the candidates named. The subscription
+  DB (`NextgcoreSession`) has no such field and `udrd`'s `build_smf_selection_data` writes only the DNN
+  name. Filed as **#264** (`decision`, `needs-human`) with three costed options and a recommendation,
+  because the fix spans the DB schema, udrd and the WebUI. **This is the most likely thing to be
+  mistaken for done.**
+* **The docker E2E is not run by CI** (it is `workflow_dispatch`-only), so the `UDM_SBI_ADDR` addition
+  and the DNN-less end-to-end path are verified by unit/stub tests and by reading the compose file, not
+  by an E2E run. If the simulator's UEs omit the DNN IE, this is the change most likely to show up
+  there first.
+* **`single-nssai` is not sent** (see Decision 3), so the SMF receives every subscribed S-NSSAI's DNN
+  list and filters locally. Correct, but more data on the wire than necessary, until #65 lands.
+* **NRF discovery here is minimal on purpose**: it reads one address out of the `SearchResult` and does
+  not populate the shared NF cache, honour `validityPeriod`, or handle multiple UDM instances beyond
+  taking the first. A UDM set with per-instance routing would need the fuller routine `amfd` has.
+* **No test drives a real AMF→SMF DNN-less create end to end.** The AMF side (omission) and the SMF side
+  (resolution, refusal) are each tested, but the join is not: smfd's create path needs a PCF and a UPF
+  past the DNN step, which no in-crate harness stands up.
+* GitNexus impact analysis unrunnable (no MCP server connected — 43rd consecutive PR). Blast radius by
+  grep: `build_create_sm_context_request` has one production caller
+  (`call_smf_create_sm_context`), which has one (`ngap_path.rs`); `validate_sm_context_create_data` has
+  one caller; nothing outside `smfd` reads the new functions.

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -3579,10 +3579,19 @@ impl NgapServer {
                     .get(&amf_ue_ngap_id)
                     .and_then(|s| s.amf_ue.allowed_nssai.first().map(|n| (n.sst, n.sd)))
                     .unwrap_or((1, None));
-                // DNN from the UE's UL NAS Transport DNN IE (e.g. "xr" for an
-                // XR session); fall back to "internet" for the legacy raw-5GSM
-                // path or when the UE omits the IE.
-                let dnn = dnn_override.unwrap_or("internet");
+                // DNN from the UE's UL NAS Transport DNN IE (e.g. "xr" for an XR
+                // session). Issue #204: when the UE omits the IE -- or on the
+                // legacy raw-5GSM path, which carries no DNN -- the member is
+                // OMITTED from SmContextCreateData rather than filled with the
+                // literal "internet". `dnn` is optional in TS 29.502 §6.1.6.2.2,
+                // and TS 23.501 §5.6.1 makes the SUBSCRIBED default the network's
+                // answer; the SMF owns that decision because it is the NF that
+                // retrieves SM subscription data (TS 23.501 §6.2.2). A literal
+                // here meant every deployment whose subscribers do not all default
+                // to a DNN named "internet" attached DNN-less sessions to the wrong
+                // data network, with the wrong UPF, policy, charging and slice --
+                // and silently, because the session established.
+                let dnn = dnn_override;
 
                 // RedCap indication: propagate the UE's Reduced-Capability
                 // status (parsed at registration in gmm_handler) to the SMF so

--- a/src/bins/nextgcore-amfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-amfd/src/sbi_path.rs
@@ -839,7 +839,7 @@ fn build_create_sm_context_request(
     pdu_session_id: u8,
     sst: u8,
     sd: Option<u32>,
-    dnn: &str,
+    dnn: Option<&str>,
     n1_sm_msg_from_ue: &[u8],
     redcap_indication: bool,
     identity: &SmContextIdentity,
@@ -850,11 +850,21 @@ fn build_create_sm_context_request(
             "sst": sst,
             "sd": sd.map(|v| format!("{v:06x}"))
         },
-        "dnn": dnn,
         "n1SmMsg": { "contentId": "n1SmMsg" },
         "redcapIndication": redcap_indication,
     });
     let obj = body.as_object_mut().expect("json! built an object");
+
+    // Issue #204: `dnn` is OPTIONAL in SmContextCreateData (TS 29.502
+    // §6.1.6.2.2) and is emitted only when the UE actually supplied a DNN IE.
+    // This used to substitute the literal `"internet"`, so a subscriber whose
+    // subscription names a different default attached to the WRONG data network
+    // -- silently, since the session established fine against it. The SMF now
+    // selects the SUBSCRIBED default from SM subscription data when the member is
+    // absent (TS 23.501 §5.6.1), which is the NF that owns that decision.
+    if let Some(dnn) = dnn {
+        obj.insert("dnn".to_string(), serde_json::json!(dnn));
+    }
 
     // Issue #73: the serving PLMN comes from the GUAMI/TAI, not a literal. When
     // it is genuinely unknown the member is OMITTED rather than filled with a
@@ -913,14 +923,15 @@ pub async fn call_smf_create_sm_context(
     pdu_session_id: u8,
     sst: u8,
     sd: Option<u32>,
-    dnn: &str,
+    dnn: Option<&str>,
     n1_sm_msg_from_ue: &[u8],
     redcap_indication: bool,
     identity: &SmContextIdentity,
 ) -> SbiResult<SmContextCreateResponse> {
     log::info!(
         "Calling SMF SM Context Create: {smf_host}:{smf_port}, PSI={pdu_session_id}, SST={sst}, \
-         DNN={dnn}, redcap={redcap_indication}"
+         DNN={}, redcap={redcap_indication}",
+        dnn.unwrap_or("<omitted: SMF selects the subscribed default>")
     );
 
     let client = crate::attach_oauth2(
@@ -2321,7 +2332,7 @@ mod tests {
             5,
             1,
             None,
-            "internet",
+            Some("internet"),
             &UE_N1_REQUEST,
             false,
             identity,
@@ -2355,6 +2366,57 @@ mod tests {
             body["ueLocation"]["nrLocation"]["tai"]["tac"].as_str(),
             Some("000001")
         );
+    }
+
+    /// **Issue #204.** `dnn` is emitted only when the UE actually supplied a DNN
+    /// IE, and is OMITTED — not defaulted to `"internet"` — when it did not.
+    ///
+    /// The literal was silent and wrong: any deployment whose subscribers do not
+    /// all default to a DNN named `internet` attached DNN-less sessions to the
+    /// wrong data network, with the wrong UPF, policy, charging and slice, while
+    /// the session established successfully. With the member absent, the SMF
+    /// selects the subscribed default from SM subscription data (TS 23.501
+    /// §5.6.1), which is the NF that owns that decision.
+    #[test]
+    fn n11_omits_dnn_when_the_ue_did_not_supply_one() {
+        let with_dnn = build_create_sm_context_request(
+            5,
+            1,
+            None,
+            Some("xr"),
+            &UE_N1_REQUEST,
+            false,
+            &SmContextIdentity::default(),
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(with_dnn.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(body["dnn"].as_str(), Some("xr"), "the UE's DNN is conveyed");
+
+        let without_dnn = build_create_sm_context_request(
+            5,
+            1,
+            None,
+            None,
+            &UE_N1_REQUEST,
+            false,
+            &SmContextIdentity::default(),
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(without_dnn.http.content.as_deref().unwrap()).unwrap();
+        assert!(
+            body.get("dnn").is_none(),
+            "dnn must be ABSENT, not null and not a literal, got {body}"
+        );
+        // Specifically not the old literal, and specifically not `null` — a `null`
+        // member is a value the SMF would have to reject rather than an omission
+        // it can resolve.
+        assert_ne!(body["dnn"].as_str(), Some("internet"));
+        assert!(!body["dnn"].is_null() || body.get("dnn").is_none());
+        // The members that are unconditional are still there, so this is an
+        // omission rather than a broken body.
+        assert_eq!(body["pduSessionId"].as_u64(), Some(5));
+        assert_eq!(body["sNssai"]["sst"].as_u64(), Some(1));
+        assert_eq!(body["n1SmMsg"]["contentId"].as_str(), Some("n1SmMsg"));
     }
 
     /// **Issue #205.** The N11 body carries the `gpsi` — the UE's EXTERNAL
@@ -2530,7 +2592,7 @@ mod tests {
             5,
             1,
             None,
-            "internet",
+            Some("internet"),
             &UE_N1_REQUEST,
             false,
             &SmContextIdentity::default(),

--- a/src/bins/nextgcore-smfd/src/gsm_sm.rs
+++ b/src/bins/nextgcore-smfd/src/gsm_sm.rs
@@ -295,22 +295,20 @@ impl GsmFsm {
     }
 
     /// Handle SBI client events in SM policy association state
+    ///
+    /// #204 removed the `nudm-sdm` arm that used to sit beside the PCF one. It was
+    /// unreachable: nothing in the crate ever issued a Nudm_SDM request, so no
+    /// `nudm-sdm` client response could be dispatched, and the arm read as if the
+    /// SMF fetched subscription data during the policy-association wait. The SMF
+    /// now really does call Nudm_SDM_Get — but for the **subscribed default DNN**,
+    /// and it must happen BEFORE the session exists, because the DNN is an input to
+    /// creating it. So the request returns on a direct `await` in
+    /// `handle_sm_context_create`, not as an FSM event, and dispatching it here as
+    /// well would put one decision in two places.
     fn handle_sbi_client_sm_policy(&mut self, event: &SmfEvent) -> GsmFsmResult {
         if let Some(ref sbi) = event.sbi {
             if let Some(ref message) = sbi.message {
-                // Check service name
-                if message.service_name == "nudm-sdm" {
-                    // UDM subscriber data response
-                    if let Some(status) = message.res_status {
-                        if status == 200 {
-                            log::debug!("UDM SDM response OK");
-                            return GsmFsmResult::Handled;
-                        } else {
-                            log::error!("UDM SDM response error: {status}");
-                            return GsmFsmResult::Transition(GsmState::Exception);
-                        }
-                    }
-                } else if message.service_name == "npcf-smpolicycontrol" {
+                if message.service_name == "npcf-smpolicycontrol" {
                     // PCF SM policy response
                     if let Some(status) = message.res_status {
                         if status == 201 {

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -975,6 +975,291 @@ async fn smf_nrf_register(sbi_addr: &str, sbi_port: u16) -> std::result::Result<
     }
 }
 
+// ---------------------------------------------------------------------------
+// Nudm_SDM consumer (issue #204): the subscribed default DNN
+// ---------------------------------------------------------------------------
+
+/// Why a subscribed default DNN could not be determined. Each variant maps to a
+/// distinct log line and, at the create handler, a distinct ProblemDetails cause —
+/// "the UDM is unreachable" and "the subscription names several DNNs and flags
+/// none" are different operator problems and must not collapse into one message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DefaultDnnError {
+    /// No UDM address could be determined (no NRF, no discovery hit, no env).
+    NoUdmEndpoint,
+    /// The Nudm_SDM_Get failed at the transport or returned a non-2xx.
+    SdmRequestFailed(String),
+    /// The subscription carries no DNN at all for this S-NSSAI.
+    NoSubscribedDnn,
+    /// Several DNNs are subscribed for this S-NSSAI and none carries
+    /// `defaultDnnIndicator: true`, so the subscription does not say which is the
+    /// default. Choosing one here would be a fabrication (issue #204).
+    AmbiguousDefault(Vec<String>),
+}
+
+impl DefaultDnnError {
+    /// The TS 29.502 ProblemDetails cause for a create that cannot resolve a DNN.
+    fn cause(&self) -> &'static str {
+        match self {
+            // The consumer's request is incomplete for THIS network: it named no
+            // DNN and the subscription does not supply one either.
+            Self::NoSubscribedDnn | Self::AmbiguousDefault(_) => "MANDATORY_IE_MISSING",
+            // Not the consumer's fault — the SMF could not reach the data it needs.
+            Self::NoUdmEndpoint | Self::SdmRequestFailed(_) => "SUBSCRIPTION_DATA_NOT_AVAILABLE",
+        }
+    }
+
+    fn detail(&self) -> String {
+        match self {
+            Self::NoUdmEndpoint => "no dnn in SmContextCreateData and no UDM endpoint is known \
+                 (set UDM_SBI_ADDR or register a UDM with the NRF)"
+                .to_string(),
+            Self::SdmRequestFailed(e) => format!(
+                "no dnn in SmContextCreateData and the subscribed default could not be \
+                 retrieved: {e}"
+            ),
+            Self::NoSubscribedDnn => "no dnn in SmContextCreateData and the subscription carries \
+                 no DNN for the requested S-NSSAI"
+                .to_string(),
+            Self::AmbiguousDefault(dnns) => format!(
+                "no dnn in SmContextCreateData and the subscription names {} DNNs for the \
+                 requested S-NSSAI ({}) with none flagged defaultDnnIndicator, so no default \
+                 can be determined",
+                dnns.len(),
+                dnns.join(", ")
+            ),
+        }
+    }
+}
+
+/// Resolve a UDM `nudm-sdm` endpoint.
+///
+/// NRF discovery first (TS 29.510 §5.3.2), because that is the mechanism a real
+/// deployment uses and the SMF already knows its NRF; `UDM_SBI_ADDR` /
+/// `UDM_SBI_PORT` is the fallback for a deployment with no NRF, matching how every
+/// other cross-NF address is wired in this tree's compose files.
+///
+/// Deliberately does NOT populate the shared NF cache: `amfd` and `udmd` each
+/// carry a full cache-populating discovery routine, and a third copy is a
+/// maintenance cost this issue does not need. What the SMF wants is one address.
+async fn discover_udm_sdm_endpoint() -> Option<(String, u16)> {
+    let sbi_ctx = global_context();
+    let nrf_uri = match sbi_ctx.get_nrf_uri().await {
+        Some(uri) => Some(uri),
+        None => std::env::var("NRF_URI").ok(),
+    };
+
+    if let Some(nrf_uri) = nrf_uri {
+        if let Some((nrf_host, nrf_port)) = parse_host_port(&nrf_uri) {
+            let client = sbi_ctx.get_client(&nrf_host, nrf_port).await;
+            let path = "/nnrf-disc/v1/nf-instances\
+                        ?target-nf-type=UDM&requester-nf-type=SMF&service-names=nudm-sdm";
+            match client.get(path).await {
+                Ok(resp) if resp.status == 200 => {
+                    if let Some(ep) = resp
+                        .http
+                        .content
+                        .as_deref()
+                        .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+                        .and_then(|json| udm_sdm_endpoint_from_search_result(&json))
+                    {
+                        log::debug!("UDM nudm-sdm discovered via NRF at {}:{}", ep.0, ep.1);
+                        return Some(ep);
+                    }
+                    log::debug!("NRF returned no usable UDM nudm-sdm endpoint");
+                }
+                Ok(resp) => log::debug!("NRF UDM discovery returned status {}", resp.status),
+                Err(e) => log::debug!("NRF UDM discovery failed: {e}"),
+            }
+        }
+    }
+
+    let host = std::env::var("UDM_SBI_ADDR").ok()?;
+    let port = std::env::var("UDM_SBI_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(7777);
+    Some((host, port))
+}
+
+/// Pull a `nudm-sdm` address out of a TS 29.510 `SearchResult`.
+///
+/// Split out so the decode is testable without an NRF. Prefers the service's own
+/// `ipEndPoints` over the instance's `ipv4Addresses`, because a UDM may serve
+/// `nudm-sdm` on a different port from its other services.
+fn udm_sdm_endpoint_from_search_result(json: &serde_json::Value) -> Option<(String, u16)> {
+    for instance in json.get("nfInstances")?.as_array()? {
+        let services = instance.get("nfServices").and_then(|v| v.as_array());
+        for svc in services.into_iter().flatten() {
+            if svc.get("serviceName").and_then(|v| v.as_str()) != Some("nudm-sdm") {
+                continue;
+            }
+            let endpoint = svc.get("ipEndPoints").and_then(|v| v.as_array());
+            let (host, port) = match endpoint.and_then(|eps| eps.first()) {
+                Some(ep) => {
+                    let host = ep
+                        .get("ipv4Address")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                        .or_else(|| {
+                            instance
+                                .get("ipv4Addresses")?
+                                .as_array()?
+                                .first()?
+                                .as_str()
+                                .map(String::from)
+                        })?;
+                    let port = ep.get("port").and_then(|v| v.as_u64()).unwrap_or(7777) as u16;
+                    (host, port)
+                }
+                None => {
+                    let host = instance
+                        .get("ipv4Addresses")?
+                        .as_array()?
+                        .first()?
+                        .as_str()?
+                        .to_string();
+                    (host, 7777)
+                }
+            };
+            return Some((host, port));
+        }
+    }
+    None
+}
+
+/// Select the subscribed default DNN out of a TS 29.503
+/// `SmfSelectionSubscriptionData` body, for the S-NSSAI the create names.
+///
+/// **This reads `smf-sel-data`, not `sm-data`, and that is a deliberate deviation
+/// from #204's suggested approach — see the spec.** The approach says to select
+/// "the `dnnConfigurations` entry flagged as the subscribed default", but
+/// `sm-data`'s `DnnConfiguration` (TS 29.503 Table 5.5.2.4-1) has **no such
+/// flag**; the default-DNN flag is `DnnInfo.defaultDnnIndicator`, which lives in
+/// `SmfSelectionSubscriptionData` (`smf-sel-data`). Selecting from
+/// `dnnConfigurations` would mean picking an arbitrary key out of a JSON *object*,
+/// which is precisely the fabrication #204 exists to remove.
+///
+/// Selection order:
+/// 1. the `dnnInfos` entry with `defaultDnnIndicator: true`;
+/// 2. if exactly ONE DNN is subscribed for the S-NSSAI and none is flagged, that
+///    one — it is unambiguous, there is nothing else the default could be;
+/// 3. otherwise `AmbiguousDefault`, because choosing among several unflagged DNNs
+///    would invent an answer the subscription does not give.
+fn select_default_dnn(
+    smf_sel_data: &serde_json::Value,
+    sst: u8,
+    sd: Option<&str>,
+) -> Result<String, DefaultDnnError> {
+    // `subscribedSnssaiInfos` is keyed by the TS 29.571 S-NSSAI string form:
+    // `{sst:02x}` or `{sst:02x}-{sd}` (udrd's `build_smf_selection_data`).
+    let key = match sd {
+        Some(sd) => format!("{sst:02x}-{sd}"),
+        None => format!("{sst:02x}"),
+    };
+    let infos = smf_sel_data.get("subscribedSnssaiInfos");
+    // Fall back to the key with no SD when the exact key is absent: a subscription
+    // provisioned without an SD still applies to a request that carries one, the
+    // same widening `nsacfd`'s quota lookup does.
+    let entry = infos
+        .and_then(|i| i.get(&key))
+        .or_else(|| infos.and_then(|i| i.get(format!("{sst:02x}"))));
+
+    let dnn_infos = entry
+        .and_then(|e| e.get("dnnInfos"))
+        .and_then(|v| v.as_array())
+        .ok_or(DefaultDnnError::NoSubscribedDnn)?;
+
+    let named: Vec<&serde_json::Value> = dnn_infos
+        .iter()
+        .filter(|i| i.get("dnn").and_then(|v| v.as_str()).is_some())
+        .collect();
+    if named.is_empty() {
+        return Err(DefaultDnnError::NoSubscribedDnn);
+    }
+    if let Some(flagged) = named
+        .iter()
+        .find(|i| i.get("defaultDnnIndicator").and_then(|v| v.as_bool()) == Some(true))
+    {
+        let dnn = flagged["dnn"].as_str().unwrap_or_default().to_string();
+        log::info!("subscribed default DNN '{dnn}' (defaultDnnIndicator) for SST {sst}");
+        return Ok(dnn);
+    }
+    if named.len() == 1 {
+        let dnn = named[0]["dnn"].as_str().unwrap_or_default().to_string();
+        log::info!(
+            "subscribed default DNN '{dnn}' for SST {sst}: the only DNN subscribed for this \
+             S-NSSAI, and none carries defaultDnnIndicator"
+        );
+        return Ok(dnn);
+    }
+    Err(DefaultDnnError::AmbiguousDefault(
+        named
+            .iter()
+            .filter_map(|i| i["dnn"].as_str().map(String::from))
+            .collect(),
+    ))
+}
+
+/// The `Nudm_SDM_Get smf-select-data` request path.
+///
+/// **No `single-nssai` query parameter, deliberately.** TS 29.503 §5.2.2.2.1 lets a
+/// consumer scope the answer to one S-NSSAI, and doing so would be tidier — but the
+/// value is JSON, so on the wire it must be percent-encoded as an RFC 3986 query
+/// component, and this tree's shared SBI server stores query values **verbatim
+/// without decoding them** (`libs/nextgcore-sbi/src/server.rs:583`, which is the gap
+/// issue #65 names). So a percent-encoded `single-nssai` reaches the in-tree UDM as
+/// the literal `%7B%22sst%22...` and cannot be parsed, while sending it unencoded
+/// would be invalid on the wire. Neither is acceptable, and scoping is an
+/// optimisation rather than a correctness requirement: `select_default_dnn` picks the
+/// S-NSSAI's entry out of `subscribedSnssaiInfos` by key regardless. Add the
+/// parameter once #65 makes query decoding work.
+///
+/// Nudm_SDM is at **v2** (TS 29.503 §6.1.1), unlike the other Nudm services.
+fn smf_select_data_path(supi: &str, _sst: u8, _sd: Option<&str>) -> String {
+    format!(
+        "/nudm-sdm/v2/{supi}/{}",
+        nextgcore_sbi::constants::resource::SMF_SELECT_DATA
+    )
+}
+
+/// Nudm_SDM_Get (`smf-sel-data`) → the subscribed default DNN for this S-NSSAI
+/// (TS 29.503 §5.2.2.2, TS 23.501 §5.6.1).
+///
+/// Issue #204: called only when `SmContextCreateData` carries no `dnn`. The
+/// literal `"internet"` the AMF used to substitute meant any deployment whose
+/// subscribers do not all default to a DNN named `internet` attached DNN-less
+/// sessions to the WRONG data network — silently, since the session established
+/// fine against it.
+async fn fetch_subscribed_default_dnn(
+    supi: &str,
+    sst: u8,
+    sd: Option<&str>,
+) -> Result<String, DefaultDnnError> {
+    let (host, port) = discover_udm_sdm_endpoint()
+        .await
+        .ok_or(DefaultDnnError::NoUdmEndpoint)?;
+    let client = global_context().get_client(&host, port).await;
+
+    let path = smf_select_data_path(supi, sst, sd);
+    let response = client.get(&path).await.map_err(|e| {
+        DefaultDnnError::SdmRequestFailed(format!("Nudm_SDM_Get smf-select-data failed: {e}"))
+    })?;
+    if !response.is_success() {
+        return Err(DefaultDnnError::SdmRequestFailed(format!(
+            "Nudm_SDM_Get smf-select-data returned status {}",
+            response.status
+        )));
+    }
+    let body = response.http.content.as_deref().ok_or_else(|| {
+        DefaultDnnError::SdmRequestFailed("empty smf-select-data body".to_string())
+    })?;
+    let json: serde_json::Value = serde_json::from_str(body).map_err(|e| {
+        DefaultDnnError::SdmRequestFailed(format!("smf-select-data is not valid JSON: {e}"))
+    })?;
+    select_default_dnn(&json, sst, sd)
+}
+
 /// Parse host and port from a URI string (e.g., "http://localhost:7777")
 fn parse_host_port(uri: &str) -> Option<(String, u16)> {
     let without_scheme = uri
@@ -1951,10 +2236,13 @@ fn validate_sm_context_create_data(body: &serde_json::Value) -> Option<&'static 
     if !psi_ok {
         return Some("MANDATORY_IE_INCORRECT");
     }
-    // dnn (M for this SMF)
-    if body["dnn"].as_str().is_none() {
-        return Some("MANDATORY_IE_MISSING");
-    }
+    // `dnn` is OPTIONAL (TS 29.502 Table 6.1.6.2.2-1), and issue #204 stopped
+    // treating it as mandatory here: when the UE omits the DNN IE the AMF now
+    // omits the member, and the SMF resolves the SUBSCRIBED DEFAULT DNN from SM
+    // subscription data instead (`fetch_subscribed_default_dnn`). Rejecting it at
+    // this validator would make that unreachable. A present-but-empty `dnn` is
+    // still wrong, and is caught in the handler.
+    //
     // sNssai.sst (M)
     if body["sNssai"]["sst"].as_u64().is_none() {
         return Some("MANDATORY_IE_MISSING");
@@ -2001,9 +2289,6 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
     else {
         return problem_400("MANDATORY_IE_INCORRECT", "pduSessionId (1..15) is required");
     };
-    let Some(dnn) = req_body["dnn"].as_str().map(str::to_string) else {
-        return problem_400("MANDATORY_IE_MISSING", "dnn is required");
-    };
     let Some(sst) = req_body["sNssai"]["sst"].as_u64().map(|v| v as u8) else {
         return problem_400("MANDATORY_IE_MISSING", "sNssai.sst is required");
     };
@@ -2028,6 +2313,35 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
         );
     };
     let supi = supi.to_string();
+
+    // ---- DNN: the UE's, else the SUBSCRIBED DEFAULT (issue #204) ----
+    // `dnn` is optional in SmContextCreateData; when the UE omits the DNN IE the
+    // AMF omits the member, and TS 23.501 §5.6.1 says the network selects the
+    // SUBSCRIBED default DNN. The AMF used to substitute the literal `"internet"`,
+    // so any deployment whose subscribers do not all default to a DNN of that name
+    // attached DNN-less sessions to the WRONG data network -- wrong UPF, wrong
+    // policy and charging, wrong slice -- and silently, because the session
+    // established fine against it.
+    //
+    // Never falls back to a literal: an unresolvable default is a REFUSED session,
+    // which is what the SMF already did for an absent `dnn` before this change,
+    // and the cause names which of the four failure modes it was.
+    let dnn = match req_body["dnn"].as_str().filter(|d| !d.is_empty()) {
+        Some(d) => d.to_string(),
+        None => {
+            log::info!(
+                "[{supi}] SmContextCreateData carries no dnn — resolving the subscribed \
+                 default for SST {sst} (TS 23.501 §5.6.1)"
+            );
+            match fetch_subscribed_default_dnn(&supi, sst, snssai_sd.as_deref()).await {
+                Ok(d) => d,
+                Err(e) => {
+                    log::warn!("[{supi}] no DNN for this session: {}", e.detail());
+                    return problem_400(e.cause(), &e.detail());
+                }
+            }
+        }
+    };
     let an_type = req_body["anType"].as_str().unwrap_or_else(|| {
         log::warn!("SmContextCreateData without anType — assuming 3GPP_ACCESS");
         "3GPP_ACCESS"
@@ -4401,12 +4715,19 @@ mod tests {
             Some("MANDATORY_IE_INCORRECT")
         );
 
+        // #204: `dnn` is OPTIONAL (TS 29.502 Table 6.1.6.2.2-1), so its absence is
+        // NOT a validator failure — the handler resolves the subscribed default
+        // instead (TS 23.501 §5.6.1). Rejecting here would make that unreachable.
         let mut no_dnn = matched_sim.clone();
         no_dnn["dnn"] = serde_json::Value::Null;
         assert_eq!(
             validate_sm_context_create_data(&no_dnn),
-            Some("MANDATORY_IE_MISSING")
+            None,
+            "an absent dnn must reach the handler, which resolves the subscribed default"
         );
+        let mut absent_dnn = matched_sim.clone();
+        absent_dnn.as_object_mut().unwrap().remove("dnn");
+        assert_eq!(validate_sm_context_create_data(&absent_dnn), None);
 
         let mut no_sst = matched_sim.clone();
         no_sst["sNssai"] = serde_json::json!({});
@@ -4418,6 +4739,332 @@ mod tests {
         let mut no_n1 = matched_sim.clone();
         no_n1["n1SmMsg"] = serde_json::Value::Null;
         assert_eq!(validate_sm_context_create_data(&no_n1), Some("N1_SM_ERROR"));
+    }
+
+    // ------------------------------- #204 -------------------------------
+
+    /// **Issue #204.** The subscribed default DNN is selected from
+    /// `SmfSelectionSubscriptionData`'s `dnnInfos`, and nothing is invented when
+    /// the subscription does not say which DNN is the default.
+    ///
+    /// Note where the flag lives: `DnnInfo.defaultDnnIndicator` in `smf-sel-data`.
+    /// The issue's suggested approach said to read `sm-data`'s `dnnConfigurations`,
+    /// which has **no** default flag at all (TS 29.503 Table 5.5.2.4-1) — see the
+    /// `select_default_dnn` doc comment.
+    #[test]
+    fn select_default_dnn_uses_the_indicator_and_refuses_to_guess() {
+        // 1. The flagged entry wins, even when it is not first.
+        let flagged = serde_json::json!({
+            "subscribedSnssaiInfos": {
+                "01": { "dnnInfos": [
+                    { "dnn": "ims" },
+                    { "dnn": "operator-default", "defaultDnnIndicator": true },
+                    { "dnn": "internet" },
+                ]}
+            }
+        });
+        assert_eq!(
+            select_default_dnn(&flagged, 1, None),
+            Ok("operator-default".to_string()),
+            "the flagged DNN wins over position"
+        );
+        // Specifically NOT the literal the AMF used to substitute, which is the
+        // whole point of #204.
+        assert_ne!(select_default_dnn(&flagged, 1, None), Ok("internet".into()));
+
+        // 2. A single subscribed DNN with no flag is unambiguous.
+        let single = serde_json::json!({
+            "subscribedSnssaiInfos": { "01": { "dnnInfos": [{ "dnn": "corp" }] } }
+        });
+        assert_eq!(select_default_dnn(&single, 1, None), Ok("corp".to_string()));
+
+        // 3. Several DNNs and no flag: the subscription does not say, so the SMF
+        //    does not either. Guessing is the fabrication this issue removes.
+        let ambiguous = serde_json::json!({
+            "subscribedSnssaiInfos": {
+                "01": { "dnnInfos": [{ "dnn": "internet" }, { "dnn": "ims" }] }
+            }
+        });
+        match select_default_dnn(&ambiguous, 1, None) {
+            Err(DefaultDnnError::AmbiguousDefault(dnns)) => {
+                assert_eq!(dnns, vec!["internet".to_string(), "ims".to_string()]);
+            }
+            other => panic!("expected AmbiguousDefault, got {other:?}"),
+        }
+
+        // 4. No DNN at all for the S-NSSAI, and an S-NSSAI that is not subscribed.
+        for empty in [
+            serde_json::json!({}),
+            serde_json::json!({ "subscribedSnssaiInfos": {} }),
+            serde_json::json!({ "subscribedSnssaiInfos": { "01": {} } }),
+            serde_json::json!({ "subscribedSnssaiInfos": { "01": { "dnnInfos": [] } } }),
+            // A dnnInfos entry with no `dnn` member names nothing.
+            serde_json::json!({ "subscribedSnssaiInfos": { "01": { "dnnInfos": [{}] } } }),
+        ] {
+            assert_eq!(
+                select_default_dnn(&empty, 1, None),
+                Err(DefaultDnnError::NoSubscribedDnn),
+                "body {empty} must not yield a DNN"
+            );
+        }
+        assert_eq!(
+            select_default_dnn(&single, 9, None),
+            Err(DefaultDnnError::NoSubscribedDnn),
+            "SST 9 is not subscribed"
+        );
+
+        // 5. The key form is the TS 29.571 S-NSSAI string `{sst:02x}[-{sd}]`, and a
+        //    subscription provisioned without an SD still applies to a request that
+        //    carries one.
+        let with_sd = serde_json::json!({
+            "subscribedSnssaiInfos": {
+                "01-000001": { "dnnInfos": [{ "dnn": "slice-a" }] },
+                "01": { "dnnInfos": [{ "dnn": "no-sd" }] }
+            }
+        });
+        assert_eq!(
+            select_default_dnn(&with_sd, 1, Some("000001")),
+            Ok("slice-a".to_string()),
+            "the exact sst-sd key wins"
+        );
+        assert_eq!(
+            select_default_dnn(&with_sd, 1, Some("999999")),
+            Ok("no-sd".to_string()),
+            "an unmatched SD widens to the no-SD entry"
+        );
+    }
+
+    /// **Issue #204.** Every `DefaultDnnError` maps to a cause that distinguishes
+    /// "the consumer named no DNN and the subscription supplies none" from "the SMF
+    /// could not reach the subscription".
+    ///
+    /// Collapsing them would leave an operator unable to tell a provisioning gap
+    /// from an unreachable UDM, which are opposite remedies.
+    #[test]
+    fn default_dnn_error_causes_are_distinct_and_never_silent() {
+        assert_eq!(
+            DefaultDnnError::NoSubscribedDnn.cause(),
+            "MANDATORY_IE_MISSING"
+        );
+        assert_eq!(
+            DefaultDnnError::AmbiguousDefault(vec!["a".into(), "b".into()]).cause(),
+            "MANDATORY_IE_MISSING"
+        );
+        assert_eq!(
+            DefaultDnnError::NoUdmEndpoint.cause(),
+            "SUBSCRIPTION_DATA_NOT_AVAILABLE"
+        );
+        assert_eq!(
+            DefaultDnnError::SdmRequestFailed("boom".into()).cause(),
+            "SUBSCRIPTION_DATA_NOT_AVAILABLE"
+        );
+
+        // Every detail says which failure it was, and none of them says "internet".
+        for e in [
+            DefaultDnnError::NoUdmEndpoint,
+            DefaultDnnError::SdmRequestFailed("status 503".into()),
+            DefaultDnnError::NoSubscribedDnn,
+            DefaultDnnError::AmbiguousDefault(vec!["internet".into(), "ims".into()]),
+        ] {
+            let detail = e.detail();
+            assert!(!detail.is_empty());
+            assert!(
+                detail.contains("dnn") || detail.contains("DNN"),
+                "detail must name the DNN problem: {detail}"
+            );
+        }
+        assert!(
+            DefaultDnnError::AmbiguousDefault(vec!["internet".into(), "ims".into()])
+                .detail()
+                .contains("internet, ims")
+        );
+    }
+
+    /// **Issue #204.** A `nudm-sdm` endpoint is taken from the NRF `SearchResult`,
+    /// preferring the service's own `ipEndPoints` over the instance address.
+    #[test]
+    fn udm_sdm_endpoint_is_read_from_the_search_result() {
+        let result = serde_json::json!({
+            "nfInstances": [
+                // A UDM that does not serve nudm-sdm must be skipped, not used.
+                { "nfType": "UDM", "ipv4Addresses": ["10.0.0.1"],
+                  "nfServices": [{ "serviceName": "nudm-uecm",
+                                   "ipEndPoints": [{ "ipv4Address": "10.0.0.1", "port": 7777 }] }] },
+                { "nfType": "UDM", "ipv4Addresses": ["10.0.0.2"],
+                  "nfServices": [{ "serviceName": "nudm-sdm",
+                                   "ipEndPoints": [{ "ipv4Address": "10.0.0.9", "port": 8080 }] }] },
+            ]
+        });
+        assert_eq!(
+            udm_sdm_endpoint_from_search_result(&result),
+            Some(("10.0.0.9".to_string(), 8080)),
+            "the nudm-sdm service's own endpoint wins over the instance address"
+        );
+
+        // No ipEndPoints: fall back to the instance address and the default port.
+        let no_endpoints = serde_json::json!({
+            "nfInstances": [{ "nfType": "UDM", "ipv4Addresses": ["10.0.0.3"],
+                              "nfServices": [{ "serviceName": "nudm-sdm" }] }]
+        });
+        assert_eq!(
+            udm_sdm_endpoint_from_search_result(&no_endpoints),
+            Some(("10.0.0.3".to_string(), 7777))
+        );
+
+        // Nothing usable yields None rather than a guessed localhost.
+        for empty in [
+            serde_json::json!({}),
+            serde_json::json!({ "nfInstances": [] }),
+            serde_json::json!({ "nfInstances": [{ "nfType": "UDM" }] }),
+            serde_json::json!({ "nfInstances": [{ "nfType": "UDM",
+                "nfServices": [{ "serviceName": "nudm-uecm" }] }] }),
+        ] {
+            assert_eq!(
+                udm_sdm_endpoint_from_search_result(&empty),
+                None,
+                "body {empty} must not yield an endpoint"
+            );
+        }
+    }
+
+    /// Serialises the tests that set the process-global `UDM_SBI_ADDR` /
+    /// `UDM_SBI_PORT` / `NRF_URI` environment. Env is per-process, so two of these
+    /// running concurrently would each see the other's UDM address — the same
+    /// process-global-state race the workspace has hit before with `UDR_SBI_*`.
+    static UDM_ENV_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// **Issue #204, end to end.** `fetch_subscribed_default_dnn` really reaches a
+    /// UDM, sends a conformant `Nudm_SDM_Get smf-select-data` with a
+    /// percent-encoded `single-nssai`, and returns the flagged DNN.
+    ///
+    /// The pure-function test above proves the SELECTION; this proves the request
+    /// and the plumbing around it, which is the half a unit test cannot see.
+    #[tokio::test]
+    async fn fetch_subscribed_default_dnn_queries_the_udm_and_returns_the_flagged_dnn() {
+        let _guard = UDM_ENV_TEST_LOCK.lock().await;
+        // The stub UDM is a loopback PLAINTEXT peer, which describes a dev-profile
+        // deployment; the default profile is Production and would require client
+        // TLS material this test has no business inventing.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let port = nextgcore_sbi::test_support::free_port();
+        type Seen = (Vec<String>, Vec<std::collections::HashMap<String, String>>);
+        let seen: Arc<std::sync::Mutex<Seen>> =
+            Arc::new(std::sync::Mutex::new((Vec::new(), Vec::new())));
+        let seen_in_handler = Arc::clone(&seen);
+
+        let server =
+            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
+                std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+            ));
+        server
+            .start(move |req: SbiRequest| {
+                let seen = Arc::clone(&seen_in_handler);
+                async move {
+                    let uri = req.header.uri.clone();
+                    {
+                        let mut s = seen.lock().unwrap();
+                        s.0.push(uri.clone());
+                        s.1.push(req.http.params.clone().into_iter().collect());
+                    }
+                    if uri.contains("/nudm-sdm/") && uri.contains("smf-select-data") {
+                        SbiResponse::with_status(200)
+                            .with_json_body(&serde_json::json!({
+                                "subscribedSnssaiInfos": {
+                                    "01": { "dnnInfos": [
+                                        { "dnn": "internet" },
+                                        { "dnn": "operator-default", "defaultDnnIndicator": true },
+                                    ]}
+                                }
+                            }))
+                            .unwrap()
+                    } else {
+                        SbiResponse::with_status(404)
+                    }
+                }
+            })
+            .await
+            .expect("stub UDM start");
+
+        // Point the fallback at the stub. NRF discovery is tried first and will
+        // fail (nothing answers nnrf-disc here), which also exercises that the
+        // fallback really is reached rather than the discovery failure being fatal.
+        std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
+        std::env::set_var("UDM_SBI_PORT", port.to_string());
+        std::env::remove_var("NRF_URI");
+
+        let dnn = fetch_subscribed_default_dnn("imsi-262011234567890", 1, None).await;
+        assert_eq!(
+            dnn,
+            Ok("operator-default".to_string()),
+            "the flagged subscribed default must be used, not the first entry \
+             and certainly not the old \"internet\" literal"
+        );
+
+        // The resource the UDM saw is the conformant one: v2 (Nudm_SDM is at v2 per
+        // TS 29.503 §6.1.1, unlike the other Nudm services) and `smf-select-data`.
+        // The server decodes the query into params, so the recorded URI carries no
+        // query string -- the ENCODING is pinned by
+        // `smf_select_data_path_percent_encodes_single_nssai` instead, and what is
+        // asserted here is that the value ARRIVED and decoded back to the S-NSSAI.
+        let (uris, params) = {
+            let s = seen.lock().unwrap();
+            (s.0.clone(), s.1.clone())
+        };
+        assert!(
+            uris.iter()
+                .any(|u| u == "/nudm-sdm/v2/imsi-262011234567890/smf-select-data"),
+            "the UDM must have been queried at the v2 smf-select-data resource, saw {uris:?}"
+        );
+        // And NO `single-nssai` is sent: the shared SBI server does not
+        // percent-decode query values (#65), so a JSON-valued parameter cannot
+        // round-trip to the in-tree UDM. Asserted rather than left implicit,
+        // because re-adding it would silently send an unparseable value.
+        assert!(
+            params.iter().all(|p| !p.contains_key("single-nssai")),
+            "no single-nssai until #65 makes query decoding work, saw {params:?}"
+        );
+
+        std::env::remove_var("UDM_SBI_ADDR");
+        std::env::remove_var("UDM_SBI_PORT");
+        // Deliberately NOT reset_sbi_profile_override(): the override is
+        // process-wide, and resetting it here flipped `policy.rs`'s
+        // `sm_policy_lifecycle_http_round_trip` back to Production mid-flight and
+        // made it fail. Every other loopback-plaintext test in this crate sets the
+        // Dev override and leaves it set; matching that is what keeps them
+        // compatible.
+        server.stop().await.expect("stop");
+    }
+
+    /// **Issue #204, criterion 4.** A DNN-less create with no reachable UDM is
+    /// REFUSED with a cause that says so — never a silent `"internet"`.
+    #[tokio::test]
+    async fn dnn_less_create_with_no_udm_is_refused_not_defaulted() {
+        let _guard = UDM_ENV_TEST_LOCK.lock().await;
+        std::env::remove_var("UDM_SBI_ADDR");
+        std::env::remove_var("UDM_SBI_PORT");
+        std::env::remove_var("NRF_URI");
+        smf_context_init(64, 256, 512);
+
+        let body = serde_json::json!({
+            "pduSessionId": 5,
+            "supi": "imsi-262011234567890",
+            "sNssai": { "sst": 1 },
+            "n1SmMsg": { "contentId": "n1SmMsg" },
+        });
+        let request = SbiRequest::post("/nsmf-pdusession/v1/sm-contexts")
+            .with_body(body.to_string(), "application/json");
+        let resp = handle_sm_context_create(&request).await;
+
+        assert_eq!(resp.status, 400, "an unresolvable DNN refuses the session");
+        let content = resp.http.content.as_deref().unwrap_or("");
+        assert!(
+            content.contains("SUBSCRIPTION_DATA_NOT_AVAILABLE"),
+            "the cause must name the real problem, got {content}"
+        );
+        assert!(
+            !content.contains("internet"),
+            "the refusal must not mention a fabricated default, got {content}"
+        );
     }
 
     // ----------------------------- smfd-07 ------------------------------


### PR DESCRIPTION
Closes #204. Refs #264, #65.

`amfd` substituted `dnn_override.unwrap_or("internet")`, so any deployment whose subscribers do not all
default to a DNN literally named `internet` attached DNN-less sessions to the **wrong data network** —
wrong UPF, wrong policy and charging, wrong slice — and **silently**, because the session established
fine against it. TS 29.502 §6.1.6.2.2 makes `dnn` optional and TS 23.501 §5.6.1 makes the *subscribed*
default the network's answer, so `amfd` now omits the member and `smfd` resolves it, which is correct
per TS 23.501 §6.2.2: the SMF is the NF that retrieves SM subscription data.

## The issue's suggested approach cannot be followed as written

Read this first if you are comparing the issue to the diff. It says to select *"the `dnnConfigurations`
entry **flagged as the subscribed default**"*. **No such flag exists.** `sm-data`'s `dnnConfigurations`
is a JSON object keyed by DNN name, and TS 29.503 Table 5.5.2.4-1's `DnnConfiguration` carries
`pduSessionTypes`, `sscModes`, `5gQosProfile` and `sessionAmbr` — no default indicator. Selecting from
it would mean picking an arbitrary key out of a map, which is the fabrication this issue exists to
remove.

The default flag is `DnnInfo.defaultDnnIndicator`, and `DnnInfo` lives in
`SmfSelectionSubscriptionData`. **So this reads `smf-select-data`, not `sm-data`** — same service, same
producer chain, the resource that can actually answer the question.

## Selection order, and what it refuses

1. the `dnnInfos` entry flagged `defaultDnnIndicator: true`;
2. else, if exactly **one** DNN is subscribed for the S-NSSAI and none is flagged, that one —
   unambiguous;
3. else **refuse**, naming the candidates.

Rule 3 is the point. Picking the first, or the alphabetically-first, or `"internet"` would all be
deterministic and all be invented. A refused session is a visible operator problem; a session on the
wrong data network is an invisible one.

Four distinct failure causes rather than one: `MANDATORY_IE_MISSING` for "the subscription supplies no
usable default" (candidates named in the detail) and `SUBSCRIPTION_DATA_NOT_AVAILABLE` for "no UDM
endpoint" / "the Nudm_SDM_Get failed". Collapsing them would leave an operator unable to tell a
provisioning gap from an unreachable UDM, which have opposite remedies.

## No `single-nssai` query parameter — not an oversight

The first draft sent one; the end-to-end test showed why it cannot work here. The value is JSON, so on
the wire it must be percent-encoded as an RFC 3986 query component — and **this tree's shared SBI server
stores query values verbatim without decoding them** (`libs/nextgcore-sbi/src/server.rs:583`, exactly
the gap #65 names). A percent-encoded `single-nssai` reaches the in-tree UDM as the literal
`%7B%22sst%22...` and cannot be parsed; sending it unencoded would be invalid. Scoping is an
optimisation, not correctness — `select_default_dnn` picks the S-NSSAI's entry by key regardless. The
test asserts the parameter is **absent**, so re-adding it before #65 lands fails loudly.

## The dormant `nudm-sdm` FSM arm is removed, not wired

Criterion 2 allows either. The DNN is an **input to creating the session**, so the fetch must happen
before the session's GSM FSM exists. The arm described a flow where the SMF fetched subscription data
*during* the policy-association wait, which never existed — and dispatching the response there too would
put one decision in two places. Its sibling `npcf-smpolicycontrol` arm **is** live, so this is a real
asymmetry rather than a dead handler.

## Sequencing, which the issue calls load-bearing

Both halves land in one commit, so no intermediate state exists. Three things make the SMF side
genuinely reachable rather than nominally present:

1. `validate_sm_context_create_data` stops rejecting an absent `dnn` — leaving it mandatory would have
   made the whole resolution path unreachable, the same class of defect as #242.
2. A UDM resolver was added, because **`smfd` had no way to reach a UDM at all**: it knows only its NRF,
   performs no NF discovery, and the `smf` container set no `UDM_SBI_ADDR`. NRF discovery first,
   `UDM_SBI_ADDR`/`UDM_SBI_PORT` as fallback.
3. `UDM_SBI_ADDR` / `UDM_SBI_PORT` added to that container, without which a DNN-less session in the E2E
   would be refused.

Note the worst case is **not a regression**: `smfd` already refused any create with no `dnn`, so an
unresolvable default still refuses, just with a better cause.

## Verification

Workspace **5982 passed / 0 failed / 6 ignored** (baseline 5976 on `35475d5`; +6 tests — smfd 392 → 397,
amfd 427 → 428). `cargo clippy -p nextgcore-smfd -p nextgcore-amfd --all-targets` adds no warning,
`cargo clippy --workspace` 0 errors, `cargo fmt --all -- --check` clean.

| revert | expected to break | result |
|---|---|---|
| `amfd` substitutes `"internet"` again | `n11_omits_dnn_when_the_ue_did_not_supply_one` | **1 failed** (`got {"dnn":"internet",...}`) |
| `smfd` falls back to the literal instead of refusing | `dnn_less_create_with_no_udm_is_refused_not_defaulted` | **1 failed** |
| `select_default_dnn` ignores `defaultDnnIndicator` | `select_default_dnn_uses_the_indicator_and_refuses_to_guess` | **1 failed** |
| several unflagged DNNs pick the first | same test | **1 failed** (`expected AmbiguousDefault, got Ok("internet")`) |
| the fetch queries `am-data` instead of `smf-select-data` | `fetch_subscribed_default_dnn_queries_the_udm...` | **1 failed** |
| the validator requires `dnn` again | `validate_sm_context_create_data_table`, `dnn_less_create...` | **2 failed** |

No false guards. Two things the work surfaced, recorded because they cost time:

- **The first end-to-end test failed on TLS**, not logic: the default `SbiProfile` is `Production`, so a
  loopback plaintext stub needs `set_sbi_profile_override(SbiProfile::Dev)`.
- **Calling `reset_sbi_profile_override()` at the end of that test broke a sibling test** — the override
  is process-wide, and resetting it flipped `policy.rs`'s `sm_policy_lifecycle_http_round_trip` back to
  Production mid-flight. Every loopback-plaintext test in this crate sets Dev and leaves it set. Tidying
  up global state was the wrong instinct.

## Ceilings

- **Nothing in this tree emits `defaultDnnIndicator`** — the subscription DB has no such field and
  `udrd`'s `build_smf_selection_data` writes only the DNN name. So against its own UDM/UDR the selection
  rests on rule 2, and a subscriber with **two or more DNNs on one S-NSSAI cannot establish a DNN-less
  PDU session** (refused, candidates named). Filed as **#264** (`decision`, `needs-human`) with three
  costed options and a recommendation, because the fix spans the DB schema, `udrd` and the WebUI.
  **This is the most likely thing to be mistaken for done.**
- **The docker E2E is `workflow_dispatch`-only**, so CI does not exercise the compose change or the
  DNN-less end-to-end path.
- **`single-nssai` is not sent** (above), so the SMF receives every subscribed S-NSSAI's DNN list and
  filters locally — correct, but more wire data than necessary until #65.
- **NRF discovery here is minimal by design**: one address, no cache population, no `validityPeriod`,
  first instance only. `amfd` and `udmd` already carry full copies; a third is a maintenance cost this
  issue does not need.
- **No test drives a real AMF→SMF DNN-less create end to end.** Each side is tested; the join is not,
  because `smfd`'s create path needs a PCF and a UPF past the DNN step.
- GitNexus impact analysis unrunnable (no MCP server connected).

`docs-book/src/configuration/smf.md` documents the resolution order, the causes, the `UDM_SBI_*` fallback
and every ceiling above.

Spec: `specs/fix-smfd-subscribed-default-dnn.md`