### PR TITLE
fix(eesd): route the five unrouted capability APIs, serve ACT status subscriptions, emit ACInfoNotification (#106)

### DIFF
--- a/specs/fix-eesd-capability-exposure-and-notifications.md
+++ b/specs/fix-eesd-capability-exposure-and-notifications.md
@@ -1,0 +1,201 @@
+# nextgcore #106 (eesd): five unrouted service APIs, ACT status subscriptions, and the dead ACInfoNotification
+
+Verified against `main` @ `143406a` (after #65/#272). The issue's cites are from `76ea248`; #105 has
+since rewritten large parts of eesd, so every line number drifted.
+
+## Verified against current main
+
+| claim in the issue | check on `143406a` | still true? |
+|---|---|---|
+| no dispatch arm for `eees-easinfoprov`, `eees-session-with-qos`, `eees-tie`, `eees-ueidentifier`, `eees-uelocation` | `grep -n '\["eees' main.rs` → 21 arms, none of those five | yes |
+| only `request-eelacr` is served on the EEL-managed ACR API | `main.rs:482`; no `/subscriptions` arm; no `ACTStatusSubsc` type anywhere | yes |
+| `handle_acinfo_create` stores and answers 201 with no callback arranged | `main.rs:1774` (cite drifted ~240 lines) | yes |
+| `ACInfoNotification` is constructed only in tests | `grep -rn 'ACInfoNotification' src/` → the struct, its doc, and `services.rs` tests. **No production constructor** | yes |
+| `services.rs` module docs mark SessionWithQoS and TIE as DEFERRED | `services.rs:24-28` | yes |
+| production `notifier::enqueue` emit sites are `EasDiscoveryNotification`, `AcrMgntEventsNotification`, `ACRInfoNotification` | unchanged; `ACInfoNotification` absent from all of them | yes |
+
+The five API roots in the issue match the vendored YAMLs exactly
+(`servers: - url: '{apiRoot}/eees-easinfoprov/v1'` etc.), so the paths were taken from the YAMLs
+rather than from the issue text.
+
+## The operation surface, taken from the YAMLs
+
+| yaml | paths | operations |
+|---|---|---|
+| `TS24558_Eees_EASInformationProvisioning` | `/declare` | `declare` |
+| `TS29558_Eees_UEIdentifier` | `/fetch`, `/get` | `FetchUEId`, `GetUEId` |
+| `TS29558_Eees_UELocation` | `/fetch`, `/subscriptions`, `/subscriptions/{id}` | fetch + subscription CRUD |
+| `TS29558_Eees_SessionWithQoS` | `/sessions`, `/sessions/{id}` | create/list + read/update/modify/delete |
+| `TS29558_Eees_TrafficInfluenceEAS` | `/instances`, `/instances/{id}` | create + read/update/modify/delete |
+| `TS29558_Eees_EELManagedACR` | `/subscriptions`, `/subscriptions/{id}` | `GetACTStatusSubscriptions`, `CreateACTStatusSubsc`, `GetACTStatusSubscription` |
+
+Note the individual ACT status subscription resource defines **only GET** — no PUT, PATCH or DELETE.
+The handler answers 405 with an `Allow` header for the others rather than inventing them.
+
+## Decision 1: three APIs answer 501, and that is the deliverable for them
+
+`eees-uelocation`, `eees-session-with-qos` and `eees-tie` all need a 5GC exposure leg that does not
+exist in this tree. nefd (after #111) serves `3gpp-monitoring-event`, `3gpp-device-triggering` and
+`nnef-eventexposure` — there is no `AsSessionWithQoS`, no UE-ID service and no traffic-influence
+service to call. So:
+
+* **Not 404.** A 404 says the resource does not exist, which is false — it is part of the API this
+  EES claims to serve, and a conformant consumer cannot tell a missing route from a typo.
+* **Not a 2xx.** Answering `201` to `CreateIndSessionWithQoS` while actuating no QoS anywhere is
+  fabricated success: the caller would believe a QoS flow exists. The same argument rules out
+  accepting `eees-uelocation` subscriptions — a subscription that can never fire is worse than a
+  refusal, because the failure is silent. That is exactly the defect #106 reports for
+  AppClientInformation, which this change fixes.
+* **501, not 503.** 503 invites a retry that can never succeed. TS 29.500 §5.2.7.2 gives
+  `NOT_IMPLEMENTED` for a capability the deployment does not have. Each 501 carries a
+  ProblemDetails naming the missing leg, so an operator reading a log does not have to guess.
+
+If a NEF leg lands later, the honest answer changes to a 2xx and these tests are what must be
+inverted — stated here so the 501s are not mistaken for permanent design.
+
+## Decision 2: `eees-easinfoprov` and `eees-ueidentifier` are served for real
+
+Both can be answered from this EES's own state, so neither gets a 501 dodge.
+
+**`easinfoprov /declare`** switches on `reqType`:
+
+* `ACR_SCENARIO_SELECTION_ANNOUNCEMENT` → 204 (the yaml lists 204 alongside 200).
+* `ACR_SCENARIO_SELECTION_REQUEST` → 200 with `selAcrScenarioList`, the intersection of what the EEC
+  asked for with `EES_SUPPORTED_ACR_SCENARIOS`, **in the EEC's order** so its preference is honoured.
+  An empty intersection is `404`, not a 200 with an empty list — an empty selection dressed as
+  success is the same lie as a fabricated 201.
+* `EAS_SELECTION` → 200 with `instEasInfo` for the first `selEasIds` entry actually registered here;
+  `404` for an EAS that never registered.
+* absent or unknown `reqType` → 204, because the enumeration is open (`anyOf` with a
+  forward-compatibility string) and refusing a future value would break it.
+
+`EES_SUPPORTED_ACR_SCENARIOS` is derived from **implemented code**, not copied from the enumeration:
+`EEC_INITIATED` (appctxtreloc), `EEC_EXECUTED_VIA_TARGET_EES` (the §5.10 context *pull* landed in
+#105), `SOURCE_EAS_DECIDED` (acr-param + acrstatus-update) and `EEL_MANAGED_ACR` (request-eelacr).
+`EEC_EXECUTED_VIA_SOURCE_EES` and `SOURCE_EES_EXECUTED` are deliberately **absent**: both need this
+EES to act as *source* and push an EEC context, and only the pull half exists (the push counterpart
+is a known open gap). Advertising a scenario we would then fail to execute is worse than advertising
+fewer, and `unsupported_acr_scenarios_are_not_advertised` pins that.
+
+**`ueidentifier /fetch` and `/get`** return an `edgeUeId` — an *edge-enabler-layer* identifier the EES
+is entitled to assign, unlike `afSpecUeId`, which is a GPSI that would have to come from the CN.
+`edge_ue_id()` is SHA-256 over a domain-separated, length-prefixed `(gpsi, easId)`, truncated to 128
+bits, which makes it stable (usable as a key), per-EAS (two EASes cannot correlate a user by
+comparing identifiers) and opaque (the GPSI is not recoverable). Two refusals, deliberately distinct:
+an IP-only request is `501` (mapping an IP to a subscriber needs the CN), and a GPSI no EEC has
+registered is `404` — minting an identifier for any input would make the API an oracle that tells the
+caller nothing.
+
+`afSpecUeId` is never populated. Echoing back the GPSI the requestor supplied would dress a value it
+already had as a CN resolution that never happened.
+
+## Decision 3: `ACInfoNotification` filter semantics, and what is not evaluated
+
+The schema states `ACFilters` only as a list of optional members, so the semantics are a choice:
+
+* **no filters** (absent or empty) matches everything — otherwise an unfiltered subscription would be
+  the one shape that never fires;
+* **across entries: OR** — a list of filters is a set of alternatives;
+* **within one entry: AND** over the present members, each an OR over its own list.
+
+Only `acIdsList` and `acTypesList` are evaluated. `svcArea`, `maxAcKpi`, `minAcKpi` and the schedule
+members are passthrough `serde_json::Value`s with no comparable counterpart on `AcProfile`, and an
+unparsed blob cannot be compared without inventing a comparison. A present-but-unevaluated member is
+treated as **not constraining** rather than as a non-match: over-notifying a subscriber who asked for
+a narrower set is recoverable at the consumer, whereas never notifying is the exact defect being
+fixed. Stated in the function docs and here so it is not mistaken for a complete filter.
+
+Only the **matching** profiles are reported, not the whole registration — asserted, because reporting
+everything would also satisfy a naive "a notification arrived" test.
+
+## Decision 4: the ACT status notification goes to `{notificationUri}/act-status`
+
+The yaml's callback is `'{$request.body#/notificationUri}/act-status'`, not the bare URI. Getting
+this wrong is invisible in-process: a POST to the bare URI would be accepted by this tree's own test
+consumers and rejected by a conformant one. Trailing slashes are trimmed so `http://eas/cb/` does not
+produce `//act-status`.
+
+Notifications fire only on a **terminal** ACT outcome (`SUCCESSFUL`/`FAILED`), because
+`ACTStatusNotif.actStatus` is an `ACTResult` and an in-progress ACR has nothing to report. Selection
+is by `easId`, the only selector the schema offers.
+
+## What was added / changed
+
+| area | change |
+|---|---|
+| `capabilities.rs` (new, 470 lines) | `EasInfoProvReq`/`EasInfoProvResp`/`InstantiatedEasInfo`, `UserInfo`/`UeId`/`UeIdInfo`, `edge_ue_id`, `is_known_ue`, `resolve_ue_ids`, `UeIdError`, `select_acr_scenarios`, `instantiated_eas`, `EES_SUPPORTED_ACR_SCENARIOS` |
+| `acr.rs` | `ACTStatusSubsc`, `ACTStatusNotif`, `ACT_STATUS_CALLBACK_SUFFIX`, `ACT_RESULT_SUCCESSFUL`/`_FAILED` |
+| `context.rs` | `act_status_subscriptions` store + create/find/list/count; `notify_act_status_subscribers`; `notify_acinfo_subscribers`; `ac_profile_matches_filters` |
+| `main.rs` | 11 new dispatch arms; `handle_eas_info_prov`, `handle_ue_identifier`, `handle_act_status_sub_{create,list,read}`, `not_implemented`; the `ACInfoNotification` hook in `handle_eec_register`; the ACT-status hook in `handle_acr_status_update`; `EEL_ACR_SUBSCRIPTIONS_PATH` |
+| `auth.rs` | five new OAuth2 scopes |
+| `types.rs` | `cause::NOT_IMPLEMENTED` |
+| `services.rs` | `Default` on `ACInfoSubscription`; module docs corrected |
+| `Cargo.toml` | `sha2` (for `edge_ue_id`) |
+
+## Verification
+
+Every guard revert-verified: undo the change, watch the **named** test fail, restore.
+
+| guard | revert applied | result |
+|---|---|---|
+| `test_acinfo_notification_fires_through_the_router` | the `notify_acinfo_subscribers` call removed from `handle_eec_register` | FAILED ✓ |
+| `test_capability_apis_are_routed_and_never_404`, `test_eas_info_prov_*` | the `eees-easinfoprov` arm removed | FAILED ✓ |
+| `test_acinfo_notify_fires_once_on_a_matching_registration` | report every profile instead of only the matching ones | FAILED ✓ |
+| `test_act_status_subscription_and_notify` | the `easId` selector dropped (notify every subscriber) | FAILED ✓ |
+| `test_act_status_subscription_and_notify` | POST to the bare `notificationUri` instead of `{uri}/act-status` | FAILED ✓ |
+| `test_act_status_notification_fires_from_a_status_update` | the terminal-state gate replaced by `None` | FAILED ✓ (see below) |
+
+### The revert that found a hole in my own coverage
+
+Replacing the ACT terminal-state gate in `handle_acr_status_update` with `None` — i.e. never
+notifying — **compiled and the whole suite still passed**. The context test covers
+`notify_act_status_subscribers` directly and says nothing about whether any handler calls it: "the
+helper is tested and the wiring is not", for the third time in this repo's history.
+`test_act_status_notification_fires_from_a_status_update` was added to close it, and the revert then
+failed.
+
+### And a flake I caused, twice
+
+The new router test failed on its first run with `left: 2, right: 1`: `test_act_status_subscription_lifecycle`
+leaves a subscription for the same `easId` in the **process-global** EES context, so both were
+notified. `GLOBAL_STATE_TEST_LOCK` serialises these tests but does not isolate them. Fixed by giving
+the test an `easId` and callback URI unique to it and filtering the drained queue by that URI — data
+isolation rather than a lock. The same shape bit the lifecycle test's `list.len() == 1`, which is a
+property of the harness and not of the API; it now asserts the created resource is *present* in the
+collection. 5 consecutive full-suite runs green.
+
+## Workspace state
+
+`6071 passed / 0 failed` (main: `6052`), `cargo clippy --workspace --all-targets` 0 errors,
+`cargo fmt --all --check` clean.
+
+## Ceilings
+
+* **The three 501s are the answer, not an implementation.** `eees-uelocation`,
+  `eees-session-with-qos` and `eees-tie` do nothing but refuse honestly. Anyone reading "five APIs
+  routed" as "five APIs working" would be wrong: two are served for real, three are conformant
+  refusals.
+* **`edgeUeId` is not a CN-resolved identity.** It is an edge-layer identifier this EES assigns. An
+  EAS that needs the subscriber's GPSI still cannot get one from this EES, and `afSpecUeId` is never
+  populated.
+* **No IP→UE binding.** `eees-ueidentifier` cannot answer an IP-only request at all; that needs
+  Nnef_UEId.
+* **ACT status subscriptions are in-memory and lost on restart**, like every other subscription
+  family in this context, and there is no DELETE — the yaml defines none, so a subscription lives
+  until the process ends.
+* **AC-information filters are partially evaluated** (`acIdsList`, `acTypesList` only), erring toward
+  over-notification. A subscriber filtering on service area or KPI receives more than it asked for.
+* **`ACInfoNotification` fires only on EEC *registration*.** An EEC update (PUT/PATCH) that adds an
+  AC profile does not notify. §5.5 arguably wants it; the registration path is where #106 named the
+  gap, and extending it to updates would need its own decision about de-duplicating repeat
+  notifications for an unchanged profile.
+* **No wire interop.** Verified in-process against this tree's own router and notifier queue. No EAS
+  or EEC peer exists in this stack, and the docker E2E is `workflow_dispatch`-only.
+* **`easinfoprov` stores nothing.** The announcement is accepted and logged; the selected scenarios
+  are not persisted against the EEC. Nothing in the issue asked for that, and the response is a pure
+  function of the request plus the EAS registry.
+* GitNexus impact analysis unrunnable (no MCP server connected — 48th consecutive PR). Blast radius
+  by grep: `notify_acinfo_subscribers` and `notify_act_status_subscribers` are new with one caller
+  each; `ACInfoSubscription` gained a derive (additive); the 11 new dispatch arms sit before the
+  fallthrough and match paths no existing arm claims (`grep '\["eees'` enumerated all 21 pre-existing
+  arms); no crate outside `nextgcore-eesd` names any type touched here.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2565,6 +2565,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "uuid",
 ]

--- a/src/bins/nextgcore-eesd/Cargo.toml
+++ b/src/bins/nextgcore-eesd/Cargo.toml
@@ -24,6 +24,9 @@ serde_json.workspace = true
 uuid.workspace = true
 clap.workspace = true
 ctrlc.workspace = true
+# #106: SHA-256 for the EDGE UE identifier (eees-ueidentifier). Needed so the
+# identifier is stable, per-EAS and opaque; a UUID would satisfy none of those.
+sha2.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/src/bins/nextgcore-eesd/src/acr.rs
+++ b/src/bins/nextgcore-eesd/src/acr.rs
@@ -261,6 +261,59 @@ pub struct EELACRResp {
     pub supp_feat: Option<String>,
 }
 
+/// `ACTStatusSubsc` (`TS29558_Eees_EELManagedACR.yaml`, `ACTStatusSubsc`) — a
+/// subscription to ACT status reporting (#106, TS 29.558 §5.11).
+///
+/// The EEL-managed ACR API served only `request-eelacr`; its subscription
+/// resource did not exist and this type had no counterpart in the tree, so
+/// `/subscriptions` and `/subscriptions/{subscriptionId}` fell through to 404.
+///
+/// Required: `easId`, `notificationUri`. The server-minted `subscriptionId` is
+/// **not** a member of the schema — it is the store key, conveyed in the
+/// `Location` header, exactly as `ACInfoSubscription` does.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ACTStatusSubsc {
+    /// Identifier of the service consumer (REQUIRED).
+    pub eas_id: String,
+    /// Callback root for ACT status notifications (REQUIRED). The notification
+    /// is POSTed to `{notificationUri}/act-status` — the callback path the yaml
+    /// declares, not the bare URI.
+    pub notification_uri: String,
+    /// Supported features.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supp_feat: Option<String>,
+}
+
+/// The callback sub-path the yaml appends to `notificationUri` for an ACT status
+/// notification (`'{$request.body#/notificationUri}/act-status'`).
+///
+/// Spelled here as a constant because getting it wrong is invisible in-process:
+/// a notification POSTed to the bare `notificationUri` would be accepted by this
+/// tree's own test consumers and rejected by a conformant one.
+pub const ACT_STATUS_CALLBACK_SUFFIX: &str = "/act-status";
+
+/// `ACTStatusNotif` (`TS29558_Eees_EELManagedACR.yaml`) — the ACT status
+/// notification body. Required: `subscriptionId`, `actStatus`.
+///
+/// `actStatus` is an `ACTResult` (`TS29558_Eees_ACRStatusUpdate.yaml`), an
+/// open enumeration of `SUCCESSFUL` / `FAILED` — carried as a `String` so a
+/// forward-compatible value from a future release round-trips rather than
+/// failing the parse.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ACTStatusNotif {
+    /// Subscription identifier (REQUIRED).
+    pub subscription_id: String,
+    /// Result of the ACT (REQUIRED): `SUCCESSFUL` or `FAILED`.
+    pub act_status: String,
+}
+
+/// `ACTResult` value for a successful ACT.
+pub const ACT_RESULT_SUCCESSFUL: &str = "SUCCESSFUL";
+/// `ACTResult` value for a failed ACT.
+pub const ACT_RESULT_FAILED: &str = "FAILED";
+
 // ---------------------------------------------------------------------------
 // eees-acrstatus-update: ACR status update (TS 29.558 §8.9)
 // ---------------------------------------------------------------------------

--- a/src/bins/nextgcore-eesd/src/auth.rs
+++ b/src/bins/nextgcore-eesd/src/auth.rs
@@ -46,6 +46,16 @@ pub const SCOPE_EECCONTEXTRELOC: &str = "eees-eeccontextreloc";
 pub const SCOPE_ACR_PARAM: &str = "eees-acr-param";
 /// OAuth2 scope required for the `eees-acrevents` service operations (D5).
 pub const SCOPE_ACREVENTS: &str = "eees-acrevents";
+/// OAuth2 scope required for the `eees-easinfoprov` service operations (#106).
+pub const SCOPE_EASINFOPROV: &str = "eees-easinfoprov";
+/// OAuth2 scope required for the `eees-ueidentifier` service operations (#106).
+pub const SCOPE_UEIDENTIFIER: &str = "eees-ueidentifier";
+/// OAuth2 scope required for the `eees-uelocation` service operations (#106).
+pub const SCOPE_UELOCATION: &str = "eees-uelocation";
+/// OAuth2 scope required for the `eees-session-with-qos` service operations (#106).
+pub const SCOPE_SESSION_WITH_QOS: &str = "eees-session-with-qos";
+/// OAuth2 scope required for the `eees-tie` service operations (#106).
+pub const SCOPE_TIE: &str = "eees-tie";
 
 /// Process-wide JWKS used to verify access tokens. `None` ⇒ unconfigured
 /// (fail-closed). Seeded from `--oauth2-jwks-file` or by tests.

--- a/src/bins/nextgcore-eesd/src/capabilities.rs
+++ b/src/bins/nextgcore-eesd/src/capabilities.rs
@@ -1,0 +1,522 @@
+//! EES capability-exposure service APIs (issue #106).
+//!
+//! Five service APIs defined by their TS 29.558 / TS 24.558 YAMLs had **no
+//! dispatch arm at all**, so every request against them fell through to
+//! `send_not_found`:
+//!
+//! | API | root | this module |
+//! |---|---|---|
+//! | EAS Information Provisioning | `eees-easinfoprov/v1` | **served locally** |
+//! | UE Identifier | `eees-ueidentifier/v1` | served where the EES owns the answer, `501` where the CN is required |
+//! | UE Location | `eees-uelocation/v1` | `501` — no location source in this build |
+//! | Session with QoS | `eees-session-with-qos/v1` | `501` — no NEF `AsSessionWithQoS` leg |
+//! | Traffic Influence (EAS) | `eees-tie/v1` | `501` — no NEF/PCF-AF traffic-influence leg |
+//!
+//! # Why some of these answer 501 rather than a 2xx
+//!
+//! A 404 says "this resource does not exist", which is false: the resource is
+//! defined by the API this EES claims to serve, and a conformant EAS/EEC cannot
+//! tell a missing route from a mistyped one. A `501 NOT_IMPLEMENTED` with a
+//! ProblemDetails naming the missing dependency says the true thing.
+//!
+//! **501, not 503.** 503 invites a retry, and for these three a retry can never
+//! succeed: the capability is structurally absent from the build, not
+//! temporarily unavailable. TS 29.500 §5.2.7.2 gives `NOT_IMPLEMENTED` for
+//! exactly this. If a NEF leg is added later, the honest answer changes to a
+//! 2xx (or to 503 when a *configured* NEF is unreachable), and the tests here
+//! are what will need inverting.
+//!
+//! **Why not accept and store instead.** Answering 201 to
+//! `CreateIndSessionWithQoS` while actuating no QoS anywhere would be
+//! fabricated success — the caller would believe a QoS flow exists. The same
+//! argument rules out creating `eees-uelocation` subscriptions: a subscription
+//! that can never fire is worse than a refusal, because the failure is silent.
+//! That is the same trap #106 itself reports for AppClientInformation, whose
+//! notification is implemented in this change.
+
+use serde::{Deserialize, Serialize};
+
+use crate::context::ees_self;
+use crate::types::{EasProfile, EndPoint};
+
+/// ACR scenarios (`ACRScenario`, `TS29558_Eecs_EESRegistration.yaml`) that this
+/// EES can actually take part in — the basis for
+/// `ACR_SCENARIO_SELECTION_REQUEST`.
+///
+/// Derived from what is implemented, not from the enumeration:
+///
+/// * `EEC_INITIATED` — `eees-appctxtreloc` determine / initiate / declare.
+/// * `EEC_EXECUTED_VIA_TARGET_EES` — this EES can act as the **target** EES: the
+///   TS 29.558 §5.10 EEC-context pull landed in #105.
+/// * `SOURCE_EAS_DECIDED` — `eees-acr-param` and `eees-acrstatus-update` accept
+///   the S-EAS's decision and its outcome.
+/// * `EEL_MANAGED_ACR` — `eees-eel-acr/request-eelacr`.
+///
+/// Deliberately **absent**: `EEC_EXECUTED_VIA_SOURCE_EES` and
+/// `SOURCE_EES_EXECUTED`. Both require this EES to act as the *source* and push
+/// an EEC context to a target EES, and only the pull half exists — the push
+/// counterpart is a known open gap. Advertising them would make an EES claim a
+/// scenario it would then fail to execute, which is worse than advertising
+/// fewer.
+pub const EES_SUPPORTED_ACR_SCENARIOS: &[&str] = &[
+    "EEC_INITIATED",
+    "EEC_EXECUTED_VIA_TARGET_EES",
+    "SOURCE_EAS_DECIDED",
+    "EEL_MANAGED_ACR",
+];
+
+/// `EasInfoProvReqType` value: the EEC announces the ACR scenarios it selected.
+pub const REQ_TYPE_ACR_ANNOUNCEMENT: &str = "ACR_SCENARIO_SELECTION_ANNOUNCEMENT";
+/// `EasInfoProvReqType` value: the EEC asks the EES to select ACR scenarios.
+pub const REQ_TYPE_ACR_REQUEST: &str = "ACR_SCENARIO_SELECTION_REQUEST";
+/// `EasInfoProvReqType` value: the EEC asks the EES to select an EAS.
+pub const REQ_TYPE_EAS_SELECTION: &str = "EAS_SELECTION";
+
+/// `EASInfoProvReq` (`TS24558_Eees_EASInformationProvisioning.yaml`) — the
+/// request body of `POST {apiRoot}/eees-easinfoprov/v1/declare`.
+///
+/// Every member is optional in the schema, including `reqType`. Only the members
+/// this EES acts on are modelled; the rest of the (large) schema is not declared
+/// at all, because declaring a member nothing reads is the shape of defect this
+/// issue is about. Unknown members in an incoming body are ignored by serde, so
+/// a conformant sender is never rejected for sending more.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EasInfoProvReq {
+    /// Identifier of the EEC making the request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eec_id: Option<String>,
+    /// Identifier of the AC.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ac_id: Option<String>,
+    /// Identifier(s) of the selected EAS(s).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sel_eas_ids: Option<Vec<String>>,
+    /// Application group identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_grp_id: Option<String>,
+    /// Identifier of the EES.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ees_id: Option<String>,
+    /// Type of provisioning request (`EasInfoProvReqType`; open enumeration, so
+    /// carried as a `String` for forward compatibility).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub req_type: Option<String>,
+    /// ACR scenarios selected by the EEC.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sel_acr_scenarios: Option<Vec<String>>,
+    /// Supported features.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supp_feat: Option<String>,
+}
+
+/// `InstantiatedEASInfo` (`TS24558_Eees_EASInformationProvisioning.yaml`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct InstantiatedEasInfo {
+    /// The EAS profile of the instantiated EAS.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eas: Option<EasProfile>,
+    /// Lifetime of the instantiated EAS (`DurationSec`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub life_time: Option<u64>,
+}
+
+/// `EASInfoProvResp` (`TS24558_Eees_EASInformationProvisioning.yaml`) — the 200
+/// response body.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EasInfoProvResp {
+    /// ACR scenarios selected **by the EES**.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sel_acr_scenario_list: Option<Vec<String>>,
+    /// Instantiated EAS information.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inst_eas_info: Option<InstantiatedEasInfo>,
+    /// Endpoint of the common EAS.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub com_eas_endpoint: Option<EndPoint>,
+    /// Endpoint of the common EES.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub com_ees_endpoint: Option<EndPoint>,
+}
+
+/// `UserInfo` (`TS29558_Eees_UEIdentifier.yaml`) — the request body of both
+/// `POST .../eees-ueidentifier/v1/fetch` and `.../get`.
+///
+/// The schema's constraint is `anyOf: [required: [ueId], required: [ipAddr]]` —
+/// at least one of the two must identify the UE. That is enforced by
+/// [`Self::validate`] rather than by serde, which cannot express `anyOf`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UserInfo {
+    /// Identifier of the requestor (EAS/EEC).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requestor_id: Option<String>,
+    /// EAS identifiers the UE IDs are requested for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eas_ids: Option<Vec<String>>,
+    /// Identifier of the ASP providing the EAS.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eas_provider_id: Option<String>,
+    /// UE identifier as a GPSI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ue_id: Option<String>,
+    /// UE IP address (`IpAddr`; passthrough — only its presence is acted on).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_addr: Option<serde_json::Value>,
+    /// Application port identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_port_id: Option<u16>,
+    /// Port number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port_number: Option<u16>,
+    /// Supported features.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supp_feat: Option<String>,
+}
+
+impl UserInfo {
+    /// Enforce the schema's `anyOf`: at least one of `ueId` / `ipAddr`.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.ue_id.is_none() && self.ip_addr.is_none() {
+            return Err(
+                "At least one of ueId / ipAddr must be present (TS29558_Eees_UEIdentifier.yaml \
+                 UserInfo anyOf)"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
+/// `UeId` (`TS29558_Eees_UEIdentifier.yaml`). The schema is
+/// `oneOf: [required: [edgeUeId], required: [afSpecUeId]]` — **exactly one**.
+///
+/// This EES returns the `edgeUeId` form. `afSpecUeId` is a GPSI obtained from
+/// the core network; echoing back the GPSI the requestor supplied would dress a
+/// value it already had as a CN resolution it never performed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UeId {
+    /// EDGE UE identifier assigned by the edge enabler layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edge_ue_id: Option<String>,
+    /// AF-specific UE identifier (a GPSI from the CN).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub af_spec_ue_id: Option<String>,
+    /// The EAS this identifier is for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eas_id: Option<String>,
+}
+
+/// `UeIdInfo` (`TS29558_Eees_UEIdentifier.yaml`) — the 200 response body.
+/// Required: `ueIds` (minItems 1).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UeIdInfo {
+    /// One entry per requested EAS.
+    pub ue_ids: Vec<UeId>,
+    /// Supported features.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supp_feat: Option<String>,
+}
+
+/// Derive the EDGE UE identifier for `(gpsi, eas_id)`.
+///
+/// The EDGE UE ID is an edge-enabler-layer identifier, so the EES is entitled to
+/// assign it — unlike `afSpecUeId`, which would have to come from the CN.
+///
+/// Requirements this satisfies, and why each matters:
+///
+/// * **Stable** — a repeat request returns the same value, so an EAS can use it
+///   as a key. A random UUID per call would be useless for that.
+/// * **Per-EAS** — the same UE is a different `edgeUeId` to a different EAS, so
+///   two EASes cannot correlate their users by comparing identifiers.
+/// * **Opaque** — the GPSI is not recoverable from it by an EAS, which is the
+///   point of not just handing out the MSISDN.
+///
+/// SHA-256 over a domain-separated input, truncated to 32 hex characters.
+/// Truncation is fine here: this is an identifier, not a MAC — an attacker
+/// gains nothing from a collision they cannot steer, and 128 bits leaves no
+/// accidental ones.
+pub fn edge_ue_id(gpsi: &str, eas_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    // Domain separation, and a length-prefixed join so ("ab","c") and ("a","bc")
+    // cannot hash to the same value.
+    hasher.update(b"nextgcore/eesd/edge-ue-id/v1\x00");
+    hasher.update((gpsi.len() as u64).to_be_bytes());
+    hasher.update(gpsi.as_bytes());
+    hasher.update((eas_id.len() as u64).to_be_bytes());
+    hasher.update(eas_id.as_bytes());
+    let digest = hasher.finalize();
+    digest[..16].iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Is `gpsi` a UE this EES knows about, i.e. one an EEC has registered for?
+///
+/// The EES answers `eees-ueidentifier` only for UEs it serves. Minting an
+/// identifier for an arbitrary GPSI would turn the API into an oracle that
+/// answers for any input, telling the caller nothing about whether the UE exists.
+pub fn is_known_ue(gpsi: &str) -> bool {
+    ees_self()
+        .read()
+        .map(|c| {
+            c.eec_list()
+                .iter()
+                .any(|r| r.ue_id.as_deref() == Some(gpsi))
+        })
+        .unwrap_or(false)
+}
+
+/// Resolve the EDGE UE identifiers for a `UserInfo` request.
+///
+/// `Ok(UeIdInfo)` when the UE is identified by a GPSI this EES serves.
+/// `Err(reason)` names why it cannot be answered, which the handler turns into
+/// the right status: an unknown GPSI is a 404, an IP-only request is a 501.
+pub fn resolve_ue_ids(req: &UserInfo) -> Result<UeIdInfo, UeIdError> {
+    let Some(gpsi) = req.ue_id.as_deref() else {
+        // Only `ipAddr` was given. Mapping a UE IP address to a subscriber needs
+        // the core network (Nnef_UEId / the T8 UE-ID API): the EES has no
+        // IP-to-UE binding of its own, and guessing one would be an invention.
+        return Err(UeIdError::CoreNetworkRequired);
+    };
+    if !is_known_ue(gpsi) {
+        return Err(UeIdError::UnknownUe);
+    }
+    // One identifier per requested EAS; with none named, a single EAS-agnostic
+    // identifier keyed on the requestor.
+    let eas_ids: Vec<String> = match req.eas_ids.as_ref().filter(|v| !v.is_empty()) {
+        Some(ids) => ids.clone(),
+        None => vec![req.requestor_id.clone().unwrap_or_default()],
+    };
+    Ok(UeIdInfo {
+        ue_ids: eas_ids
+            .into_iter()
+            .map(|eas_id| UeId {
+                edge_ue_id: Some(edge_ue_id(gpsi, &eas_id)),
+                af_spec_ue_id: None,
+                eas_id: (!eas_id.is_empty()).then_some(eas_id),
+            })
+            .collect(),
+        supp_feat: None,
+    })
+}
+
+/// Why `eees-ueidentifier` could not be answered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UeIdError {
+    /// The request identified the UE only by IP address, which needs the CN.
+    CoreNetworkRequired,
+    /// The GPSI is not a UE this EES serves.
+    UnknownUe,
+}
+
+/// Select the ACR scenarios this EES will use, given what the EEC asked for.
+///
+/// The intersection, in the **EEC's** order so its preference is honoured. An
+/// EEC that named nothing gets this EES's full supported set, since the request
+/// type asks the EES to choose.
+pub fn select_acr_scenarios(requested: Option<&[String]>) -> Vec<String> {
+    match requested.filter(|r| !r.is_empty()) {
+        Some(req) => req
+            .iter()
+            .filter(|s| EES_SUPPORTED_ACR_SCENARIOS.contains(&s.as_str()))
+            .cloned()
+            .collect(),
+        None => EES_SUPPORTED_ACR_SCENARIOS
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    }
+}
+
+/// Look up the EAS profiles for the `selEasIds` an EEC named, from this EES's
+/// own registrations. Unknown identifiers are simply absent from the result —
+/// the response reports what is instantiated, and an EAS that never registered
+/// is not.
+pub fn instantiated_eas(sel_eas_ids: Option<&[String]>) -> Option<InstantiatedEasInfo> {
+    let ids = sel_eas_ids?;
+    let ctx = ees_self();
+    let guard = ctx.read().ok()?;
+    let eas = ids
+        .iter()
+        .find_map(|id| guard.eas_discover(Some(id), None).into_iter().next())?;
+    Some(InstantiatedEasInfo {
+        eas: Some(eas),
+        life_time: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The EDGE UE ID is stable for the same pair, differs per EAS, and does not
+    /// leak the GPSI. Each property is asserted separately because they fail
+    /// independently: a random id breaks stability, a GPSI-only hash breaks
+    /// per-EAS separation, and a plain echo breaks opacity.
+    #[test]
+    fn edge_ue_id_is_stable_per_eas_and_opaque() {
+        let a = edge_ue_id("msisdn-491701234567", "eas1.example.com");
+        assert_eq!(
+            a,
+            edge_ue_id("msisdn-491701234567", "eas1.example.com"),
+            "the same (UE, EAS) pair must always give the same identifier"
+        );
+        assert_ne!(
+            a,
+            edge_ue_id("msisdn-491701234567", "eas2.example.com"),
+            "two EASes must not be able to correlate a UE by identifier"
+        );
+        assert_ne!(
+            a,
+            edge_ue_id("msisdn-491709999999", "eas1.example.com"),
+            "two UEs must not share an identifier at one EAS"
+        );
+        assert!(
+            !a.contains("491701234567"),
+            "the GPSI must not be recoverable from the identifier: {a}"
+        );
+        assert_eq!(a.len(), 32, "128 bits as hex");
+        // The length-prefixed hash input: these two must not collide.
+        assert_ne!(edge_ue_id("ab", "c"), edge_ue_id("a", "bc"));
+    }
+
+    /// `UserInfo` must carry at least one UE identifier (the schema's `anyOf`).
+    #[test]
+    fn user_info_requires_a_ue_identifier() {
+        assert!(UserInfo::default().validate().is_err());
+        assert!(UserInfo {
+            ue_id: Some("msisdn-1".into()),
+            ..Default::default()
+        }
+        .validate()
+        .is_ok());
+        assert!(UserInfo {
+            ip_addr: Some(serde_json::json!({"ipv4Addr": "10.0.0.1"})),
+            ..Default::default()
+        }
+        .validate()
+        .is_ok());
+    }
+
+    /// An IP-only request cannot be answered by the EES alone, and says so with
+    /// a distinct error rather than an empty success.
+    #[test]
+    fn an_ip_only_request_reports_that_the_core_network_is_required() {
+        let req = UserInfo {
+            ip_addr: Some(serde_json::json!({"ipv4Addr": "10.0.0.1"})),
+            ..Default::default()
+        };
+        assert_eq!(resolve_ue_ids(&req), Err(UeIdError::CoreNetworkRequired));
+    }
+
+    /// Scenario selection is the intersection, in the EEC's order, and never
+    /// advertises a scenario this EES cannot execute.
+    #[test]
+    fn acr_scenario_selection_is_the_intersection() {
+        // The EEC's order is preserved.
+        assert_eq!(
+            select_acr_scenarios(Some(&[
+                "EEL_MANAGED_ACR".to_string(),
+                "EEC_INITIATED".to_string()
+            ])),
+            vec!["EEL_MANAGED_ACR".to_string(), "EEC_INITIATED".to_string()]
+        );
+        // A scenario needing the source-side context push is dropped.
+        assert_eq!(
+            select_acr_scenarios(Some(&[
+                "SOURCE_EES_EXECUTED".to_string(),
+                "EEC_INITIATED".to_string()
+            ])),
+            vec!["EEC_INITIATED".to_string()]
+        );
+        // Nothing in common: an empty list, which the handler must not dress up
+        // as a selection.
+        assert!(select_acr_scenarios(Some(&["SOURCE_EES_EXECUTED".to_string()])).is_empty());
+        // Nothing asked for: the EES's full supported set.
+        assert_eq!(
+            select_acr_scenarios(None).len(),
+            EES_SUPPORTED_ACR_SCENARIOS.len()
+        );
+    }
+
+    /// The advertised set must not include a scenario whose execution path is
+    /// missing. Pinned as a test because the tempting "complete" list is the
+    /// whole enumeration.
+    #[test]
+    fn unsupported_acr_scenarios_are_not_advertised() {
+        for never in ["EEC_EXECUTED_VIA_SOURCE_EES", "SOURCE_EES_EXECUTED"] {
+            assert!(
+                !EES_SUPPORTED_ACR_SCENARIOS.contains(&never),
+                "{never} needs a source-side EEC-context push, which this EES does not have"
+            );
+        }
+        assert!(EES_SUPPORTED_ACR_SCENARIOS.contains(&"EEL_MANAGED_ACR"));
+    }
+
+    /// The request body parses from the spec spelling, including members this
+    /// EES does not model (which must be ignored, not rejected).
+    #[test]
+    fn eas_info_prov_req_parses_the_spec_spelling() {
+        let body = r#"{
+            "eecId": "eec-1",
+            "acId": "ac-1",
+            "selEasIds": ["eas1.example.com"],
+            "reqType": "ACR_SCENARIO_SELECTION_REQUEST",
+            "selAcrScenarios": ["EEC_INITIATED"],
+            "appGrpId": "grp-1",
+            "dnais": ["dnai-1"],
+            "svcArea": [{"geographicAreas": []}]
+        }"#;
+        let req: EasInfoProvReq = serde_json::from_str(body).expect("parses");
+        assert_eq!(req.eec_id.as_deref(), Some("eec-1"));
+        assert_eq!(req.req_type.as_deref(), Some(REQ_TYPE_ACR_REQUEST));
+        assert_eq!(
+            req.sel_acr_scenarios.as_deref(),
+            Some(&["EEC_INITIATED".to_string()][..])
+        );
+    }
+
+    /// The response serialises under the camelCase names the yaml uses. Asserted
+    /// on the TEXT: a round trip of our own struct passes even when every field
+    /// name is wrong.
+    #[test]
+    fn eas_info_prov_resp_uses_the_yaml_member_names() {
+        let resp = EasInfoProvResp {
+            sel_acr_scenario_list: Some(vec!["EEC_INITIATED".to_string()]),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&resp).expect("json");
+        assert!(
+            json.contains("\"selAcrScenarioList\""),
+            "expected the yaml spelling, got {json}"
+        );
+        // Absent members are omitted, not sent as null.
+        assert!(!json.contains("instEasInfo"), "got {json}");
+        assert!(!json.contains("null"), "got {json}");
+    }
+
+    /// `UeIdInfo` serialises `ueIds` / `edgeUeId` per the yaml, and omits the
+    /// `afSpecUeId` this EES does not resolve.
+    #[test]
+    fn ue_id_info_uses_the_yaml_member_names() {
+        let info = UeIdInfo {
+            ue_ids: vec![UeId {
+                edge_ue_id: Some("deadbeef".into()),
+                af_spec_ue_id: None,
+                eas_id: Some("eas1".into()),
+            }],
+            supp_feat: None,
+        };
+        let json = serde_json::to_string(&info).expect("json");
+        assert!(json.contains("\"ueIds\""), "got {json}");
+        assert!(json.contains("\"edgeUeId\""), "got {json}");
+        assert!(
+            !json.contains("afSpecUeId"),
+            "a GPSI this EES never resolved must not be echoed as one: {json}"
+        );
+    }
+}

--- a/src/bins/nextgcore-eesd/src/context.rs
+++ b/src/bins/nextgcore-eesd/src/context.rs
@@ -6,7 +6,8 @@
 //! the consumer `easId` separately for discovery.
 
 use crate::acr::{
-    acr_ue_key, AcrContextError, AcrDecReq, AcrDetermReq, AcrInitReq, AcrState, AcrStatus,
+    acr_ue_key, ACTStatusNotif, ACTStatusSubsc, AcrContextError, AcrDecReq, AcrDetermReq,
+    AcrInitReq, AcrState, AcrStatus, ACT_STATUS_CALLBACK_SUFFIX,
 };
 use crate::acrevents::{
     ACRCompleteEventInfo, ACREventsSubscription, ACRInfoNotification, TargetInfo,
@@ -16,9 +17,9 @@ use crate::eec::{
     unfulfill_reason, AcProfile, AcServiceKpis, EecRegistration, UnfulfilledAcProfile,
 };
 use crate::services::{
-    ACInfoSubscription, ACRParamsInfo, AcrMgntEventReport, AcrMgntEventsNotification,
-    AcrMgntEventsSubscription, CommonEASInfo, EECContext, ACINFO_PATCHABLE_FIELDS,
-    ACRMGNT_PATCHABLE_FIELDS,
+    ACInfoNotification, ACInfoSubscription, ACInformation, ACRParamsInfo, AcrMgntEventReport,
+    AcrMgntEventsNotification, AcrMgntEventsSubscription, CommonEASInfo, EECContext,
+    ACINFO_PATCHABLE_FIELDS, ACRMGNT_PATCHABLE_FIELDS,
 };
 use crate::types::{
     apply_merge_patch, is_expired, DiscoveredEas, EasDiscoveryFilter, EasDiscoveryNotification,
@@ -105,6 +106,58 @@ fn eas_suffices_kpis(eas: &EasProfile, required: Option<&AcServiceKpis>) -> bool
     true
 }
 
+/// Does an AC profile satisfy an AppClientInformation subscription's filters
+/// (TS 29.558 §5.5, `ACFilters`)? — #106.
+///
+/// Semantics, chosen deliberately because the schema states them only as a list
+/// of optional members:
+///
+/// * **No filters at all** (absent, or an empty list) matches everything. The
+///   member is optional, so a subscriber that named no filter asked for all AC
+///   information; refusing to notify them would make an unfiltered subscription
+///   the one shape that never fires.
+/// * **Across filter entries: OR.** `acFltrs` is a list, and a list of filters
+///   is a set of alternatives — a subscriber naming two AC types wants both.
+/// * **Within one entry: AND** over the members that are present, each member
+///   being an OR over its own list. An entry naming `acIdsList` *and*
+///   `acTypesList` is one narrower criterion, not two broader ones.
+///
+/// Only `acIdsList` and `acTypesList` are evaluated. `svcArea`, `maxAcKpi`,
+/// `minAcKpi` and the schedule members are passthrough `serde_json::Value`s in
+/// [`ACFilters`] with no comparable counterpart on [`AcProfile`], and an
+/// unparsed JSON blob cannot be compared without inventing a comparison. A
+/// present-but-unevaluated member is treated as **not constraining** rather than
+/// as a non-match: over-notifying a subscriber that asked for a narrower set is
+/// recoverable at the consumer, whereas silently never notifying is the defect
+/// this function exists to fix. The limit is stated in the module docs and in
+/// the spec so it is not mistaken for a full filter implementation.
+///
+/// [`ACFilters`]: crate::services::ACFilters
+fn ac_profile_matches_filters(
+    prof: &AcProfile,
+    filters: Option<&[crate::services::ACFilters]>,
+) -> bool {
+    let Some(filters) = filters.filter(|f| !f.is_empty()) else {
+        return true;
+    };
+    filters.iter().any(|f| {
+        let id_ok = match f.ac_ids_list.as_ref().filter(|l| !l.is_empty()) {
+            Some(ids) => ids.iter().any(|id| id == &prof.ac_id),
+            None => true,
+        };
+        let type_ok = match f.ac_types_list.as_ref().filter(|l| !l.is_empty()) {
+            // An AC profile with no acType cannot satisfy a type filter: the
+            // subscriber constrained on a value this profile does not state.
+            Some(types) => prof
+                .ac_type
+                .as_deref()
+                .is_some_and(|t| types.iter().any(|want| want == t)),
+            None => true,
+        };
+        id_ok && type_ok
+    })
+}
+
 /// Outcome of a merge-patch / replace update that can fail for several
 /// spec-distinct reasons mapped to different HTTP status codes by the handler.
 #[derive(Debug, PartialEq, Eq)]
@@ -151,6 +204,11 @@ pub struct EesContext {
     /// EEC contexts (`eees-eeccontextreloc`, TS 29.558 §8.7.2), keyed by the
     /// spec pull key `cntxId` (the `eec-cntx-id` query parameter).
     eec_contexts: RwLock<HashMap<String, EECContext>>,
+    /// ACT status subscriptions (`eees-eel-acr/v1/subscriptions`, TS 29.558
+    /// §5.11, #106), keyed by the server-minted `subscriptionId`. The spec
+    /// `ACTStatusSubsc` body carries no id member, so the key lives only here and
+    /// in the `Location` header.
+    act_status_subscriptions: RwLock<HashMap<String, ACTStatusSubsc>>,
     /// Maximum registrations (applied per resource family).
     max_eas: usize,
     /// Context initialized flag.
@@ -170,6 +228,7 @@ impl EesContext {
             acr_mgnt_subscriptions: RwLock::new(HashMap::new()),
             acrevents_subscriptions: RwLock::new(HashMap::new()),
             eec_contexts: RwLock::new(HashMap::new()),
+            act_status_subscriptions: RwLock::new(HashMap::new()),
             max_eas: 0,
             initialized: AtomicBool::new(false),
         }
@@ -217,6 +276,9 @@ impl EesContext {
         }
         if let Ok(mut ctxs) = self.eec_contexts.write() {
             ctxs.clear();
+        }
+        if let Ok(mut subs) = self.act_status_subscriptions.write() {
+            subs.clear();
         }
         self.initialized.store(false, Ordering::SeqCst);
         log::info!("EES context finalized");
@@ -1327,6 +1389,186 @@ impl EesContext {
     /// `(uri, body)` pairs are collected UNDER the read lock and enqueued only
     /// AFTER it is released — the documented NF-context AB-BA rule (the notifier
     /// must never be invoked while holding the `EesContext` lock).
+    // ---- eees-eel-acr — ACT status subscriptions (TS 29.558 §5.11, #106) ----
+
+    /// Store an `ACTStatusSubsc`; mints and returns the server `subscriptionId`.
+    ///
+    /// `None` on capacity exhaustion (the handler answers 507), matching every
+    /// other subscription family in this context.
+    pub fn act_status_sub_create(&self, sub: ACTStatusSubsc) -> Option<String> {
+        let mut subs = self.act_status_subscriptions.write().ok()?;
+        if subs.len() >= self.max_eas {
+            return None;
+        }
+        let id = Uuid::new_v4().to_string();
+        subs.insert(id.clone(), sub.clone());
+        log::info!(
+            "ACTStatusSubsc created: subscriptionId={id} easId={} notificationUri={}",
+            sub.eas_id,
+            sub.notification_uri
+        );
+        Some(id)
+    }
+
+    pub fn act_status_sub_find(&self, subscription_id: &str) -> Option<ACTStatusSubsc> {
+        self.act_status_subscriptions
+            .read()
+            .ok()?
+            .get(subscription_id)
+            .cloned()
+    }
+
+    /// All active ACT status subscriptions (`GetACTStatusSubscriptions` returns
+    /// the array directly, not a wrapper object).
+    pub fn act_status_sub_list(&self) -> Vec<ACTStatusSubsc> {
+        self.act_status_subscriptions
+            .read()
+            .map(|s| s.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn act_status_sub_count(&self) -> usize {
+        self.act_status_subscriptions
+            .read()
+            .map(|s| s.len())
+            .unwrap_or(0)
+    }
+
+    /// Emit `ACTStatusNotif` to the ACT status subscribers for `eas_id` (#106).
+    ///
+    /// Called when an ACR reaches a terminal ACT outcome, which is the only
+    /// moment the notification has content: `ACTStatusNotif.actStatus` is an
+    /// `ACTResult` of `SUCCESSFUL` or `FAILED`, so an in-progress ACR has nothing
+    /// to report.
+    ///
+    /// Only subscriptions whose `easId` matches are notified. `easId` is the sole
+    /// selector the schema offers — there is no per-UE or per-ACR filter — so a
+    /// consumer subscribing for one EAS does not receive another's ACT results.
+    ///
+    /// The notification is POSTed to `{notificationUri}/act-status`, the callback
+    /// path the yaml declares. Returns how many were enqueued.
+    pub fn notify_act_status_subscribers(&self, eas_id: &str, act_status: &str) -> usize {
+        let mut pending: Vec<(String, serde_json::Value)> = Vec::new();
+        {
+            let subs = match self.act_status_subscriptions.read() {
+                Ok(s) => s,
+                Err(_) => return 0,
+            };
+            for (id, sub) in subs.iter() {
+                if sub.eas_id != eas_id {
+                    continue;
+                }
+                let notif = ACTStatusNotif {
+                    subscription_id: id.clone(),
+                    act_status: act_status.to_string(),
+                };
+                if let Ok(body) = serde_json::to_value(&notif) {
+                    // Trailing slashes are trimmed so a consumer that registered
+                    // `http://eas/cb/` does not receive a POST to `//act-status`.
+                    let uri = format!(
+                        "{}{ACT_STATUS_CALLBACK_SUFFIX}",
+                        sub.notification_uri.trim_end_matches('/')
+                    );
+                    pending.push((uri, body));
+                }
+            }
+        }
+        let notified = pending.len();
+        for (uri, body) in pending {
+            crate::notifier::enqueue(uri, body, "ACTStatusNotif");
+        }
+        if notified > 0 {
+            log::info!(
+                "ACTStatusNotif({act_status}) enqueued to {notified} subscriber(s) for easId={eas_id}"
+            );
+        }
+        notified
+    }
+
+    /// Emit `ACInfoNotification` to every AppClientInformation subscriber whose
+    /// filters match the AC profiles of a just-registered EEC
+    /// (TS 29.558 §5.5.2.2, #106).
+    ///
+    /// # Why this exists
+    ///
+    /// `acinfo_create` stored a subscription and answered `201 + Location`, and
+    /// nothing ever produced the callback that gives the subscription its
+    /// purpose: `ACInfoNotification` was constructed only in tests. A consumer
+    /// that subscribed was therefore never told anything, with no error surface
+    /// to reveal it — the worst shape of interop failure, because it looks like
+    /// it worked.
+    ///
+    /// Returns how many subscribers were notified, which is what lets a test
+    /// assert *exactly one* emission rather than "at least something happened".
+    ///
+    /// Collect-then-enqueue, like [`notify_acrmgnt_subscribers`]: the
+    /// subscription lock is released before any `notifier::enqueue`, so a slow
+    /// or blocking notifier cannot hold the store shut against the SBI handlers.
+    ///
+    /// [`notify_acrmgnt_subscribers`]: Self::notify_acrmgnt_subscribers
+    pub fn notify_acinfo_subscribers(&self, reg: &crate::eec::EecRegistration) -> usize {
+        let Some(profs) = reg.ac_profs.as_ref().filter(|p| !p.is_empty()) else {
+            // No AC profiles: there is nothing an AC-information filter could
+            // match, so this is not a missed notification.
+            return 0;
+        };
+
+        let mut pending: Vec<(String, serde_json::Value)> = Vec::new();
+        {
+            let subs = match self.app_client_infos.read() {
+                Ok(s) => s,
+                Err(_) => return 0,
+            };
+            let now = crate::types::now_epoch();
+            for (id, sub) in subs.iter() {
+                // An expired subscription must not fire. The sweep is periodic,
+                // so an entry can still be present past its expTime. Uses the
+                // crate's own `is_expired` rather than a second time comparison,
+                // so "expired" means one thing across eesd.
+                if is_expired(sub.exp_time.as_deref(), now) {
+                    continue;
+                }
+                // `notificationDestination` is OPTIONAL in the schema, and a
+                // subscription without one has nowhere to be delivered. Skipped
+                // rather than treated as a match, so the returned count stays
+                // "notifications actually enqueued".
+                let Some(dest) = sub.notification_destination.as_deref() else {
+                    continue;
+                };
+                let matched: Vec<serde_json::Value> = profs
+                    .iter()
+                    .filter(|p| ac_profile_matches_filters(p, sub.ac_fltrs.as_deref()))
+                    .filter_map(|p| serde_json::to_value(p).ok())
+                    .collect();
+                if matched.is_empty() {
+                    continue;
+                }
+                let notif = ACInfoNotification {
+                    sub_id: id.clone(),
+                    ac_infs: vec![ACInformation {
+                        ac_profs: matched,
+                        ue_ids: reg.ue_id.clone().map(|u| vec![u]),
+                        ue_loc_infs: None,
+                    }],
+                };
+                if let Ok(body) = serde_json::to_value(&notif) {
+                    pending.push((dest.to_string(), body));
+                }
+            }
+        }
+        let notified = pending.len();
+        for (uri, body) in pending {
+            crate::notifier::enqueue(uri, body, "ACInfoNotification");
+        }
+        if notified > 0 {
+            log::info!(
+                "ACInfoNotification enqueued to {notified} subscriber(s) for eecId={}",
+                reg.eec_id
+            );
+        }
+        notified
+    }
+
     pub fn notify_acrmgnt_subscribers(&self, event: &str, app_grp_id: Option<&str>) -> usize {
         let mut pending: Vec<(String, serde_json::Value)> = Vec::new();
         {
@@ -1788,5 +2030,255 @@ mod tests {
         assert!(!ctx
             .eas_discover(Some("forever.example.com"), None)
             .is_empty());
+    }
+
+    // ─── #106: AppClientInformation and ACT status notifications ────────────
+
+    /// An `AcProfile` with the given id and optional type.
+    fn ac_prof(ac_id: &str, ac_type: Option<&str>) -> AcProfile {
+        AcProfile {
+            ac_id: ac_id.into(),
+            ac_type: ac_type.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    /// #106 acceptance: an AppClientInformation subscription whose filter matches
+    /// a subsequent EEC registration causes **exactly one** `ACInfoNotification`
+    /// to be enqueued via `notifier::enqueue`.
+    ///
+    /// This is the emit assertion the issue asks for: before this change
+    /// `ACInfoNotification` was constructed only in a test, and no production path
+    /// produced one — the subscription was accepted and then inert.
+    #[test]
+    fn test_acinfo_notify_fires_once_on_a_matching_registration() {
+        use crate::notifier::Notifier;
+        use crate::services::{ACFilters, ACInfoSubscription};
+
+        let _g = crate::auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let n = Arc::new(crate::notifier::QueueNotifier::default());
+        crate::notifier::set_notifier(n.clone());
+        let _ = n.drain();
+
+        let mut ctx = EesContext::new();
+        ctx.init(8);
+
+        // Subscriber wants AC "ac-1" only.
+        let sub_id = ctx
+            .acinfo_create(ACInfoSubscription {
+                eas_id: "eas1.example.com".into(),
+                notification_destination: Some("http://eas/ac-info".into()),
+                ac_fltrs: Some(vec![ACFilters {
+                    ac_ids_list: Some(vec!["ac-1".into()]),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            })
+            .expect("subscription created");
+
+        // A registration carrying that AC fires exactly one notification.
+        let mut reg = make_eec("eec-1");
+        reg.ac_profs = Some(vec![ac_prof("ac-1", Some("V2X")), ac_prof("ac-9", None)]);
+        assert_eq!(ctx.notify_acinfo_subscribers(&reg), 1);
+
+        let queued = n.drain();
+        assert_eq!(queued.len(), 1, "exactly one notification");
+        assert_eq!(queued[0].uri, "http://eas/ac-info");
+        assert_eq!(
+            queued[0].kind, "ACInfoNotification",
+            "the production emit must be tagged as an ACInfoNotification"
+        );
+        let notif: ACInfoNotification = serde_json::from_value(queued[0].body.clone()).unwrap();
+        assert_eq!(notif.sub_id, sub_id);
+        assert_eq!(notif.ac_infs.len(), 1);
+        // Only the MATCHING profile is reported -- not the whole registration.
+        assert_eq!(
+            notif.ac_infs[0].ac_profs.len(),
+            1,
+            "ac-9 does not match the filter and must not be reported"
+        );
+        assert_eq!(notif.ac_infs[0].ac_profs[0]["acId"], "ac-1");
+        assert_eq!(
+            notif.ac_infs[0].ue_ids.as_deref(),
+            Some(&["gpsi-1".to_string()][..]),
+            "the UE hosting the AC is reported"
+        );
+
+        // A registration with no matching AC fires nothing.
+        let mut other = make_eec("eec-2");
+        other.ac_profs = Some(vec![ac_prof("ac-9", None)]);
+        assert_eq!(ctx.notify_acinfo_subscribers(&other), 0);
+        assert!(n.drain().is_empty());
+
+        crate::notifier::set_notifier(Arc::new(crate::notifier::QueueNotifier::default()));
+    }
+
+    /// #106: the filter semantics, each asserted separately because they fail
+    /// independently.
+    #[test]
+    fn test_acinfo_filter_semantics() {
+        use crate::services::ACFilters;
+
+        // No filters at all: everything matches (an unfiltered subscription must
+        // not be the one shape that never fires).
+        assert!(ac_profile_matches_filters(&ac_prof("ac-1", None), None));
+        assert!(ac_profile_matches_filters(
+            &ac_prof("ac-1", None),
+            Some(&[])
+        ));
+
+        // Within one entry: AND. Both the id and the type must match.
+        let id_and_type = [ACFilters {
+            ac_ids_list: Some(vec!["ac-1".into()]),
+            ac_types_list: Some(vec!["V2X".into()]),
+            ..Default::default()
+        }];
+        assert!(ac_profile_matches_filters(
+            &ac_prof("ac-1", Some("V2X")),
+            Some(&id_and_type)
+        ));
+        assert!(
+            !ac_profile_matches_filters(&ac_prof("ac-1", Some("AR")), Some(&id_and_type)),
+            "the id matches but the type does not: one entry is a conjunction"
+        );
+        assert!(
+            !ac_profile_matches_filters(&ac_prof("ac-1", None), Some(&id_and_type)),
+            "a profile stating no acType cannot satisfy a type filter"
+        );
+
+        // Across entries: OR.
+        let either = [
+            ACFilters {
+                ac_ids_list: Some(vec!["ac-1".into()]),
+                ..Default::default()
+            },
+            ACFilters {
+                ac_ids_list: Some(vec!["ac-2".into()]),
+                ..Default::default()
+            },
+        ];
+        assert!(ac_profile_matches_filters(
+            &ac_prof("ac-2", None),
+            Some(&either)
+        ));
+        assert!(!ac_profile_matches_filters(
+            &ac_prof("ac-3", None),
+            Some(&either)
+        ));
+    }
+
+    /// #106: a subscription with no `notificationDestination`, or one already
+    /// past its `expTime`, must not produce a notification. Both are silent
+    /// no-delivery cases that a count-only assertion would miss.
+    #[test]
+    fn test_acinfo_notify_skips_undeliverable_and_expired() {
+        use crate::notifier::Notifier;
+        use crate::services::ACInfoSubscription;
+
+        let _g = crate::auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let n = Arc::new(crate::notifier::QueueNotifier::default());
+        crate::notifier::set_notifier(n.clone());
+        let _ = n.drain();
+
+        let mut ctx = EesContext::new();
+        ctx.init(8);
+        // No notificationDestination: nowhere to deliver.
+        ctx.acinfo_create(ACInfoSubscription {
+            eas_id: "eas1".into(),
+            notification_destination: None,
+            ..Default::default()
+        });
+        // Expired an hour ago.
+        ctx.acinfo_create(ACInfoSubscription {
+            eas_id: "eas2".into(),
+            notification_destination: Some("http://eas/late".into()),
+            exp_time: Some(crate::types::epoch_to_rfc3339(
+                crate::types::now_epoch() - 3600,
+            )),
+            ..Default::default()
+        });
+
+        let mut reg = make_eec("eec-1");
+        reg.ac_profs = Some(vec![ac_prof("ac-1", None)]);
+        assert_eq!(
+            ctx.notify_acinfo_subscribers(&reg),
+            0,
+            "neither subscription is deliverable"
+        );
+        assert!(n.drain().is_empty());
+
+        crate::notifier::set_notifier(Arc::new(crate::notifier::QueueNotifier::default()));
+    }
+
+    /// #106: ACT status subscriptions are per-`easId`, and the notification goes
+    /// to `{notificationUri}/act-status` — the callback path the yaml declares,
+    /// not the bare URI.
+    #[test]
+    fn test_act_status_subscription_and_notify() {
+        use crate::notifier::Notifier;
+
+        let _g = crate::auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let n = Arc::new(crate::notifier::QueueNotifier::default());
+        crate::notifier::set_notifier(n.clone());
+        let _ = n.drain();
+
+        let mut ctx = EesContext::new();
+        ctx.init(8);
+
+        let id = ctx
+            .act_status_sub_create(ACTStatusSubsc {
+                eas_id: "eas1.example.com".into(),
+                // Trailing slash on purpose: the join must not produce `//`.
+                notification_uri: "http://eas/cb/".into(),
+                supp_feat: None,
+            })
+            .expect("created");
+        // A second subscriber, for a DIFFERENT easId.
+        ctx.act_status_sub_create(ACTStatusSubsc {
+            eas_id: "other.example.com".into(),
+            notification_uri: "http://other/cb".into(),
+            supp_feat: None,
+        });
+        assert_eq!(ctx.act_status_sub_count(), 2);
+        assert_eq!(ctx.act_status_sub_list().len(), 2);
+        assert_eq!(
+            ctx.act_status_sub_find(&id).map(|s| s.eas_id),
+            Some("eas1.example.com".to_string())
+        );
+        assert!(ctx.act_status_sub_find("no-such-id").is_none());
+
+        // Only the matching easId is notified.
+        assert_eq!(
+            ctx.notify_act_status_subscribers(
+                "eas1.example.com",
+                crate::acr::ACT_RESULT_SUCCESSFUL
+            ),
+            1
+        );
+        let queued = n.drain();
+        assert_eq!(queued.len(), 1, "the other easId must not be notified");
+        assert_eq!(
+            queued[0].uri, "http://eas/cb/act-status",
+            "the yaml appends /act-status to notificationUri, with no doubled slash"
+        );
+        assert_eq!(queued[0].kind, "ACTStatusNotif");
+        let notif: ACTStatusNotif = serde_json::from_value(queued[0].body.clone()).unwrap();
+        assert_eq!(notif.subscription_id, id);
+        assert_eq!(notif.act_status, "SUCCESSFUL");
+
+        // An easId nobody subscribed for notifies nothing.
+        assert_eq!(
+            ctx.notify_act_status_subscribers("unknown.example.com", "FAILED"),
+            0
+        );
+        assert!(n.drain().is_empty());
+
+        crate::notifier::set_notifier(Arc::new(crate::notifier::QueueNotifier::default()));
     }
 }

--- a/src/bins/nextgcore-eesd/src/main.rs
+++ b/src/bins/nextgcore-eesd/src/main.rs
@@ -41,8 +41,26 @@
 //!   (`eees-appclientinformation`, TS 29.558 §5.5), ACRManagementEvent
 //!   (`eees-acrmgntevent`, TS 29.558 §5.8), EECContextRelocation
 //!   (`eees-eeccontextreloc`, TS 29.558 §5.10), ACRParameterInformation
-//!   (`eees-acr-param`, TS 29.558 §5.13). SessionWithQoS and TIE DEFERRED
-//!   (NEF/PCF-AF exposure path missing in this repo).
+//!   (`eees-acr-param`, TS 29.558 §5.13).
+//!
+//! Implemented (#106) — the capability-exposure surface (`capabilities.rs`).
+//! Five service APIs had NO dispatch arm at all and answered 404 for every
+//! request; all five are now routed:
+//! - `eees-easinfoprov` (TS 24.558 EAS Information Provisioning) — served
+//!   locally from this EES's own state: ACR-scenario announcement (204),
+//!   ACR-scenario selection (200, intersected with what this EES can actually
+//!   execute), and EAS selection (200 from the registered EAS profiles).
+//! - `eees-ueidentifier` (TS 29.558 §5.7) — `fetch`/`get` return an `edgeUeId`
+//!   for a UE this EES serves; an IP-only request is `501` (needs the CN UE-ID
+//!   leg) and an unknown GPSI is `404`.
+//! - `eees-uelocation`, `eees-session-with-qos`, `eees-tie` — `501
+//!   NOT_IMPLEMENTED` with a ProblemDetails naming the missing 5GC leg. 501 and
+//!   not 503, because a retry can never succeed; and refused rather than
+//!   accepted, because a stored session that actuates nothing, or a subscription
+//!   that can never notify, fails silently.
+//! Also #106: the `eees-eel-acr` ACT status subscription resource
+//! (`/subscriptions`, `/subscriptions/{subscriptionId}`) is served, and
+//! `ACTStatusNotif` is emitted when an ACR reaches a terminal ACT outcome.
 //!
 //! Implemented (Wave 6, D1+D2):
 //! - D1: `eees-appclientinformation` bodies are spec-exact
@@ -90,6 +108,7 @@ use std::time::Duration;
 mod acr;
 mod acrevents;
 mod auth;
+mod capabilities;
 mod context;
 mod ecs_registration;
 mod eec;
@@ -135,6 +154,10 @@ const ACRMGNTEVENT_SUBSCRIPTIONS_PATH: &str = "/eees-acrmgntevent/v1/subscriptio
 /// Resource path prefix for ACR events subscription resources
 /// (`eees-acrevents`, TS 24.558 §6.4, D5).
 const ACREVENTS_SUBSCRIPTIONS_PATH: &str = "/eees-acrevents/v1/subscriptions";
+
+/// Resource collection path for the `eees-eel-acr` ACT status subscriptions
+/// (#106); used to build the `Location` header of a created subscription.
+const EEL_ACR_SUBSCRIPTIONS_PATH: &str = "/eees-eel-acr/v1/subscriptions";
 
 /// NextGCore EES - Edge Enabler Server
 #[derive(Parser, Debug)]
@@ -488,6 +511,31 @@ async fn ees_sbi_request_handler(request: SbiRequest) -> SbiResponse {
                 _ => send_method_not_allowed(method, "request-eelacr"),
             }
         }
+        // #106: the EEL-managed ACR API's ACT status subscription resource
+        // (`TS29558_Eees_EELManagedACR.yaml` /subscriptions). Only
+        // `request-eelacr` was served, so these two paths were 404.
+        ["eees-eel-acr", "v1", "subscriptions"] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_EEL_ACR) {
+                return resp;
+            }
+            match method {
+                "POST" => handle_act_status_sub_create(&request).await,
+                "GET" => handle_act_status_sub_list().await,
+                _ => send_method_not_allowed(method, "subscriptions"),
+            }
+        }
+        ["eees-eel-acr", "v1", "subscriptions", subscription_id] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_EEL_ACR) {
+                return resp;
+            }
+            match method {
+                "GET" => handle_act_status_sub_read(subscription_id).await,
+                // The yaml defines only GET on the individual resource: no PUT,
+                // PATCH or DELETE. Answering 405 with an Allow header is the
+                // spec-correct refusal (TS 29.500 §5.2.7.2).
+                _ => send_method_not_allowed(method, "subscriptions/{subscriptionId}"),
+            }
+        }
         // eesd-07: eees-acrstatus-update (TS 29.558 §5.12) — ACR status notification.
         ["eees-acrstatus-update", "v1", "request-acrupdate"] => {
             if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_ACRSTATUS_UPDATE) {
@@ -617,6 +665,114 @@ async fn ees_sbi_request_handler(request: SbiRequest) -> SbiResponse {
                 "PATCH" => handle_acrevents_modify(subscription_id, &request).await,
                 "DELETE" => handle_acrevents_delete(subscription_id).await,
                 _ => send_method_not_allowed(method, "subscriptions/{subscriptionId}"),
+            }
+        }
+        // ---- #106: EES capability-exposure APIs ----------------------------
+        //
+        // Five service APIs had NO dispatch arm, so every request against their
+        // spec paths fell through to the 404 below — indistinguishable, to a
+        // conformant EAS/EEC, from a mistyped URI. See `capabilities.rs` for why
+        // three of them answer 501 rather than a fabricated 2xx.
+
+        // eees-easinfoprov (TS24558_Eees_EASInformationProvisioning.yaml) —
+        // served locally: everything it needs is in this EES's own state.
+        ["eees-easinfoprov", "v1", "declare"] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_EASINFOPROV) {
+                return resp;
+            }
+            match method {
+                "POST" => handle_eas_info_prov(&request).await,
+                _ => send_method_not_allowed(method, "declare"),
+            }
+        }
+        // eees-ueidentifier (TS29558_Eees_UEIdentifier.yaml) — `fetch` and `get`
+        // take the same body and differ only in the operation name, so both land
+        // on one handler.
+        ["eees-ueidentifier", "v1", op @ ("fetch" | "get")] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_UEIDENTIFIER) {
+                return resp;
+            }
+            match method {
+                "POST" => handle_ue_identifier(&request).await,
+                _ => send_method_not_allowed(method, op),
+            }
+        }
+        // eees-uelocation (TS29558_Eees_UELocation.yaml) — 501: no location
+        // source. The subscription paths are routed so a consumer gets a spec
+        // answer instead of a bare 404; creating a subscription that could never
+        // fire would be worse than refusing it.
+        ["eees-uelocation", "v1", "fetch"] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_UELOCATION) {
+                return resp;
+            }
+            match method {
+                "POST" => not_implemented(UELOCATION_UNAVAILABLE),
+                _ => send_method_not_allowed(method, "fetch"),
+            }
+        }
+        ["eees-uelocation", "v1", "subscriptions"] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_UELOCATION) {
+                return resp;
+            }
+            match method {
+                "POST" => not_implemented(UELOCATION_UNAVAILABLE),
+                _ => send_method_not_allowed(method, "subscriptions"),
+            }
+        }
+        ["eees-uelocation", "v1", "subscriptions", _subscription_id] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_UELOCATION) {
+                return resp;
+            }
+            match method {
+                // No subscription can exist (create is refused above), so 404 is
+                // the truthful answer for any id — with a ProblemDetails saying
+                // why, rather than the router's generic not-found.
+                "GET" | "PUT" | "PATCH" | "DELETE" => send_not_found(
+                    "No UE location subscription exists: creating one is not implemented \
+                     (no UE location source is available to this EES)",
+                    Some(cause::RESOURCE_NOT_FOUND),
+                ),
+                _ => send_method_not_allowed(method, "subscriptions/{subscriptionId}"),
+            }
+        }
+        // eees-session-with-qos (TS29558_Eees_SessionWithQoS.yaml) — 501: needs
+        // the NEF AsSessionWithQoS leg. A 201 here would claim a QoS flow exists.
+        ["eees-session-with-qos", "v1", "sessions"] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_SESSION_WITH_QOS) {
+                return resp;
+            }
+            match method {
+                "POST" | "GET" => not_implemented(SESSION_WITH_QOS_UNAVAILABLE),
+                _ => send_method_not_allowed(method, "sessions"),
+            }
+        }
+        ["eees-session-with-qos", "v1", "sessions", _session_id] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_SESSION_WITH_QOS) {
+                return resp;
+            }
+            match method {
+                "GET" | "PUT" | "PATCH" | "DELETE" => not_implemented(SESSION_WITH_QOS_UNAVAILABLE),
+                _ => send_method_not_allowed(method, "sessions/{sessionId}"),
+            }
+        }
+        // eees-tie (TS29558_Eees_TrafficInfluenceEAS.yaml) — 501: needs the
+        // NEF/PCF-AF traffic-influence leg.
+        ["eees-tie", "v1", "instances"] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_TIE) {
+                return resp;
+            }
+            match method {
+                "POST" => not_implemented(TIE_UNAVAILABLE),
+                _ => send_method_not_allowed(method, "instances"),
+            }
+        }
+        ["eees-tie", "v1", "instances", _instance_id] => {
+            if let Some(resp) = auth::require_oauth2(&request, auth::SCOPE_TIE) {
+                return resp;
+            }
+            match method {
+                "GET" | "PUT" | "PATCH" | "DELETE" => not_implemented(TIE_UNAVAILABLE),
+                _ => send_method_not_allowed(method, "instances/{instanceId}"),
             }
         }
         _ => send_not_found(&format!("Resource not found: {path}"), None),
