### PR TITLE
fix(sbi): decode query params, react to overload, drain on stop, keep repeated headers (#65)

### DIFF
--- a/specs/fix-sbi-wire-correctness-query-overload-goaway-headers.md
+++ b/specs/fix-sbi-wire-correctness-query-overload-goaway-headers.md
@@ -1,0 +1,208 @@
+# nextgcore #65 (nextgcore-sbi): query percent-decode, overload reaction, GOAWAY drain, header multiplicity
+
+Verified against `main` @ `60eecd6` (after #205, #242, #95, #204, #215, #111, #267, #105, #100).
+The issue's cites are from `76ea248`, so every line number drifted; one whole claim is now **stale**.
+
+## Verified against current main
+
+| claim in the issue | check on `60eecd6` | still true? |
+|---|---|---|
+| `send_once` builds the query by raw `format!` with no percent-encoding (`client.rs:753-768`) | now `client.rs:799-824` | **NO — already fixed by #101**, which routes both key and value through `uri_encode::encode_query_value` |
+| the request `uri` is `req.uri().path()` only, discarding the query (`server.rs:544`) | `server.rs:563` | yes |
+| the query is split and stored raw with no decoding (`server.rs:562-568`) | `server.rs:581-584` | yes |
+| a parameter lacking `=` is dropped | `server.rs:583` `if let Some((key, value)) = pair.split_once('=')` | yes |
+| nssfd carries a local `percent_decode` (`main.rs:481-519`, `:658-666`) | `main.rs:657-680` (the cite drifted ~180 lines) | yes |
+| mbsmfd feeds the raw param to `serde_json::from_str` (`main.rs:1350-1351`) | `main.rs:1356-1357` | yes |
+| `OverloadControl::enabled` defaults false and nothing consumes OCI/LCI | `overload.rs:12`; grep for `Oci::parse` outside `overload.rs` → **nothing** | yes |
+| `stop()` only fires `shutdown_tx`; no GOAWAY, nothing drained | `server.rs:955-965`, connections spawned detached at `:904`/`:931` | yes |
+| headers are `HashMap<String, String>`, collapsing repeats | `message.rs:192` | yes |
+| `SNssai.sd` is `Option<[u8;3]>` and the type is publicly re-exported | `message.rs:876`, `lib.rs:85-88` | yes |
+
+Two things the issue did not name, found while verifying:
+
+* **nrfd's decoder is used for two different surfaces, and is wrong for one of them.**
+  `nrfd/main.rs:379` maps `+` to a space and was applied to *query* values (`:1752`, `:2205`) as
+  well as to the `application/x-www-form-urlencoded` token body (`:3113`). `+` is a space only in
+  the form encoding; in an RFC 3986 query component it is a literal plus. So a query value carrying
+  a base64 token or an RFC 3339 offset (`+02:00`) was silently corrupted. This is the exact hazard
+  `uri_encode`'s module docs predicted for the *encode* direction, in the decode direction.
+* **nssfd's shim would have become a double-decode.** Once the server decodes,
+  `percent_decode(params.get(k))` decodes twice, and a value whose plaintext legitimately contains
+  `%20` (sent as `%2520`) turns into a space nobody sent. So removing the per-NF shims is a
+  correctness requirement of this change, not tidying that could be deferred.
+
+## Read this first: the encode half was already done, the decode half was the defect
+
+The issue's headline is "the client composes query strings by raw `format!` … and the server drops
+the query string and never percent-decodes". Only the second half is true today. #101 fixed the
+client in the one place every SBI query passes through.
+
+That matters for how the fix is shaped: there was nothing to add on the emit side, and the
+`encode_query_value` / `encode_form_value` **pair** #101 deliberately kept separate (they differ on
+`+`, and merging them corrupts one surface) dictated the shape of the decoders. This change adds
+`decode_query_value` / `decode_form_value` as the mirror pair, with the same anti-deduplication
+guard pinning the one input they disagree on.
+
+## What was added / changed
+
+| area | change |
+|---|---|
+| `uri_encode.rs` | `decode_query_value` / `decode_form_value` (+ `hex_val`), mirroring the encoder pair. Byte-wise so multi-octet UTF-8 reassembles; malformed escapes pass through verbatim; infallible via lossy UTF-8 |
+| `server.rs` `convert_request` | query keys **and** values percent-decoded with the QUERY decoder; `=`-less flags kept as present-but-empty; headers ingested with `append_header` so repeated field lines survive |
+| `client.rs` `convert_response` | same `append_header` ingest, so a multi-scope OCI on a response is not collapsed |
+| `message.rs` | `append_header` (RFC 9110 §5.3 comma-combining) and `get_header_all` (splits on top-level commas, quoted commas respected) |
+| `overload.rs` | `OverloadRegistry` (consumer-side memory of which producers reported overload, per target × scope, with expiry), `SendDecision`, `DEFAULT_OCI_VALIDITY`, `OverloadReporter` (producer-side metric the SBI server stamps) |
+| `client.rs` | `send_with_overload_reaction` around the existing send stack; `with_alternate_targets`, `with_overload_shedding`, `overload_registry()`; `ConnectTarget::base_uri`; binding learned from `3gpp-Sbi-Binding` and echoed as `3gpp-Sbi-Routing-Binding` |
+| `error.rs` | `SbiError::OverloadShed`, reporting onward as 503 |
+| `server.rs` | `RunningState` (accept shutdown + graceful watch + drain barrier), `serve_connection_gracefully`, `GRACEFUL_DRAIN_TIMEOUT`, `stop()` rewritten; `SbiServerConfig::with_overload_reporter` and OCI stamping in `convert_response_with_identity` |
+| `message.rs` | TS 29.571 serde for the `CommonData` types: `hex3`, `hex3_opt`, `digits3`, `digits_var`; `Tai.plmn_id`/`Guami.amf_id` renamed to `plmnId`/`amfId` |
+| nssfd, nrfd | local `percent_decode` copies deleted; nrfd's form body now uses `decode_form_value` and its query path `decode_query_value`; both stop decoding `http.params` |
+| mbsmfd | no code change needed — the "shim" the issue names is correct once the server decodes; an end-to-end test now pins it |
+| scpd | a comment claiming the client serialises params verbatim was false since #101; corrected |
+
+## Decision 1: reselection is on by default, shedding is not
+
+TS 29.500 §6.4.2.2 mandates abatement, and the recorded convention is that new behaviour ships as a
+runtime switch **defaulting ON, except where the behaviour drops traffic**. Overload reaction has
+both kinds in it, so it is split:
+
+* **On by default:** recording an OCI, and *reselecting* to an alternate producer. Neither can lose
+  a request — rerouting sends it somewhere healthier, and with no alternate configured (the
+  default) the decision degrades to "send", which is byte-identical to the pre-change client.
+* **Off by default:** *shedding*, i.e. failing a request locally without sending it. It is the
+  spec's literal reaction, and it is the one that converts a producer's header into dropped
+  requests here. A `metric: 100` with no `Period-of-Validity`, sent in error, would otherwise stop
+  this consumer talking to a healthy producer indefinitely.
+
+`the_default_client_records_oci_but_does_not_shed` is the guard on that default: same producer, same
+OCI, one builder call different from the shedding test. Whether shedding should become the default
+is a deployment-posture call for the maintainer and is filed separately as a `decision` issue.
+
+## Decision 2: an absent Period-of-Validity gets a 30s local ceiling
+
+§6.4.3.3 makes the parameter optional and says an OCI applies until superseded. Taken literally, a
+producer that reported overload once and then went quiet is avoided **forever**. The ceiling makes
+the worst case "wrong for 30 seconds"; a producer that is still overloaded restates the OCI on its
+next response, which refreshes the entry. A *declared* validity is honoured as sent, however long —
+the producer said what it meant.
+
+## Decision 3: only the unscoped OCI decides; scoped ones are recorded
+
+§6.4.3.3 allows an OCI to name a scope (`NF-Instance`, `S-NSSAI`, `DNN`). Matching a per-S-NSSAI or
+per-DNN scope needs the request's S-NSSAI/DNN, which lives in the body and is not available at the
+transport layer. So scoped occurrences are stored and countable (`live_count`) but do not gate
+requests. The alternative — applying a per-DNN metric to every request — would shed traffic for a
+reason the producer did not state.
+
+## Decision 4: header multiplicity via RFC 9110 §5.3 combining, not a second map
+
+`headers` is a `pub` field with **88 direct readers** across the tree. Changing its type to
+`HashMap<String, Vec<String>>` is a mechanical edit at all 88, and adding a parallel multi-valued
+map beside it creates two sources of truth that can disagree — the denormalised-pair hazard this
+repo has already been bitten by. Instead occurrences are combined into one field value separated by
+`, `, exactly the representation RFC 9110 §5.3 sanctions, and `get_header_all` splits them back.
+Safe for OCI/LCI/Binding, whose grammars are `;`-separated and contain no commas. Documented as
+unsuitable for `Set-Cookie` (SBI carries no cookies) and for singleton fields whose value may
+contain a comma.
+
+## Decision 5: the query is decoded into `params`, not re-attached to `header.uri`
+
+The issue's suggested approach says to "preserve the raw query" on the request URI. Deliberately not
+done: `header.uri` is what every daemon routes on, and the routers split it on `/` and match path
+segments exactly, so a query suffix would land inside the last segment and break routing across 19
+daemons. `http.params` is where every consumer already reads query values, and scpd's proxy copies
+`http.params` into the forwarded request (`proxy.rs:1683`), which the client re-encodes — so
+decode-in/encode-out is correct across a proxy hop as well.
+
+## Verification
+
+Every guard below was revert-verified: the change was undone, the **named** test was watched to
+fail, then restored.
+
+| guard | revert applied | result |
+|---|---|---|
+| `server_percent_decodes_query_parameters` | `set_param(key, value)` verbatim again | FAILED ✓ |
+| `percent_encoded_tmgi_list_deallocates_and_does_not_400` (mbsmfd) | same | FAILED ✓ |
+| `server_preserves_valueless_query_flags` | `continue` on a missing `=` | FAILED ✓ |
+| `server_keeps_every_repeated_oci_occurrence` | `append_header` → `set_header` on ingest | FAILED ✓ (see below) |
+| `stop_drains_an_in_flight_request` | `graceful_shutdown()` + drive → early `Ok(())` | FAILED ✓ |
+| `responses_carry_oci_when_the_nf_reports_overload` | reporter never consulted | FAILED ✓ |
+| `a_503_with_oci_reroutes_the_next_request_to_an_alternate` | `send_request` back to the pre-#65 body | FAILED ✓ |
+| `shedding_stops_the_next_request_from_being_sent_at_all` | same | FAILED ✓ |
+| `the_default_client_records_oci_but_does_not_shed` | same | FAILED ✓ |
+| `a_learned_binding_is_echoed_on_the_next_request` | same | FAILED ✓ |
+| `an_oci_on_a_success_response_is_recorded_and_acted_on` | same | FAILED ✓ (see below) |
+| `scoped_oci_is_recorded_but_only_the_unscoped_one_decides` | `effective_oci` returns any live entry | FAILED ✓ (see below) |
+| `an_oci_without_a_validity_period_expires_under_the_ceiling` | ceiling → effectively unbounded | FAILED ✓ |
+| `snssai_serialises_sd_as_six_hex_characters`, `tai_and_guami_serialise_per_ts_29_571` | `with = "hex3"` / `hex3_opt` removed | FAILED ✓ |
+
+### Three of my own guards proved nothing on the first attempt
+
+1. **`server_keeps_every_repeated_oci_occurrence` passed with the fix reverted.** It drove the
+   request through `SbiClient`, which stores headers in a map and can only emit **one field line per
+   name** — so the two occurrences were comma-joined *before* the wire and the test was really
+   exercising `get_header_all`'s splitting, not the server's ingest. Rewritten with a raw
+   `hyper::client::conn::http2` client, where `Request::builder().header()` appends and two genuine
+   field lines cross the wire. Only then did the revert bite.
+2. **`metric_zero_on_a_success_response_clears_the_reaction` passed with the entire reaction
+   reverted.** It asserted that *nothing happened* (no reroute), and an absence is satisfied by a
+   code path that never arrives. Replaced by two positive tests:
+   `an_oci_on_a_success_response_is_recorded_and_acted_on` (the alternate serving the second request
+   is the only way it can pass) and `metric_zero_supersedes_a_live_reduction`, which asserts *both*
+   states — Reselect while live, Send once withdrawn.
+3. **`scoped_oci_is_recorded_but_only_the_unscoped_one_decides` passed with the scope logic
+   reverted.** It used a default registry, where every branch ends in `Send` because shedding is
+   off — the outcome was decided by the default posture, not by scope. Rewritten against a
+   `with_shedding()` registry, which leaves scope as the only variable.
+
+All three are the same failure mode from the other side: the test was reachable by a second route to
+the expected outcome.
+
+## Workspace state
+
+`6052 passed / 0 failed` (main: `6024`), `cargo clippy --workspace --all-targets` 0 errors,
+`cargo fmt --all --check` clean.
+
+## Ceilings
+
+* **No wire interop.** Everything is verified against this tree's own client and server. "Decodes
+  conformantly" means "matches RFC 3986 and the TS 29.500 prose", not "was accepted by another
+  vendor's NF".
+* **GOAWAY is asserted by consequence, not by frame.** `stop_drains_an_in_flight_request` proves
+  the in-flight stream completes and that `stop()` *waited* for it; `stop_refuses_new_connections`
+  proves the listener closed. Neither reads the GOAWAY frame — hyper exposes no hook for the peer's
+  view of it, so frame-level inspection would need a raw h2 client this crate does not otherwise
+  use. The behaviour is pinned; the frame is inferred.
+* **The drain has a 5s bound.** A peer holding a stream open past it is abandoned with a warn line
+  naming the consequence. Unbounded waiting would hang `stop()`, which runs in test teardown and on
+  the daemons' SIGTERM path.
+* **`OverloadReporter` measures nothing.** It carries a metric the NF sets. No NF sets one yet, so
+  the producer half is wired and reachable but not driven — a generic HTTP layer has no basis for
+  deciding an AMF is overloaded, and inventing one from request latency would report overload the NF
+  does not believe in. Filed as a follow-up rather than guessed at here.
+* **Alternate targets are empty by default**, so reselection is live-but-inert until an NF passes
+  the producers it discovered. That plumbing is per-daemon (each has its own NRF discovery path) and
+  is not in this change.
+* **`3gpp-Sbi-Callback` / `3gpp-Sbi-Message-Priority` emission is NOT included.** It appears in the
+  issue's suggested approach item 4 but in **none** of its acceptance criteria. It is also already
+  scoped in the backlog as cross-NF work needing a per-NF survey of which notifications exist. Not
+  smuggled in here.
+* **Binding reselection is the §6.12.2 echo, not NF-set resolution.** A learned `3gpp-Sbi-Binding`
+  is conveyed back as `3gpp-Sbi-Routing-Binding` so an SCP can route on it. Resolving an `nfset` to
+  addresses needs NRF discovery, which this crate does not have.
+* **`get_header_all` splits on commas.** Correct for the list-valued fields it is meant for; wrong
+  if applied to a singleton field whose value contains a comma (an IMF-fixdate `Date`). Documented
+  at the accessor.
+* **The `CommonData` types remain in-memory-only.** Nothing outside `nextgcore-sbi::context`
+  constructs them and no NF serialises them to the wire today; each daemon has its own S-NSSAI /
+  PLMN type. The serde fix makes the publicly re-exported shape correct for a future user rather
+  than fixing a live wire defect. `PlmnId.mnc` keeps its stored width, so a 2-digit MNC cannot be
+  padded into a different network.
+* GitNexus impact analysis unrunnable (no MCP server connected — 47th consecutive PR).
+  `nextgcore/CLAUDE.md`'s mandate to run `gitnexus_impact` before editing stays unsatisfiable.
+  Blast radius by grep: `set_header` on an ingest path (2 sites, both changed); direct `.headers`
+  field readers (88, all unaffected because the field type and its single-valued semantics are
+  unchanged); `percent_decode` (3 definitions, 2 deleted, 1 was seppd's unrelated `b64url_decode`);
+  `convert_response_with_identity` (3 production + 4 test call sites, all updated);
+  `SbiService` construction (3 sites); no crate outside `nextgcore-sbi` names `OverloadControl`,
+  `Oci`, `Lci`, or the `CommonData` types.

--- a/src/bins/nextgcore-mbsmfd/src/main.rs
+++ b/src/bins/nextgcore-mbsmfd/src/main.rs
@@ -1350,6 +1350,14 @@ async fn handle_tmgi_allocate(request: &SbiRequest) -> SbiResponse {
 /// Handle TMGI Deallocate (TS 29.532 §5.2.2.3, DELETE /nmbsmf-tmgi/v1/tmgi).
 /// [mbsmfd-04] A `tmgi-list` query param selects specific TMGIs; absent means
 /// deallocate all. Always returns 204 No Content.
+///
+/// `tmgi-list` is a JSON array in a query parameter, so every conformant sender
+/// percent-encodes it (TS 29.500 §5.2.10.2): `[`, `{`, `"` and `:` are all
+/// reserved. Feeding `get_param` straight to `serde_json` is therefore only
+/// correct because the shared SBI server decodes query values on the way in
+/// (#65) — before that it answered 400 to exactly the requests that were
+/// spelled correctly. `percent_encoded_tmgi_list_deallocates_and_does_not_400`
+/// drives the encoded form over a real connection to keep that true.
 async fn handle_tmgi_deallocate(request: &SbiRequest) -> SbiResponse {
     let ctx = mbsmf_self();
 
@@ -2589,6 +2597,81 @@ mod tests {
         )
         .await;
         assert_eq!(rsp.status, 204);
+    }
+
+    /// #65 acceptance: a conformant **percent-encoded** `tmgi-list` must be
+    /// parsed, not answered 400.
+    ///
+    /// End to end over a real HTTP/2 connection, because that is the only place
+    /// the defect lived. The handler and its `serde_json::from_str` were always
+    /// fine, and `test_router_tmgi_allocate_deallocate` above — which calls the
+    /// handler directly with an UNencoded param — passes whether or not the
+    /// server decodes anything. Here the value goes onto the wire encoded (the
+    /// client has encoded query values since #101) and can only arrive parseable
+    /// if the server decodes it.
+    ///
+    /// Asserts 204 AND that the untouched TMGI survived: a deallocate-all
+    /// fallback would also answer 204 while silently freeing everything, which is
+    /// a worse outcome than the 400 this replaces.
+    #[tokio::test]
+    async fn percent_encoded_tmgi_list_deallocates_and_does_not_400() {
+        mbsmf_context_init(256);
+        let port = nextgcore_sbi::test_support::free_port();
+        let server = SbiServer::new(NextgcoreSbiServerConfig::new(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            port,
+        ))));
+        server
+            .start(mbsmf_sbi_request_handler)
+            .await
+            .expect("server start");
+        let client = nextgcore_sbi::client::SbiClient::with_host_port("127.0.0.1", port);
+
+        // Allocate two so a targeted deallocate is distinguishable from all.
+        let alloc = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.send_request(
+                SbiRequest::post("/nmbsmf-tmgi/v1/tmgi")
+                    .with_body(r#"{"tmgiNumber":2}"#, "application/json"),
+            ),
+        )
+        .await
+        .expect("bounded")
+        .expect("allocate");
+        assert_eq!(alloc.status, 200);
+        let allocated: types::TmgiAllocated =
+            serde_json::from_str(alloc.http.content.as_deref().unwrap()).expect("allocated");
+        assert_eq!(allocated.tmgi_list.len(), 2);
+        let survivor = context_tmgi_from(Some(&allocated.tmgi_list[1]));
+
+        // Name ONLY the first, as a JSON array. `set_param` hands the client raw
+        // JSON; what crosses the wire is `tmgi-list=%5B%7B%22mbsServiceId%22...`.
+        let raw = serde_json::to_string(&vec![allocated.tmgi_list[0].clone()]).expect("json");
+        let mut req = SbiRequest::delete("/nmbsmf-tmgi/v1/tmgi");
+        req.http.set_param("tmgi-list", raw);
+        let resp =
+            tokio::time::timeout(std::time::Duration::from_secs(5), client.send_request(req))
+                .await
+                .expect("bounded")
+                .expect("deallocate");
+        assert_eq!(
+            resp.status, 204,
+            "a percent-encoded tmgi-list must parse; 400 here means the server is \
+             not decoding query values (TS 29.500 §5.2.10.2)"
+        );
+
+        // Positive assertion: the OTHER TMGI is still held, so the 204 came from
+        // the targeted path and not from the deallocate-all fallback.
+        assert!(
+            mbsmf_self()
+                .read()
+                .map(|c| c.tmgi_expiry_of(&survivor).is_some())
+                .unwrap_or(false),
+            "only the named TMGI should have been freed; the untouched one is gone, \
+             so the tmgi-list was not honoured"
+        );
+
+        server.stop().await.expect("stop");
     }
 
     // mbsmfd-10: only the spec resource set responds — `/members` is not exposed

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -373,27 +373,6 @@ fn nrf_self_uri() -> &'static str {
         .unwrap_or("http://127.0.0.1:7777")
 }
 
