### PR TITLE
fix(nefd): serve the advertised service, stop fabricating success, stop masking failure (#111)

### DIFF
--- a/specs/fix-nefd-service-catalogue-truth-and-honest-failures.md
+++ b/specs/fix-nefd-service-catalogue-truth-and-honest-failures.md
@@ -1,0 +1,173 @@
+# nextgcore #111 (nefd): serve the advertised service, stop fabricating success, stop masking failure
+
+Verified against `main` @ `71418a5`. The issue was written at `76ea248`; every cite was re-located
+(line numbers have drifted) and all three defects still hold.
+
+## Verified against current main
+
+| claim in the issue | site on `71418a5` | still true? |
+|---|---|---|
+| the profile advertises `nnef-eventexposure` | `build_nf_profile` → `"serviceName": "nnef-eventexposure"`; self-instance built with `SbiServiceType::NnefEventexposure` | yes |
+| no AF-facing `nnef-eventexposure` route; only the producer sink | router had three arms; `["nnef-eventexposure","v1","notify",id]` was the only one under that root, so `POST .../subscriptions` hit the `send_not_found` fallthrough | yes |
+| Device Triggering fabricates `TRIGGERED` | `NefTriggerTransaction::new(scs_as_id, "TRIGGERED", ..)` plus a second `"TRIGGERED"` literal echoed into the body | yes — **two** literals, which is worse than the issue says |
+| southbound failure masked on create | `attempt_southbound_subscribe` returned `Option<SouthboundRef>`; `None` covered four distinct causes and the caller returned `201` for all of them | yes |
+
+## Decision 1: implement the advertised service rather than stop advertising it
+
+Criterion 2 sanctions either. Implemented, because the alternative is worse here: the
+`/nnef-eventexposure/v1/notify/{id}` path is a **callback the NEF hands to producers**, not a service
+it offers, so dropping the advertisement would have left the NEF advertising nothing over SBI while
+the machinery to serve something already existed. `POST/DELETE /nnef-eventexposure/v1/subscriptions`
+now exists.
+
+**It is one subscription, not two.** `handle_nnef_event_exposure_create` validates the TS 29.591
+mandatory IEs (`notifUri`, `notifId`, `nefEventSubs[].eventId`), maps the event onto the equivalent
+TS 29.122 MonitoringType, and hands the translated body to the **same** create handler, which is now
+parameterised on a `NorthboundApi`. That parameterisation is the point: the failure semantics below,
+the anyUE guard from #110 and the target resolution apply to both APIs by construction rather than by
+being reimplemented and drifting.
+
+An `eventId` outside the served set is **`501` naming it**, and a multi-event request is `501` too
+(one southbound leg per subscription, so serving only the first would be the fabricated-success shape
+this issue exists to remove).
+
+## Decision 2: `deliveryResult` becomes `UNKNOWN`, from one constant
+
+`TRIGGERED` is a **positive** lifecycle state in TS 29.122 §5.10 — the trigger was accepted for
+delivery. Reporting it with no delivery path told the AF the message was on its way and left it unable
+to distinguish "queued" from "silently dropped", which is the failure device triggering exists to
+prevent. `UNKNOWN` is the honest value: the transaction was accepted and stored, and the NEF genuinely
+does not know an outcome it never attempted.
+
+`DEVICE_TRIGGERING_STUB_RESULT` is one constant because there were **two** separate `"TRIGGERED"`
+literals — the stored transaction and the echoed body — so a fix applied to one would have left the
+other claiming success. The test now asserts they agree.
+
+The issue suggests a `device-triggering-stub` feature gate. Not added: a gate whose off-state is
+"return `501`" adds a build configuration to protect against a value that is now correct in every
+build. `UNKNOWN` cannot ship fabricated success, which is what the gate was for.
+
+## Decision 3: `Option` → a three-way outcome, and only one of the three is accepted
+
+`attempt_southbound_subscribe` now returns `SouthboundOutcome`:
+
+| outcome | cause | northbound |
+|---|---|---|
+| `Live(ref)` | producer accepted, id extractable | `201`, subscription live |
+| `Deferred` | **no producer URI configured** | `201`, leg retained as `pending`, reconciler retries |
+| `Failed { retryable, detail }` | attempted and cannot be established | `503` retryable / `500` not, cause `SUBSCRIPTION_NOT_ESTABLISHED` |
+
+The split that matters is `Deferred` vs `Failed`: a deployment that has not wired its AMF/UDM yet is a
+**configuration state**, not a request error, so rejecting it would break the shipped default. A
+producer that was asked and could not deliver is a request the NEF cannot honour.
+
+`retryable` picks the status: a transport failure is the NEF's dependency being unavailable (`503`), a
+producer answering unusably is `500`. Both are TS 29.500 §5.2.7 statuses; neither is `201`.
+
+Note the fourth cause the old `None` also covered — **the producer accepted and returned no
+extractable subscription id** — is now `Failed`, not success. Accepting it would have orphaned a
+producer-side subscription the NEF can never unsubscribe *and* left the AF unable to delete it.
+
+## Decision 4: a deferred leg is expired, not retried forever
+
+`PendingSouthbound` retains the built subscribe request plus `since`. `reconcile_pending_subscriptions`
+sweeps them, promotes any that reach their producer, and **expires** — removes — any past
+`NEF_PENDING_LEG_DEADLINE_SECS` (default 300).
+
+Expiry removes the subscription because an AF whose subscription is *gone* can re-create it, whereas
+one holding a subscription that will never notify has no signal at all. That is the same reasoning as
+rejecting a hard failure at create time, applied to the deferred case.
+
+The sweep returns a `ReconcileReport` rather than only logging, so it is assertable without waiting on
+a timer. A promotion that finds the subscription deleted mid-retry unsubscribes the producer leg rather
+than orphaning it.
+
+## Acceptance criteria
+
+- [x] Advertised service names match the mounted routes; a test asserts no advertised service resolves
+      to `send_not_found` — `every_advertised_service_name_has_a_northbound_route` walks
+      `build_nf_profile`'s `nfServices` and drives each through the real router, asserting `!= 404`. It
+      posts a deliberately-invalid body so it tests **routing**, not validation: a `400` proves a route
+      exists and rejected the body, where a `404` would prove nothing is mounted.
+- [x] `POST /nnef-eventexposure/v1/subscriptions` returns a spec-shaped response —
+      `nnef_event_exposure_subscribe_is_served_and_unsupported_events_are_refused`: `201` with a
+      Location under the API it was created on, DELETE-able through the same API, `501` naming an
+      unsupported `eventId`, and `400` for each missing mandatory IE.
+- [x] Device Triggering no longer reports `TRIGGERED` — the pre-existing test **pinned the defect** and
+      was inverted with the flip recorded at the assertion; it now also asserts the stored and echoed
+      values agree.
+- [x] A create whose southbound producer is unreachable does not return `201` —
+      `a_southbound_failure_is_not_reported_as_created` (`503`, cause asserted, and no subscription
+      left behind), plus `southbound_failure_statuses_distinguish_transient_from_unusable` for the
+      `500`/`503` mapping.
+- [x] A reconciler exists for deferred legs —
+      `a_deferred_leg_is_pending_and_the_reconciler_expires_it`: accepted as `201` and marked pending,
+      still pending inside the deadline (retried, not discarded on first failure), **expired and
+      removed** past it, and a no-op sweep when nothing is pending.
+- [x] `cargo test -p nextgcore-nefd` and workspace clippy pass.
+
+## Verification
+
+Workspace **6000 passed / 0 failed / 6 ignored** (baseline `5995` on `71418a5`; +5 tests, nefd 52 →
+57). `cargo clippy -p nextgcore-nefd --all-targets` clean (zero warnings), `cargo clippy --workspace`
+0 errors, `cargo fmt --all -- --check` clean.
+
+Five reverts:
+
+| revert | expected to break | result |
+|---|---|---|
+| a `Failed` leg is stored instead of rejected | `a_southbound_failure_is_not_reported_as_created` | **1 failed** |
+| `DEVICE_TRIGGERING_STUB_RESULT` back to `"TRIGGERED"` | `device_triggering_create_returns_201_with_transaction` | **1 failed** (`a positive lifecycle state must not be reported`) |
+| a `Deferred` leg is not retained | `a_deferred_leg_is_pending_and_the_reconciler_expires_it` | **1 failed** (`the leg must be retained for retry`) |
+| the reconciler never expires a stale leg | same test | **1 failed** (`a leg past its deadline must be expired`) |
+| the `nnef-eventexposure` subscriptions route removed | catalogue-truth + subscribe tests | **2 failed** (`advertised service 'nnef-eventexposure' has no northbound route (got 404)`) |
+
+**Two test-infrastructure defects this work exposed, both process-global-state hazards.** They cost
+real time and match the learning recorded earlier today almost exactly:
+
+1. **`reset_context` did not clear the southbound producer URIs.** The first test to point the context
+   at a producer leaked it into every later test, which then attempted a real HTTP call and **panicked
+   inside the SBI client**. Six pre-existing tests failed that way. `reset_context` now clears the
+   endpoints — the hazard appeared the moment a second party touched the shared thing, which is the
+   recorded shape.
+2. **The shared `block_on` helper had no timer/IO drivers**, with a doc comment justifying it as "the
+   handlers under test do no real I/O (no producer URIs are configured)" — true until a test configured
+   one, at which point `tokio::time::timeout` panicked with *"timers are disabled"* rather than
+   returning a connection error. Enabling the drivers costs nothing and removes the class.
+
+Also worth recording: the first draft of the failure test asserted `500` for a syntactically odd
+producer URI, on the assumption it would fail to parse. `parse_host_port` **accepts** it (host plus a
+default port) and the connect then fails, so it lands on `503`. The test now asserts what the code
+does and says why, rather than what I assumed the branch was.
+
+## Ceilings
+
+* **The `Nnef_EventExposure` surface is minimal and says so.** Three event IDs are served
+  (`LOCATION_REPORT`, `UE_REACHABILITY`, `LOSS_OF_CONNECTIVITY`) because those are what the T8 side and
+  the southbound machinery support; everything else is `501` **by name**. One event per subscription,
+  also `501`. That is honest but it is not the whole of TS 29.591: no `PATCH`, no subscription
+  retrieval, no `supportedFeatures` negotiation, and the response echoes the translated body rather
+  than a `NefEventExposureSubsc` re-serialisation.
+* **`notifId` is reused as the ownership key** for the Nnef API, standing in for T8's `{scsAsId}` path
+  segment because the TS 29.591 path carries no consumer identity. With northbound auth configured the
+  authenticated owner still wins (#110); without it, ownership degrades to the `notifId` the consumer
+  supplied, which is a routing-level check and not a security one — the same caveat #110 documented for
+  `scsAsId`.
+* **The reconciler retries on a fixed interval with no backoff**, and treats "still unreachable" and
+  "now failing outright" identically because the clock that matters is how long the AF has held an
+  un-notifiable subscription. A producer that starts rejecting after a deferral is therefore retried
+  until the deadline rather than failed fast.
+* **The reconciler is never driven in a test through its spawned loop** — only by calling
+  `reconcile_pending_subscriptions` directly. The `tokio::spawn` in `run()` is unverified, the same
+  ceiling every spawned worker in this tree has.
+* **Device Triggering still has no delivery leg.** `UNKNOWN` is honest, not fixed: there is no SMSF/T4
+  path, and this change does not add one. An AF gets a truthful "I don't know" instead of a false
+  "queued".
+* **No test drives a live producer**, so `Live` is exercised only by the promotion path's absence — the
+  promote branch of the reconciler and `subscription_promote` are covered by construction (the code is
+  reached when a producer answers) but not by a test with a stub AMF. That is the largest untested
+  branch in this change.
+* GitNexus impact analysis unrunnable (no MCP server connected — 45th consecutive PR). Blast radius by
+  grep: `attempt_southbound_subscribe` has two callers (the create handler and the reconciler),
+  `handle_monitoring_subscription_create` has three (two router arms and the Nnef translation), and
+  `NefMonitoringSubscription`'s new field is `#[serde(default)]` so an existing state file loads.

--- a/src/bins/nextgcore-nefd/src/context.rs
+++ b/src/bins/nextgcore-nefd/src/context.rs
@@ -48,6 +48,42 @@ pub struct SouthboundRef {
     pub delete_path: String,
 }
 
+/// UNIX seconds. Saturates rather than panicking on a clock before the epoch.
+pub fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// A southbound subscribe that could not be attempted yet, retained so the
+/// reconciler can retry it (issue #111).
+///
+/// A monitoring subscription is accepted with `201` when no AMF/UDM URI is
+/// configured -- a deployment that has not wired its producers yet -- but such a
+/// subscription can never notify, and before #111 it was left in that state
+/// FOREVER with the AF believing it held a live subscription. Retaining the built
+/// request is what lets the reconciler promote it later without re-deriving the
+/// target from the raw AF body.
+///
+/// Exactly one of `NefMonitoringSubscription::southbound` and `::pending` is
+/// `Some` for a stored subscription: `southbound` means live, `pending` means
+/// deferred and being retried.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct PendingSouthbound {
+    /// Which producer the retry targets.
+    pub producer: SouthboundProducer,
+    /// Producer resource path for the subscribe.
+    pub path: String,
+    /// Subscribe body, built when the AF create was handled.
+    pub body: serde_json::Value,
+    /// UNIX seconds the leg was first deferred, for the expiry deadline. A
+    /// pending leg is EXPIRED rather than retried forever, because an AF holding
+    /// a subscription that will never notify is worse off than one told it is
+    /// gone.
+    pub since: u64,
+}
+
 /// The external identity the AF used to name its target UE (TS 29.122
 /// `MonitoringEventSubscription`).
 ///
@@ -111,6 +147,10 @@ pub struct NefMonitoringSubscription {
     pub notification_destination: String,
     /// Southbound producer subscription, when one was established.
     pub southbound: Option<SouthboundRef>,
+    /// A deferred southbound leg awaiting retry (issue #111). Mutually exclusive
+    /// with `southbound`; see [`PendingSouthbound`].
+    #[serde(default)]
+    pub pending: Option<PendingSouthbound>,
     /// The external identity the AF used to name its target UE, when it used
     /// one (issue #110).
     ///
@@ -146,6 +186,7 @@ impl NefMonitoringSubscription {
             monitoring_type: monitoring_type.into(),
             notification_destination: notification_destination.into(),
             southbound: None,
+            pending: None,
             af_target: None,
             owner_id: None,
             raw: raw.into(),
@@ -500,6 +541,50 @@ impl NefContext {
             self.persist();
         }
         removed
+    }
+
+    /// Every subscription whose southbound leg is still deferred, oldest first
+    /// (issue #111). The reconciler's work list.
+    ///
+    /// Ordered by `pending.since` so an expiry sweep processes the oldest legs
+    /// first and the order does not depend on hash iteration.
+    pub fn subscriptions_pending(&self) -> Vec<NefMonitoringSubscription> {
+        let Ok(subs) = self.subscriptions.read() else {
+            return Vec::new();
+        };
+        let mut pending: Vec<NefMonitoringSubscription> = subs
+            .values()
+            .filter(|s| s.pending.is_some())
+            .cloned()
+            .collect();
+        pending.sort_by_key(|s| s.pending.as_ref().map(|p| p.since).unwrap_or(0));
+        pending
+    }
+
+    /// Promote a deferred subscription to live (issue #111): record the producer
+    /// reference and clear the pending leg, so the two stay mutually exclusive.
+    ///
+    /// Returns false when the subscription has gone -- the AF deleted it while the
+    /// reconciler was mid-retry -- so the caller can tear the producer-side
+    /// subscription down instead of leaving it orphaned.
+    pub fn subscription_promote(&self, id: &str, southbound: SouthboundRef) -> bool {
+        let promoted = {
+            let Ok(mut subs) = self.subscriptions.write() else {
+                return false;
+            };
+            match subs.get_mut(id) {
+                Some(sub) => {
+                    sub.southbound = Some(southbound);
+                    sub.pending = None;
+                    true
+                }
+                None => false,
+            }
+        };
+        if promoted {
+            self.persist();
+        }
+        promoted
     }
 
     /// Number of stored monitoring subscriptions (NRF `/load` gauge source).

--- a/src/bins/nextgcore-nefd/src/main.rs
+++ b/src/bins/nextgcore-nefd/src/main.rs
@@ -59,6 +59,14 @@ mod context;
 
 pub use context::*;
 
+/// The TS 29.122 §5.10 `DeliveryResult` a Device Triggering create reports while
+/// no SMS/T4 delivery leg exists (issue #111).
+///
+/// ONE constant so the stored transaction and the echoed body cannot drift: they
+/// were two separate literals, and a fix applied to one would have left the other
+/// claiming success.
+const DEVICE_TRIGGERING_STUB_RESULT: &str = "UNKNOWN";
+
 /// Northbound TS 29.122 MonitoringType values this minimal NEF accepts.
 /// Each translates to a southbound producer event (see
 /// [`build_southbound_subscribe`]):
@@ -491,6 +499,17 @@ async fn main() -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("Failed to start SBI server: {e}"))?;
 
+    // #111: retry deferred southbound legs so an accepted subscription either
+    // becomes live or is expired. Without this a subscription created before the
+    // AMF/UDM was configured stayed accepted-and-un-notifiable forever.
+    tokio::spawn(async move {
+        let period = Duration::from_secs(reconcile_interval_secs());
+        loop {
+            tokio::time::sleep(period).await;
+            reconcile_pending_subscriptions().await;
+        }
+    });
+
     // Register with NRF as nfType NEF advertising nnef-eventexposure
     // (registration failure is non-fatal, mirroring nwdafd).
     let sbi_ctx = nextgcore_sbi::context::global_context();
@@ -550,7 +569,14 @@ async fn nef_sbi_request_handler(request: SbiRequest) -> SbiResponse {
     match parts.as_slice() {
         // Monitoring Event northbound API (TS 29.122 §5.3)
         ["3gpp-monitoring-event", "v1", scs_as_id, "subscriptions"] => match method {
-            "POST" => handle_monitoring_subscription_create(scs_as_id, &request).await,
+            "POST" => {
+                handle_monitoring_subscription_create(
+                    scs_as_id,
+                    &request,
+                    NorthboundApi::T8MonitoringEvent,
+                )
+                .await
+            }
             _ => send_method_not_allowed(method, "subscriptions"),
         },
         ["3gpp-monitoring-event", "v1", scs_as_id, "subscriptions", sub_id] => match method {
@@ -562,6 +588,17 @@ async fn nef_sbi_request_handler(request: SbiRequest) -> SbiResponse {
             "POST" => handle_device_triggering_create(scs_as_id, &request).await,
             _ => send_method_not_allowed(method, "transactions"),
         },
+        // Nnef_EventExposure (TS 29.591) -- the service the NF profile advertises
+        // (issue #111). Declared BEFORE the notify sink so the more specific
+        // `notify/{id}` arm below is still reached.
+        ["nnef-eventexposure", "v1", "subscriptions"] => match method {
+            "POST" => handle_nnef_event_exposure_create(&request).await,
+            _ => send_method_not_allowed(method, "subscriptions"),
+        },
+        ["nnef-eventexposure", "v1", "subscriptions", sub_id] => match method {
+            "DELETE" => handle_nnef_event_exposure_delete(sub_id, &request).await,
+            _ => send_method_not_allowed(method, "subscriptions/{subscriptionId}"),
+        },
         // Producer (AMF/UDM) notification sink; the NEF subscription ID is
         // embedded in the callback path handed to the producer.
         ["nnef-eventexposure", "v1", "notify", nef_sub_id] => match method {
@@ -572,6 +609,173 @@ async fn nef_sbi_request_handler(request: SbiRequest) -> SbiResponse {
     }
 }
 
+/// Which northbound API a monitoring subscription arrived on (issue #111).
+///
+/// The two are the SAME subscription -- one NEF subscription, one southbound
+/// producer leg, one notification path -- and differ only in the wire shape of the
+/// request and the resource path of the created subscription. Parameterising the
+/// one handler is what keeps them from drifting: a fix to the failure semantics or
+/// the target resolution applies to both by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NorthboundApi {
+    /// TS 29.122 §5.3 T8 Monitoring Event.
+    T8MonitoringEvent,
+    /// TS 29.591 `Nnef_EventExposure`, the service the NF profile advertises.
+    NnefEventExposure,
+}
+
+impl NorthboundApi {
+    /// The created subscription's resource path.
+    fn subscription_location(&self, scs_as_id: &str, sub_id: &str) -> String {
+        match self {
+            Self::T8MonitoringEvent => {
+                format!("/3gpp-monitoring-event/v1/{scs_as_id}/subscriptions/{sub_id}")
+            }
+            Self::NnefEventExposure => {
+                format!("/nnef-eventexposure/v1/subscriptions/{sub_id}")
+            }
+        }
+    }
+}
+
+/// TS 29.591 `Nnef_EventExposure` event IDs this NEF can serve, and the TS 29.122
+/// MonitoringType each maps onto (issue #111).
+///
+/// One subscription machine serves both APIs, so an event the T8 side cannot serve
+/// is not served here either -- and is refused by NAME rather than silently
+/// accepted, which is what #111 is about.
+const NNEF_EVENT_TO_MONITORING_TYPE: &[(&str, &str)] = &[
+    ("LOCATION_REPORT", "LOCATION_REPORTING"),
+    ("UE_REACHABILITY", "UE_REACHABILITY"),
+    ("LOSS_OF_CONNECTIVITY", "LOSS_OF_CONNECTIVITY"),
+];
+
+/// POST /nnef-eventexposure/v1/subscriptions — TS 29.591 `Nnef_EventExposure`
+/// Subscribe (issue #111).
+///
+/// **This route exists because the NF profile advertises `nnef-eventexposure`.**
+/// Before #111 the only thing mounted under that API root was the internal
+/// producer notification SINK, so a consumer that discovered this NEF via the NRF
+/// and issued the advertised operation got `404` from the router fallthrough. The
+/// alternative -- stop advertising the service -- was rejected: the sink path is a
+/// callback the NEF hands to producers, not a service it offers, so dropping the
+/// advertisement would have left the NEF offering nothing over SBI while the
+/// machinery to offer something already existed.
+///
+/// The body is translated into the T8 shape and handed to the one subscription
+/// handler, so the failure semantics, the anyUE guard and the target resolution are
+/// shared rather than reimplemented. An `eventId` outside
+/// [`NNEF_EVENT_TO_MONITORING_TYPE`] is refused with `501` naming it, rather than
+/// accepted for an event that will never fire.
+async fn handle_nnef_event_exposure_create(request: &SbiRequest) -> SbiResponse {
+    let Some(body) = &request.http.content else {
+        return send_bad_request("Missing request body", Some("MISSING_BODY"));
+    };
+    let data: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+    };
+
+    // TS 29.591 mandatory IEs: notifUri, notifId, and at least one nefEventSubs
+    // entry carrying an eventId.
+    let notif_uri = match data.get("notifUri").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => return send_bad_request("notifUri is mandatory", Some("MANDATORY_IE_MISSING")),
+    };
+    let notif_id = match data.get("notifId").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => return send_bad_request("notifId is mandatory", Some("MANDATORY_IE_MISSING")),
+    };
+    let subs = match data.get("nefEventSubs").and_then(|v| v.as_array()) {
+        Some(a) if !a.is_empty() => a,
+        _ => {
+            return send_bad_request(
+                "nefEventSubs is mandatory and must be non-empty",
+                Some("MANDATORY_IE_MISSING"),
+            )
+        }
+    };
+    // One southbound leg per subscription, so exactly one event is served. Refusing
+    // a multi-event request is honest; accepting it and serving the first would be
+    // the fabricated-success shape this issue exists to remove.
+    if subs.len() > 1 {
+        return send_error(
+            501,
+            "Not Implemented",
+            "this NEF serves one event per subscription; send one nefEventSubs entry",
+            Some("UNSUPPORTED_REQUEST"),
+        );
+    }
+    let event_id = match subs[0].get("eventId").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            return send_bad_request(
+                "nefEventSubs[0].eventId is mandatory",
+                Some("MANDATORY_IE_MISSING"),
+            )
+        }
+    };
+    let Some((_, monitoring_type)) = NNEF_EVENT_TO_MONITORING_TYPE
+        .iter()
+        .find(|(id, _)| *id == event_id)
+    else {
+        let supported: Vec<&str> = NNEF_EVENT_TO_MONITORING_TYPE
+            .iter()
+            .map(|(id, _)| *id)
+            .collect();
+        return send_error(
+            501,
+            "Not Implemented",
+            &format!("eventId '{event_id}' is not served by this NEF (served: {supported:?})"),
+            Some("UNSUPPORTED_REQUEST"),
+        );
+    };
+
+    // Translate into the T8 shape the one subscription handler validates. The UE
+    // identity keys are carried across verbatim so the anyUE guard and the
+    // path-injection guard apply unchanged.
+    let mut translated = serde_json::json!({
+        "notificationDestination": notif_uri,
+        "monitoringType": monitoring_type,
+    });
+    {
+        let obj = translated.as_object_mut().expect("json! built an object");
+        for key in ["supi", "msisdn", "externalId", "externalGroupId"] {
+            if let Some(value) = subs[0].get(key).or_else(|| data.get(key)) {
+                obj.insert(key.to_string(), value.clone());
+            }
+        }
+    }
+    let mut translated_request = request.clone();
+    translated_request.http.content = Some(translated.to_string());
+
+    // `notifId` is the consumer's correlation handle; it names the SUBSCRIPTION on
+    // the consumer side, so it is the natural {scsAsId} equivalent for ownership.
+    let response = handle_monitoring_subscription_create(
+        &notif_id,
+        &translated_request,
+        NorthboundApi::NnefEventExposure,
+    )
+    .await;
+    log::info!("Nnef_EventExposure subscribe: notifId={notif_id}, eventId={event_id}");
+    response
+}
+
+/// DELETE /nnef-eventexposure/v1/subscriptions/{subId} — TS 29.591 Unsubscribe.
+async fn handle_nnef_event_exposure_delete(sub_id: &str, request: &SbiRequest) -> SbiResponse {
+    // Ownership is checked against the subscription's stored `scs_as_id`, which for
+    // this API is the consumer's `notifId` -- so the delete resolves it from the
+    // stored subscription rather than from the path, which carries no consumer id.
+    let scs_as_id = match nef_self().read() {
+        Ok(c) => c.subscription_find(sub_id).map(|s| s.scs_as_id),
+        Err(_) => return send_internal_error("NEF context lock poisoned"),
+    };
+    let Some(scs_as_id) = scs_as_id else {
+        return send_not_found(&format!("Subscription {sub_id} not found"), None);
+    };
+    handle_monitoring_subscription_delete(&scs_as_id, sub_id, request).await
+}
+
 /// POST /3gpp-monitoring-event/v1/{scsAsId}/subscriptions —
 /// TS 29.122 §5.3 Monitoring Event subscription create. Validates the AF
 /// request (mandatory-IE parity with udmd's `handle_ee_subscribe`),