@@ -1267,6 +1423,19 @@ async fn handle_eec_register(request: &SbiRequest) -> SbiResponse {
     let stored = ctx.read().ok().and_then(|c| c.eec_register(reg));
     match stored {
         Some(stored) => {
+            // #106: TS 29.558 §5.5.2.2 — tell every AppClientInformation
+            // subscriber whose filters match this EEC's AC profiles. Before this,
+            // `handle_acinfo_create` accepted a subscription, answered 201, and
+            // nothing ever produced the callback, so the subscription was inert
+            // with no error surface to show it.
+            //
+            // After the registration is stored, not before: a notification about
+            // a registration that then failed on capacity would be a lie. The
+            // read guard is taken and dropped inside `notify_acinfo_subscribers`,
+            // which enqueues after releasing the subscription lock.
+            if let Ok(guard) = ctx.read() {
+                guard.notify_acinfo_subscribers(&stored);
+            }
             let id = stored.registration_id.clone().unwrap_or_default();
             SbiResponse::with_status(201)
                 .with_header("Location", format!("{EECREG_REGISTRATIONS_PATH}/{id}"))
@@ -1544,6 +1713,246 @@ async fn handle_acr_declare(request: &SbiRequest) -> SbiResponse {
     }
 }
 
+// ---- #106: EES capability-exposure handlers ---------------------------------
+
+/// Detail for the `501` answered by `eees-uelocation`.
+const UELOCATION_UNAVAILABLE: &str = "UE location reporting is not implemented: this EES has no \
+     UE location source. TS 23.558 §8.6.5 obtains it from the 5GC (a NEF \
+     MonitoringEvent LOCATION_REPORTING subscription) or from the EEC, and \
+     neither leg exists in this build. A subscription is refused rather than \
+     accepted, because a subscription that can never notify fails silently.";
+
+/// Detail for the `501` answered by `eees-session-with-qos`.
+const SESSION_WITH_QOS_UNAVAILABLE: &str =
+    "Session with QoS is not implemented: establishing one requires the NEF \
+     AsSessionWithQoS leg (TS 23.558 §8.6.6), which does not exist in this build. \
+     The resource is refused rather than created, because answering 201 would tell \
+     the consumer a QoS flow exists when nothing was actuated anywhere.";
+
+/// Detail for the `501` answered by `eees-tie`.
+const TIE_UNAVAILABLE: &str = "Traffic influence toward the EAS is not implemented: it requires \
+     the NEF/PCF-AF traffic-influence leg (TS 29.558 §5.15), which does not \
+     exist in this build.";
+
+/// A `501 Not Implemented` carrying the reason, per TS 29.500 §5.2.7.2.
+///
+/// Deliberately distinct from the router's 404: the resource IS part of the API
+/// this EES serves, and a consumer must be able to tell "not built here" from
+/// "no such path". `detail` names the missing dependency so an operator reading a
+/// log does not have to guess.
+fn not_implemented(detail: &str) -> SbiResponse {
+    send_error(501, "Not Implemented", detail, Some(cause::NOT_IMPLEMENTED))
+}
+
+/// `declare` (`POST {apiRoot}/eees-easinfoprov/v1/declare`,
+/// `TS24558_Eees_EASInformationProvisioning.yaml`) — #106.
+///
+/// Served entirely from this EES's own state; there is no 5GC dependency, which
+/// is why this one returns real answers rather than a 501.
+///
+/// The `reqType` decides the answer:
+///
+/// * `ACR_SCENARIO_SELECTION_ANNOUNCEMENT` — the EEC states the scenarios it
+///   selected. Nothing is returned: `204` (which the yaml lists alongside 200).
+/// * `ACR_SCENARIO_SELECTION_REQUEST` — the EES selects, and answers `200` with
+///   `selAcrScenarioList`. The selection is the intersection with what this EES
+///   can actually execute; when the intersection is EMPTY the request is refused
+///   `404`, because an empty list dressed as a selection would read as success.
+/// * `EAS_SELECTION` — the EES answers `200` with `instEasInfo` for the first
+///   `selEasIds` entry that is registered here. An unregistered EAS is `404`.
+/// * absent / unknown `reqType` — `204`: the announcement is the schema's
+///   no-op-shaped case, and refusing a forward-compatible value would break the
+///   open enumeration.
+async fn handle_eas_info_prov(request: &SbiRequest) -> SbiResponse {
+    log::info!("EAS Information Provisioning");
+    let value = match parse_json_body(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
+    };
+    let req: capabilities::EasInfoProvReq = match serde_json::from_value(value) {
+        Ok(r) => r,
+        Err(e) => {
+            return send_bad_request(
+                &format!("Invalid EASInfoProvReq: {e}"),
+                Some(cause::INVALID_MSG_FORMAT),
+            );
+        }
+    };
+
+    match req.req_type.as_deref() {
+        Some(capabilities::REQ_TYPE_ACR_REQUEST) => {
+            let selected = capabilities::select_acr_scenarios(req.sel_acr_scenarios.as_deref());
+            if selected.is_empty() {
+                return send_not_found(
+                    "None of the requested ACR scenarios is supported by this EES",
+                    Some(cause::RESOURCE_NOT_FOUND),
+                );
+            }
+            let resp = capabilities::EasInfoProvResp {
+                sel_acr_scenario_list: Some(selected),
+                ..Default::default()
+            };
+            SbiResponse::with_status(200)
+                .with_json_body(&resp)
+                .unwrap_or_else(|_| SbiResponse::with_status(204))
+        }
+        Some(capabilities::REQ_TYPE_EAS_SELECTION) => {
+            match capabilities::instantiated_eas(req.sel_eas_ids.as_deref()) {
+                Some(inst) => {
+                    let resp = capabilities::EasInfoProvResp {
+                        inst_eas_info: Some(inst),
+                        ..Default::default()
+                    };
+                    SbiResponse::with_status(200)
+                        .with_json_body(&resp)
+                        .unwrap_or_else(|_| SbiResponse::with_status(204))
+                }
+                None => send_not_found(
+                    "None of the selected EAS identifiers is registered with this EES",
+                    Some(cause::RESOURCE_NOT_FOUND),
+                ),
+            }
+        }
+        // The announcement, and any forward-compatible value: accepted, no body.
+        _ => {
+            log::info!(
+                "EAS info provisioning announcement accepted: eecId={:?} selAcrScenarios={:?}",
+                req.eec_id,
+                req.sel_acr_scenarios
+            );
+            SbiResponse::with_status(204)
+        }
+    }
+}
+
+/// `FetchUEId` / `GetUEId` (`POST {apiRoot}/eees-ueidentifier/v1/{fetch,get}`,
+/// `TS29558_Eees_UEIdentifier.yaml`) — #106.
+///
+/// Both operations take the same `UserInfo` body and return the same `UeIdInfo`,
+/// so they share a handler.
+///
+/// Answers with an `edgeUeId` — an edge-enabler-layer identifier this EES is
+/// entitled to assign — for a UE it serves. Two refusals, deliberately distinct:
+///
+/// * a request identifying the UE only by `ipAddr` gets `501`: mapping an IP to a
+///   subscriber needs the core network (Nnef_UEId / the T8 UE-ID API), and no
+///   such leg exists here;
+/// * a GPSI no EEC has registered gets `404`, because this EES serves identifiers
+///   only for UEs it knows. Minting one for any input would make the API an
+///   oracle that tells the caller nothing.
+async fn handle_ue_identifier(request: &SbiRequest) -> SbiResponse {
+    log::info!("UE Identifier request");
+    let value = match parse_json_body(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
+    };
+    let req: capabilities::UserInfo = match serde_json::from_value(value) {
+        Ok(r) => r,
+        Err(e) => {
+            return send_bad_request(
+                &format!("Invalid UserInfo: {e}"),
+                Some(cause::INVALID_MSG_FORMAT),
+            );
+        }
+    };
+    if let Err(detail) = req.validate() {
+        return send_bad_request(&detail, Some(cause::MANDATORY_IE_MISSING));
+    }
+    match capabilities::resolve_ue_ids(&req) {
+        Ok(info) => SbiResponse::with_status(200)
+            .with_json_body(&info)
+            .unwrap_or_else(|_| SbiResponse::with_status(500)),
+        Err(capabilities::UeIdError::CoreNetworkRequired) => not_implemented(
+            "Resolving a UE identifier from an IP address is not implemented: it requires the \
+             core-network UE-ID exposure leg (Nnef_UEId, TS 23.558 §8.6.2), which does not exist \
+             in this build. Identify the UE by its GPSI (`ueId`) instead.",
+        ),
+        Err(capabilities::UeIdError::UnknownUe) => send_not_found(
+            "No EEC is registered for that UE identifier, so this EES serves no identifier for it",
+            Some(cause::RESOURCE_NOT_FOUND),
+        ),
+    }
+}
+
+/// `CreateACTStatusSubsc`
+/// (`POST {apiRoot}/eees-eel-acr/v1/subscriptions`,
+/// `TS29558_Eees_EELManagedACR.yaml`) — #106.
+///
+/// Mandatory IEs: `easId`, `notificationUri`. Returns `201` with the created
+/// representation and a `Location` header; the `subscriptionId` is server-minted
+/// and is not a member of the schema.
+async fn handle_act_status_sub_create(request: &SbiRequest) -> SbiResponse {
+    log::info!("ACT Status Subscription create");
+    let value = match parse_json_body(request) {
+        Ok(v) => v,
+        Err(resp) => return *resp,
+    };
+    let sub: acr::ACTStatusSubsc = match serde_json::from_value(value) {
+        Ok(s) => s,
+        Err(e) => {
+            return send_bad_request(
+                &format!("Missing or invalid mandatory IE (easId/notificationUri): {e}"),
+                Some(cause::MANDATORY_IE_MISSING),
+            );
+        }
+    };
+    // serde accepts an empty string for a required String, so the presence check
+    // has to be explicit — a subscription with a blank notificationUri has
+    // nowhere to deliver and would be an accepted-but-inert resource.
+    if sub.eas_id.trim().is_empty() || sub.notification_uri.trim().is_empty() {
+        return send_bad_request(
+            "easId and notificationUri must both be non-empty",
+            Some(cause::MANDATORY_IE_MISSING),
+        );
+    }
+    let created = ees_self()
+        .read()
+        .ok()
+        .and_then(|c| c.act_status_sub_create(sub.clone()));
+    match created {
+        Some(id) => SbiResponse::with_status(201)
+            .with_header("Location", format!("{EEL_ACR_SUBSCRIPTIONS_PATH}/{id}"))
+            .with_json_body(&sub)
+            .unwrap_or_else(|_| SbiResponse::with_status(201)),
+        None => send_error(
+            507,
+            "Insufficient Storage",
+            "Failed to create ACT status subscription (capacity exhausted)",
+            Some(cause::INSUFFICIENT_RESOURCES),
+        ),
+    }
+}
+
+/// `GetACTStatusSubscriptions` (`GET {apiRoot}/eees-eel-acr/v1/subscriptions`).
+/// The yaml's 200 body is the array itself, not a wrapper object.
+async fn handle_act_status_sub_list() -> SbiResponse {
+    let subs = ees_self()
+        .read()
+        .map(|c| c.act_status_sub_list())
+        .unwrap_or_default();
+    SbiResponse::with_status(200)
+        .with_json_body(&subs)
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+/// `GetACTStatusSubscription`
+/// (`GET {apiRoot}/eees-eel-acr/v1/subscriptions/{subscriptionId}`).
+async fn handle_act_status_sub_read(subscription_id: &str) -> SbiResponse {
+    match ees_self()
+        .read()
+        .ok()
+        .and_then(|c| c.act_status_sub_find(subscription_id))
+    {
+        Some(sub) => SbiResponse::with_status(200)
+            .with_json_body(&sub)
+            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        None => send_not_found(
+            &format!("ACT status subscription not found: {subscription_id}"),
+            Some(cause::SUBSCRIPTION_NOT_FOUND),
+        ),
+    }
+}
+
 /// eesd-07: `Eees_EELManagedACR_Request`
 /// (`POST .../eees-eel-acr/v1/request-eelacr`).
 ///
@@ -1652,6 +2061,18 @@ async fn handle_acr_status_update(request: &SbiRequest) -> SbiResponse {
     let ctx = ees_self();
     if let Ok(c) = ctx.read() {
         c.acr_status_update(&req.eas_id, status.clone());
+        // #106: an ACR that reached a terminal ACT outcome is what an
+        // `ACTStatusSubsc` subscribes to (TS 29.558 §5.11). Only the terminal
+        // states carry a reportable `ACTResult` — an in-progress ACR has neither
+        // SUCCESSFUL nor FAILED to report, so nothing is sent for it.
+        let act_status = match status {
+            AcrStatus::Completed => Some(acr::ACT_RESULT_SUCCESSFUL),
+            AcrStatus::Failed => Some(acr::ACT_RESULT_FAILED),
+            _ => None,
+        };
+        if let Some(act_status) = act_status {
+            c.notify_act_status_subscribers(&req.eas_id, act_status);
+        }
     }
     // D5: a status-update reaching COMPLETED fires ACR_COMPLETE to matching
     // acrevents subscribers. This path carries no eecId/ueId, so easId
@@ -5026,6 +5447,508 @@ mod tests {
         assert_eq!(notif.event_id, "TARGET_INFORMATION");
 
         delete_acrevents(&sk, &id);
+        auth::clear_auth_jwks();
+    }
+
+    // ─── #106: the five previously-unrouted capability APIs ─────────────────
+
+    /// #106 acceptance: **no** capability API answers 404 any more.
+    ///
+    /// One test over all five roots, because the defect was uniform — no dispatch
+    /// arm at all — and the property to pin is uniform too: a request against a
+    /// path the spec defines must get a spec answer. `assert_ne!(404)` is the
+    /// weakest form of that, so each row also names the status it must actually
+    /// return.
+    #[test]
+    fn test_capability_apis_are_routed_and_never_404() {
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ees_context_init(512);
+        let sk = signing_key();
+        auth::set_auth_jwks(jwks_for(&sk, "k1"));
+
+        // (path, scope, body, expected status)
+        let cases: &[(&str, &str, &str, u16)] = &[
+            // Served locally: an announcement is accepted with no body.
+            (
+                "/eees-easinfoprov/v1/declare",
+                auth::SCOPE_EASINFOPROV,
+                r#"{"eecId":"eec-1","reqType":"ACR_SCENARIO_SELECTION_ANNOUNCEMENT"}"#,
+                204,
+            ),
+            // 501: needs the CN UE-ID leg (identified by IP only).
+            (
+                "/eees-ueidentifier/v1/get",
+                auth::SCOPE_UEIDENTIFIER,
+                r#"{"ipAddr":{"ipv4Addr":"10.0.0.1"}}"#,
+                501,
+            ),
+            (
+                "/eees-ueidentifier/v1/fetch",
+                auth::SCOPE_UEIDENTIFIER,
+                r#"{"ipAddr":{"ipv4Addr":"10.0.0.1"}}"#,
+                501,
+            ),
+            // 501: no UE location source.
+            (
+                "/eees-uelocation/v1/fetch",
+                auth::SCOPE_UELOCATION,
+                r#"{"easId":"eas1"}"#,
+                501,
+            ),
+            (
+                "/eees-uelocation/v1/subscriptions",
+                auth::SCOPE_UELOCATION,
+                r#"{"easId":"eas1","notificationDestination":"http://eas/cb"}"#,
+                501,
+            ),
+            // 501: no NEF AsSessionWithQoS leg.
+            (
+                "/eees-session-with-qos/v1/sessions",
+                auth::SCOPE_SESSION_WITH_QOS,
+                r#"{"easId":"eas1"}"#,
+                501,
+            ),
+            // 501: no NEF/PCF-AF traffic-influence leg.
+            (
+                "/eees-tie/v1/instances",
+                auth::SCOPE_TIE,
+                r#"{"easId":"eas1"}"#,
+                501,
+            ),
+        ];
+
+        for (path, scope, body, expected) in cases {
+            let req = SbiRequest::post(*path)
+                .with_header("Authorization", bearer(&sk, "k1", scope))
+                .with_body(*body, "application/json");
+            let resp = block_on(ees_sbi_request_handler(req));
+            assert_ne!(
+                resp.status, 404,
+                "{path} must be routed; 404 is the #106 defect"
+            );
+            assert_eq!(
+                resp.status, *expected,
+                "{path} must answer {expected}, got {}",
+                resp.status
+            );
+            // Every 501 must say WHY, so an operator is not left guessing.
+            if *expected == 501 {
+                let problem: nextgcore_sbi::message::ProblemDetails =
+                    serde_json::from_str(resp.http.content.as_deref().unwrap_or("{}"))
+                        .expect("a 501 must carry ProblemDetails");
+                assert_eq!(problem.cause.as_deref(), Some("NOT_IMPLEMENTED"));
+                assert!(
+                    problem
+                        .detail
+                        .as_deref()
+                        .is_some_and(|d| d.contains("not implemented")),
+                    "the 501 detail must name the missing capability: {problem:?}"
+                );
+            }
+        }
+        auth::clear_auth_jwks();
+    }
+
+    /// #106: `eees-easinfoprov` answers the ACR-scenario-selection request from
+    /// this EES's real capability set, and refuses a request naming only
+    /// scenarios it cannot execute rather than returning an empty selection.
+    #[test]
+    fn test_eas_info_prov_selects_acr_scenarios() {
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ees_context_init(512);
+        let sk = signing_key();
+        auth::set_auth_jwks(jwks_for(&sk, "k1"));
+
+        let post = |body: &str| {
+            let req = SbiRequest::post("/eees-easinfoprov/v1/declare")
+                .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EASINFOPROV))
+                .with_body(body.to_string(), "application/json");
+            block_on(ees_sbi_request_handler(req))
+        };
+
+        // A supported scenario is selected and echoed back.
+        let resp = post(
+            r#"{"reqType":"ACR_SCENARIO_SELECTION_REQUEST",
+                "selAcrScenarios":["EEL_MANAGED_ACR","SOURCE_EES_EXECUTED"]}"#,
+        );
+        assert_eq!(resp.status, 200);
+        let body: capabilities::EasInfoProvResp =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            body.sel_acr_scenario_list.as_deref(),
+            Some(&["EEL_MANAGED_ACR".to_string()][..]),
+            "the unsupported SOURCE_EES_EXECUTED must be dropped, not echoed"
+        );
+
+        // Only-unsupported: 404, not a 200 with an empty list.
+        let resp = post(
+            r#"{"reqType":"ACR_SCENARIO_SELECTION_REQUEST","selAcrScenarios":["SOURCE_EES_EXECUTED"]}"#,
+        );
+        assert_eq!(
+            resp.status, 404,
+            "an empty selection must not be dressed up as success"
+        );
+        auth::clear_auth_jwks();
+    }
+
+    /// #106: `EAS_SELECTION` returns the profile of a registered EAS, and 404 for
+    /// one that never registered here.
+    #[test]
+    fn test_eas_info_prov_eas_selection() {
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ees_context_init(512);
+        let sk = signing_key();
+        auth::set_auth_jwks(jwks_for(&sk, "k1"));
+
+        // Register an EAS so there is something to select.
+        let reg = SbiRequest::post("/eees-easregistration/v1/registrations")
+            .with_header(
+                "Authorization",
+                bearer(&sk, "k1", auth::SCOPE_EASREGISTRATION),
+            )
+            .with_body(
+                r#"{"easProf":{"easId":"eas1.example.com","endPt":{"fqdn":"eas1.example.com"}}}"#,
+                "application/json",
+            );
+        assert_eq!(block_on(ees_sbi_request_handler(reg)).status, 201);
+
+        let post = |body: &str| {
+            let req = SbiRequest::post("/eees-easinfoprov/v1/declare")
+                .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EASINFOPROV))
+                .with_body(body.to_string(), "application/json");
+            block_on(ees_sbi_request_handler(req))
+        };
+
+        let resp = post(r#"{"reqType":"EAS_SELECTION","selEasIds":["eas1.example.com"]}"#);
+        assert_eq!(resp.status, 200);
+        let body: capabilities::EasInfoProvResp =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        let eas = body
+            .inst_eas_info
+            .and_then(|i| i.eas)
+            .expect("the registered EAS profile is returned");
+        assert_eq!(eas.eas_id, "eas1.example.com");
+
+        // An EAS that never registered here.
+        let resp = post(r#"{"reqType":"EAS_SELECTION","selEasIds":["ghost.example.com"]}"#);
+        assert_eq!(resp.status, 404);
+        auth::clear_auth_jwks();
+    }
+
+    /// #106: `eees-ueidentifier` returns an `edgeUeId` for a UE this EES serves,
+    /// stable across calls, and 404 for a GPSI no EEC registered.
+    #[test]
+    fn test_ue_identifier_resolves_a_known_ue() {
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ees_context_init(512);
+        let sk = signing_key();
+        auth::set_auth_jwks(jwks_for(&sk, "k1"));
+
+        // An EEC registers, carrying the UE's GPSI.
+        let reg = SbiRequest::post("/eees-eecregistration/v1/registrations")
+            .with_header(
+                "Authorization",
+                bearer(&sk, "k1", auth::SCOPE_EECREGISTRATION),
+            )
+            .with_body(
+                r#"{"eecId":"eec-1","ueId":"msisdn-491701234567"}"#,
+                "application/json",
+            );
+        assert_eq!(block_on(ees_sbi_request_handler(reg)).status, 201);
+
+        let fetch = || {
+            let req = SbiRequest::post("/eees-ueidentifier/v1/fetch")
+                .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_UEIDENTIFIER))
+                .with_body(
+                    r#"{"ueId":"msisdn-491701234567","easIds":["eas1.example.com"]}"#,
+                    "application/json",
+                );
+            block_on(ees_sbi_request_handler(req))
+        };
+
+        let resp = fetch();
+        assert_eq!(resp.status, 200);
+        let info: capabilities::UeIdInfo =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(info.ue_ids.len(), 1);
+        let first = info.ue_ids[0].edge_ue_id.clone().expect("an edgeUeId");
+        assert!(
+            !first.contains("491701234567"),
+            "the GPSI must not leak into the identifier: {first}"
+        );
+        assert_eq!(info.ue_ids[0].eas_id.as_deref(), Some("eas1.example.com"));
+
+        // Stable across calls, so an EAS can use it as a key.
+        let again: capabilities::UeIdInfo =
+            serde_json::from_str(fetch().http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(again.ue_ids[0].edge_ue_id.as_deref(), Some(first.as_str()));
+
+        // A GPSI no EEC registered: 404, not an invented identifier.
+        let req = SbiRequest::post("/eees-ueidentifier/v1/get")
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_UEIDENTIFIER))
+            .with_body(r#"{"ueId":"msisdn-000000000000"}"#, "application/json");
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 404);
+
+        // Neither ueId nor ipAddr: 400 (the schema's anyOf).
+        let req = SbiRequest::post("/eees-ueidentifier/v1/get")
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_UEIDENTIFIER))
+            .with_body(r#"{"requestorId":"eas1"}"#, "application/json");
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 400);
+        auth::clear_auth_jwks();
+    }
+
+    /// #106 acceptance: the EEL-managed ACR ACT status subscription resource —
+    /// create, list and read, per `TS29558_Eees_EELManagedACR.yaml`.
+    #[test]
+    fn test_act_status_subscription_lifecycle() {
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ees_context_init(512);
+        let sk = signing_key();
+        auth::set_auth_jwks(jwks_for(&sk, "k1"));
+
+        // Create: 201 + Location.
+        let req = SbiRequest::post("/eees-eel-acr/v1/subscriptions")
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EEL_ACR))
+            .with_body(
+                r#"{"easId":"eas1.example.com","notificationUri":"http://eas/cb"}"#,
+                "application/json",
+            );
+        let resp = block_on(ees_sbi_request_handler(req));
+        assert_eq!(resp.status, 201);
+        let loc = resp.http.get_header("location").cloned().unwrap();
+        assert!(loc.starts_with(EEL_ACR_SUBSCRIPTIONS_PATH), "got {loc}");
+        let id = loc.rsplit('/').next().unwrap().to_string();
+        let created: acr::ACTStatusSubsc =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(created.eas_id, "eas1.example.com");
+
+        // Read the individual resource.
+        let req = SbiRequest::get(&format!("/eees-eel-acr/v1/subscriptions/{id}"))
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EEL_ACR));
+        let resp = block_on(ees_sbi_request_handler(req));
+        assert_eq!(resp.status, 200);
+        let read: acr::ACTStatusSubsc =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(read, created);
+
+        // List the collection: a bare array, per the yaml.
+        let req = SbiRequest::get("/eees-eel-acr/v1/subscriptions")
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EEL_ACR));
+        let resp = block_on(ees_sbi_request_handler(req));
+        assert_eq!(resp.status, 200);
+        let list: Vec<acr::ACTStatusSubsc> =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        // Presence, not an exact count: the EES context is process-global and
+        // shared with sibling tests (which the GLOBAL_STATE_TEST_LOCK serialises
+        // but does not isolate), so a count assertion here fails whenever another
+        // test creates a subscription -- a property of the harness, not of this
+        // API. Asserting the created resource is in the list is what this test is
+        // actually about.
+        assert!(
+            list.contains(&created),
+            "the created subscription must appear in the collection, got {list:?}"
+        );
+
+        // Unknown id: 404.
+        let req = SbiRequest::get("/eees-eel-acr/v1/subscriptions/no-such-id")
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EEL_ACR));
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 404);
+
+        // A missing mandatory IE is refused.
+        let req = SbiRequest::post("/eees-eel-acr/v1/subscriptions")
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EEL_ACR))
+            .with_body(r#"{"easId":"eas1.example.com"}"#, "application/json");
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 400);
+        // ...including a present-but-empty one, which serde accepts.
+        let req = SbiRequest::post("/eees-eel-acr/v1/subscriptions")
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EEL_ACR))
+            .with_body(
+                r#"{"easId":"eas1.example.com","notificationUri":""}"#,
+                "application/json",
+            );
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 400);
+
+        // The yaml defines only GET on the individual resource.
+        let req = SbiRequest::delete(&format!("/eees-eel-acr/v1/subscriptions/{id}"))
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EEL_ACR));
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 405);
+        auth::clear_auth_jwks();
+    }
+
+    /// #106: an ACR status update reaching a terminal ACT outcome produces an
+    /// `ACTStatusNotif` **through the router**, and an in-progress one produces
+    /// nothing.
+    ///
+    /// Added after a revert exposed the hole: with the terminal-state gate in
+    /// `handle_acr_status_update` replaced by `None`, the whole suite still
+    /// passed. The context-level test covers `notify_act_status_subscribers` and
+    /// says nothing about whether any handler calls it — "the helper is tested and
+    /// the wiring is not".
+    ///
+    /// Uses an `easId` and callback URI unique to this test. The EES context is
+    /// process-global, so a sibling test's subscription for a shared `easId` would
+    /// be notified too and the count would depend on test order — which is how
+    /// this test failed on its first run.
+    #[test]
+    fn test_act_status_notification_fires_from_a_status_update() {
+        use notifier::Notifier;
+
+        const EAS: &str = "eas-act-notify-test.example.com";
+        const CB: &str = "http://eas-act-notify-test/cb";
+
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ees_context_init(512);
+        let sk = signing_key();
+        auth::set_auth_jwks(jwks_for(&sk, "k1"));
+        let n = std::sync::Arc::new(notifier::QueueNotifier::default());
+        notifier::set_notifier(n.clone());
+        let _ = n.drain();
+
+        // Subscribe for ACT status on this EAS.
+        let req = SbiRequest::post("/eees-eel-acr/v1/subscriptions")
+            .with_header("Authorization", bearer(&sk, "k1", auth::SCOPE_EEL_ACR))
+            .with_body(
+                format!(r#"{{"easId":"{EAS}","notificationUri":"{CB}"}}"#),
+                "application/json",
+            );
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 201);
+        let _ = n.drain();
+
+        let status_update = |body: String| {
+            let req = SbiRequest::post("/eees-acrstatus-update/v1/request-acrupdate")
+                .with_header(
+                    "Authorization",
+                    bearer(&sk, "k1", auth::SCOPE_ACRSTATUS_UPDATE),
+                )
+                .with_body(body, "application/json");
+            block_on(ees_sbi_request_handler(req))
+        };
+        // Only this test's own callback, so a sibling subscription cannot
+        // contribute to the count.
+        let mine = |n: &notifier::QueueNotifier| -> Vec<notifier::QueuedNotification> {
+            n.drain()
+                .into_iter()
+                .filter(|q| q.kind == "ACTStatusNotif" && q.uri.starts_with(CB))
+                .collect()
+        };
+
+        // An update carrying no ACT result is in-progress: nothing to report.
+        assert_eq!(
+            status_update(format!(r#"{{"easId":"{EAS}","e3SubscIds":["sub-1"]}}"#)).status,
+            204
+        );
+        assert!(
+            mine(&n).is_empty(),
+            "an in-progress ACR has no ACTResult to report"
+        );
+
+        // A successful ACT fires exactly one notification.
+        assert_eq!(
+            status_update(format!(
+                r#"{{"easId":"{EAS}","actResultInfo":{{"actResult":"SUCCESSFUL"}}}}"#
+            ))
+            .status,
+            204
+        );
+        let acts = mine(&n);
+        assert_eq!(acts.len(), 1, "exactly one ACTStatusNotif, got {acts:?}");
+        assert_eq!(acts[0].uri, format!("{CB}/act-status"));
+        let notif: acr::ACTStatusNotif = serde_json::from_value(acts[0].body.clone()).unwrap();
+        assert_eq!(notif.act_status, "SUCCESSFUL");
+
+        // A failed ACT reports FAILED, not SUCCESSFUL.
+        assert_eq!(
+            status_update(format!(
+                r#"{{"easId":"{EAS}","actResultInfo":{{"actResult":"FAILED"}}}}"#
+            ))
+            .status,
+            204
+        );
+        let acts = mine(&n);
+        assert_eq!(acts.len(), 1);
+        let notif: acr::ACTStatusNotif = serde_json::from_value(acts[0].body.clone()).unwrap();
+        assert_eq!(
+            notif.act_status, "FAILED",
+            "a failed ACT must not be reported as successful"
+        );
+
+        notifier::set_notifier(std::sync::Arc::new(notifier::QueueNotifier::default()));
+        auth::clear_auth_jwks();
+    }
+
+    /// #106 acceptance, end to end through the router: an AppClientInformation
+    /// subscription created over SBI, then an EEC registration over SBI, produces
+    /// exactly one `ACInfoNotification` from the PRODUCTION path.
+    ///
+    /// Distinct from the context-level test: this one proves the wiring in
+    /// `handle_eec_register` calls the notifier at all. A context test passes
+    /// whether or not the handler is wired — the mistake this repo has recorded
+    /// twice as "the helper is tested and the wiring is not".
+    #[test]
+    fn test_acinfo_notification_fires_through_the_router() {
+        use notifier::Notifier;
+
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ees_context_init(512);
+        let sk = signing_key();
+        auth::set_auth_jwks(jwks_for(&sk, "k1"));
+        let n = std::sync::Arc::new(notifier::QueueNotifier::default());
+        notifier::set_notifier(n.clone());
+        let _ = n.drain();
+
+        // Subscribe for AC information about "ac-1".
+        let req = SbiRequest::post("/eees-appclientinformation/v1/subscriptions")
+            .with_header(
+                "Authorization",
+                bearer(&sk, "k1", auth::SCOPE_APPCLIENTINFORMATION),
+            )
+            .with_body(
+                r#"{"easId":"eas1.example.com","notificationDestination":"http://eas/ac-info",
+                    "acFltrs":[{"acIdsList":["ac-1"]}]}"#,
+                "application/json",
+            );
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 201);
+        let _ = n.drain();
+
+        // Register an EEC serving that AC.
+        let req = SbiRequest::post("/eees-eecregistration/v1/registrations")
+            .with_header(
+                "Authorization",
+                bearer(&sk, "k1", auth::SCOPE_EECREGISTRATION),
+            )
+            .with_body(
+                r#"{"eecId":"eec-1","ueId":"msisdn-1","acProfs":[{"acId":"ac-1"}]}"#,
+                "application/json",
+            );
+        assert_eq!(block_on(ees_sbi_request_handler(req)).status, 201);
+
+        let queued = n.drain();
+        let ac_infos: Vec<_> = queued
+            .iter()
+            .filter(|q| q.kind == "ACInfoNotification")
+            .collect();
+        assert_eq!(
+            ac_infos.len(),
+            1,
+            "the registration must produce exactly one ACInfoNotification, got {queued:?}"
+        );
+        assert_eq!(ac_infos[0].uri, "http://eas/ac-info");
+
+        notifier::set_notifier(std::sync::Arc::new(notifier::QueueNotifier::default()));
         auth::clear_auth_jwks();
     }
 }