-/// Decodes percent-encoding (and `+` as space) in a query parameter value.
-/// Discovery parameters like `snssais` and `target-plmn-list` carry JSON in
-/// the query string (TS 29.510 §6.2.3.2.3.1, content: application/json).
-fn percent_decode(value: &str) -> String {
-    let bytes = value.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(byte) = u8::from_str_radix(&value[i + 1..i + 3], 16) {
-                out.push(byte);
-                i += 3;
-                continue;
-            }
-        }
-        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
-        i += 1;
-    }
-    String::from_utf8_lossy(&out).to_string()
-}
-
 /// Where the ES256 signing key is persisted, when the operator configured a path
 /// (issue #64 gap 4). Set once at startup from `--signing-key-file`.
 static NRF_SIGNING_KEY_FILE: OnceLock<std::path::PathBuf> = OnceLock::new();
@@ -1748,9 +1727,19 @@ fn query_params(uri: &str) -> Vec<(String, String)> {
     query
         .split('&')
         .filter(|pair| !pair.is_empty())
+        // #65: the shared QUERY decoder, where `+` is a literal plus. nrfd's
+        // deleted local copy mapped `+` to a space here, which is the form-body
+        // rule -- so a query value carrying a base64 token or an RFC 3339 offset
+        // (`+02:00`) was silently corrupted.
         .map(|pair| match pair.split_once('=') {
-            Some((k, v)) => (percent_decode(k), percent_decode(v)),
-            None => (percent_decode(pair), String::new()),
+            Some((k, v)) => (
+                nextgcore_sbi::uri_encode::decode_query_value(k),
+                nextgcore_sbi::uri_encode::decode_query_value(v),
+            ),
+            None => (
+                nextgcore_sbi::uri_encode::decode_query_value(pair),
+                String::new(),
+            ),
         })
         .collect()
 }