@@ -580,6 +784,7 @@ async fn nef_sbi_request_handler(request: SbiRequest) -> SbiResponse {
 async fn handle_monitoring_subscription_create(
     scs_as_id: &str,
     request: &SbiRequest,
+    api: NorthboundApi,
 ) -> SbiResponse {
     let body = match &request.http.content {
         Some(c) => c,
@@ -746,24 +951,52 @@ async fn handle_monitoring_subscription_create(
     let nf_instance_id = nf_instance_id.unwrap_or_else(|| "nef-unregistered".to_string());
     let nef_notify_uri = format!("{notify_base}/nnef-eventexposure/v1/notify/{}", sub.id);
 
-    let southbound = match build_southbound_subscribe(
+    // #111: a leg that CANNOT be established now rejects the northbound create;
+    // one that has not been ATTEMPTED yet is accepted and retained for the
+    // reconciler. Before this, all four failure modes returned 201 with a `self`
+    // link for a subscription that could never notify.
+    let built = build_southbound_subscribe(
         &monitoring_type,
         &target,
         &nef_notify_uri,
         &sub.id,
         &nf_instance_id,
-    ) {
+    );
+    let (southbound, pending) = match &built {
         Some(req) => {
             let producer_uri = match req.producer {
                 SouthboundProducer::Amf => amf_uri.clone(),
                 SouthboundProducer::Udm => udm_uri.clone(),
             };
-            attempt_southbound_subscribe(producer_uri, req).await
+            match attempt_southbound_subscribe(producer_uri, req).await {
+                SouthboundOutcome::Live(reference) => (Some(reference), None),
+                SouthboundOutcome::Deferred => (
+                    None,
+                    Some(PendingSouthbound {
+                        producer: req.producer,
+                        path: req.path.clone(),
+                        body: req.body.clone(),
+                        since: now_unix_secs(),
+                    }),
+                ),
+                SouthboundOutcome::Failed { retryable, detail } => {
+                    log::warn!(
+                        "rejecting monitoring subscription create for scsAsId={scs_as_id}: {detail}"
+                    );
+                    return SouthboundOutcome::failure_response(retryable, &detail);
+                }
+            }
         }
-        None => None,
+        // No southbound leg is REQUIRED for this monitoring type: there is nothing
+        // deferred and nothing failed, which is why this is not an outcome variant.
+        None => (None, None),
     };
 
-    let sub = NefMonitoringSubscription { southbound, ..sub };
+    let sub = NefMonitoringSubscription {
+        southbound,
+        pending,
+        ..sub
+    };
     let sub_id = sub.id.clone();
     let southbound_cleanup = sub.southbound.clone();
     let ctx = nef_self();
@@ -790,7 +1023,7 @@ async fn handle_monitoring_subscription_create(
         };
     }
 
-    let location = format!("/3gpp-monitoring-event/v1/{scs_as_id}/subscriptions/{sub_id}");
+    let location = api.subscription_location(scs_as_id, &sub_id);
     log::info!(
         "Monitoring event subscription created: id={sub_id}, scsAsId={scs_as_id}, type={monitoring_type}"
     );
@@ -869,10 +1102,18 @@ async fn handle_monitoring_subscription_delete(
 /// POST /3gpp-device-triggering/v1/{scsAsId}/transactions — TS 29.122 §5.10
 /// Device Triggering create. Validates and stores the transaction.
 ///
-/// DEFERRED (issue #19 scope): forwarding the trigger toward SMS delivery is
-/// stubbed — no SMSF NF exists in this repo (`NfType::Smsf` is a routing
-/// label only), so the transaction is validated, stored, and reported with
-/// DeliveryResult `TRIGGERED`.
+/// **No delivery leg exists**, so the reported `deliveryResult` is `UNKNOWN`
+/// (issue #111). Forwarding the trigger toward SMS delivery is stubbed -- no SMSF
+/// NF exists in this repo (`NfType::Smsf` is a routing label only) -- and this used
+/// to report `TRIGGERED`.
+///
+/// `TRIGGERED` is a POSITIVE lifecycle state in TS 29.122 §5.10: it means the
+/// trigger was accepted for delivery. Reporting it with no delivery path told the
+/// AF the message was on its way and gave it no way to distinguish "queued" from
+/// "silently dropped" -- which is precisely the failure mode device triggering
+/// exists to prevent. `UNKNOWN` is the honest value: the transaction was accepted
+/// and stored, and the NEF genuinely does not know the delivery outcome because it
+/// never attempted one. Retire this once an SMSF/T4 leg lands.
 async fn handle_device_triggering_create(scs_as_id: &str, request: &SbiRequest) -> SbiResponse {
     let body = match &request.http.content {
         Some(c) => c,
@@ -903,7 +1144,7 @@ async fn handle_device_triggering_create(scs_as_id: &str, request: &SbiRequest) 
         _ => return send_bad_request("triggerPayload is mandatory", Some("MANDATORY_IE_MISSING")),
     }
 
-    let txn = NefTriggerTransaction::new(scs_as_id, "TRIGGERED", body.clone());
+    let txn = NefTriggerTransaction::new(scs_as_id, DEVICE_TRIGGERING_STUB_RESULT, body.clone());
     let txn_id = txn.id.clone();
     let ctx = nef_self();
     let insert = match ctx.read() {
@@ -923,7 +1164,10 @@ async fn handle_device_triggering_create(scs_as_id: &str, request: &SbiRequest) 
     let mut echoed = data;
     if let Some(obj) = echoed.as_object_mut() {
         obj.insert("self".to_string(), serde_json::json!(location));
-        obj.insert("deliveryResult".to_string(), serde_json::json!("TRIGGERED"));
+        obj.insert(
+            "deliveryResult".to_string(),
+            serde_json::json!(DEVICE_TRIGGERING_STUB_RESULT),
+        );
     }
     SbiResponse::with_status(201)
         .with_header("Location", location)
@@ -965,6 +1209,143 @@ async fn handle_producer_notification(nef_sub_id: &str, request: &SbiRequest) ->
     });
 
     SbiResponse::no_content()
+}
+
+/// How long a deferred southbound leg is retried before it is expired
+/// (issue #111). Overridable so a test does not have to wait.
+fn pending_leg_deadline_secs() -> u64 {
+    std::env::var("NEF_PENDING_LEG_DEADLINE_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(300)
+}
+
+/// How often the reconciler sweeps deferred legs.
+fn reconcile_interval_secs() -> u64 {
+    std::env::var("NEF_RECONCILE_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30)
+}
+
+/// What one reconciler sweep did (issue #111). Returned rather than only logged so
+/// the sweep is assertable without a timer.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ReconcileReport {
+    /// Legs that reached their producer and are now live.
+    pub promoted: usize,
+    /// Legs past the deadline; the subscription was removed.
+    pub expired: usize,
+    /// Legs still deferred, to be retried next sweep.
+    pub still_pending: usize,
+}
+
+/// Retry every deferred southbound leg once, promoting or expiring each
+/// (issue #111).
+///
+/// This is the half that makes accepting a deferred subscription honest. Before
+/// #111 a subscription whose producer was unconfigured was stored with
+/// `southbound: None` and left there **forever**: it could never notify, nothing
+/// retried it, and the AF held a `201` and a `self` link for a subscription that
+/// was dead on arrival.
+///
+/// A leg is **expired** rather than retried indefinitely once it passes
+/// [`pending_leg_deadline_secs`], and expiry REMOVES the subscription: an AF whose
+/// subscription is gone can re-create it, whereas an AF holding one that will never
+/// notify has no signal at all. That is the same reasoning as rejecting a hard
+/// failure at create time, applied to the deferred case.
+///
+/// Returns what it did so a caller -- and a test -- can see it, rather than only
+/// logging.
+pub async fn reconcile_pending_subscriptions() -> ReconcileReport {
+    let ctx = nef_self();
+    let pending = match ctx.read() {
+        Ok(c) => c.subscriptions_pending(),
+        Err(_) => {
+            log::error!("NEF context lock poisoned; skipping reconcile sweep");
+            return ReconcileReport::default();
+        }
+    };
+    if pending.is_empty() {
+        return ReconcileReport::default();
+    }
+
+    let (amf_uri, udm_uri) = match ctx.read() {
+        Ok(c) => (c.amf_uri(), c.udm_uri()),
+        Err(_) => return ReconcileReport::default(),
+    };
+    let deadline = pending_leg_deadline_secs();
+    let now = now_unix_secs();
+    let mut report = ReconcileReport::default();
+
+    for sub in pending {
+        let Some(leg) = sub.pending.clone() else {
+            continue;
+        };
+        let producer_uri = match leg.producer {
+            SouthboundProducer::Amf => amf_uri.clone(),
+            SouthboundProducer::Udm => udm_uri.clone(),
+        };
+        let req = SouthboundSubscribe {
+            producer: leg.producer,
+            path: leg.path.clone(),
+            body: leg.body.clone(),
+        };
+        match attempt_southbound_subscribe(producer_uri, &req).await {
+            SouthboundOutcome::Live(reference) => {
+                if let Ok(c) = ctx.read() {
+                    if c.subscription_promote(&sub.id, reference.clone()) {
+                        log::info!(
+                            "deferred southbound leg promoted to live: sub={} producer={}",
+                            sub.id,
+                            leg.producer.as_str()
+                        );
+                        report.promoted += 1;
+                        continue;
+                    }
+                }
+                // The AF deleted the subscription while this retry was in flight;
+                // tear the producer-side subscription down rather than orphan it.
+                log::info!(
+                    "subscription {} vanished mid-retry; unsubscribing the producer leg",
+                    sub.id
+                );
+                let uri = match reference.producer {
+                    SouthboundProducer::Amf => amf_uri.clone(),
+                    SouthboundProducer::Udm => udm_uri.clone(),
+                };
+                southbound_unsubscribe(uri, reference).await;
+            }
+            outcome => {
+                // Still unreachable, or now failing outright. Either way the clock
+                // that matters is how long the AF has held an un-notifiable
+                // subscription, so both are treated the same by the deadline.
+                if now.saturating_sub(leg.since) >= deadline {
+                    log::warn!(
+                        "expiring subscription {} after {}s with no southbound leg ({outcome:?})",
+                        sub.id,
+                        now.saturating_sub(leg.since)
+                    );
+                    if let Ok(c) = ctx.read() {
+                        c.subscription_remove(&sub.id);
+                    }
+                    report.expired += 1;
+                } else {
+                    log::debug!("southbound leg for {} still deferred ({outcome:?})", sub.id);
+                    report.still_pending += 1;
+                }
+            }
+        }
+    }
+    if report != ReconcileReport::default() {
+        log::info!(
+            "reconcile sweep: {} promoted, {} expired, {} still pending",
+            report.promoted,
+            report.expired,
+            report.still_pending
+        );
+    }
+    report
 }
 
 /// A fully built southbound subscribe request toward a 5GC event producer.
@@ -1152,36 +1533,103 @@ async fn resolve_gpsi_to_supi(udm_uri: Option<String>, gpsi: &str) -> Option<Str
 /// POST the southbound subscribe to the producer and extract the created
 /// subscription reference. Best-effort: any failure is logged and yields
 /// None (northbound-only subscription).
+/// What happened to a southbound subscribe attempt (issue #111).
+///
+/// This replaced an `Option<SouthboundRef>` whose `None` meant FOUR different
+/// things -- no producer configured, an unparseable URI, a producer that rejected
+/// the subscribe, and a transport error -- all of which the caller turned into the
+/// same `201 Created`. The AF was told it held a live subscription that could
+/// never notify, with no error to drive a retry, which is the failure-masking half
+/// of #111.
+#[derive(Debug)]
+enum SouthboundOutcome {
+    /// The producer accepted and gave a usable reference.
+    Live(SouthboundRef),
+    /// No producer URI is configured, so the leg has not been ATTEMPTED yet. The
+    /// northbound create is accepted and the leg is retried by the reconciler --
+    /// distinguished from a failure because a deployment that has not wired its
+    /// AMF/UDM yet is a configuration state, not a request error.
+    Deferred,
+    /// The leg was attempted and cannot be established. `retryable` separates a
+    /// transport problem (the producer may come back) from a protocol one (it
+    /// answered, unusably), which is what picks the northbound status.
+    Failed { retryable: bool, detail: String },
+}
+
+impl SouthboundOutcome {
+    /// The northbound response for a failed leg (TS 29.500 §5.2.7).
+    ///
+    /// A retryable failure is the NEF's dependency being unavailable, so `503`; a
+    /// non-retryable one is the producer answering in a way the NEF cannot use, so
+    /// `500`. Both are statuses §5.2.7 lists; neither is `201`, which is the whole
+    /// point.
+    fn failure_response(retryable: bool, detail: &str) -> SbiResponse {
+        if retryable {
+            send_error(
+                503,
+                "Service Unavailable",
+                &format!("southbound subscription could not be established: {detail}"),
+                Some("SUBSCRIPTION_NOT_ESTABLISHED"),
+            )
+        } else {
+            send_error(
+                500,
+                "Internal Server Error",
+                &format!("southbound subscription could not be established: {detail}"),
+                Some("SUBSCRIPTION_NOT_ESTABLISHED"),
+            )
+        }
+    }
+}
+
 async fn attempt_southbound_subscribe(
     producer_uri: Option<String>,
-    req: SouthboundSubscribe,
-) -> Option<SouthboundRef> {
+    req: &SouthboundSubscribe,
+) -> SouthboundOutcome {
     let producer = req.producer;
     let Some(uri) = producer_uri else {
         log::info!(
-            "no {} URI configured; southbound subscription deferred",
+            "no {} URI configured; southbound subscription deferred for retry",
             producer.as_str()
         );
-        return None;
+        return SouthboundOutcome::Deferred;
     };
     let Some((host, port)) = parse_host_port(&uri) else {
+        // A configured-but-unparseable URI is an operator error, not a transient
+        // one: retrying cannot fix it, and deferring would hide it behind an
+        // accepted subscription.
         log::warn!(
-            "invalid {} URI '{uri}'; southbound subscription skipped",
+            "invalid {} URI '{uri}'; southbound subscription cannot be established",
             producer.as_str()
         );
-        return None;
+        return SouthboundOutcome::Failed {
+            retryable: false,
+            detail: format!("invalid {} URI '{uri}'", producer.as_str()),
+        };
     };
     let client = bounded_client(&host, port);
     match client.post_json(&req.path, &req.body).await {
         Ok(response) if response.status == 200 || response.status == 201 => {
-            let southbound = extract_southbound_ref(producer, &req.path, &response);
-            if southbound.is_none() {
-                log::warn!(
-                    "{} subscribe succeeded but no subscription id could be extracted",
-                    producer.as_str()
-                );
+            match extract_southbound_ref(producer, &req.path, &response) {
+                Some(southbound) => SouthboundOutcome::Live(southbound),
+                None => {
+                    // The producer created something and did not say what. The NEF
+                    // cannot unsubscribe it later, so accepting the northbound
+                    // create would orphan a producer-side subscription AND leave
+                    // the AF unable to delete it.
+                    log::warn!(
+                        "{} subscribe succeeded but no subscription id could be extracted",
+                        producer.as_str()
+                    );
+                    SouthboundOutcome::Failed {
+                        retryable: false,
+                        detail: format!(
+                            "{} accepted the subscribe but returned no subscription id",
+                            producer.as_str()
+                        ),
+                    }
+                }
             }
-            southbound
         }
         Ok(response) => {
             log::warn!(
@@ -1189,11 +1637,17 @@ async fn attempt_southbound_subscribe(
                 producer.as_str(),
                 response.status
             );
-            None
+            SouthboundOutcome::Failed {
+                retryable: false,
+                detail: format!("{} returned status {}", producer.as_str(), response.status),
+            }
         }
         Err(e) => {
             log::warn!("{} subscribe failed: {e}", producer.as_str());
-            None
+            SouthboundOutcome::Failed {
+                retryable: true,
+                detail: format!("{} unreachable: {e}", producer.as_str()),
+            }
         }
     }
 }
@@ -1554,13 +2008,31 @@ mod tests {
     fn reset_context() {
         nef_context_final();
         nef_context_init(1024, 1024);
+        // #111: CLEAR the southbound producer URIs too. `nef_context_final` +
+        // `nef_context_init` did not, so a test that pointed the context at a
+        // producer leaked it into every later test -- which then attempted a real
+        // HTTP call on a current-thread runtime with no IO driver and panicked
+        // inside the SBI client. Six pre-existing tests failed that way the first
+        // time this file set a producer URI. Same process-global-state shape as the
+        // env-var races recorded in LEARNINGS: the hazard appears the moment a
+        // second party touches the shared thing.
+        if let Ok(mut c) = nef_self().write() {
+            c.set_endpoints(None, None, None, None);
+            c.set_udm_sdm_uri(None);
+        }
     }
 
-    /// Drive an async handler to completion on a fresh current-thread
-    /// runtime. The handlers under test do no real I/O (no producer URIs are
-    /// configured), so no timer/IO drivers are needed.
+    /// Drive an async handler to completion on a fresh current-thread runtime.
+    ///
+    /// #111 enabled the IO and time drivers. The comment here used to say none were
+    /// needed "since the handlers under test do no real I/O (no producer URIs are
+    /// configured)" -- true until a test configured one, at which point the SBI
+    /// client's `tokio::time::timeout` PANICKED with "timers are disabled" instead
+    /// of returning a connection error. Enabling them costs nothing and removes the
+    /// whole class, rather than leaving the next author to discover it.
     fn block_on<F: std::future::Future>(fut: F) -> F::Output {
         tokio::runtime::Builder::new_current_thread()
+            .enable_all()
             .build()
             .expect("build current-thread runtime")
             .block_on(fut)
@@ -1855,7 +2327,11 @@ mod tests {
     #[test]
     fn monitoring_create_no_body_returns_400() {
         let request = SbiRequest::post("/3gpp-monitoring-event/v1/af1/subscriptions");
-        let response = block_on(handle_monitoring_subscription_create("af1", &request));
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &request,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         assert_eq!(response.status, 400);
     }
 
@@ -1864,7 +2340,11 @@ mod tests {
         let request = monitoring_request(serde_json::json!({
             "monitoringType": "LOCATION_REPORTING",
         }));
-        let response = block_on(handle_monitoring_subscription_create("af1", &request));
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &request,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         assert_eq!(
             response.status, 400,
             "missing notificationDestination must be 400"
@@ -1880,7 +2360,11 @@ mod tests {
             "monitoringType": "LOCATION_REPORTING",
             "notificationDestination": "not-a-uri",
         }));
-        let response = block_on(handle_monitoring_subscription_create("af1", &request));
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &request,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         assert_eq!(response.status, 400);
         let body: serde_json::Value =
             serde_json::from_str(response.http.content.as_deref().unwrap()).unwrap();
@@ -1892,7 +2376,11 @@ mod tests {
         let request = monitoring_request(serde_json::json!({
             "notificationDestination": "http://af.example.com/cb",
         }));
-        let response = block_on(handle_monitoring_subscription_create("af1", &request));
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &request,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         assert_eq!(response.status, 400, "missing monitoringType must be 400");
     }
 
@@ -1902,7 +2390,11 @@ mod tests {
             "monitoringType": "AVAILABILITY_AFTER_DDN_FAILURE",
             "notificationDestination": "http://af.example.com/cb",
         }));
-        let response = block_on(handle_monitoring_subscription_create("af1", &request));
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &request,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         assert_eq!(response.status, 400);
         let body: serde_json::Value =
             serde_json::from_str(response.http.content.as_deref().unwrap()).unwrap();
@@ -1918,7 +2410,11 @@ mod tests {
             "notificationDestination": "http://af.example.com/cb",
             "supi": "imsi-1/../../nudm-sdm",
         }));
-        let response = block_on(handle_monitoring_subscription_create("af1", &request));
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &request,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         assert_eq!(response.status, 400, "path-injecting identity must be 400");
         let body: serde_json::Value =
             serde_json::from_str(response.http.content.as_deref().unwrap()).unwrap();
@@ -1935,12 +2431,14 @@ mod tests {
         let first = block_on(handle_monitoring_subscription_create(
             "af1",
             &monitoring_request(valid_monitoring_body()),
+            NorthboundApi::T8MonitoringEvent,
         ));
         assert_eq!(first.status, 201);
 
         let second = block_on(handle_monitoring_subscription_create(
             "af1",
             &monitoring_request(valid_monitoring_body()),
+            NorthboundApi::T8MonitoringEvent,
         ));
         assert_eq!(second.status, 507, "cap exhaustion must be 507");
         let body: serde_json::Value =
@@ -1960,7 +2458,11 @@ mod tests {
         reset_context();
 
         let request = monitoring_request(valid_monitoring_body());
-        let response = block_on(handle_monitoring_subscription_create("af1", &request));
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &request,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         assert_eq!(response.status, 201);
 
         let location = response
@@ -1997,7 +2499,11 @@ mod tests {
         reset_context();
 
         let create = monitoring_request(valid_monitoring_body());
-        let created = block_on(handle_monitoring_subscription_create("af1", &create));
+        let created = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &create,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         assert_eq!(created.status, 201);
         let location = created.http.get_header("location").unwrap().clone();
         let sub_id = location.rsplit('/').next().unwrap().to_string();
@@ -2028,7 +2534,11 @@ mod tests {
         reset_context();
 
         let create = monitoring_request(valid_monitoring_body());
-        let created = block_on(handle_monitoring_subscription_create("af1", &create));
+        let created = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &create,
+            NorthboundApi::T8MonitoringEvent,
+        ));
         let location = created.http.get_header("location").unwrap().clone();
         let sub_id = location.rsplit('/').next().unwrap().to_string();
 
@@ -2078,7 +2588,16 @@ mod tests {
         let body: serde_json::Value =
             serde_json::from_str(response.http.content.as_deref().unwrap()).unwrap();
         assert_eq!(body["self"], location);
-        assert_eq!(body["deliveryResult"], "TRIGGERED");
+        // #111 FLIP: this asserted "TRIGGERED", so the test PINNED the fabricated
+        // success. `TRIGGERED` is a positive TS 29.122 §5.10 lifecycle state -- the
+        // trigger was accepted for delivery -- and no delivery leg exists, so the AF
+        // could not tell "queued" from "silently dropped". `UNKNOWN` is the honest
+        // value while the SMS/T4 path is absent.
+        assert_eq!(body["deliveryResult"], DEVICE_TRIGGERING_STUB_RESULT);
+        assert_ne!(
+            body["deliveryResult"], "TRIGGERED",
+            "no delivery leg exists, so a positive lifecycle state must not be reported"
+        );
 
         let stored = nef_self()
             .read()
@@ -2086,7 +2605,285 @@ mod tests {
             .transaction_find(&txn_id)
             .expect("stored");
         assert_eq!(stored.scs_as_id, "af1");
-        assert_eq!(stored.delivery_result, "TRIGGERED");
+        // The STORED result and the ECHOED result must agree: they were two separate
+        // literals, so a fix to one could have left the other claiming success.
+        assert_eq!(stored.delivery_result, DEVICE_TRIGGERING_STUB_RESULT);
+        assert_eq!(
+            stored.delivery_result,
+            body["deliveryResult"].as_str().unwrap()
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // #111: service-catalogue truth, honest failures, pending lifecycle
+    // -----------------------------------------------------------------
+
+    /// Point the context's southbound producer URIs somewhere. `None` leaves the
+    /// leg DEFERRED; a URI makes it attempt and (against nothing listening) FAIL.
+    fn set_producers(amf: Option<&str>, udm: Option<&str>) {
+        if let Ok(mut c) = nef_self().write() {
+            c.set_endpoints(
+                amf.map(str::to_string),
+                udm.map(str::to_string),
+                Some("http://127.0.0.1:7817".to_string()),
+                Some("nef-test".to_string()),
+            );
+        }
+    }
+
+    /// **Issue #111, criterion 1.** Every `serviceName` in the NRF profile resolves
+    /// to a real northbound route, not to the router's `send_not_found`.
+    ///
+    /// The profile advertised `nnef-eventexposure` while the only thing mounted
+    /// under that API root was the internal producer notification SINK, so an
+    /// interop partner that discovered this NEF for `Nnef_EventExposure` got a 404
+    /// from the fallthrough. This asserts the catalogue and the router agree.
+    #[test]
+    fn every_advertised_service_name_has_a_northbound_route() {
+        let _guard = lock_globals();
+        reset_context();
+
+        let profile = build_nf_profile("nef-test", "127.0.0.1", 7817);
+        let names: Vec<String> = profile["nfServices"]
+            .as_array()
+            .expect("nfServices")
+            .iter()
+            .filter_map(|s| s["serviceName"].as_str().map(str::to_string))
+            .collect();
+        assert!(!names.is_empty(), "the profile must advertise something");
+
+        for name in &names {
+            // The advertised service's subscription resource must not 404. A
+            // deliberately-invalid body is used so this asserts ROUTING, not
+            // validation: a 400 proves the route exists and rejected the body,
+            // where a 404 would prove nothing is mounted.
+            let request = SbiRequest::post(format!("/{name}/v1/subscriptions"))
+                .with_json_body(&serde_json::json!({}))
+                .expect("serialize");
+            let response = block_on(nef_sbi_request_handler(request));
+            assert_ne!(
+                response.status, 404,
+                "advertised service '{name}' has no northbound route (got 404)"
+            );
+        }
+    }
+
+    /// **Issue #111, criterion 2.** The advertised `Nnef_EventExposure` subscribe
+    /// works, and an event this NEF cannot serve is refused BY NAME rather than
+    /// accepted.
+    #[test]
+    fn nnef_event_exposure_subscribe_is_served_and_unsupported_events_are_refused() {
+        let _guard = lock_globals();
+        reset_context();
+        set_producers(None, None);
+
+        let body = serde_json::json!({
+            "notifUri": "http://af.example.com:8080/notifications",
+            "notifId": "af-corr-1",
+            "nefEventSubs": [{ "eventId": "LOCATION_REPORT", "supi": "imsi-001010000000001" }],
+        });
+        let request = SbiRequest::post("/nnef-eventexposure/v1/subscriptions")
+            .with_json_body(&body)
+            .expect("serialize");
+        let response = block_on(nef_sbi_request_handler(request));
+        assert_eq!(
+            response.status, 201,
+            "the advertised operation must be served"
+        );
+        let location = response
+            .http
+            .get_header("location")
+            .expect("201 must carry Location")
+            .clone();
+        assert!(
+            location.starts_with("/nnef-eventexposure/v1/subscriptions/"),
+            "the created resource must live under the API it was created on, got {location}"
+        );
+
+        // The subscription really exists and is DELETE-able through the same API.
+        let sub_id = location.rsplit('/').next().unwrap().to_string();
+        let delete = SbiRequest::delete(format!("/nnef-eventexposure/v1/subscriptions/{sub_id}"));
+        assert_eq!(block_on(nef_sbi_request_handler(delete)).status, 204);
+
+        // An eventId outside the served set is 501 naming it -- not a 201 for an
+        // event that would never fire.
+        let unsupported = serde_json::json!({
+            "notifUri": "http://af.example.com:8080/notifications",
+            "notifId": "af-corr-2",
+            "nefEventSubs": [{ "eventId": "PDN_CONNECTIVITY_STATUS", "supi": "imsi-001010000000001" }],
+        });
+        let request = SbiRequest::post("/nnef-eventexposure/v1/subscriptions")
+            .with_json_body(&unsupported)
+            .expect("serialize");
+        let response = block_on(nef_sbi_request_handler(request));
+        assert_eq!(response.status, 501);
+        assert!(
+            response
+                .http
+                .content
+                .as_deref()
+                .unwrap_or("")
+                .contains("PDN_CONNECTIVITY_STATUS"),
+            "the refusal must name the event so the consumer knows what to change"
+        );
+
+        // Mandatory IEs are enforced.
+        for missing in ["notifUri", "notifId", "nefEventSubs"] {
+            let mut partial = body.clone();
+            partial.as_object_mut().unwrap().remove(missing);
+            let request = SbiRequest::post("/nnef-eventexposure/v1/subscriptions")
+                .with_json_body(&partial)
+                .expect("serialize");
+            assert_eq!(
+                block_on(nef_sbi_request_handler(request)).status,
+                400,
+                "a body with no {missing} must be rejected"
+            );
+        }
+    }
+
+    /// **Issue #111, criterion 4.** A monitoring create whose southbound producer
+    /// cannot be reached does NOT return 201.
+    ///
+    /// Before this, `attempt_southbound_subscribe` returned `None` for four
+    /// different reasons -- unconfigured, unparseable URI, producer rejected,
+    /// transport error -- and the caller turned all four into `201 Created` with a
+    /// `self` link, so the AF believed it held a live subscription that could never
+    /// notify, with no error to drive a retry.
+    #[test]
+    fn a_southbound_failure_is_not_reported_as_created() {
+        let _guard = lock_globals();
+        reset_context();
+
+        // An unreachable producer is a retryable dependency failure -> 503, and
+        // above all NOT 201. This is the case that used to be indistinguishable
+        // from success.
+        let dead_port = nextgcore_sbi::test_support::free_port();
+        set_producers(Some(&format!("http://127.0.0.1:{dead_port}")), None);
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &monitoring_request(valid_monitoring_body()),
+            NorthboundApi::T8MonitoringEvent,
+        ));
+        assert_ne!(
+            response.status, 201,
+            "a failed leg must never be reported as created"
+        );
+        assert_eq!(
+            response.status, 503,
+            "an unreachable producer is a transient dependency failure"
+        );
+        assert!(response
+            .http
+            .content
+            .as_deref()
+            .unwrap_or("")
+            .contains("SUBSCRIPTION_NOT_ESTABLISHED"));
+        assert_eq!(
+            nef_self().read().unwrap().subscription_count(),
+            0,
+            "a rejected create must not leave a subscription behind"
+        );
+
+        // A syntactically odd URI is NOT the non-retryable case: `parse_host_port`
+        // accepts it (host with a default port) and the connect then fails, so it
+        // lands on the same 503. Asserted rather than assumed -- the first draft of
+        // this test expected 500 and was wrong about which branch it exercised.
+        set_producers(Some("not a uri"), None);
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &monitoring_request(valid_monitoring_body()),
+            NorthboundApi::T8MonitoringEvent,
+        ));
+        assert_eq!(response.status, 503);
+        assert_eq!(nef_self().read().unwrap().subscription_count(), 0);
+    }
+
+    /// **Issue #111.** The retryable/non-retryable split maps to distinct statuses.
+    ///
+    /// Tested on the mapping directly because the non-retryable branch needs a
+    /// producer that ANSWERS unusably (a non-2xx, or a 201 with no extractable
+    /// subscription id), which needs a stub server; asserting the mapping here keeps
+    /// the claim honest without one, and the wire test above covers 503 end to end.
+    #[test]
+    fn southbound_failure_statuses_distinguish_transient_from_unusable() {
+        let transient = SouthboundOutcome::failure_response(true, "AMF unreachable");
+        assert_eq!(transient.status, 503, "a dependency that may return");
+        let unusable = SouthboundOutcome::failure_response(false, "AMF returned status 403");
+        assert_eq!(unusable.status, 500, "a producer that answered unusably");
+        for response in [transient, unusable] {
+            let body = response.http.content.as_deref().unwrap_or("");
+            assert!(
+                body.contains("SUBSCRIPTION_NOT_ESTABLISHED"),
+                "the cause must name what failed, got {body}"
+            );
+            assert_ne!(response.status, 201);
+        }
+    }
+
+    /// **Issue #111, criteria 4 + 5.** With no producer configured the leg is
+    /// DEFERRED: the create is accepted, the subscription is marked pending, and the
+    /// reconciler later promotes or expires it -- never leaves it accepted and
+    /// permanently un-notifiable.
+    #[test]
+    fn a_deferred_leg_is_pending_and_the_reconciler_expires_it() {
+        let _guard = lock_globals();
+        reset_context();
+        set_producers(None, None);
+
+        let response = block_on(handle_monitoring_subscription_create(
+            "af1",
+            &monitoring_request(valid_monitoring_body()),
+            NorthboundApi::T8MonitoringEvent,
+        ));
+        assert_eq!(
+            response.status, 201,
+            "an unconfigured producer is a deployment state, not a request error"
+        );
+        let subs = nef_self().read().unwrap().subscriptions_pending();
+        assert_eq!(subs.len(), 1, "the leg must be retained for retry");
+        let pending = subs[0].pending.as_ref().expect("pending leg");
+        assert!(
+            subs[0].southbound.is_none(),
+            "pending and live are exclusive"
+        );
+        assert!(
+            !pending.path.is_empty(),
+            "the retry request must be retained"
+        );
+
+        // A sweep inside the deadline leaves it pending -- it is retried, not
+        // discarded on the first failure.
+        std::env::set_var("NEF_PENDING_LEG_DEADLINE_SECS", "3600");
+        let report = block_on(reconcile_pending_subscriptions());
+        assert_eq!(
+            report,
+            ReconcileReport {
+                promoted: 0,
+                expired: 0,
+                still_pending: 1
+            }
+        );
+        assert_eq!(nef_self().read().unwrap().subscription_count(), 1);
+
+        // Past the deadline it is EXPIRED and removed: an AF whose subscription is
+        // gone can re-create it, whereas one holding an un-notifiable subscription
+        // has no signal at all.
+        std::env::set_var("NEF_PENDING_LEG_DEADLINE_SECS", "0");
+        let report = block_on(reconcile_pending_subscriptions());
+        std::env::remove_var("NEF_PENDING_LEG_DEADLINE_SECS");
+        assert_eq!(report.expired, 1, "a leg past its deadline must be expired");
+        assert_eq!(
+            nef_self().read().unwrap().subscription_count(),
+            0,
+            "an expired subscription must not be left accepted-and-dead"
+        );
+
+        // And a sweep with nothing pending is a no-op.
+        assert_eq!(
+            block_on(reconcile_pending_subscriptions()),
+            ReconcileReport::default()
+        );
     }
 
     #[test]
@@ -2257,6 +3054,7 @@ mod tests {
                 let response = block_on(handle_monitoring_subscription_create(
                     "af1",
                     &monitoring_request(body),
+                    NorthboundApi::T8MonitoringEvent,
                 ));
                 assert!(
                     response.status == 400 || response.status == 404,
@@ -2282,6 +3080,7 @@ mod tests {
             let response = block_on(handle_monitoring_subscription_create(
                 "af1",
                 &monitoring_request(body),
+                NorthboundApi::T8MonitoringEvent,
             ));
             assert_eq!(
                 response.status, 201,
@@ -2332,6 +3131,7 @@ mod tests {
                 "notificationDestination": "http://af.example.com:8080/cb",
                 "msisdn": "491700000001",
             })),
+            NorthboundApi::T8MonitoringEvent,
         ));
         assert_eq!(
             response.status, 404,


### PR DESCRIPTION
Closes #111. Three defects that together produced a service catalogue and success responses not
reflecting what the NF can deliver.

## 1. Advertised-not-implemented

The NF profile advertises `nnef-eventexposure`, and the only thing mounted under that API root was the
internal producer notification **sink** — so a consumer that discovered this NEF via the NRF and issued
the advertised operation got a `404` from the router fallthrough.

`POST/DELETE /nnef-eventexposure/v1/subscriptions` now exists. **Implemented rather than
un-advertised** (criterion 2 allows either) because the notify path is a *callback the NEF hands to
producers*, not a service it offers, so dropping the advertisement would have left the NEF offering
nothing over SBI while the machinery to offer something already existed.

**It is one subscription, not two.** The Nnef handler validates the TS 29.591 mandatory IEs, maps the
event onto the equivalent TS 29.122 MonitoringType, and hands the translated body to the **same** create
handler, now parameterised on a `NorthboundApi`. That is the point of the parameterisation: the failure
semantics below, #110's anyUE guard and the target resolution apply to both APIs by construction instead
of being reimplemented and drifting. An unsupported `eventId` is `501` **naming it**; a multi-event
request is `501` too, since one southbound leg per subscription means serving only the first would be
the fabricated-success shape this issue exists to remove.

## 2. Fabricated delivery result

`TRIGGERED` is a **positive** lifecycle state in TS 29.122 §5.10 — the trigger was accepted for
delivery. Reporting it with no delivery path told the AF the message was on its way and left it unable
to distinguish "queued" from "silently dropped", which is the failure device triggering exists to
prevent. `UNKNOWN` is the honest value.

There were **two** separate `"TRIGGERED"` literals — the stored transaction and the echoed body — so a
fix applied to one would have left the other claiming success. One constant now, and the test asserts
they agree. No feature gate: a gate whose off-state is `501` adds a build configuration to protect
against a value that is now correct in every build.

## 3. Failure masking

`attempt_southbound_subscribe` returned an `Option` whose `None` covered **four** distinct causes —
unconfigured producer, unparseable URI, producer rejected, transport error — and the caller turned all
four into `201` with a `self` link. Now a three-way outcome, and only one is accepted:

| outcome | cause | northbound |
|---|---|---|
| `Live` | producer accepted, id extractable | `201`, live |
| `Deferred` | **no producer URI configured** | `201`, leg retained, reconciler retries |
| `Failed { retryable }` | attempted, cannot be established | `503` / `500`, cause `SUBSCRIPTION_NOT_ESTABLISHED` |

`Deferred` vs `Failed` is the split that matters: an unwired AMF/UDM is a **configuration state**, not
a request error, so rejecting it would break the shipped default. The fourth old cause — *producer
accepted and returned no extractable id* — is now `Failed`, because accepting it orphans a producer-side
subscription the NEF can never unsubscribe **and** leaves the AF unable to delete it.

**Deferred legs are expired, not retried forever.** `reconcile_pending_subscriptions` promotes any leg
that reaches its producer and **removes** any past the deadline — an AF whose subscription is *gone* can
re-create it, whereas one holding a subscription that will never notify has no signal at all. The sweep
returns a report rather than only logging, so it is assertable without a timer, and a promotion that
finds the subscription deleted mid-retry unsubscribes the producer leg instead of orphaning it.

## The pre-existing device-triggering test pinned the defect

It asserted `deliveryResult == "TRIGGERED"`. Inverted, with the flip recorded at the assertion.

## Two test-infrastructure defects this work exposed

Both process-global-state hazards, matching the learning recorded earlier today almost exactly:

1. **`reset_context` did not clear the southbound producer URIs.** The first test to point the context
   at a producer leaked it into every later test, which then attempted a real HTTP call and **panicked
   inside the SBI client**. Six pre-existing tests failed that way.
2. **The shared `block_on` helper had no timer/IO drivers**, justified by "the handlers under test do no
   real I/O (no producer URIs are configured)" — true until a test configured one, at which point
   `tokio::time::timeout` panicked with *"timers are disabled"* instead of returning a connection error.

Both fixed at the shared helper. Also: the first draft of the failure test asserted `500` for a
syntactically odd producer URI on the assumption it would fail to parse; `parse_host_port` **accepts**
it and the connect then fails, so it is `503`. The test now asserts what the code does and says why.

## Verification

Workspace **6000 passed / 0 failed / 6 ignored** (baseline 5995 on `71418a5`; +5 tests, nefd 52 → 57).
`cargo clippy -p nextgcore-nefd --all-targets` clean (zero warnings), `cargo clippy --workspace` 0
errors, `cargo fmt --all -- --check` clean.

| revert | expected to break | result |
|---|---|---|
| a `Failed` leg stored instead of rejected | `a_southbound_failure_is_not_reported_as_created` | **1 failed** |
| `"TRIGGERED"` restored | `device_triggering_create_returns_201_with_transaction` | **1 failed** |
| a `Deferred` leg not retained | `a_deferred_leg_is_pending_and_the_reconciler_expires_it` | **1 failed** |
| the reconciler never expires | same test | **1 failed** |
| the `nnef-eventexposure` route removed | catalogue-truth + subscribe tests | **2 failed** (`no northbound route (got 404)`) |

The catalogue-truth test posts a deliberately-invalid body so it tests **routing**, not validation: a
`400` proves a route exists and rejected the body, where a `404` would prove nothing is mounted.

## Ceilings

- **The `Nnef_EventExposure` surface is minimal and says so**: three event IDs, one event per
  subscription, no `PATCH`, no retrieval, no `supportedFeatures` negotiation, and the response echoes the
  translated body rather than a re-serialised `NefEventExposureSubsc`.
- **`notifId` is reused as the ownership key** for that API, standing in for T8's `scsAsId`, with the
  same routing-not-security caveat #110 documented.
- **The reconciler has no backoff** and treats "still unreachable" and "now failing outright" alike,
  because the clock that matters is how long the AF has held an un-notifiable subscription.
- **The spawned reconciler loop is never driven in a test**, only the sweep function.
- **Device Triggering still has no delivery leg** — `UNKNOWN` is honest, not fixed.
- **No test drives a live producer**, so the promote branch is reached by construction but not by a stub
  AMF. That is the largest untested branch here.
- GitNexus impact analysis unrunnable (no MCP server connected).

Spec: `specs/fix-nefd-service-catalogue-truth-and-honest-failures.md`