--- a/src/bins/nextgcore-eesd/src/services.rs
+++ b/src/bins/nextgcore-eesd/src/services.rs
@@ -21,11 +21,22 @@
 //!   information ([`ACRParamsInfo`]) TO the EES via the custom operation
 //!   `POST /send-acrparamsinfo` (→ 204, no response body).
 //!
-//! DEFERRED (eesd-13 subset requiring 5GC NEF/PCF-AF exposure path):
-//! * `eees-session-with-qos` (TS 29.558 §5.6) — needs Nnef_TrafficInfluence
-//!   to a live NEF; no NEF exposure path exists in this repo.
+//! ROUTED-AND-REFUSED, not deferred (#106). These two still need a 5GC
+//! NEF/PCF-AF exposure path that does not exist here, but they are no longer
+//! UNROUTED: both now answer `501 NOT_IMPLEMENTED` with a ProblemDetails naming
+//! the missing leg, instead of falling through to a `404` that told a conformant
+//! consumer the resource did not exist. See `capabilities.rs`.
+//! * `eees-session-with-qos` (TS 29.558 §5.6) — needs the NEF AsSessionWithQoS
+//!   leg. Answering `201` while actuating no QoS anywhere would be worse than
+//!   refusing: the consumer would believe a QoS flow existed.
 //! * `eees-tie` (TS 29.558 §5.15) — Traffic Influence EAS; same NEF/PCF-AF