@@ -2197,12 +2186,15 @@ fn extract_patch_validity_time(patch: &serde_json::Value) -> Option<String> {
 /// permits it to be empty, and the reference NRF (Open5GS) answers 200 OK
 /// with an empty list. 404 is NOT mandated for "target NF type unregistered".
 async fn handle_nf_discover(request: &SbiRequest) -> SbiResponse {
+    // #65: `http.params` arrives already percent-decoded from the shared SBI
+    // server, so this must NOT decode again -- a second pass turns a legitimately
+    // escaped `%2520` into a space that the consumer never sent.
     let param = |name: &str| {
         request
             .http
             .params
             .get(name)
-            .map(|s| percent_decode(s))
+            .cloned()
             .filter(|s| !s.is_empty())
     };
 
@@ -3109,9 +3101,12 @@ fn parse_token_request(body: &str) -> TokenRequestParams {
         };
         for pair in body.split('&') {
             if let Some((key, value)) = pair.split_once('=') {
-                // nrfd-09: percent-decode key AND value (+ => space).
-                let key = percent_decode(key);
-                let value = percent_decode(value);
+                // nrfd-09: percent-decode key AND value (+ => space). #65: this
+                // is the FORM decoder, not the query one -- `application/x-www-
+                // form-urlencoded` defines `+` as a space, and nextgcore-sbi's
+                // `encode_form_value` emits it that way when minting this body.
+                let key = nextgcore_sbi::uri_encode::decode_form_value(key);
+                let value = nextgcore_sbi::uri_encode::decode_form_value(value);
                 match key.as_str() {
                     "grant_type" => p.grant_type = value,
                     "nfInstanceId" => p.nf_instance_id = value,
@@ -3592,17 +3587,25 @@ mod tests {
         assert!(vk.verify(b"header.tampered", &sig).is_err());
     }
 
+    /// #65: nrfd's local `percent_decode` is gone. What it did for a FORM body is
+    /// now `decode_form_value`; what it did for a QUERY value is
+    /// `decode_query_value`, which differs on `+` -- and that difference is the
+    /// defect the split fixed, so both are pinned here from nrfd's side too.
     #[test]
     fn test_percent_decode() {
-        assert_eq!(percent_decode("plain"), "plain");
-        assert_eq!(percent_decode("a+b"), "a b");
+        use nextgcore_sbi::uri_encode::{decode_form_value, decode_query_value};
+        assert_eq!(decode_query_value("plain"), "plain");
         assert_eq!(
-            percent_decode("%5B%7B%22sst%22%3A1%7D%5D"),
+            decode_query_value("%5B%7B%22sst%22%3A1%7D%5D"),
             r#"[{"sst":1}]"#
         );
         // Malformed escapes pass through unchanged.
-        assert_eq!(percent_decode("100%"), "100%");
-        assert_eq!(percent_decode("%zz"), "%zz");
+        assert_eq!(decode_query_value("100%"), "100%");
+        assert_eq!(decode_query_value("%zz"), "%zz");
+        // The form body keeps the `+`-as-space rule the old copy applied
+        // everywhere; a query value keeps the plus.
+        assert_eq!(decode_form_value("a+b"), "a b");
+        assert_eq!(decode_query_value("a+b"), "a+b");
     }
 
     #[test]
@@ -3874,8 +3877,8 @@ mod tests {
             // Issue #101: the RAW JSON. This used to be hand-percent-encoded
             // here, compensating for a client that did not encode -- so the test
             // exercised a path no real consumer takes. The client encodes now, and
-            // nrfd's `percent_decode` reverses it, so this asserts the real
-            // round trip.
+            // the shared SBI server decodes it on the way in (#65), so this
+            // asserts the real round trip.
             req.http
                 .set_param("snssais", r#"[{"sst":1,"sd":"010203"}]"#);
             let resp = client.send_request(req).await.expect("discover");
@@ -5488,8 +5491,8 @@ mod tests {
     ///
     /// Worth its own test because the two halves live in different crates and
     /// neither one alone can prove the round trip. A form body is
-    /// percent-encoded and `percent_decode` maps `+` to space; a JWT is
-    /// base64url plus `.` separators, which `url_encode` leaves untouched — but
+    /// percent-encoded and `decode_form_value` maps `+` to space; a JWT is
+    /// base64url plus `.` separators, which `encode_form_value` leaves untouched — but
     /// that is a property of two functions agreeing, not something either
     /// guarantees on its own. If it ever stops holding, every NF silently fails
     /// authentication.

--- a/src/bins/nextgcore-nssfd/src/main.rs
+++ b/src/bins/nextgcore-nssfd/src/main.rs
@@ -653,34 +653,14 @@ fn problem_details(status: u16, title: &str, detail: &str, cause: Option<&str>) 
     SbiResponse::with_status(status).with_body(body.to_string(), "application/problem+json")
 }
 
-/// Percent-decode a URI component (RFC 3986; does not treat '+' as space)
-fn percent_decode(s: &str) -> String {
-    fn hex_val(b: u8) -> Option<u8> {
-        match b {
-            b'0'..=b'9' => Some(b - b'0'),
-            b'a'..=b'f' => Some(b - b'a' + 10),
-            b'A'..=b'F' => Some(b - b'A' + 10),
-            _ => None,
-        }
-    }
-    let bytes = s.as_bytes();
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
-                out.push((hi << 4) | lo);
-                i += 3;
-                continue;
-            }
-        }
-        out.push(bytes[i]);
-        i += 1;
-    }
-    String::from_utf8_lossy(&out).into_owned()
-}
-
-/// Parse the query string of a request URI into percent-decoded key/values
+/// Parse the query string of a request URI into percent-decoded key/values.
+///
+/// #65: the local `percent_decode` copy this used is gone; decoding now happens
+/// once, in the shared SBI server, and this function exists only for a caller
+/// that still holds a whole URI with its query attached (a handler invoked
+/// directly, without going through the server glue). It delegates to
+/// [`nextgcore_sbi::uri_encode::decode_query_value`] so there is one decoder in
+/// the tree rather than three that disagree.
 fn parse_query_params(uri: &str) -> HashMap<String, String> {
     let query = match uri.split_once('?') {
         Some((_, q)) => q,
@@ -691,7 +671,10 @@ fn parse_query_params(uri: &str) -> HashMap<String, String> {
         .filter(|kv| !kv.is_empty())
         .map(|kv| {
             let (k, v) = kv.split_once('=').unwrap_or((kv, ""));
-            (percent_decode(k), percent_decode(v))
+            (
+                nextgcore_sbi::uri_encode::decode_query_value(k),
+                nextgcore_sbi::uri_encode::decode_query_value(v),
+            )
         })
         .collect()
 }
@@ -829,16 +812,20 @@ async fn nssf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
 // ---------------------------------------------------------------------------
 
 async fn handle_ns_selection(request: &SbiRequest) -> SbiResponse {
-    // The nextgcore-sbi server glue strips the query string from header.uri and
-    // stores the RAW (still percent-encoded) values in http.params, so
-    // decode on access. parse_query_params covers callers that kept the
-    // full URI (e.g. direct handler invocation).
+    // #65: `http.params` now arrives ALREADY percent-decoded from the shared SBI
+    // server, so this no longer decodes on access. It must not: decoding again
+    // would corrupt any value whose plaintext legitimately contains a `%`
+    // escape (`%2520` -> `%20` -> a space that was never sent).
+    //
+    // parse_query_params still covers a caller that kept the full URI with its
+    // query attached (a handler invoked directly rather than through the server
+    // glue, which is how several tests below drive this).
     let query = parse_query_params(&request.header.uri);
     let get_param = |k: &str| -> Option<String> {
         query
             .get(k)
             .cloned()
-            .or_else(|| request.http.params.get(k).map(|v| percent_decode(v)))
+            .or_else(|| request.http.params.get(k).cloned())
     };
 
     // nf-type and nf-id are mandatory query parameters (TS 29.531 §6.1.3.2.3.1)
@@ -3210,8 +3197,8 @@ mod tests {
 
     #[test]
     fn test_percent_decode_and_query_parse() {
-        assert_eq!(percent_decode("a%20b%7B%22x%22%3A1%7D"), "a b{\"x\":1}");
-        assert_eq!(percent_decode("plain"), "plain");
+        // #65: the decoder itself is now nextgcore_sbi::uri_encode, tested there.
+        // What is still nssfd's own behaviour is this URI-with-query parse.
         let params = parse_query_params("/x/y?nf-type=AMF&nf-id=abc&j=%7B%22sst%22%3A1%7D&empty");
         assert_eq!(params.get("nf-type").map(String::as_str), Some("AMF"));
         assert_eq!(params.get("j").map(String::as_str), Some(r#"{"sst":1}"#));

--- a/src/bins/nextgcore-scpd/src/proxy.rs
+++ b/src/bins/nextgcore-scpd/src/proxy.rs
@@ -5110,10 +5110,12 @@ mod tests {
         )
         .await;
 
-        // NOTE: the nextgcore-sbi client serializes query params verbatim (no
-        // percent-encoding, a pre-existing lib gap outside scpd's ownership), so
-        // factor *values* here are query-safe tokens. scpd-06 is about the
-        // header→param *mapping*, which is value-independent.
+        // NOTE: the factor *values* here are query-safe tokens, which keeps this
+        // test about the header→param *mapping* (scpd-06) and nothing else. The
+        // lib gap this note used to cite is closed: the client percent-encodes
+        // query values (#101) and the server percent-decodes them (#65), so a
+        // reserved-character factor now survives the proxy hop too — see
+        // `server_percent_decodes_query_parameters` in nextgcore-sbi.
         let request = SbiRequest::post("/nudm-uecm/v1/registrations")
             .with_header("3gpp-Sbi-Discovery-target-nf-type", "UDM")
             .with_header("3gpp-Sbi-Discovery-requester-nf-type", "AMF")

--- a/src/libs/nextgcore-sbi/src/client.rs
+++ b/src/libs/nextgcore-sbi/src/client.rs
@@ -5,8 +5,8 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
@@ -19,9 +19,11 @@ use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio_rustls::TlsConnector;
 
+use crate::constants::custom_header;
 use crate::error::{SbiError, SbiResult};
 use crate::message::{SbiRequest, SbiResponse};
 use crate::oauth::OAuth2Client;
+use crate::overload::{OverloadRegistry, SendDecision};
 use crate::tls;
 use crate::types::{NfType, UriScheme};
 
@@ -193,6 +195,15 @@ struct ConnectTarget {
     port: u16,
 }
 
+impl ConnectTarget {
+    /// `scheme://host:port` — the key overload state is recorded against, and
+    /// the same spelling [`SbiClientConfig::base_uri`] produces for the primary,
+    /// so an alternate and a primary naming the same producer share one entry.
+    fn base_uri(&self) -> String {
+        format!("{}://{}:{}", self.scheme, self.host, self.port)
+    }
+}
+
 /// SBI Client configuration
 #[derive(Debug, Clone)]
 pub struct SbiClientConfig {
@@ -310,6 +321,18 @@ pub struct SbiClient {
     /// Bounded retry / NF-reselection policy (sbi-05). Defaults to a single
     /// attempt (`max_attempts == 1`), so retry is dormant unless opted in.
     retry: RetryPolicy,
+    /// #65: which producers have reported overload, and what to do about it.
+    /// Shared behind an `Arc` because a clone of this client must react to an
+    /// OCI the original recorded — per-clone state would forget it.
+    overload: Arc<OverloadRegistry>,
+    /// #65: alternate producers to reselect to when the primary reports overload
+    /// or fails before the request was sent (TS 29.500 §6.5). Empty by default,
+    /// in which case reselection is a no-op and behaviour is unchanged.
+    alternates: Arc<Vec<ConnectTarget>>,
+    /// #65: binding indications learned from `3gpp-Sbi-Binding` on responses,
+    /// keyed by producer, echoed back as `3gpp-Sbi-Routing-Binding` on later
+    /// requests to the same producer (TS 29.500 §6.12.2).
+    bindings: Arc<StdMutex<HashMap<String, String>>>,
 }
 
 impl SbiClient {
@@ -326,6 +349,9 @@ impl SbiClient {
             client_nf_type: None,
             client_nf_id: None,
             retry: RetryPolicy::default(),
+            overload: Arc::new(OverloadRegistry::new()),
+            alternates: Arc::new(Vec::new()),
+            bindings: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -385,6 +411,53 @@ impl SbiClient {
     pub fn with_retry_policy(mut self, retry: RetryPolicy) -> Self {
         self.retry = retry;
         self
+    }
+
+    /// Register **alternate producers** for overload reselection and pre-send
+    /// failure reselection (#65, TS 29.500 §6.5).
+    ///
+    /// A consumer that discovered several instances of a producer NF from the NRF
+    /// passes the runners-up here. When the primary reports overload, or fails in
+    /// a way that proves the request was never processed, the request goes to the
+    /// first alternate that is not itself under a live OCI instead of failing.
+    ///
+    /// Default is empty, which makes reselection a no-op: existing callers are
+    /// byte-for-byte unchanged.
+    pub fn with_alternate_targets<I, S>(mut self, targets: I) -> Self
+    where
+        I: IntoIterator<Item = (S, u16)>,
+        S: Into<String>,
+    {
+        let scheme = self.config.scheme;
+        self.alternates = Arc::new(
+            targets
+                .into_iter()
+                .map(|(host, port)| ConnectTarget {
+                    scheme,
+                    host: host.into(),
+                    port,
+                })
+                .collect(),
+        );
+        self
+    }
+
+    /// Enable TS 29.500 §6.4.2.2 local **shedding** (#65).
+    ///
+    /// Recording an OCI and reselecting away from an overloaded producer are
+    /// always on. This additionally allows the client to fail a request locally,
+    /// with [`SbiError::OverloadShed`], when the producer asked for reduction and
+    /// there is no alternate to send it to. Off by default — it is the only part
+    /// of the reaction that can lose a request, so an operator opts in.
+    pub fn with_overload_shedding(mut self) -> Self {
+        self.overload = Arc::new(OverloadRegistry::with_shedding());
+        self
+    }
+
+    /// The overload registry, for an NF that wants to inspect or reset what this
+    /// client has recorded about its producers.
+    pub fn overload_registry(&self) -> &Arc<OverloadRegistry> {
+        &self.overload
     }
 
     /// Get the client configuration
@@ -574,11 +647,166 @@ impl SbiClient {
     ///   skipped entirely (fast path), so a normal request is byte-for-byte and
     ///   call-sequence identical to the pre-sbi-04/05 client.
     pub async fn send_request(&self, request: SbiRequest) -> SbiResult<SbiResponse> {
-        if self.retry.max_attempts <= 1 {
-            // Fast path: a single attempt, no retry loop, no request clone.
-            return self.send_following_redirects(request).await;
+        self.send_with_overload_reaction(request).await
+    }
+
+    /// #65: the TS 29.500 §6.4/§6.5 reaction that used to be missing entirely.
+    ///
+    /// `overload.rs` could parse an OCI and decide whether to shed since sbi-08,
+    /// but no code path called it, so a 503 carrying an OCI was handed to the
+    /// caller and the very next request went straight back to the producer that
+    /// had just said it was overloaded. This is the layer that closes that loop:
+    /// consult before sending, record after responding.
+    ///
+    /// Order of preference, deliberately: **reselect, then shed, then send
+    /// anyway**. Rerouting keeps the request alive, so it wins whenever an
+    /// alternate exists; shedding only happens when there is nowhere else to go
+    /// AND an operator enabled it; otherwise the request is sent and the OCI is
+    /// logged, which is the pre-#65 behaviour and the default.
+    async fn send_with_overload_reaction(&self, request: SbiRequest) -> SbiResult<SbiResponse> {
+        let primary = self.config.base_uri();
+        let now = Instant::now();
+
+        // Pick a target: the primary, or an alternate when the primary is under a
+        // live OCI. `first_healthy_alternate` returns None when every alternate is
+        // also overloaded, which correctly collapses to shed-or-send below.
+        let reselected = match self.overload.decide(&primary, self.has_alternate(now), now) {
+            SendDecision::Send => None,
+            SendDecision::Reselect(oci) => match self.first_healthy_alternate(now) {
+                Some(alt) => {
+                    log::info!(
+                        "Reselecting away from overloaded producer {primary} \
+                         (Overload-Reduction-Metric: {}) to {}://{}:{} (TS 29.500 §6.5)",
+                        oci.reduction_metric,
+                        alt.scheme,
+                        alt.host,
+                        alt.port
+                    );
+                    Some(alt)
+                }
+                None => None,
+            },
+            SendDecision::Shed(oci) => {
+                log::warn!(
+                    "Shedding request to {primary}: producer asked for {}% traffic reduction \
+                     (TS 29.500 §6.4.2.2) and no alternate target is configured",
+                    oci.reduction_metric
+                );
+                return Err(SbiError::OverloadShed(format!(
+                    "{primary} requested {}% reduction",
+                    oci.reduction_metric
+                )));
+            }
+        };
+
+        // With no alternate chosen, a live OCI may still call for shedding — the
+        // `decide` above returned Reselect on the promise of an alternate that
+        // turned out to be overloaded too.
+        if reselected.is_none() {
+            if let SendDecision::Shed(oci) = self.overload.decide(&primary, false, now) {
+                log::warn!(
+                    "Shedding request to {primary}: producer asked for {}% traffic reduction \
+                     and every configured alternate is also overloaded",
+                    oci.reduction_metric
+                );
+                return Err(SbiError::OverloadShed(format!(
+                    "{primary} requested {}% reduction; all alternates overloaded",
+                    oci.reduction_metric
+                )));
+            }
         }
-        self.send_with_retry(request).await
+
+        let target_key = match &reselected {
+            Some(alt) => alt.base_uri(),
+            None => primary.clone(),
+        };
+
+        let result = self.dispatch(request, reselected, &target_key).await;
+
+        // Record what the response reported, whether it was a 503 or a 200: an
+        // OCI can ride on ANY response (§6.4.3.2), and a producer signals recovery
+        // by sending metric 0 — which only lands if success responses are read too.
+        if let Ok(response) = &result {
+            self.record_overload_and_binding(&target_key, response);
+        }
+        result
+    }
+
+    /// Send via the retry/redirect stack, optionally against a reselected target.
+    async fn dispatch(
+        &self,
+        request: SbiRequest,
+        reselected: Option<ConnectTarget>,
+        target_key: &str,
+    ) -> SbiResult<SbiResponse> {
+        let mut request = request;
+        // Echo a previously learned binding indication back to this producer
+        // (TS 29.500 §6.12.2): the producer told us which instance/set holds the
+        // resource, and a consumer is expected to convey it on subsequent
+        // requests so an SCP can route them there.
+        if let Some(binding) = self.learned_binding(target_key) {
+            if request.http.routing_binding().is_none() {
+                request.http.set_routing_binding(binding);
+            }
+        }
+
+        match reselected {
+            // Reselected: one direct attempt against the alternate. The pooled
+            // connection belongs to the primary, so this deliberately bypasses it
+            // rather than reusing a connection to the overloaded producer.
+            Some(target) => {
+                self.prepare_request(&mut request).await?;
+                self.send_once(&request, Some(&target)).await
+            }
+            None if self.retry.max_attempts <= 1 => {
+                // Fast path: a single attempt, no retry loop, no request clone.
+                self.send_following_redirects(request).await
+            }
+            None => self.send_with_retry(request).await,
+        }
+    }
+
+    /// Whether any configured alternate is currently free of a live OCI.
+    fn has_alternate(&self, now: Instant) -> bool {
+        self.first_healthy_alternate(now).is_some()
+    }
+
+    /// The first alternate with no live OCI recorded against it.
+    fn first_healthy_alternate(&self, now: Instant) -> Option<ConnectTarget> {
+        self.alternates
+            .iter()
+            .find(|alt| {
+                self.overload
+                    .effective_oci(&alt.base_uri(), now)
+                    .map(|oci| oci.reduction_metric == 0)
+                    .unwrap_or(true)
+            })
+            .cloned()
+    }
+
+    /// Store every OCI occurrence and any binding indication from a response.
+    fn record_overload_and_binding(&self, target_key: &str, response: &SbiResponse) {
+        // get_header_all, not get_header: §6.4.3 allows one occurrence per
+        // reporting scope, and reading only the first (or last) would silently
+        // discard the rest.
+        let ocis = response.http.get_header_all(custom_header::OCI);
+        if !ocis.is_empty() {
+            let stored = self.overload.record(target_key, &ocis, Instant::now());
+            log::debug!(
+                "Recorded {stored} OCI occurrence(s) from {target_key} (status {})",
+                response.status
+            );
+        }
+        if let Some(binding) = response.http.binding() {
+            if let Ok(mut bindings) = self.bindings.lock() {
+                bindings.insert(target_key.to_string(), binding.clone());
+            }
+        }
+    }
+
+    /// A binding indication previously learned from this producer.
+    fn learned_binding(&self, target_key: &str) -> Option<String> {
+        self.bindings.lock().ok()?.get(target_key).cloned()
     }
 
     /// Stamp the standard outbound headers on `request` exactly once before the
@@ -903,13 +1131,21 @@ impl SbiClient {
     ) -> SbiResult<SbiResponse> {
         let status = response.status().as_u16();
 
-        // Extract headers
-        let mut headers = HashMap::new();
+        // Extract headers.
+        //
+        // #65: repeated field lines are APPENDED, not overwritten. A producer
+        // reporting overload for several scopes sends one `3gpp-Sbi-Oci` per
+        // scope (TS 29.500 §6.4.3); inserting into the map by name kept only the
+        // last, so the abatement below would have acted on one scope and
+        // silently ignored the rest. `SbiHttpMessage::get_header_all` splits them
+        // back apart.
+        let mut http_headers = crate::message::SbiHttpMessage::new();
         for (key, value) in response.headers() {
             if let Ok(v) = value.to_str() {
-                headers.insert(key.to_string(), v.to_string());
+                http_headers.append_header(key.to_string(), v.to_string());
             }
         }
+        let headers = http_headers.headers;
 
         // Read body
         let body_bytes = response
@@ -1796,6 +2032,359 @@ mod tests {
         assert!(
             !matches!(err, SbiError::AuthenticationFailed(_)),
             "a client with no OAuth2 must not fail on authentication: got {err:?}"
+        );
+    }
+
+    /// #65 acceptance: the query the client puts ON THE WIRE is percent-encoded.
+    ///
+    /// Asserted against the raw query string the peer received, not against a
+    /// decoded param — the encode and decode halves are separate defects, and a
+    /// test that encodes then decodes in-process passes even if both are wrong in
+    /// the same way. Reserved characters must be absent from the wire form.
+    ///
+    /// The encoding itself landed in #101; this pins it from the wire side, which
+    /// is what §5.2.10.2 actually constrains, and is the assertion the #65
+    /// criterion asks for.
+    #[tokio::test]
+    async fn the_emitted_query_is_percent_encoded_on_the_wire() {
+        let seen: Arc<StdMutex<Option<String>>> = Arc::new(StdMutex::new(None));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let seen_srv = seen.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let seen_srv = seen_srv.clone();
+                tokio::spawn(async move {
+                    let io = hyper_util::rt::TokioIo::new(stream);
+                    let svc = hyper::service::service_fn(move |req: hyper::Request<Incoming>| {
+                        let seen_srv = seen_srv.clone();
+                        async move {
+                            *seen_srv.lock().unwrap_or_else(|e| e.into_inner()) =
+                                req.uri().query().map(|q| q.to_string());
+                            Ok::<_, std::convert::Infallible>(
+                                hyper::Response::builder()
+                                    .status(204)
+                                    .body(http_body_util::Full::new(bytes::Bytes::new()))
+                                    .unwrap(),
+                            )
+                        }
+                    });
+                    let _ = hyper::server::conn::http2::Builder::new(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .serve_connection(io, svc)
+                    .await;
+                });
+            }
+        });
+
+        let client = SbiClient::with_host_port("127.0.0.1", addr.port());
+        let mut request = SbiRequest::get("/nnrf-disc/v1/nf-instances");
+        request
+            .http
+            .set_param("snssais", r#"[{"sst":1,"sd":"000001"}]"#);
+        assert_eq!(
+            client.send_request(request).await.expect("response").status,
+            204
+        );
+
+        let query = seen
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .expect("the peer saw a query");
+        assert_eq!(
+            query, "snssais=%5B%7B%22sst%22%3A1%2C%22sd%22%3A%22000001%22%7D%5D",
+            "the JSON value must arrive percent-encoded (TS 29.500 §5.2.10.2)"
+        );
+        for reserved in ['[', ']', '{', '}', '"'] {
+            assert!(
+                !query.contains(reserved),
+                "{reserved:?} must not appear unencoded in the query, got {query}"
+            );
+        }
+    }
+
+    // ─── #65: overload reaction (TS 29.500 §6.4.2.2 / §6.5) ─────────────────
+
+    /// An OCI header value at the given metric, with a bounded validity so a
+    /// recorded entry cannot outlive the test process.
+    fn oci_header(metric: u8) -> (String, String) {
+        (
+            custom_header::OCI.to_string(),
+            format!(
+                "Timestamp: 2026-01-01T00:00:00Z; Period-of-Validity: 30s; \
+                 Overload-Reduction-Metric: {metric}"
+            ),
+        )
+    }
+
+    /// #65 acceptance, the default posture: after a 503 carrying OCI, the NEXT
+    /// request is **rerouted to an alternate** rather than sent back into the
+    /// overloaded producer (and rather than the caller getting a bare 503).
+    ///
+    /// The counters are the assertion: the primary is hit exactly once, and the
+    /// alternate serves the second request. Asserting only on the second
+    /// response's status would pass even if the request had gone to the primary
+    /// and the primary had recovered.
+    #[tokio::test]
+    async fn a_503_with_oci_reroutes_the_next_request_to_an_alternate() {
+        let primary_hits = Arc::new(AtomicUsize::new(0));
+        let primary = serve_fixed(
+            503,
+            vec![oci_header(60)],
+            "overloaded",
+            primary_hits.clone(),
+        )
+        .await;
+        let alt_hits = Arc::new(AtomicUsize::new(0));
+        let alternate = serve_fixed(200, vec![], "served", alt_hits.clone()).await;
+
+        let client = SbiClient::with_host_port("127.0.0.1", primary.port())
+            .with_alternate_targets([("127.0.0.1", alternate.port())]);
+
+        // First request: nothing is known yet, so it goes to the primary and the
+        // caller sees its 503. This is the response that TEACHES the client.
+        let first = client
+            .send_request(SbiRequest::get("/nudm-sdm/v2/imsi-1/x"))
+            .await
+            .expect("a 503 is a response, not an error");
+        assert_eq!(first.status, 503);
+        assert_eq!(primary_hits.load(Ordering::SeqCst), 1);
+        assert_eq!(alt_hits.load(Ordering::SeqCst), 0);
+
+        // Second request: the OCI is live, so it must be rerouted.
+        let second = client
+            .send_request(SbiRequest::get("/nudm-sdm/v2/imsi-1/x"))
+            .await
+            .expect("rerouted request succeeds");
+        assert_eq!(
+            second.status, 200,
+            "the second request must be served by the alternate, not answered 503"
+        );
+        assert_eq!(
+            primary_hits.load(Ordering::SeqCst),
+            1,
+            "the overloaded producer must NOT be dialled again"
+        );
+        assert_eq!(
+            alt_hits.load(Ordering::SeqCst),
+            1,
+            "the alternate must have served exactly the second request"
+        );
+    }
+
+    /// #65 acceptance, the opt-in half: with shedding enabled and no alternate,
+    /// the second request is **throttled locally** — it never reaches the wire.
+    ///
+    /// `primary_hits` staying at 1 is what proves abatement happened; a test that
+    /// only asserted on the error would also pass if the request had been sent and
+    /// 503'd again.
+    #[tokio::test]
+    async fn shedding_stops_the_next_request_from_being_sent_at_all() {
+        let primary_hits = Arc::new(AtomicUsize::new(0));
+        let primary = serve_fixed(
+            503,
+            // 100% reduction makes the probabilistic shed deterministic.
+            vec![oci_header(100)],
+            "overloaded",
+            primary_hits.clone(),
+        )
+        .await;
+
+        let client =
+            SbiClient::with_host_port("127.0.0.1", primary.port()).with_overload_shedding();
+
+        assert_eq!(
+            client
+                .send_request(SbiRequest::get("/x"))
+                .await
+                .expect("response")
+                .status,
+            503
+        );
+        assert_eq!(primary_hits.load(Ordering::SeqCst), 1);
+
+        let err = client
+            .send_request(SbiRequest::get("/x"))
+            .await
+            .expect_err("the second request must be shed");
+        assert!(
+            matches!(err, SbiError::OverloadShed(_)),
+            "expected a local shed, got {err:?}"
+        );
+        assert_eq!(
+            primary_hits.load(Ordering::SeqCst),
+            1,
+            "a shed request must never reach the producer"
+        );
+        // It still reports as 503 onward, so a caller relaying the failure is
+        // unaffected by the distinction.
+        assert_eq!(err.status_code(), Some(503));
+    }
+
+    /// #65: the DEFAULT client does not shed. With no alternate configured, a
+    /// live OCI is recorded and logged but the request is still sent — so
+    /// upgrading to this change cannot start dropping any NF's requests.
+    ///
+    /// This is the guard on the default posture, and it is deliberately the
+    /// inverse of the test above: same producer, same OCI, one builder call
+    /// different.
+    #[tokio::test]
+    async fn the_default_client_records_oci_but_does_not_shed() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let producer = serve_fixed(503, vec![oci_header(100)], "overloaded", hits.clone()).await;
+
+        let client = SbiClient::with_host_port("127.0.0.1", producer.port());
+        for _ in 0..3 {
+            let resp = client
+                .send_request(SbiRequest::get("/x"))
+                .await
+                .expect("every request is still sent");
+            assert_eq!(resp.status, 503);
+        }
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            3,
+            "the default posture must not withhold requests"
+        );
+        // The OCI was nonetheless recorded — the reaction is available, just not
+        // destructive by default.
+        assert!(
+            client
+                .overload_registry()
+                .effective_oci(&client.config().base_uri(), Instant::now())
+                .is_some(),
+            "the OCI must be recorded even when it is not acted on"
+        );
+    }
+
+    /// #65: an OCI riding on a **success** response is recorded and acted on
+    /// (TS 29.500 §6.4.3.2 — an OCI may accompany any response, not only a 503).
+    ///
+    /// Positive by construction: the alternate serving the second request is the
+    /// only way this passes. The first version of this test asserted that a
+    /// metric-0 OCI caused NO reroute, which passed with the whole reaction
+    /// reverted — an absence is satisfied by a code path that never arrives.
+    /// Recovery (metric 0 superseding a live reduction) is pinned in
+    /// `overload::tests::metric_zero_supersedes_a_live_reduction`, where both
+    /// states can be asserted.
+    #[tokio::test]
+    async fn an_oci_on_a_success_response_is_recorded_and_acted_on() {
+        let primary_hits = Arc::new(AtomicUsize::new(0));
+        // 200, not 503: the producer is serving requests AND asking for reduction.
+        let primary = serve_fixed(200, vec![oci_header(100)], "served", primary_hits.clone()).await;
+        let alt_hits = Arc::new(AtomicUsize::new(0));
+        let alternate = serve_fixed(200, vec![], "alt", alt_hits.clone()).await;
+
+        let client = SbiClient::with_host_port("127.0.0.1", primary.port())
+            .with_alternate_targets([("127.0.0.1", alternate.port())]);
+
+        assert_eq!(
+            client
+                .send_request(SbiRequest::get("/x"))
+                .await
+                .expect("first")
+                .status,
+            200
+        );
+        assert_eq!(primary_hits.load(Ordering::SeqCst), 1);
+
+        client
+            .send_request(SbiRequest::get("/x"))
+            .await
+            .expect("second");
+        assert_eq!(
+            alt_hits.load(Ordering::SeqCst),
+            1,
+            "an OCI on a 200 must still drive reselection"
+        );
+        assert_eq!(
+            primary_hits.load(Ordering::SeqCst),
+            1,
+            "the producer that asked for 100% reduction must not be dialled again"
+        );
+    }
+
+    /// #65: a `3gpp-Sbi-Binding` learned from a response is echoed back as
+    /// `3gpp-Sbi-Routing-Binding` on the next request to that producer
+    /// (TS 29.500 §6.12.2).
+    ///
+    /// The get/set helpers for both headers existed and had no caller; this is
+    /// the consumer behaviour the spec actually asks for, and the reason the
+    /// helpers are no longer dead.
+    #[tokio::test]
+    async fn a_learned_binding_is_echoed_on_the_next_request() {
+        // Capture what the producer received on each request.
+        let seen: Arc<StdMutex<Vec<Option<String>>>> = Arc::new(StdMutex::new(Vec::new()));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let seen_srv = seen.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let seen_srv = seen_srv.clone();
+                tokio::spawn(async move {
+                    let io = hyper_util::rt::TokioIo::new(stream);
+                    let svc = hyper::service::service_fn(move |req: hyper::Request<Incoming>| {
+                        let seen_srv = seen_srv.clone();
+                        async move {
+                            let observed = req
+                                .headers()
+                                .get(custom_header::ROUTING_BINDING)
+                                .and_then(|v| v.to_str().ok())
+                                .map(|s| s.to_string());
+                            seen_srv
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .push(observed);
+                            Ok::<_, std::convert::Infallible>(
+                                hyper::Response::builder()
+                                    .status(200)
+                                    .header(
+                                        custom_header::BINDING,
+                                        "bl=nf-set; nfset=set1.smfset.5gc.mnc012.mcc345",
+                                    )
+                                    .body(http_body_util::Full::new(bytes::Bytes::from("ok")))
+                                    .unwrap(),
+                            )
+                        }
+                    });
+                    let _ = hyper::server::conn::http2::Builder::new(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .serve_connection(io, svc)
+                    .await;
+                });
+            }
+        });
+
+        let client = SbiClient::with_host_port("127.0.0.1", addr.port());
+        client
+            .send_request(SbiRequest::get("/x"))
+            .await
+            .expect("first");
+        client
+            .send_request(SbiRequest::get("/x"))
+            .await
+            .expect("second");
+
+        let observed = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(observed.len(), 2);
+        assert!(
+            observed[0].is_none(),
+            "nothing is known before the first response, so the first request \
+             carries no routing binding"
+        );
+        assert_eq!(
+            observed[1].as_deref(),
+            Some("bl=nf-set; nfset=set1.smfset.5gc.mnc012.mcc345"),
+            "the binding learned from the first response must be conveyed back"
         );
     }
 }

--- a/src/libs/nextgcore-sbi/src/error.rs
+++ b/src/libs/nextgcore-sbi/src/error.rs
@@ -82,6 +82,18 @@ pub enum SbiError {
     /// Internal error
     #[error("Internal error: {0}")]
     Internal(String),
+
+    /// The request was **not sent**: the target producer reported overload and
+    /// the consumer applied TS 29.500 §6.4.2.2 traffic abatement (#65).
+    ///
+    /// A distinct variant rather than reusing [`Self::ServiceUnavailable`]
+    /// because the two mean opposite things to a caller. A 503 from the producer
+    /// says the request reached it and was refused; this says the request never
+    /// left, so retrying the same target immediately is pointless while trying a
+    /// different producer is not — and, unlike a 503, nothing on the producer
+    /// side has any record of it.
+    #[error("Request shed locally: target reported overload ({0})")]
+    OverloadShed(String),
 }
 
 impl SbiError {
@@ -102,6 +114,10 @@ impl SbiError {
             Self::AuthenticationFailed(_) => Some(401),
             Self::AuthorizationFailed(_) => Some(403),
             Self::ServiceUnavailable(_) => Some(503),
+            // #65: what the caller should report onward. The request was not
+            // served, and 503 is the status a consumer of THIS NF should see when
+            // its upstream producer is overloaded (TS 29.500 §5.2.7.2).
+            Self::OverloadShed(_) => Some(503),
             Self::Timeout => Some(408),
             _ => None,
         }

--- a/src/libs/nextgcore-sbi/src/lib.rs
+++ b/src/libs/nextgcore-sbi/src/lib.rs
@@ -93,7 +93,7 @@ pub use oauth::{
     AccessTokenError, AccessTokenRequest, AccessTokenResponse, JwksCache, OAuth2Client, TokenCache,
     OAUTH2_STANDARD_PATHS_ENV,
 };
-pub use overload::{Lci, Oci, OverloadControl};
+pub use overload::{Lci, Oci, OverloadControl, OverloadRegistry, OverloadReporter, SendDecision};
 #[cfg(feature = "6g-extensions")]
 pub use pubsub::{
     EventBroker, EventFilter, EventReplayBuffer, SbiEvent, SbiEventCategory, Subscription,

--- a/src/libs/nextgcore-sbi/src/message.rs
+++ b/src/libs/nextgcore-sbi/src/message.rs
@@ -250,6 +250,99 @@ impl SbiHttpMessage {
             .map(|(_, v)| v)
     }
 
+    /// **Append** a header occurrence, preserving any value already stored
+    /// (issue #65).
+    ///
+    /// TS 29.500 §6.4.3 defines `3gpp-Sbi-Oci` and `3gpp-Sbi-Lci` as headers
+    /// that may occur **multiple times**, each occurrence an independent scope
+    /// (per NF instance, per S-NSSAI, per DNN). [`set_header`](Self::set_header)
+    /// replaces, so ingesting repeated occurrences with it kept only the last
+    /// one and an NF reporting overload for two scopes was read as reporting for
+    /// one.
+    ///
+    /// Occurrences are combined into a single field value separated by `, `,
+    /// which is exactly the representation RFC 9110 §5.3 sanctions for a
+    /// list-valued field ("a recipient MAY combine multiple field lines … by
+    /// appending each subsequent field line value … separated by a comma").
+    /// [`get_header_all`](Self::get_header_all) splits them back apart. Storing
+    /// it this way — rather than adding a second, multi-valued map beside
+    /// `headers` — keeps ONE source of truth, so the ~88 call sites that read
+    /// the `headers` field directly cannot disagree with the accessor.
+    ///
+    /// Not for `Set-Cookie`, whose grammar forbids comma-combining (RFC 9110
+    /// §5.3). SBI carries no cookies; use [`set_header`](Self::set_header) if
+    /// that ever changes.
+    pub fn append_header(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        let key = key.into().to_ascii_lowercase();
+        let value = value.into();
+        match self
+            .headers
+            .iter_mut()
+            .find(|(k, _)| k.eq_ignore_ascii_case(&key))
+        {
+            Some((_, existing)) => {
+                existing.push_str(", ");
+                existing.push_str(&value);
+            }
+            None => {
+                self.headers.insert(key, value);
+            }
+        }
+    }
+
+    /// Get **every** occurrence of a header, case-insensitively (issue #65).
+    ///
+    /// Splits the stored value on top-level commas — the inverse of
+    /// [`append_header`](Self::append_header) — so two `3gpp-Sbi-Oci` field
+    /// lines are returned as two entries. A comma inside a double-quoted string
+    /// does not split, so a quoted parameter value survives.
+    ///
+    /// Returns an empty vector when the header is absent, and a single entry for
+    /// the ordinary (non-repeated) case. Use this only for fields whose grammar
+    /// is a comma-separated list — OCI, LCI, `3gpp-Sbi-Binding`, `Accept`. For a
+    /// singleton field whose value may itself contain a comma (an IMF-fixdate
+    /// `Date`, a free-text `Server`), use [`get_header`](Self::get_header).
+    pub fn get_header_all(&self, key: &str) -> Vec<String> {
+        let Some(raw) = self.get_header(key) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut current = String::new();
+        let mut in_quotes = false;
+        let mut escaped = false;
+        for ch in raw.chars() {
+            // A quoted-pair (RFC 9110 §5.6.4): whatever follows the backslash is
+            // literal, including a `"` or a `,`. Handled before the match so the
+            // flag is always cleared, whichever character arrives.
+            if escaped {
+                escaped = false;
+                current.push(ch);
+                continue;
+            }
+            match ch {
+                '\\' if in_quotes => {
+                    escaped = true;
+                    current.push(ch);
+                }
+                '"' => {
+                    in_quotes = !in_quotes;
+                    current.push(ch);
+                }
+                ',' if !in_quotes => {
+                    out.push(current.trim().to_string());
+                    current = String::new();
+                }
+                _ => current.push(ch),
+            }
+        }
+        out.push(current.trim().to_string());
+        // A trailing or doubled comma is legal in an HTTP list ("#rule" allows
+        // empty elements); dropping the empties means a caller never has to
+        // check for them.
+        out.retain(|v| !v.is_empty());
+        out
+    }
+
     /// Remove a header by name, case-insensitively.
     /// Returns the removed value (the last one, if duplicates existed).
     pub fn remove_header(&mut self, key: &str) -> Option<String> {
@@ -867,12 +960,25 @@ impl SbiDiscoveryOption {
     }
 }
 
-/// S-NSSAI (Single Network Slice Selection Assistance Information)
+/// S-NSSAI (Single Network Slice Selection Assistance Information).
+///
+/// Wire shape is TS 29.571 §5.4.4.2: `{"sst": 1, "sd": "000001"}` — `sd` is a
+/// **6-hexadecimal-character string**, not the three raw bytes that a derived
+/// `Serialize` on `[u8; 3]` produces (`[0, 0, 1]`). See [`hex3_opt`] for why the
+/// in-memory type stays a byte triple.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SNssai {
     /// Slice/Service Type (SST)
     pub sst: u8,
-    /// Slice Differentiator (SD) - optional, 3 bytes
+    /// Slice Differentiator (SD) — optional, 3 bytes in memory, 6 hex chars on
+    /// the wire. Absent (`None`) is omitted entirely rather than sent as `null`,
+    /// which is what `sd` being an optional property in the schema means.
+    #[serde(
+        default,
+        with = "hex3_opt",
+        skip_serializing_if = "Option::is_none",
+        rename = "sd"
+    )]
     pub sd: Option<[u8; 3]>,
 }
 
@@ -886,21 +992,38 @@ impl SNssai {
     }
 }
 
-/// TAI (Tracking Area Identity)
+/// TAI (Tracking Area Identity).
+///
+/// Wire shape is TS 29.571 §5.4.4.6: `{"plmnId": {...}, "tac": "000001"}`, the
+/// TAC a 4- or 6-hex-character string.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Tai {
     /// PLMN ID
+    #[serde(rename = "plmnId")]
     pub plmn_id: PlmnId,
-    /// TAC (Tracking Area Code)
+    /// TAC (Tracking Area Code) — 3 bytes in memory, 6 hex chars on the wire.
+    /// A 4-character TAC is accepted on input (§5.4.4.6 permits both widths) and
+    /// zero-extended; output is always 6.
+    #[serde(with = "hex3")]
     pub tac: [u8; 3],
 }
 
-/// PLMN ID (Public Land Mobile Network Identity)
+/// PLMN ID (Public Land Mobile Network Identity).
+///
+/// Wire shape is TS 29.571 §5.4.4.3: `{"mcc": "001", "mnc": "01"}` — decimal
+/// **digit strings**, MNC 2 or 3 digits. In memory both are one digit per byte
+/// (value `0..=9`, not ASCII), which is what every caller in this tree builds and
+/// compares.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PlmnId {
-    /// Mobile Country Code (MCC) - 3 digits
+    /// Mobile Country Code (MCC) — 3 digits.
+    #[serde(with = "digits3")]
     pub mcc: [u8; 3],
-    /// Mobile Network Code (MNC) - 2 or 3 digits
+    /// Mobile Network Code (MNC) — 2 or 3 digits. The stored length IS the
+    /// digit count, so a 2-digit MNC round-trips as `"01"` and never as `"010"`:
+    /// MNC 01 and MNC 010 are different networks, and padding one into the other
+    /// misroutes.
+    #[serde(with = "digits_var")]
     pub mnc: Vec<u8>,
 }
 
@@ -910,13 +1033,149 @@ impl PlmnId {
     }
 }
 
-/// GUAMI (Globally Unique AMF Identifier)
+/// GUAMI (Globally Unique AMF Identifier).
+///
+/// Wire shape is TS 29.571 §5.4.4.4: `{"plmnId": {...}, "amfId": "000001"}`,
+/// `amfId` a 6-hex-character string (AMF Region ID, Set ID and Pointer packed).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Guami {
     /// PLMN ID
+    #[serde(rename = "plmnId")]
     pub plmn_id: PlmnId,
-    /// AMF ID
+    /// AMF ID — 3 bytes in memory, 6 hex chars on the wire.
+    #[serde(rename = "amfId", with = "hex3")]
     pub amf_id: [u8; 3],
+}
+
+/// TS 29.571 serde for a 3-octet field carried as 6 hex characters (#65).
+///
+/// # Why the in-memory type is not simply a `String`
+///
+/// The byte triple is what the callers use: `crate::context` compares S-NSSAIs
+/// and PLMN IDs by value, and a TAC/AMF ID is packed from and unpacked into
+/// bit-fields elsewhere in the stack. Storing the hex text instead would move a
+/// parse to every comparison site and make `"000001"` and `"000001 "` two
+/// different slices. So the representation stays binary and the *serde boundary*
+/// does the conversion — which is where the spec's requirement actually applies.
+mod hex3 {
+    use serde::de::Error as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8; 3], s: S) -> Result<S::Ok, S::Error> {
+        // Lowercase: the patterns in TS 29.571 accept either case, and lowercase
+        // is what the vendored OpenAPI examples use.
+        s.serialize_str(&format!("{:02x}{:02x}{:02x}", bytes[0], bytes[1], bytes[2]))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u8; 3], D::Error> {
+        let text = String::deserialize(d)?;
+        parse(&text).ok_or_else(|| {
+            D::Error::custom(format!(
+                "expected a 4- or 6-hexadecimal-character string (TS 29.571 §5.4.4), got {text:?}"
+            ))
+        })
+    }
+
+    /// Accepts 6 hex characters, or 4 (the narrower TAC width) zero-extended on
+    /// the left. Anything else is `None`.
+    pub(super) fn parse(text: &str) -> Option<[u8; 3]> {
+        let padded = match text.len() {
+            4 => format!("00{text}"),
+            6 => text.to_string(),
+            _ => return None,
+        };
+        let mut out = [0u8; 3];
+        for (i, chunk) in padded.as_bytes().chunks(2).enumerate() {
+            let hi = (chunk[0] as char).to_digit(16)?;
+            let lo = (chunk[1] as char).to_digit(16)?;
+            out[i] = ((hi << 4) | lo) as u8;
+        }
+        Some(out)
+    }
+}
+
+/// The same 6-hex-character encoding for an optional field (`Snssai.sd`).
+mod hex3_opt {
+    use serde::de::Error as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &Option<[u8; 3]>, s: S) -> Result<S::Ok, S::Error> {
+        match bytes {
+            Some(b) => super::hex3::serialize(b, s),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<[u8; 3]>, D::Error> {
+        let Some(text) = Option::<String>::deserialize(d)? else {
+            return Ok(None);
+        };
+        super::hex3::parse(&text).map(Some).ok_or_else(|| {
+            D::Error::custom(format!(
+                "expected a 6-hexadecimal-character sd (TS 29.571 §5.4.4.2), got {text:?}"
+            ))
+        })
+    }
+}
+
+/// TS 29.571 serde for a fixed 3-digit decimal field carried as a string (MCC).
+mod digits3 {
+    use serde::de::Error as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(digits: &[u8; 3], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&super::digits_var::to_text(digits))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u8; 3], D::Error> {
+        let text = String::deserialize(d)?;
+        let parsed = super::digits_var::from_text(&text)
+            .filter(|v| v.len() == 3)
+            .ok_or_else(|| {
+                D::Error::custom(format!(
+                    "expected a 3-digit mcc (TS 29.571 §5.4.4.3), got {text:?}"
+                ))
+            })?;
+        Ok([parsed[0], parsed[1], parsed[2]])
+    }
+}
+
+/// TS 29.571 serde for a variable-length decimal digit field (MNC: 2 or 3).
+mod digits_var {
+    use serde::de::Error as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(digits: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&to_text(digits))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let text = String::deserialize(d)?;
+        let parsed = from_text(&text).filter(|v| v.len() == 2 || v.len() == 3);
+        parsed.ok_or_else(|| {
+            D::Error::custom(format!(
+                "expected a 2- or 3-digit mnc (TS 29.571 §5.4.4.3), got {text:?}"
+            ))
+        })
+    }
+
+    /// One digit per byte to its decimal text. A stored value above 9 is not a
+    /// digit; it is clamped to `9` rather than silently emitting a second
+    /// character and changing the field's length.
+    pub(super) fn to_text(digits: &[u8]) -> String {
+        digits
+            .iter()
+            .map(|d| char::from_digit((*d).min(9) as u32, 10).unwrap_or('0'))
+            .collect()
+    }
+
+    /// Decimal text to one digit per byte. `None` when any character is not a
+    /// decimal digit.
+    pub(super) fn from_text(text: &str) -> Option<Vec<u8>> {
+        text.chars()
+            .map(|c| c.to_digit(10).map(|d| d as u8))
+            .collect()
+    }
 }
 
 /// SBI Message Parameters - matches param struct in nextgcore_sbi_message_t
@@ -1465,5 +1724,176 @@ mod tests {
 
         // Only the media type differs; the serialized body is identical.
         assert_eq!(hal.http.content, plain.http.content);
+    }
+
+    // ─── #65: header multiplicity ───────────────────────────────────────────
+
+    /// `append_header` keeps every occurrence; `get_header_all` hands them back
+    /// one by one. `set_header` still replaces, so nothing that relied on
+    /// last-wins changes.
+    #[test]
+    fn append_header_preserves_occurrences_and_set_header_still_replaces() {
+        let mut http = SbiHttpMessage::new();
+        http.append_header(custom_header::OCI, "Overload-Reduction-Metric: 10");
+        http.append_header(custom_header::OCI, "Overload-Reduction-Metric: 60");
+        assert_eq!(
+            http.get_header_all(custom_header::OCI),
+            vec![
+                "Overload-Reduction-Metric: 10".to_string(),
+                "Overload-Reduction-Metric: 60".to_string()
+            ]
+        );
+        // The single-valued view is the RFC 9110 §5.3 combined form.
+        assert_eq!(
+            http.get_header(custom_header::OCI).map(String::as_str),
+            Some("Overload-Reduction-Metric: 10, Overload-Reduction-Metric: 60")
+        );
+
+        // set_header replaces the lot — the pre-#65 semantics, unchanged.
+        http.set_header(custom_header::OCI, "Overload-Reduction-Metric: 5");
+        assert_eq!(
+            http.get_header_all(custom_header::OCI),
+            vec!["Overload-Reduction-Metric: 5".to_string()]
+        );
+    }
+
+    /// Case-insensitivity and absence behave as for `get_header`, and an
+    /// occurrence appended under a different spelling joins the same field.
+    #[test]
+    fn get_header_all_is_case_insensitive_and_empty_when_absent() {
+        let mut http = SbiHttpMessage::new();
+        assert!(http.get_header_all(custom_header::OCI).is_empty());
+        http.append_header("3GPP-SBI-OCI", "Overload-Reduction-Metric: 1");
+        http.append_header("3gpp-sbi-oci", "Overload-Reduction-Metric: 2");
+        assert_eq!(http.get_header_all("3gpp-Sbi-Oci").len(), 2);
+    }
+
+    /// A comma inside a quoted string does not split an occurrence, and empty
+    /// elements are dropped rather than surfacing as blank entries.
+    #[test]
+    fn get_header_all_respects_quoted_commas_and_drops_empties() {
+        let mut http = SbiHttpMessage::new();
+        http.set_header("x-list", r#"a="one,two", b, , c,"#);
+        assert_eq!(
+            http.get_header_all("x-list"),
+            vec![
+                r#"a="one,two""#.to_string(),
+                "b".to_string(),
+                "c".to_string()
+            ]
+        );
+        // A quoted-pair escaping a quote must not end the quoted string early.
+        http.set_header("x-esc", r#"a="he said \"hi, there\"", b"#);
+        assert_eq!(
+            http.get_header_all("x-esc"),
+            vec![r#"a="he said \"hi, there\"""#.to_string(), "b".to_string()]
+        );
+    }
+
+    // ─── #65: TS 29.571 CommonData wire shapes ──────────────────────────────
+
+    /// `Snssai.sd` is a 6-hex-character string on the wire (TS 29.571 §5.4.4.2),
+    /// not the byte triple a derived `Serialize` produces.
+    ///
+    /// Asserts the serialized TEXT, then deserialises a hand-written spec-shaped
+    /// body — a round trip of our own struct would pass even with the wrong
+    /// representation on both sides.
+    #[test]
+    fn snssai_serialises_sd_as_six_hex_characters() {
+        let json = serde_json::to_string(&SNssai::with_sd(1, [0x00, 0x00, 0x01])).expect("json");
+        assert_eq!(json, r#"{"sst":1,"sd":"000001"}"#);
+        assert!(
+            !json.contains('['),
+            "sd must not be a byte array on the wire, got {json}"
+        );
+
+        // A body copied out of the spec must parse back to the same bytes.
+        let parsed: SNssai = serde_json::from_str(r#"{"sst":2,"sd":"0a1b2c"}"#).expect("parses");
+        assert_eq!(parsed.sst, 2);
+        assert_eq!(parsed.sd, Some([0x0a, 0x1b, 0x2c]));
+
+        // An absent sd is omitted entirely, not sent as null.
+        assert_eq!(
+            serde_json::to_string(&SNssai::new(1)).expect("json"),
+            r#"{"sst":1}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<SNssai>(r#"{"sst":1}"#)
+                .expect("parses")
+                .sd,
+            None
+        );
+
+        // A malformed sd is rejected rather than silently truncated.
+        assert!(serde_json::from_str::<SNssai>(r#"{"sst":1,"sd":"xyz"}"#).is_err());
+        assert!(serde_json::from_str::<SNssai>(r#"{"sst":1,"sd":"00000"}"#).is_err());
+    }
+
+    /// `PlmnId` is a pair of decimal digit STRINGS, and a 2-digit MNC must not be
+    /// padded to 3 — MNC 01 and MNC 010 are different networks.
+    #[test]
+    fn plmn_id_serialises_as_digit_strings_and_preserves_mnc_width() {
+        let two = PlmnId::new([0, 0, 1], vec![0, 1]);
+        assert_eq!(
+            serde_json::to_string(&two).expect("json"),
+            r#"{"mcc":"001","mnc":"01"}"#
+        );
+        let three = PlmnId::new([3, 1, 0], vec![4, 1, 0]);
+        assert_eq!(
+            serde_json::to_string(&three).expect("json"),
+            r#"{"mcc":"310","mnc":"410"}"#
+        );
+
+        // Round trip from spec-shaped text, both widths.
+        assert_eq!(
+            serde_json::from_str::<PlmnId>(r#"{"mcc":"001","mnc":"01"}"#).expect("parses"),
+            two
+        );
+        assert_eq!(
+            serde_json::from_str::<PlmnId>(r#"{"mcc":"310","mnc":"410"}"#).expect("parses"),
+            three
+        );
+
+        // Non-digits and wrong widths are refused.
+        assert!(serde_json::from_str::<PlmnId>(r#"{"mcc":"00","mnc":"01"}"#).is_err());
+        assert!(serde_json::from_str::<PlmnId>(r#"{"mcc":"abc","mnc":"01"}"#).is_err());
+        assert!(serde_json::from_str::<PlmnId>(r#"{"mcc":"001","mnc":"0"}"#).is_err());
+    }
+
+    /// `Tai.tac` and `Guami.amfId` are hex strings under camelCase names, and a
+    /// 4-character TAC (the narrower width §5.4.4.6 permits) is accepted.
+    #[test]
+    fn tai_and_guami_serialise_per_ts_29_571() {
+        let tai = Tai {
+            plmn_id: PlmnId::new([0, 0, 1], vec![0, 1]),
+            tac: [0x00, 0x00, 0x01],
+        };
+        assert_eq!(
+            serde_json::to_string(&tai).expect("json"),
+            r#"{"plmnId":{"mcc":"001","mnc":"01"},"tac":"000001"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<Tai>(r#"{"plmnId":{"mcc":"001","mnc":"01"},"tac":"000001"}"#)
+                .expect("parses"),
+            tai
+        );
+        // 4-hex TAC zero-extends.
+        assert_eq!(
+            serde_json::from_str::<Tai>(r#"{"plmnId":{"mcc":"001","mnc":"01"},"tac":"0001"}"#)
+                .expect("parses")
+                .tac,
+            [0x00, 0x00, 0x01]
+        );
+
+        let guami = Guami {
+            plmn_id: PlmnId::new([0, 0, 1], vec![0, 1]),
+            amf_id: [0xca, 0xfe, 0x01],
+        };
+        let json = serde_json::to_string(&guami).expect("json");
+        assert_eq!(
+            json,
+            r#"{"plmnId":{"mcc":"001","mnc":"01"},"amfId":"cafe01"}"#
+        );
+        assert_eq!(serde_json::from_str::<Guami>(&json).expect("parses"), guami);
     }
 }

--- a/src/libs/nextgcore-sbi/src/overload.rs
+++ b/src/libs/nextgcore-sbi/src/overload.rs
@@ -29,6 +29,10 @@
 //! (e.g. `NF-Instance`, `S-NSSAI`, `DNN`) are preserved verbatim in `extra` so
 //! a parsed header re-emits losslessly.
 
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering};
+use std::time::{Duration, Instant};
+
 /// Split a header value into its `Name: value` parameters and route the
 /// recognised keys to `on_known`, collecting the rest into `extra`.
 ///
@@ -253,6 +257,259 @@ impl OverloadControl {
     }
 }
 
+/// Longest period of validity honoured for an OCI that declares none (#65).
+///
+/// TS 29.500 §6.4.3.3 makes `Period-of-Validity` optional and says an OCI stays
+/// valid until superseded. Taken literally, a producer that once reported
+/// `Overload-Reduction-Metric: 100` and then went quiet would be avoided by this
+/// consumer **forever** — one header turning into a permanent self-inflicted
+/// outage toward a healthy NF. A ceiling makes the worst case "wrong for 30
+/// seconds" instead of "wrong until restart"; a producer that is really still
+/// overloaded restates the OCI on the next response, which refreshes the entry.
+const DEFAULT_OCI_VALIDITY: Duration = Duration::from_secs(30);
+
+/// What the consumer should do with a request bound for a given producer (#65).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendDecision {
+    /// Send it: no live OCI, or the OCI does not call for reduction.
+    Send,
+    /// Route it to an alternate producer instead — the preferred reaction
+    /// whenever one exists, because it neither loads the overloaded producer nor
+    /// fails the caller (TS 29.500 §6.5).
+    Reselect(Oci),
+    /// Reject locally without sending (§6.4.2.2 abatement). Only ever returned
+    /// when shedding has been explicitly enabled; see [`OverloadRegistry`].
+    Shed(Oci),
+}
+
+/// One recorded OCI and when it stops applying.
+#[derive(Debug, Clone)]
+struct OciEntry {
+    oci: Oci,
+    expires_at: Instant,
+}
+
+/// Consumer-side record of which producers have reported overload (#65).
+///
+/// # Why this exists
+///
+/// [`Oci`] could already be parsed and emitted before this, and
+/// [`OverloadControl`] could already decide whether to shed — but nothing ever
+/// called either from the request path, so a 503 carrying an OCI was handed
+/// straight to the caller and the next request went to the same overloaded
+/// producer. This is the missing piece: the memory between the response that
+/// reported overload and the request that should react to it.
+///
+/// # Default posture: react by rerouting, not by dropping
+///
+/// * Recording and **reselection** are ON by default. Neither can lose a
+///   request: rerouting sends it somewhere healthier, and with no alternate
+///   configured the decision degrades to [`SendDecision::Send`], i.e. exactly
+///   the previous behaviour.
+/// * **Shedding** — failing a request locally without sending it — is OFF by
+///   default and must be enabled explicitly. It is the spec's literal §6.4.2.2
+///   reaction, but it is also the one that turns a producer's header into
+///   dropped requests here: a metric of 100 with no `Period-of-Validity`, sent
+///   in error, would stop this consumer talking to that producer at all. The
+///   validity ceiling above bounds that, and this switch means an operator opts
+///   into it knowingly.
+///
+/// # Scoped OCI is recorded but not matched
+///
+/// §6.4.3.3 allows an OCI to name a scope (`NF-Instance`, `S-NSSAI`, `DNN`).
+/// Only the **unscoped** (whole-producer) OCI is acted upon: matching a
+/// per-S-NSSAI or per-DNN scope needs the request's S-NSSAI/DNN, which is in the
+/// body and not available at this layer. Scoped occurrences are still stored and
+/// countable via [`OverloadRegistry::live_count`], so a scope-aware reaction can
+/// be added without changing the ingest side — and, until it is, this reports
+/// honestly rather than silently applying a per-DNN metric to every request.
+#[derive(Debug, Default)]
+pub struct OverloadRegistry {
+    /// Keyed by producer (`scheme://host:port`), then by scope key — `""` for
+    /// the unscoped OCI, the verbatim scope parameters otherwise.
+    entries: std::sync::Mutex<HashMap<String, HashMap<String, OciEntry>>>,
+    /// Governs shedding only. Recording and reselection do not consult it.
+    shed: OverloadControl,
+}
+
+impl OverloadRegistry {
+    /// A registry that records and reselects but never sheds (the default).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A registry that also applies §6.4.2.2 shedding.
+    pub fn with_shedding() -> Self {
+        Self {
+            entries: std::sync::Mutex::new(HashMap::new()),
+            shed: OverloadControl::enabled(),
+        }
+    }
+
+    /// Whether local shedding is enabled on this registry.
+    pub fn sheds(&self) -> bool {
+        self.shed.enabled
+    }
+
+    /// Record every OCI occurrence carried by a response from `target`.
+    ///
+    /// Takes the occurrences already split by
+    /// [`SbiHttpMessage::get_header_all`](crate::message::SbiHttpMessage::get_header_all),
+    /// so a producer reporting several scopes is recorded as several entries
+    /// rather than only its last. Returns how many were stored.
+    ///
+    /// A metric of `0` is stored like any other: §6.4.3.3 uses it to signal
+    /// recovery, so it must overwrite a previous non-zero entry rather than being
+    /// dropped as uninteresting.
+    pub fn record(&self, target: &str, oci_headers: &[String], now: Instant) -> usize {
+        let mut stored = 0;
+        let Ok(mut entries) = self.entries.lock() else {
+            // A poisoned lock means another thread panicked while recording.
+            // Overload state is advisory: losing it degrades to the pre-#65
+            // behaviour (send anyway), which is strictly better than propagating
+            // the panic into the request path.
+            return 0;
+        };
+        let per_target = entries.entry(target.to_string()).or_default();
+        for raw in oci_headers {
+            let Some(oci) = Oci::parse(raw) else { continue };
+            // A declared Period-of-Validity is honoured as sent — the producer
+            // said how long it means it. Only an ABSENT one falls back to the
+            // ceiling, which is the case that would otherwise never expire.
+            let validity = oci
+                .period_of_validity_secs
+                .map(Duration::from_secs)
+                .unwrap_or(DEFAULT_OCI_VALIDITY);
+            let scope_key = oci
+                .extra
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(";");
+            per_target.insert(
+                scope_key,
+                OciEntry {
+                    oci,
+                    expires_at: now + validity,
+                },
+            );
+            stored += 1;
+        }
+        stored
+    }
+
+    /// Decide what to do with a request bound for `target`.
+    ///
+    /// `alternate_available` says whether the caller has somewhere else to send
+    /// it; when it does, reselection wins over shedding, because rerouting keeps
+    /// the request alive.
+    pub fn decide(&self, target: &str, alternate_available: bool, now: Instant) -> SendDecision {
+        let Some(oci) = self.effective_oci(target, now) else {
+            return SendDecision::Send;
+        };
+        if oci.reduction_metric == 0 {
+            return SendDecision::Send;
+        }
+        if alternate_available {
+            return SendDecision::Reselect(oci);
+        }
+        if self.shed.should_shed_thread(&oci) {
+            return SendDecision::Shed(oci);
+        }
+        SendDecision::Send
+    }
+
+    /// The live **unscoped** OCI for `target`, if any, dropping expired entries.
+    pub fn effective_oci(&self, target: &str, now: Instant) -> Option<Oci> {
+        let mut entries = self.entries.lock().ok()?;
+        let per_target = entries.get_mut(target)?;
+        per_target.retain(|_, e| e.expires_at > now);
+        let result = per_target.get("").map(|e| e.oci.clone());
+        if per_target.is_empty() {
+            entries.remove(target);
+        }
+        result
+    }
+
+    /// Number of live OCI entries recorded for `target`, scoped ones included.
+    /// Exists so a caller (and the tests) can see that scoped occurrences were
+    /// kept rather than silently discarded.
+    pub fn live_count(&self, target: &str, now: Instant) -> usize {
+        let Ok(mut entries) = self.entries.lock() else {
+            return 0;
+        };
+        let Some(per_target) = entries.get_mut(target) else {
+            return 0;
+        };
+        per_target.retain(|_, e| e.expires_at > now);
+        per_target.len()
+    }
+
+    /// Forget everything recorded for `target` — used when a producer answers
+    /// normally again and the consumer wants to stop reacting immediately.
+    pub fn clear(&self, target: &str) {
+        if let Ok(mut entries) = self.entries.lock() {
+            entries.remove(target);
+        }
+    }
+}
+
+/// Producer-side overload reporter (#65).
+///
+/// An NF that knows it is overloaded stores a reduction metric here; the SBI
+/// server then stamps `3gpp-Sbi-Oci` on every response it sends, which is the
+/// half of TS 29.500 §6.4 that no NF in this tree could perform before — the
+/// emission code existed, but nothing was wired to a server response.
+///
+/// This deliberately does **not** measure load itself. A generic HTTP layer has
+/// no basis for deciding that an AMF is overloaded (queue depth, UE count and
+/// N2 backlog are the NF's business), and inventing a metric from request
+/// latency here would report overload that the NF does not believe in. The NF
+/// sets the number; this carries it.
+#[derive(Debug, Default)]
+pub struct OverloadReporter {
+    /// 0 = not overloaded, and no header is emitted at all.
+    metric: AtomicU8,
+    /// `Period-of-Validity` in seconds; 0 omits the parameter.
+    validity_secs: AtomicU64,
+}
+
+impl OverloadReporter {
+    /// A reporter that is not overloaded and emits nothing.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the reduction metric (0..=100). `0` stops emission.
+    pub fn set_reduction_metric(&self, metric: u8) {
+        self.metric.store(metric.min(100), AtomicOrdering::Relaxed);
+    }
+
+    /// Set the advertised `Period-of-Validity`, in seconds. `0` omits it.
+    pub fn set_validity_secs(&self, secs: u64) {
+        self.validity_secs.store(secs, AtomicOrdering::Relaxed);
+    }
+
+    /// The current metric.
+    pub fn reduction_metric(&self) -> u8 {
+        self.metric.load(AtomicOrdering::Relaxed)
+    }
+
+    /// The OCI to stamp on a response, or `None` when not overloaded.
+    pub fn oci(&self) -> Option<Oci> {
+        let metric = self.reduction_metric();
+        if metric == 0 {
+            return None;
+        }
+        let mut oci = Oci::new(metric);
+        let validity = self.validity_secs.load(AtomicOrdering::Relaxed);
+        if validity > 0 {
+            oci.period_of_validity_secs = Some(validity);
+        }
+        Some(oci)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -334,6 +591,106 @@ mod tests {
             assert!(!ctl.should_shed(&Oci::new(0), &mut rng));
             assert!(ctl.should_shed(&Oci::new(100), &mut rng));
         }
+    }
+
+    /// #65: a later OCI supersedes an earlier one for the same scope, so a
+    /// producer signalling recovery with `Overload-Reduction-Metric: 0` stops the
+    /// reaction (TS 29.500 §6.4.3.3).
+    ///
+    /// Both states are asserted — Reselect while the reduction is live, Send once
+    /// it is withdrawn. Asserting only the second would pass against a registry
+    /// that never reacted at all.
+    #[test]
+    fn metric_zero_supersedes_a_live_reduction() {
+        let registry = OverloadRegistry::new();
+        let now = Instant::now();
+        let target = "http://127.0.0.1:8080";
+
+        assert_eq!(registry.record(target, &[Oci::new(70).to_header()], now), 1);
+        assert!(
+            matches!(registry.decide(target, true, now), SendDecision::Reselect(o) if o.reduction_metric == 70),
+            "a live reduction with an alternate available must reselect"
+        );
+
+        // Recovery.
+        assert_eq!(registry.record(target, &[Oci::new(0).to_header()], now), 1);
+        assert_eq!(
+            registry.decide(target, true, now),
+            SendDecision::Send,
+            "metric 0 must supersede the earlier reduction"
+        );
+    }
+
+    /// #65: each scope is an independent entry, and only the UNSCOPED one drives
+    /// the decision — a per-DNN metric must not be applied to every request.
+    ///
+    /// Uses a SHEDDING registry deliberately. With the default (non-shedding) one
+    /// every branch ends in `Send`, so the first version of this test passed even
+    /// when `effective_oci` was reverted to "return any live entry, scoped or
+    /// not": the outcome was decided by shedding being off, not by the scope
+    /// logic. With shedding on, scope is the only variable left.
+    #[test]
+    fn scoped_oci_is_recorded_but_only_the_unscoped_one_decides() {
+        let registry = OverloadRegistry::with_shedding();
+        let now = Instant::now();
+        let target = "http://127.0.0.1:8080";
+
+        let scoped = "Overload-Reduction-Metric: 100; DNN: internet";
+        assert_eq!(registry.record(target, &[scoped.to_string()], now), 1);
+        assert_eq!(registry.live_count(target, now), 1, "it IS recorded");
+        assert_eq!(
+            registry.decide(target, false, now),
+            SendDecision::Send,
+            "a per-DNN metric must not gate unrelated requests, even at 100%"
+        );
+
+        // Add the whole-producer OCI: now the decision changes, and both entries
+        // are still held.
+        registry.record(target, &[Oci::new(100).to_header()], now);
+        assert_eq!(registry.live_count(target, now), 2);
+        assert!(
+            matches!(registry.decide(target, false, now), SendDecision::Shed(o) if o.reduction_metric == 100),
+            "an unscoped 100% reduction with no alternate must shed"
+        );
+        // With an alternate, rerouting is preferred over shedding.
+        assert!(matches!(
+            registry.decide(target, true, now),
+            SendDecision::Reselect(_)
+        ));
+    }
+
+    /// #65: an OCI with no `Period-of-Validity` expires under the local ceiling
+    /// instead of applying forever. One erroneous `metric: 100` must not become a
+    /// permanent outage toward a healthy producer.
+    #[test]
+    fn an_oci_without_a_validity_period_expires_under_the_ceiling() {
+        let registry = OverloadRegistry::new();
+        let now = Instant::now();
+        let target = "http://127.0.0.1:8080";
+
+        // No Period-of-Validity in the header at all.
+        registry.record(target, &["Overload-Reduction-Metric: 100".to_string()], now);
+        assert!(registry.effective_oci(target, now).is_some());
+
+        let after = now + DEFAULT_OCI_VALIDITY + Duration::from_secs(1);
+        assert!(
+            registry.effective_oci(target, after).is_none(),
+            "an OCI with no declared validity must not outlive the ceiling"
+        );
+        assert_eq!(registry.decide(target, false, after), SendDecision::Send);
+
+        // A DECLARED validity is honoured as sent, even a long one.
+        registry.record(
+            target,
+            &["Period-of-Validity: 600s; Overload-Reduction-Metric: 100".to_string()],
+            now,
+        );
+        assert!(
+            registry
+                .effective_oci(target, now + Duration::from_secs(500))
+                .is_some(),
+            "a producer's declared validity is not shortened by the ceiling"
+        );
     }
 
     #[test]

--- a/src/libs/nextgcore-sbi/src/server.rs
+++ b/src/libs/nextgcore-sbi/src/server.rs
@@ -8,6 +8,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full, Limited};
@@ -17,11 +18,12 @@ use hyper::service::Service;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{mpsc, oneshot, watch, Mutex};
 use tokio_rustls::TlsAcceptor;
 
 use crate::error::{SbiError, SbiResult};
 use crate::message::{SbiHttpMessage, SbiRequest, SbiResponse};
+use crate::overload::OverloadReporter;
 use crate::tls;
 use crate::types::{NfType, UriScheme};
 
@@ -102,6 +104,14 @@ pub struct SbiServerConfig {
     /// This NF's instance ID / FQDN, combined with `server_nf_type` as the
     /// `Server` value `<NFTYPE>-<id>` (sbi-02).
     pub server_nf_id: Option<String>,
+    /// #65: producer-side overload reporter. When set and its metric is
+    /// non-zero, every response carries `3gpp-Sbi-Oci` so consumers can apply
+    /// TS 29.500 §6.4.2.2 abatement. `None` (default) emits no OCI, which is the
+    /// prior behaviour.
+    ///
+    /// The NF owns the metric — see [`OverloadReporter`] for why this layer does
+    /// not try to measure load itself.
+    pub overload_reporter: Option<Arc<OverloadReporter>>,
 }
 
 impl Default for SbiServerConfig {
@@ -124,6 +134,7 @@ impl Default for SbiServerConfig {
             max_header_list_size: Some(DEFAULT_MAX_HEADER_LIST_SIZE),
             server_nf_type: None,
             server_nf_id: None,
+            overload_reporter: None,
         }
     }
 }
@@ -177,6 +188,16 @@ impl SbiServerConfig {
     /// Set the expected OAuth2 `aud` claim from an [`NfType`] (T1.2).
     pub fn with_expected_audience_nf_type(mut self, nf_type: NfType) -> Self {
         self.oauth2_expected_audience = Some(nf_type.to_str().to_string());
+        self
+    }
+
+    /// Attach a producer-side overload reporter (#65).
+    ///
+    /// Responses carry `3gpp-Sbi-Oci` whenever the reporter's metric is non-zero,
+    /// which is the emission half of TS 29.500 §6.4 — present in `overload.rs`
+    /// since sbi-08 but never reachable from a response until now.
+    pub fn with_overload_reporter(mut self, reporter: Arc<OverloadReporter>) -> Self {
+        self.overload_reporter = Some(reporter);
         self
     }
 
@@ -317,6 +338,8 @@ struct SbiService<H: SbiRequestHandler> {
     /// This NF's `(NfType, id)` identity for the `Server` response header
     /// (sbi-02). `None` emits no `Server` header.
     server_identity: Option<(NfType, String)>,
+    /// #65: producer-side OCI source. `None` emits no `3gpp-Sbi-Oci`.
+    overload_reporter: Option<Arc<OverloadReporter>>,
 }
 
 impl<H: SbiRequestHandler> Clone for SbiService<H> {
@@ -328,6 +351,7 @@ impl<H: SbiRequestHandler> Clone for SbiService<H> {
             tls_exporter_secret: self.tls_exporter_secret.clone(),
             peer_cert_nf_instance_id: self.peer_cert_nf_instance_id.clone(),
             server_identity: self.server_identity.clone(),
+            overload_reporter: self.overload_reporter.clone(),
         }
     }
 }
@@ -344,6 +368,7 @@ impl<H: SbiRequestHandler> Service<Request<Incoming>> for SbiService<H> {
         let tls_exporter_secret = self.tls_exporter_secret.clone();
         let peer_cert_nf_instance_id = self.peer_cert_nf_instance_id.clone();
         let server_identity = self.server_identity.clone();
+        let overload_reporter = self.overload_reporter.clone();
         let path = req.uri().path().to_string();
 
         Box::pin(async move {
@@ -380,6 +405,7 @@ impl<H: SbiRequestHandler> Service<Request<Incoming>> for SbiService<H> {
                         return Ok(convert_response_with_identity(
                             resp,
                             server_identity.as_ref(),
+                            overload_reporter.as_ref(),
                         ));
                     }
                 };
@@ -427,6 +453,7 @@ impl<H: SbiRequestHandler> Service<Request<Incoming>> for SbiService<H> {
                         return Ok(convert_response_with_identity(
                             resp,
                             server_identity.as_ref(),
+                            overload_reporter.as_ref(),
                         ));
                     }
                 }
@@ -452,7 +479,11 @@ impl<H: SbiRequestHandler> Service<Request<Incoming>> for SbiService<H> {
 
             // Convert SbiResponse to hyper response, stamping the Server
             // header (sbi-02) when a server identity is configured.
-            let response = convert_response_with_identity(sbi_response, server_identity.as_ref());
+            let response = convert_response_with_identity(
+                sbi_response,
+                server_identity.as_ref(),
+                overload_reporter.as_ref(),
+            );
 
             Ok(response)
         })
@@ -562,11 +593,17 @@ async fn convert_request(
     let method = req.method().to_string();
     let uri = req.uri().path().to_string();
 
-    // Extract headers
+    // Extract headers.
+    //
+    // #65: APPEND rather than set. hyper yields one entry per field LINE, so a
+    // peer sending two `3gpp-Sbi-Oci` occurrences (TS 29.500 §6.4.3 — one per
+    // reporting scope) arrived here as two calls; `set_header` replaces, so the
+    // first scope was discarded and a producer reporting overload for two scopes
+    // was read as reporting for one.
     let mut http = SbiHttpMessage::new();
     for (key, value) in req.headers() {
         if let Ok(v) = value.to_str() {
-            http.set_header(key.to_string(), v.to_string());
+            http.append_header(key.to_string(), v.to_string());
         }
     }
 
@@ -577,12 +614,40 @@ async fn convert_request(
     // outbound by the SBI client.
     let correlation_id = extract_or_generate_correlation_id(&http);
 
-    // Extract query parameters
+    // Extract query parameters, percent-DECODED (#65, TS 29.500 §5.2.10.2).
+    //
+    // Two defects fixed here, both of which made a conformant peer look
+    // malformed:
+    //
+    // 1. Values were stored verbatim. A producer must percent-encode a query
+    //    value containing reserved characters, so a JSON-valued factor (the MBS
+    //    `tmgi-list`, an S-NSSAI list) arrived as `%5B%7B%22...` and every
+    //    consumer that fed it to `serde_json` answered 400. Two NFs carried
+    //    their own decoder to compensate; both are deleted in this change,
+    //    because a local shim on top of a decoding server DOUBLE-decodes, and a
+    //    value whose plaintext legitimately contains `%20` is then corrupted.
+    //
+    // 2. A parameter with no `=` was DROPPED. RFC 3986 permits a bare flag, and
+    //    dropping it is indistinguishable from the peer never sending it. It is
+    //    now stored with an empty value, so `get_param` returns `Some("")` —
+    //    present-but-empty, which is what the peer said.
+    //
+    // The QUERY decoder is used, not the form decoder: in a query component `+`
+    // is a literal plus. Decoding it as a space would corrupt every RFC 3339
+    // timestamp carrying a non-UTC offset and every base64 value.
     if let Some(query) = req.uri().query() {
         for pair in query.split('&') {
-            if let Some((key, value)) = pair.split_once('=') {
-                http.set_param(key.to_string(), value.to_string());
+            if pair.is_empty() {
+                continue;
             }
+            let (key, value) = match pair.split_once('=') {
+                Some((k, v)) => (k, v),
+                None => (pair, ""),
+            };
+            http.set_param(
+                crate::uri_encode::decode_query_value(key),
+                crate::uri_encode::decode_query_value(value),
+            );
         }
     }
 
@@ -764,6 +829,7 @@ fn convert_response(mut sbi_response: SbiResponse) -> Response<Full<Bytes>> {
 fn convert_response_with_identity(
     mut sbi_response: SbiResponse,
     identity: Option<&(NfType, String)>,
+    overload: Option<&Arc<OverloadReporter>>,
 ) -> Response<Full<Bytes>> {
     if let Some((nf_type, nf_id)) = identity {
         if sbi_response.http.get_header("Server").is_none() {
@@ -772,14 +838,56 @@ fn convert_response_with_identity(
                 .set_header("Server", format!("{}-{}", nf_type.as_server_token(), nf_id));
         }
     }
+    // #65: stamp `3gpp-Sbi-Oci` when this NF has declared itself overloaded
+    // (TS 29.500 §6.4.3.2 — an OCI may ride on any response, not only a 503).
+    // A handler that set its own OCI wins: it knows a per-scope reason this
+    // layer does not.
+    if let Some(reporter) = overload {
+        if let Some(oci) = reporter.oci() {
+            if sbi_response
+                .http
+                .get_header(crate::constants::custom_header::OCI)
+                .is_none()
+            {
+                sbi_response
+                    .http
+                    .set_header(crate::constants::custom_header::OCI, oci.to_header());
+            }
+        }
+    }
     convert_response(sbi_response)
 }
 
 /// Server state
 enum ServerState {
     Stopped,
-    Running(oneshot::Sender<()>),
+    Running(RunningState),
 }
+
+/// Everything `stop()` needs to shut a running server down gracefully (#65).
+struct RunningState {
+    /// Breaks the accept loop, so no NEW connection is taken.
+    accept_shutdown: oneshot::Sender<()>,
+    /// Broadcasts "start draining" to every live connection task, each of which
+    /// answers by sending an HTTP/2 GOAWAY and finishing its in-flight streams.
+    graceful: watch::Sender<bool>,
+    /// Drain barrier. Every connection task holds a clone of the paired
+    /// [`mpsc::Sender`]; when the last one drops, `recv()` here resolves to
+    /// `None`. That is the only reliable "all connections have finished" signal —
+    /// counting with an atomic races with a task that has decremented but not yet
+    /// flushed its final frames.
+    drain: mpsc::Receiver<()>,
+}
+
+/// How long [`SbiServer::stop`] waits for in-flight streams to finish after the
+/// GOAWAY before abandoning them (#65).
+///
+/// A bound is required rather than optional: a peer holding a stream open (a slow
+/// notification consumer, a half-dead TCP connection) would otherwise make
+/// `stop()` hang forever, and `stop()` is called from test teardown and from the
+/// daemons' SIGTERM path — both places where hanging is worse than dropping a
+/// straggler. Exceeding it is logged at warn with the count.
+const GRACEFUL_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// SBI Server - HTTP/2 server for SBI communication
 /// Matches nextgcore_sbi_server_t
@@ -859,7 +967,16 @@ impl SbiServer {
         };
 
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
-        *state = ServerState::Running(shutdown_tx);
+        // #65: graceful-shutdown plumbing. `graceful_tx` tells live connections to
+        // send GOAWAY and drain; `drain_tx` is cloned into each connection task
+        // purely so that `stop()` can await the last clone being dropped.
+        let (graceful_tx, graceful_rx) = watch::channel(false);
+        let (drain_tx, drain_rx) = mpsc::channel::<()>(1);
+        *state = ServerState::Running(RunningState {
+            accept_shutdown: shutdown_tx,
+            graceful: graceful_tx,
+            drain: drain_rx,
+        });
         drop(state);
 
         let handler = Arc::new(handler);
@@ -876,6 +993,8 @@ impl SbiServer {
         let http2_limits = Http2Limits::from_config(&self.config);
         // sbi-02: resolve the NF identity once for Server-header stamping.
         let server_identity = self.config.server_identity();
+        // #65: the producer-side OCI source, shared by every connection.
+        let overload_reporter = self.config.overload_reporter.clone();
 
         // Spawn the server task
         tokio::spawn(async move {
@@ -888,6 +1007,14 @@ impl SbiServer {
                                 let oauth_ref = oauth.clone();
                                 let http2_limits = http2_limits;
                                 let server_identity_ref = server_identity.clone();
+                                let overload_reporter_ref = overload_reporter.clone();
+                                // #65: one shutdown receiver and one drain token
+                                // per connection. The token must be cloned HERE,
+                                // not inside the spawned task: cloning inside
+                                // races with `stop()` observing the channel
+                                // closed before the new task has registered.
+                                let conn_graceful = graceful_rx.clone();
+                                let conn_drain = drain_tx.clone();
 
                                 if let Some(ref acceptor) = tls_acceptor {
                                     let acceptor = acceptor.clone();
@@ -944,18 +1071,19 @@ impl SbiServer {
                                                     tls_exporter_secret,
                                                     peer_cert_nf_instance_id,
                                                     server_identity: server_identity_ref,
+                                                    overload_reporter:
+                                                        overload_reporter_ref,
                                                 };
                                                 let io = TokioIo::new(tls_stream);
-                                                let mut builder = http2::Builder::new(
-                                                    hyper_util::rt::TokioExecutor::new()
-                                                );
-                                                http2_limits.apply(&mut builder);
-                                                if let Err(e) = builder
-                                                    .serve_connection(io, service)
-                                                    .await
-                                                {
-                                                    eprintln!("HTTP/2 TLS connection error: {e}");
-                                                }
+                                                serve_connection_gracefully(
+                                                    io,
+                                                    service,
+                                                    http2_limits,
+                                                    conn_graceful,
+                                                    conn_drain,
+                                                    "HTTP/2 TLS",
+                                                )
+                                                .await;
                                             }
                                             Err(e) => {
                                                 eprintln!("TLS accept error: {e}");
@@ -972,20 +1100,17 @@ impl SbiServer {
                                         tls_exporter_secret: None,
                                         peer_cert_nf_instance_id: None,
                                         server_identity: server_identity_ref,
+                                        overload_reporter: overload_reporter_ref,
                                     };
                                     let io = TokioIo::new(stream);
-                                    tokio::spawn(async move {
-                                        let mut builder = http2::Builder::new(
-                                            hyper_util::rt::TokioExecutor::new()
-                                        );
-                                        http2_limits.apply(&mut builder);
-                                        if let Err(e) = builder
-                                            .serve_connection(io, service)
-                                            .await
-                                        {
-                                            eprintln!("HTTP/2 connection error: {e}");
-                                        }
-                                    });
+                                    tokio::spawn(serve_connection_gracefully(
+                                        io,
+                                        service,
+                                        http2_limits,
+                                        conn_graceful,
+                                        conn_drain,
+                                        "HTTP/2",
+                                    ));
                                 }
                             }
                             Err(e) => {
@@ -1003,14 +1128,57 @@ impl SbiServer {
         Ok(())
     }
 
-    /// Stop the server
+    /// Stop the server **gracefully** (#65).
+    ///
+    /// Three steps, in this order (RFC 9113 §6.8):
+    ///
+    /// 1. break the accept loop, so no new connection is taken;
+    /// 2. tell every live connection to send GOAWAY and finish its in-flight
+    ///    streams;
+    /// 3. wait — bounded by [`GRACEFUL_DRAIN_TIMEOUT`] — for those streams to
+    ///    complete.
+    ///
+    /// Step 2 and step 3 are what this used to skip. Firing the accept-loop
+    /// signal alone left the connection tasks detached: they were killed when the
+    /// runtime dropped, so a peer with a request in flight during a restart got a
+    /// transport error instead of its response, and no GOAWAY ever told it to
+    /// stop opening streams.
+    ///
+    /// The order matters. Signalling graceful shutdown before closing the
+    /// listener would let a connection accepted in between miss the signal
+    /// entirely and hold the drain open until the timeout.
     pub async fn stop(&self) -> SbiResult<()> {
         let mut state = self.state.lock().await;
 
-        if let ServerState::Running(shutdown_tx) =
-            std::mem::replace(&mut *state, ServerState::Stopped)
-        {
-            let _ = shutdown_tx.send(());
+        let ServerState::Running(running) = std::mem::replace(&mut *state, ServerState::Stopped)
+        else {
+            return Ok(());
+        };
+        let RunningState {
+            accept_shutdown,
+            graceful,
+            mut drain,
+        } = running;
+
+        // 1. No new connections.
+        let _ = accept_shutdown.send(());
+        // 2. GOAWAY + finish in-flight streams on the live ones. A send error
+        //    means every connection task has already exited, which is the same
+        //    end state.
+        let _ = graceful.send(true);
+        // 3. Drop our own token so the barrier depends only on the connections,
+        //    then wait for the last one. `recv()` returns None when every cloned
+        //    sender has dropped; a `Some` cannot happen (nothing ever sends).
+        drop(graceful);
+        match tokio::time::timeout(GRACEFUL_DRAIN_TIMEOUT, drain.recv()).await {
+            Ok(_) => {}
+            Err(_) => log::warn!(
+                "SBI server on {} still had connections in flight after {}s of graceful \
+                 shutdown; abandoning them. A peer holding a stream open (a slow notification \
+                 consumer, or a half-dead TCP connection) will see a transport error.",
+                self.config.addr,
+                GRACEFUL_DRAIN_TIMEOUT.as_secs()
+            ),
         }
 
         Ok(())
@@ -1021,6 +1189,66 @@ impl SbiServer {
         let state = self.state.lock().await;
         matches!(*state, ServerState::Running(_))
     }
+}
+
+/// Serve one HTTP/2 connection, honouring a graceful-shutdown signal (#65).
+///
+/// Before this existed the connection future was awaited directly in a detached
+/// task, so `stop()` had no handle on it: the process dropped the listener and
+/// every live connection was torn down mid-stream with no GOAWAY. A peer with a
+/// request in flight saw a transport error rather than a completed response,
+/// which is what makes a rolling restart lossy (RFC 9113 §6.8: an endpoint
+/// shutting down gracefully sends GOAWAY so the peer stops opening new streams
+/// while existing ones finish).
+///
+/// On the signal this calls `graceful_shutdown()` — which queues the GOAWAY —
+/// and then keeps polling the same connection future, because the GOAWAY is only
+/// written, and the in-flight streams only complete, while the connection is
+/// still being driven. Returning here instead (the tempting one-liner) sends
+/// nothing and drops everything.
+///
+/// `drain_token` is never used; holding it until this function returns is the
+/// point. [`RunningState::drain`] resolves once every token has dropped.
+async fn serve_connection_gracefully<I, H>(
+    io: I,
+    service: SbiService<H>,
+    http2_limits: Http2Limits,
+    mut graceful: watch::Receiver<bool>,
+    drain_token: mpsc::Sender<()>,
+    label: &'static str,
+) where
+    I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+    H: SbiRequestHandler,
+{
+    let mut builder = http2::Builder::new(hyper_util::rt::TokioExecutor::new());
+    http2_limits.apply(&mut builder);
+    let conn = builder.serve_connection(io, service);
+    let mut conn = std::pin::pin!(conn);
+
+    // Two futures race: the connection finishing on its own, and the shutdown
+    // signal arriving. Only the second needs handling; the first is the normal
+    // keep-alive close.
+    let drained = tokio::select! {
+        result = conn.as_mut() => result,
+        signal = graceful.changed() => {
+            match signal {
+                // `stop()` fired: queue the GOAWAY, then drive the connection to
+                // completion so it is actually written and the in-flight streams
+                // get their responses.
+                Ok(()) => {
+                    conn.as_mut().graceful_shutdown();
+                    conn.as_mut().await
+                }
+                // The watch sender is gone (the server was dropped without
+                // stop()). Nothing to wait for; serve the connection out.
+                Err(_) => conn.as_mut().await,
+            }
+        }
+    };
+    if let Err(e) = drained {
+        eprintln!("{label} connection error: {e}");
+    }
+    drop(drain_token);
 }
 
 /// Stream identifier for tracking requests
@@ -1396,7 +1624,7 @@ mod tests {
         // identity is configured (TS 29.500 §6.10.8.2 EXAMPLE 3 shape).
         let identity = (NfType::Smf, "54804518-abcd".to_string());
         let resp = send_error(404, "Not Found", "missing", None);
-        let hyper_resp = convert_response_with_identity(resp, Some(&identity));
+        let hyper_resp = convert_response_with_identity(resp, Some(&identity), None);
         assert_eq!(
             hyper_resp
                 .headers()
@@ -1407,7 +1635,7 @@ mod tests {
 
         // A 2xx success response is stamped too (harmless, aids debugging).
         let ok = SbiResponse::ok().with_body("{}", "application/json");
-        let hyper_ok = convert_response_with_identity(ok, Some(&identity));
+        let hyper_ok = convert_response_with_identity(ok, Some(&identity), None);
         assert_eq!(
             hyper_ok
                 .headers()
@@ -1465,7 +1693,7 @@ mod tests {
     fn test_convert_response_no_server_header_without_identity() {
         // No identity → no Server header (prior behaviour preserved).
         let resp = send_error(500, "Internal Server Error", "boom", None);
-        let hyper_resp = convert_response_with_identity(resp, None);
+        let hyper_resp = convert_response_with_identity(resp, None, None);
         assert!(hyper_resp.headers().get("server").is_none());
     }
 
@@ -1474,7 +1702,7 @@ mod tests {
         // A handler-supplied Server header is not overwritten.
         let identity = (NfType::Scp, "scp1.operator.com".to_string());
         let resp = SbiResponse::ok().with_header("Server", "custom-server/2.0");
-        let hyper_resp = convert_response_with_identity(resp, Some(&identity));
+        let hyper_resp = convert_response_with_identity(resp, Some(&identity), None);
         assert_eq!(
             hyper_resp
                 .headers()
@@ -1987,6 +2215,306 @@ mod tests {
             observed.is_none(),
             "an unverified bearer header must NOT become an attested identity, got {observed:?}"
         );
+
+        server.stop().await.expect("stop");
+    }
+
+    // ─── #65: query percent-decode, header multiplicity, graceful shutdown ───
+
+    /// Capture what the handler saw, so a test can assert on the DECODED params
+    /// rather than on a response the handler could have produced anyway.
+    fn param_capturing_handler() -> (
+        impl SbiRequestHandler,
+        Arc<std::sync::Mutex<Option<SbiRequest>>>,
+    ) {
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let sink = seen.clone();
+        let handler = move |req: SbiRequest| {
+            let sink = sink.clone();
+            async move {
+                *sink.lock().unwrap_or_else(|e| e.into_inner()) = Some(req);
+                SbiResponse::with_status(204)
+            }
+        };
+        (handler, seen)
+    }
+
+    /// #65 acceptance: the server percent-DECODES query parameters.
+    ///
+    /// The query is put on the request URI verbatim so the client cannot be the
+    /// thing that decodes it — the assertion is about `convert_request` and
+    /// nothing else. The value is the JSON shape TS 29.500 §5.2.10.2 forces a
+    /// producer to encode.
+    #[tokio::test]
+    async fn server_percent_decodes_query_parameters() {
+        use crate::client::SbiClient;
+
+        let (handler, seen) = param_capturing_handler();
+        let (server, port) = start_test_server(SbiServerConfig::default(), handler).await;
+        let client = SbiClient::with_host_port("127.0.0.1", port);
+
+        // %5B%7B%22sst%22%3A1%2C%22sd%22%3A%22000001%22%7D%5D == [{"sst":1,"sd":"000001"}]
+        let resp = client
+            .send_request(SbiRequest::get(
+                "/nnrf-disc/v1/nf-instances?snssais=%5B%7B%22sst%22%3A1%2C%22sd%22%3A%22000001%22%7D%5D",
+            ))
+            .await
+            .expect("response");
+        assert_eq!(resp.status, 204);
+
+        let req = seen
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .expect("handler ran");
+        let snssais = req.http.get_param("snssais").expect("param present");
+        assert_eq!(
+            snssais, r#"[{"sst":1,"sd":"000001"}]"#,
+            "the server must decode; a verbatim value here is the #65 defect"
+        );
+        // The whole point: it is now parseable JSON, which is what every consumer
+        // does with it.
+        let parsed: serde_json::Value = serde_json::from_str(snssais).expect("valid JSON");
+        assert_eq!(parsed[0]["sd"], "000001");
+
+        server.stop().await.expect("stop");
+    }
+
+    /// #65 acceptance: an `=`-less query parameter survives as present-but-empty.
+    ///
+    /// It used to be dropped, which a handler cannot tell apart from the peer
+    /// never having sent it.
+    #[tokio::test]
+    async fn server_preserves_valueless_query_flags() {
+        use crate::client::SbiClient;
+
+        let (handler, seen) = param_capturing_handler();
+        let (server, port) = start_test_server(SbiServerConfig::default(), handler).await;
+        let client = SbiClient::with_host_port("127.0.0.1", port);
+
+        client
+            .send_request(SbiRequest::get("/x/y?flag&other=1"))
+            .await
+            .expect("response");
+
+        let req = seen
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .expect("handler ran");
+        assert_eq!(
+            req.http.get_param("flag").map(String::as_str),
+            Some(""),
+            "a valueless flag must be present with an empty value, not absent"
+        );
+        assert_eq!(req.http.get_param("other").map(String::as_str), Some("1"));
+
+        server.stop().await.expect("stop");
+    }
+
+    /// #65 acceptance: two `3gpp-Sbi-Oci` **field lines** are individually
+    /// retrievable — the header map no longer collapses repeated occurrences.
+    ///
+    /// TS 29.500 §6.4.3 gives each occurrence an independent scope, so keeping
+    /// only one is not a formatting detail: a producer reporting overload for two
+    /// scopes was read as reporting for one.
+    ///
+    /// Driven with a RAW hyper client on purpose. `SbiClient` stores headers in a
+    /// map, so it can only ever emit one field line per name — the first version
+    /// of this test used it, and passed with the server-side fix reverted, because
+    /// it was really only exercising `get_header_all`'s comma splitting. Two
+    /// genuine field lines are the only input that can distinguish `append_header`
+    /// from `set_header` on the ingest path.
+    #[tokio::test]
+    async fn server_keeps_every_repeated_oci_occurrence() {
+        let (handler, seen) = param_capturing_handler();
+        let (server, port) = start_test_server(SbiServerConfig::default(), handler).await;
+
+        let stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("connect");
+        let (mut sender, conn) = hyper::client::conn::http2::handshake(
+            hyper_util::rt::TokioExecutor::new(),
+            TokioIo::new(stream),
+        )
+        .await
+        .expect("h2 handshake");
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        // `Builder::header` APPENDS, so this is two field lines on the wire.
+        let request = Request::builder()
+            .method("GET")
+            .uri("/x")
+            .header(
+                crate::constants::custom_header::OCI,
+                "Timestamp: 2026-01-01T00:00:00Z; Overload-Reduction-Metric: 10; DNN: internet",
+            )
+            .header(
+                crate::constants::custom_header::OCI,
+                "Timestamp: 2026-01-01T00:00:01Z; Overload-Reduction-Metric: 60",
+            )
+            .body(Full::new(Bytes::new()))
+            .expect("request");
+        let response = sender.send_request(request).await.expect("response");
+        assert_eq!(response.status().as_u16(), 204);
+
+        let seen_req = seen
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .expect("handler ran");
+        let all = seen_req
+            .http
+            .get_header_all(crate::constants::custom_header::OCI);
+        assert_eq!(
+            all.len(),
+            2,
+            "both OCI field lines must survive ingest, got {all:?}"
+        );
+        let metrics: Vec<u8> = all
+            .iter()
+            .filter_map(|v| crate::overload::Oci::parse(v))
+            .map(|o| o.reduction_metric)
+            .collect();
+        assert_eq!(
+            metrics,
+            vec![10, 60],
+            "each occurrence must parse independently, in arrival order"
+        );
+        // The scoped occurrence kept its scope parameter, which is what makes a
+        // future per-DNN reaction possible.
+        assert!(
+            all[0].contains("DNN: internet"),
+            "the scope parameter must survive verbatim, got {:?}",
+            all[0]
+        );
+
+        server.stop().await.expect("stop");
+    }
+
+    /// #65 acceptance: `stop()` drains in-flight streams instead of killing them.
+    ///
+    /// The handler sleeps, so shutdown is requested while the request is
+    /// genuinely mid-flight. Before the graceful path existed, the connection task
+    /// was detached and the client saw a transport error here.
+    ///
+    /// Ceiling, stated rather than implied: this asserts the OBSERVABLE
+    /// consequence of the GOAWAY (in-flight completes, connection then closes),
+    /// not the frame itself — hyper exposes no hook to read the peer's GOAWAY, so
+    /// frame-level inspection would need a raw h2 client this crate does not use.
+    #[tokio::test]
+    async fn stop_drains_an_in_flight_request() {
+        use crate::client::SbiClient;
+
+        let (server, port) =
+            start_test_server(SbiServerConfig::default(), |_req: SbiRequest| async {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                SbiResponse::with_status(200).with_body("drained", "text/plain")
+            })
+            .await;
+        let client = Arc::new(SbiClient::with_host_port("127.0.0.1", port));
+
+        // Fire the request, let it reach the handler, then stop the server.
+        let in_flight = {
+            let client = client.clone();
+            tokio::spawn(async move { client.send_request(SbiRequest::get("/slow")).await })
+        };
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        let stop_started = std::time::Instant::now();
+        server.stop().await.expect("stop");
+        // stop() must have WAITED for the drain rather than returning at once.
+        assert!(
+            stop_started.elapsed() >= Duration::from_millis(150),
+            "stop() returned in {:?}, so it did not wait for the in-flight stream",
+            stop_started.elapsed()
+        );
+
+        let response = in_flight
+            .await
+            .expect("task joined")
+            .expect("an in-flight request must complete across a graceful shutdown");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.http.content.as_deref(), Some("drained"));
+    }
+
+    /// #65: after a graceful stop the listener is gone, so a NEW connection is
+    /// refused. Together with the drain test above this pins both halves of
+    /// RFC 9113 §6.8 — finish what is in flight, accept nothing new.
+    #[tokio::test]
+    async fn stop_refuses_new_connections() {
+        use crate::client::SbiClient;
+
+        let (server, port) =
+            start_test_server(SbiServerConfig::default(), |_req: SbiRequest| async {
+                SbiResponse::with_status(204)
+            })
+            .await;
+        let client = SbiClient::with_host_port("127.0.0.1", port);
+        assert_eq!(
+            client
+                .send_request(SbiRequest::get("/x"))
+                .await
+                .expect("first response")
+                .status,
+            204
+        );
+
+        server.stop().await.expect("stop");
+
+        // A fresh client cannot connect at all.
+        let after = SbiClient::with_host_port("127.0.0.1", port);
+        assert!(
+            after.send_request(SbiRequest::get("/x")).await.is_err(),
+            "the listener must be closed after stop()"
+        );
+    }
+
+    /// #65: with a reporter attached and a non-zero metric, every response
+    /// carries `3gpp-Sbi-Oci` — the producer half of TS 29.500 §6.4 that had no
+    /// caller before.
+    #[tokio::test]
+    async fn responses_carry_oci_when_the_nf_reports_overload() {
+        use crate::client::SbiClient;
+        use crate::overload::OverloadReporter;
+
+        let reporter = Arc::new(OverloadReporter::new());
+        let config = SbiServerConfig::default().with_overload_reporter(reporter.clone());
+        let (server, port) = start_test_server(config, |_req: SbiRequest| async {
+            SbiResponse::with_status(204)
+        })
+        .await;
+        let client = SbiClient::with_host_port("127.0.0.1", port);
+
+        // Not overloaded: no header at all, so an NF that never sets a metric is
+        // byte-identical to before.
+        let quiet = client
+            .send_request(SbiRequest::get("/x"))
+            .await
+            .expect("response");
+        assert!(
+            quiet
+                .http
+                .get_header(crate::constants::custom_header::OCI)
+                .is_none(),
+            "a reporter at metric 0 must emit nothing"
+        );
+
+        reporter.set_reduction_metric(40);
+        reporter.set_validity_secs(75);
+        let loaded = client
+            .send_request(SbiRequest::get("/x"))
+            .await
+            .expect("response");
+        let oci = loaded
+            .http
+            .get_header(crate::constants::custom_header::OCI)
+            .expect("OCI stamped once the NF reports overload");
+        let parsed = crate::overload::Oci::parse(oci).expect("parseable OCI");
+        assert_eq!(parsed.reduction_metric, 40);
+        assert_eq!(parsed.period_of_validity_secs, Some(75));
 
         server.stop().await.expect("stop");
     }

--- a/src/libs/nextgcore-sbi/src/uri_encode.rs
+++ b/src/libs/nextgcore-sbi/src/uri_encode.rs
@@ -1,4 +1,5 @@
-//! Percent-encoding for SBI URIs and form bodies (issue #101).
+//! Percent-encoding and -decoding for SBI URIs and form bodies (issues #101,
+//! #65).
 //!
 //! # Why there are two functions and not one
 //!
@@ -57,6 +58,84 @@ enum SpaceAs {
     Percent20,
     /// `application/x-www-form-urlencoded`.
     Plus,
+}
+
+/// Percent-**decode** a value taken from an RFC 3986 **query component**
+/// (issue #65).
+///
+/// `+` is a **literal plus**, not a space — the exact mirror of
+/// [`encode_query_value`], and the reason this is a separate function from
+/// [`decode_form_value`]. Getting this wrong is not theoretical: a query value
+/// carrying an RFC 3339 timestamp (`2026-01-01T00:00:00+02:00`, TS 29.571
+/// `DateTime`) or a base64 token is silently corrupted by the form decoder.
+///
+/// Invalid escapes are left verbatim rather than rejected: a trailing `%`, or a
+/// `%zz` that is not two hex digits, passes through as written. A query
+/// parameter is attacker-controlled input on a network-facing path, and the
+/// alternative — failing the whole request — turns a cosmetically malformed
+/// value into a 400 for a request that may not even read that parameter.
+pub fn decode_query_value(s: &str) -> String {
+    decode_with(s, SpaceAs::Percent20)
+}
+
+/// Percent-**decode** a value taken from an `application/x-www-form-urlencoded`
+/// **body** (issue #65).
+///
+/// `+` decodes to a space, per the media type. Use this only for form bodies —
+/// notably the NRF access-token request (`grant_type`, `scope`, `nfInstanceId`).
+pub fn decode_form_value(s: &str) -> String {
+    decode_with(s, SpaceAs::Plus)
+}
+
+fn decode_with(s: &str, space: SpaceAs) -> String {
+    // Decode over BYTES and build the result as bytes: a percent-escape names an
+    // OCTET, and a multi-byte UTF-8 scalar arrives as several independent
+    // escapes (RFC 3986 §2.5) that only form a character once reassembled.
+    // Decoding per-char would make `%C3%A9` two replacement characters.
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => {
+                match (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                    (Some(hi), Some(lo)) => {
+                        out.push((hi << 4) | lo);
+                        i += 3;
+                    }
+                    // Not a valid escape: emit the '%' verbatim and continue, so
+                    // `100%` and `%zz` survive unchanged.
+                    _ => {
+                        out.push(b'%');
+                        i += 1;
+                    }
+                }
+            }
+            b'+' if space == SpaceAs::Plus => {
+                out.push(b' ');
+                i += 1;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    // A percent-escape can name an octet that is not valid UTF-8 (a truncated
+    // sequence, or a deliberately malformed one). Lossy conversion keeps the
+    // decoder infallible; the alternative is a `Result` at ~40 call sites for an
+    // input no conformant peer produces.
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Value of a single hex digit, or `None` when the byte is not one.
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
 }
 
 fn encode_with(s: &str, space: SpaceAs) -> String {
@@ -144,5 +223,103 @@ mod tests {
         assert_eq!(encode_query_value("日"), "%E6%97%A5");
         // Uppercase, not lowercase.
         assert_eq!(encode_query_value("\u{7f}"), "%7F");
+    }
+
+    /// **The decoder's anti-deduplication guard** (issue #65), mirroring
+    /// [`query_and_form_encoders_differ_on_space`]. The two decoders disagree on
+    /// exactly one input for the same reason the encoders do.
+    #[test]
+    fn query_and_form_decoders_differ_on_plus() {
+        assert_eq!(decode_query_value("a+b"), "a+b");
+        assert_eq!(decode_form_value("a+b"), "a b");
+        // %20 is a space for both.
+        assert_eq!(decode_query_value("a%20b"), "a b");
+        assert_eq!(decode_form_value("a%20b"), "a b");
+    }
+
+    /// The concrete corruption the split prevents: an RFC 3339 `DateTime` and a
+    /// base64 value both carry a meaningful literal `+`. Decoding either with the
+    /// form decoder silently changes the value — for the timestamp, into
+    /// something the RFC 3339 parser rejects, which every consumer in this tree
+    /// reads as "no deadline".
+    #[test]
+    fn a_literal_plus_in_a_query_value_is_not_a_space() {
+        assert_eq!(
+            decode_query_value("2026-01-01T00:00:00+02:00"),
+            "2026-01-01T00:00:00+02:00"
+        );
+        assert_eq!(decode_query_value("YWJj+ZGVm"), "YWJj+ZGVm");
+        // What the form decoder would have done to them.
+        assert_eq!(
+            decode_form_value("2026-01-01T00:00:00+02:00"),
+            "2026-01-01T00:00:00 02:00"
+        );
+    }
+
+    /// Encode-then-decode is the identity for every value in this tree's query
+    /// vocabulary, INCLUDING one already containing a percent-escape — the case
+    /// that a double-decode (server decodes, then an NF's leftover local shim
+    /// decodes again) gets wrong.
+    #[test]
+    fn query_encode_decode_round_trips() {
+        for input in [
+            "",
+            "plain",
+            r#"[{"sst":1,"sd":"000001"}]"#,
+            "a=b&c",
+            "café",
+            "a+b",
+            "~-._",
+            "100%",
+            // Already-escaped text: encoding gives %2520, and ONE decode must
+            // return the literal %20 rather than a space.
+            "a%20b",
+            "2026-01-01T00:00:00+02:00",
+        ] {
+            assert_eq!(
+                decode_query_value(&encode_query_value(input)),
+                input,
+                "round trip must be the identity for {input:?}"
+            );
+        }
+        // The double-decode hazard, stated as an assertion: decoding twice does
+        // NOT give the input back once the value contained an escape.
+        let twice = decode_query_value(&decode_query_value(&encode_query_value("a%20b")));
+        assert_eq!(twice, "a b", "second decode corrupts an escaped value");
+    }
+
+    /// A conformant percent-encoded JSON array — the MBS `tmgi-list` shape the
+    /// issue names — decodes back to parseable JSON.
+    #[test]
+    fn an_encoded_json_array_decodes_to_parseable_json() {
+        let encoded = "%5B%7B%22sst%22%3A1%7D%5D";
+        let decoded = decode_query_value(encoded);
+        assert_eq!(decoded, r#"[{"sst":1}]"#);
+        let parsed: serde_json::Value = serde_json::from_str(&decoded).expect("valid JSON");
+        assert_eq!(parsed[0]["sst"], 1);
+    }
+
+    /// Malformed escapes pass through verbatim rather than failing the decode.
+    /// nrfd's local decoder behaved this way and its tests pinned it; the shared
+    /// decoder keeps the behaviour so removing that copy is not a change.
+    #[test]
+    fn malformed_escapes_pass_through() {
+        assert_eq!(decode_query_value("100%"), "100%");
+        assert_eq!(decode_query_value("%zz"), "%zz");
+        assert_eq!(decode_query_value("%2"), "%2");
+        assert_eq!(decode_query_value("%"), "%");
+        assert_eq!(decode_query_value("a%2"), "a%2");
+        // A valid escape after a malformed one still decodes.
+        assert_eq!(decode_query_value("%zz%20"), "%zz ");
+    }
+
+    /// Multi-byte UTF-8 is reassembled from its per-octet escapes.
+    #[test]
+    fn multibyte_utf8_decodes_from_per_octet_escapes() {
+        assert_eq!(decode_query_value("%C3%A9"), "é");
+        assert_eq!(decode_query_value("%E6%97%A5"), "日");
+        // Lowercase hex decodes too (RFC 3986 §2.1: producers SHOULD uppercase,
+        // recipients MUST accept both).
+        assert_eq!(decode_query_value("%c3%a9"), "é");
     }
 }


### PR DESCRIPTION
Closes #65. Spec: `specs/fix-sbi-wire-correctness-query-overload-goaway-headers.md`.

All eight acceptance criteria, one PR. Verified against `main` @ `60eecd6`; the issue's cites are from `76ea248`, so every line number drifted and **one whole claim is stale**.

## The issue's first claim no longer holds

> `send_once` builds the query by mapping params through `format!` … there is no percent-encoding

**Already fixed by #101.** `client.rs:799-824` routes both key and value through `uri_encode::encode_query_value`. So there was nothing to add on the emit side; criterion 1 is covered by a new test asserting the encoded form **on the wire** (`the_emitted_query_is_percent_encoded_on_the_wire`), which is what §5.2.10.2 actually constrains.

Every other cite still held. Two things the issue did not name:

- **nrfd's decoder was wrong for one of its two surfaces.** `nrfd/main.rs:379` mapped `+` to a space — the `application/x-www-form-urlencoded` rule — and was applied to *query* values as well as to the token form body. In a query component `+` is a literal plus, so a base64 value or an RFC 3339 offset (`+02:00`) was silently corrupted. This is exactly the hazard `uri_encode`'s module docs predicted for the encode direction, in the decode direction.
- **Removing the per-NF shims is required, not tidying.** Once the server decodes, a leftover local `percent_decode(params.get(k))` decodes **twice**, and a value whose plaintext contains `%20` (sent as `%2520`) becomes a space nobody sent.

## Criteria

| # | criterion | where |
|---|---|---|
| 1 | `send_once` percent-encodes; reserved chars round-trip in the emitted URI | `the_emitted_query_is_percent_encoded_on_the_wire` (raw hyper peer reads the query verbatim) |
| 2 | server percent-decodes; `=`-less flags preserved | `server_percent_decodes_query_parameters`, `server_preserves_valueless_query_flags` |
| 3 | nssfd + nrfd workarounds removed; mbsmfd parses an encoded `tmgi-list` (2xx not 400) | both decoders deleted; `percent_encoded_tmgi_list_deallocates_and_does_not_400` |
| 4 | on a 503 with OCI, abatement + reselection where an alternate exists | `a_503_with_oci_reroutes_the_next_request_to_an_alternate`, `shedding_stops_the_next_request_from_being_sent_at_all`, `an_oci_on_a_success_response_is_recorded_and_acted_on`, `a_learned_binding_is_echoed_on_the_next_request` |
| 5 | `stop()` sends GOAWAY and drains in-flight streams | `stop_drains_an_in_flight_request`, `stop_refuses_new_connections` |
| 6 | repeated `3gpp-Sbi-Oci` individually retrievable | `server_keeps_every_repeated_oci_occurrence` (+3 unit tests) |
| 7 | `CommonData` serialises per TS 29.571 | `snssai_serialises_sd_as_six_hex_characters`, `plmn_id_serialises_as_digit_strings_and_preserves_mnc_width`, `tai_and_guami_serialise_per_ts_29_571` |
| 8 | workspace lint + full suite pass | `6052 passed / 0 failed` (main: `6024`), clippy 0 errors, fmt clean |

## Decisions worth a reviewer's attention

**Reselection defaults ON, shedding defaults OFF.** §6.4.2.2 mandates abatement, and this repo's convention is default-ON *except where the behaviour drops traffic* — overload reaction contains both kinds. Recording and rerouting cannot lose a request (and with no alternate configured the decision degrades to "send", i.e. byte-identical to before). Local shedding can, so it is opt-in: a `metric: 100` with no `Period-of-Validity`, sent in error, would otherwise stop this consumer talking to a healthy producer indefinitely. `the_default_client_records_oci_but_does_not_shed` guards that default. **Whether shedding should become the default is a maintainer posture call — filed as a separate `decision` issue rather than decided here.**

**An absent `Period-of-Validity` gets a 30s local ceiling.** §6.4.3.3 taken literally means "until superseded" = forever. A still-overloaded producer restates the OCI on its next response; a declared validity is honoured as sent, however long.

**Only the unscoped OCI decides.** Matching a per-S-NSSAI/per-DNN scope needs the request body, which the transport layer does not have. Scoped occurrences are recorded and countable but do not gate requests — applying a per-DNN metric to every request would shed traffic for a reason the producer never gave.

**Header multiplicity by RFC 9110 §5.3 combining, not a type change.** `headers` is a `pub` field with **88 direct readers**; a second multi-valued map beside it would be two sources of truth that can disagree. Occurrences are joined with `, ` (the representation §5.3 sanctions) and split by `get_header_all`.

**The query is decoded into `params`, not re-attached to `header.uri`.** The suggested approach says to preserve the raw query; deliberately not done, because every daemon routes on `header.uri` by splitting on `/` and matching segments, so a query suffix lands inside the last segment. scpd copies `http.params` into the forwarded request and the client re-encodes, so decode-in/encode-out is correct across a proxy hop too.

## Three of my own guards proved nothing on the first attempt

Found by revert-verifying each one (undo the fix, watch the *named* test fail, restore):

1. `server_keeps_every_repeated_oci_occurrence` **passed with the fix reverted** — it drove `SbiClient`, which stores headers in a map and can only emit **one field line per name**, so the two occurrences were comma-joined before the wire and the test was really exercising `get_header_all`. Rewritten with a raw `hyper::client::conn::http2` client, where `Request::builder().header()` appends and two genuine field lines cross the wire.
2. A recovery test asserting a metric-0 OCI caused **no** reroute **passed with the entire reaction reverted** — an absence is satisfied by a code path that never arrives. Replaced with two positive tests, one where the alternate serving the request is the only way to pass, and one asserting *both* states of the transition.
3. `scoped_oci_is_recorded_but_only_the_unscoped_one_decides` **passed with the scope logic reverted** — it used a default registry, where every branch ends in `Send` because shedding is off, so the outcome was decided by the default posture rather than by scope. Rewritten against `with_shedding()`.

The full revert table (14 guards) is in the spec.

## Ceilings

- **GOAWAY is asserted by consequence, not by frame.** The tests prove the in-flight stream completes, that `stop()` *waited* for it, and that the listener closed. Reading the GOAWAY frame itself would need a raw h2 client this crate does not otherwise use.
- **The drain is bounded at 5s**, then abandons stragglers with a warn line. Unbounded waiting would hang `stop()`, which runs in test teardown and on the SIGTERM path.
- **`OverloadReporter` measures nothing** — it carries a metric the NF sets, and no NF sets one yet. A generic HTTP layer has no basis for deciding an AMF is overloaded; inventing one from request latency would report overload the NF does not believe in.
- **Alternate targets are empty by default**, so reselection is live but inert until a daemon passes the producers it discovered (per-NF NRF plumbing, not in this change).
- **`3gpp-Sbi-Callback` / `3gpp-Sbi-Message-Priority` emission is NOT included** — it is in the issue's suggested approach but in *none* of its acceptance criteria, and is already scoped in the backlog as cross-NF work needing a per-NF survey.
- **Binding reselection is the §6.12.2 echo, not NF-set resolution** (that needs NRF discovery).
- **No wire interop anywhere** — verified against this tree's own client and server.
- GitNexus impact analysis unrunnable (no MCP server connected — 47th consecutive PR); blast radius established by grep and enumerated in the spec.