-//!   dependency; blocked until Nnef/Npcf AF exposure is wired.
+//!   dependency.
+//!
+//! `ACInfoNotification` is now EMITTED (#106): an `eees-appclientinformation`
+//! subscription whose `acFltrs` match a subsequent EEC registration's `acProfs`
+//! produces one, via `EesContext::notify_acinfo_subscribers`. It was previously
+//! constructed only in tests, so a subscriber was accepted and then never told
+//! anything.
 
 use serde::{Deserialize, Serialize};
 
@@ -116,7 +127,11 @@ pub struct GrpConnInfo {
 /// `WebsockNotifConfig` from TS 29.122) are carried as passthrough JSON
 /// values, per the established `acr.rs` convention (preserve wire bytes
 /// without fabricating a local model).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+// `Default` is derived (#106) so a test can name only the members it cares about
+// while every optional member stays `None`. `easId` is REQUIRED on the wire, and
+// `Default` gives it an empty string — which is why the create handler checks it
+// explicitly rather than relying on serde, since serde also accepts `""`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ACInfoSubscription {
     /// Identifier of the EAS subscribing for AC information report

--- a/src/bins/nextgcore-eesd/src/types.rs
+++ b/src/bins/nextgcore-eesd/src/types.rs
@@ -567,6 +567,11 @@ pub mod cause {
     /// TS 24.558 §5.2.2.2: the cause an EEC registration is refused with when no
     /// matching EAS is identified for even one of its AC profiles.
     pub const RESOURCE_NOT_FOUND: &str = "RESOURCE_NOT_FOUND";
+    /// TS 29.500 §5.2.7.2: the operation is defined by the API but this EES does
+    /// not implement it. Used by the #106 capability APIs whose execution needs a
+    /// 5GC exposure leg that does not exist in this build — a retry can never
+    /// succeed, which is why they are 501 and not 503.
+    pub const NOT_IMPLEMENTED: &str = "NOT_IMPLEMENTED";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #106. Spec: `specs/fix-eesd-capability-exposure-and-notifications.md`.

All six acceptance criteria, one PR. Verified against `main` @ `143406a` — #105 rewrote large parts of eesd since `76ea248`, so every cite in the issue drifted (the nssfd-style ~240-line drift on `handle_acinfo_create`, for instance). Every claim still held.

Paths and operations were taken from the **vendored YAMLs**, not the issue text; they agree (`servers: - url: '{apiRoot}/eees-easinfoprov/v1'` etc.). One thing the YAML settles that the issue does not: the individual ACT status subscription resource defines **only GET** — no PUT/PATCH/DELETE — so the handler answers 405 rather than inventing them.

## Two APIs are served for real; three are honest refusals

**Read this before "five APIs routed" is mistaken for "five APIs working".**

| API | answer |
|---|---|
| `eees-easinfoprov` | **served locally** — 204 / 200 / 404 depending on `reqType` |
| `eees-ueidentifier` | **served** for a UE this EES knows (200); `501` for IP-only, `404` for an unknown GPSI |
| `eees-uelocation` | `501 NOT_IMPLEMENTED` — no UE location source |
| `eees-session-with-qos` | `501` — no NEF `AsSessionWithQoS` leg |
| `eees-tie` | `501` — no NEF/PCF-AF traffic-influence leg |

nefd (after #111) serves `3gpp-monitoring-event`, `3gpp-device-triggering` and `nnef-eventexposure` — there is no `AsSessionWithQoS`, no UE-ID service, no traffic-influence service to call. So for those three:

- **not 404** — that claims the resource does not exist, and a conformant consumer cannot tell a missing route from a typo;
- **not a 2xx** — answering `201` to `CreateIndSessionWithQoS` while actuating no QoS anywhere is fabricated success, and accepting a `eees-uelocation` subscription that can never fire is the *same silent failure this issue reports for AppClientInformation*;
- **501, not 503** — 503 invites a retry that can never succeed. Each 501 carries a ProblemDetails naming the missing leg.

If a NEF leg lands later the honest answer becomes a 2xx, and these tests are what must be inverted. Said out loud so the 501s don't read as permanent design.

## `easinfoprov`: the supported-scenario set is derived from code, not from the enumeration

`EES_SUPPORTED_ACR_SCENARIOS` = `EEC_INITIATED` (appctxtreloc), `EEC_EXECUTED_VIA_TARGET_EES` (the §5.10 context **pull**, landed in #105), `SOURCE_EAS_DECIDED` (acr-param + acrstatus-update), `EEL_MANAGED_ACR` (request-eelacr).

`EEC_EXECUTED_VIA_SOURCE_EES` and `SOURCE_EES_EXECUTED` are deliberately **absent**: both need this EES to act as *source* and push an EEC context, and only the pull half exists — the push counterpart is a known open gap. Advertising a scenario we would then fail to execute is worse than advertising fewer. `unsupported_acr_scenarios_are_not_advertised` pins it.

A selection request whose scenarios don't intersect gets **404, not a 200 with an empty list** — an empty selection dressed as success is the same lie as a fabricated 201.

## `ueidentifier`: an edge-layer identifier, not a CN-resolved identity

`edge_ue_id()` is SHA-256 over a domain-separated, **length-prefixed** `(gpsi, easId)`, truncated to 128 bits — stable (usable as a key), per-EAS (two EASes can't correlate a user by comparing identifiers), opaque (the GPSI isn't recoverable). Each property is asserted separately because they fail independently, and the length-prefixing is asserted too (`("ab","c")` vs `("a","bc")`).

`afSpecUeId` is **never populated**: echoing back the GPSI the requestor supplied would dress a value it already had as a CN resolution that never happened.

## `ACInfoNotification` — the defect with real behavioural impact

It was constructed only in tests. A subscriber was accepted, answered `201 + Location`, and then never told anything, with no error surface — the worst shape of interop failure. It now fires from EEC registration by matching `acFltrs` against `acProfs`, reporting **only the matching profiles**, not the whole registration (asserted — reporting everything would also satisfy a naive "a notification arrived" test).

Filter semantics are a choice the schema doesn't state, so they're documented: no filters matches everything (else an unfiltered subscription is the one shape that never fires); across entries OR; within an entry AND. Only `acIdsList`/`acTypesList` are evaluated — `svcArea`/`maxAcKpi`/`minAcKpi` are passthrough JSON with no `AcProfile` counterpart, so they're treated as **not constraining** rather than as a non-match. Over-notifying is recoverable at the consumer; never notifying is the bug being fixed.

## ACT status notifications go to `{notificationUri}/act-status`

The yaml's callback is `'{$request.body#/notificationUri}/act-status'`. Getting this wrong is invisible in-process — a POST to the bare URI is accepted by this tree's own test consumers and rejected by a conformant one. Trailing slashes are trimmed so `http://eas/cb/` doesn't produce `//act-status`. Fires only on a **terminal** ACT outcome, because `actStatus` is an `ACTResult` and an in-progress ACR has nothing to report.

## A revert exposed a hole in my own coverage

Replacing the ACT terminal-state gate in `handle_acr_status_update` with `None` — never notifying — **compiled and the whole suite still passed**. The context test exercises `notify_act_status_subscribers` directly and says nothing about whether any handler calls it: *"the helper is tested and the wiring is not"*, for the third time in this repo's history. `test_act_status_notification_fires_from_a_status_update` closes it, and the revert then failed.

That new test then **failed on its first run** (`left: 2, right: 1`): a sibling test leaves a subscription for the same `easId` in the process-global EES context, so both were notified. `GLOBAL_STATE_TEST_LOCK` serialises those tests but does not isolate them. Fixed with data isolation (an `easId` and callback URI unique to the test, then filtering the drained queue by it) rather than another lock. The same shape bit the lifecycle test's `list.len() == 1`, which is a property of the harness and not of the API — it now asserts the created resource is *present* in the collection. 5 consecutive full-suite runs green.

Full revert table (6 guards) in the spec.

## Criteria

| # | criterion | where |
|---|---|---|
| 1 | each of the five APIs returns a spec status, not 404 | `test_capability_apis_are_routed_and_never_404` (all five roots, each asserting the status it must return *and* that every 501 carries `NOT_IMPLEMENTED` + a reason) |
| 2 | `eel-acr/subscriptions` create+list, `/{id}` read; `ACTStatusSubsc` exists | `test_act_status_subscription_lifecycle` (+ 405 on the methods the yaml omits, 400 on a present-but-empty `notificationUri`) |
| 3 | a matching subscription+registration causes exactly one `ACInfoNotification` | `test_acinfo_notify_fires_once_on_a_matching_registration` |
| 4 | a test asserts a **production** `notifier::enqueue(_, _, "ACInfoNotification")` | `test_acinfo_notification_fires_through_the_router` — through the router, so it proves the wiring, not just the helper |
| 5 | module docs updated | `main.rs:28-45` and `services.rs:24-28` rewritten; "DEFERRED" → "ROUTED-AND-REFUSED, not deferred" with the reason |
| 6 | clippy + eesd suite pass | `6071 passed / 0 failed` (main: `6052`), clippy 0 errors, fmt clean |

## Ceilings

- **The three 501s do nothing but refuse honestly** — that is the deliverable for them, not an implementation.
- **`edgeUeId` is not a CN identity**; an EAS needing the subscriber's GPSI still cannot get one here.
- **No IP→UE binding** — `eees-ueidentifier` cannot answer an IP-only request at all.
- **ACT status subscriptions are in-memory, lost on restart, and have no DELETE** (the yaml defines none).
- **AC-information filters are partially evaluated**, erring toward over-notification.
- **`ACInfoNotification` fires only on EEC *registration***, not on an update that adds an AC profile — §5.5 arguably wants it, but that needs its own decision about de-duplicating repeat notifications for an unchanged profile.
- **`easinfoprov` stores nothing** — the response is a pure function of the request plus the EAS registry.
- **No wire interop** — in-process against this tree's own router and notifier queue; no EAS/EEC peer exists in this stack.
- GitNexus impact analysis unrunnable (no MCP server connected — 48th consecutive PR); blast radius by grep, enumerated in the spec.