### PR TITLE
fix(dccfd): read notificURI, key the fan-out, conformant notify/201/PUT, and coordinate producer subscriptions (#112)

### DIFF
--- a/specs/fix-dccfd-data-management-conformance-and-coordination.md
+++ b/specs/fix-dccfd-data-management-conformance-and-coordination.md
@@ -1,0 +1,188 @@
+# nextgcore #112 (dccfd): Ndccf_DataManagement wire conformance and producer-subscription coordination
+
+Verified against `main` @ `08bd7ab` (after #65/#272 and #106/#274). Every cite in the issue still
+held — dccfd had not been touched since `76ea248`.
+
+## Verified against current main
+
+| claim in the issue | check on `08bd7ab` | still true? |
+|---|---|---|
+| the callback is read from `"notifyUri"` | `main.rs:125` | yes |
+| only `(sub_id, notify_uri)` is stored | `context.rs:12-18` `DccfSubscription` has exactly those two fields | yes |
+| the `201` is a bespoke `{"subscriptionId":..,"status":"ACTIVE"}` with no `Location` | `main.rs:133-134` | yes |
+| a missing/unparseable body still yields `201` | `main.rs:129` `unwrap_or_default()` | yes |
+| `PUT` falls through to `405` | `main.rs:141-159` matches only GET/DELETE | yes |
+| the notify fan-out wraps the body as `{"data": <string>}` | `main.rs:181` | yes |
+| `dccf_context_fanout_notify` returns every subscription with a non-empty URI | `context.rs:135` | yes |
+| no `dataSub`/`anaSub` parsing, no NRF discovery, no producer-subscription state | grep across the crate → nothing | yes |
+| `notifCorrId` is never parsed, stored or echoed | grep → no occurrence in the crate | yes |
+
+## Which schema is authoritative
+
+TS 29.574's OpenAPI file is **not vendored**. Its data model is the same as `Nnwdaf_DataManagement`,
+whose file **is** vendored, so everything below was read out of
+`6g_docs/specs/TS29520_Nnwdaf_DataManagement.yaml`:
+
+* `NnwdafDataManagementSubsc`: `required: [notifCorrId, notificURI]`, `oneOf: [anaSub | dataSub]`
+* `POST /subscriptions` → `201` + `Location` (`required: true`) echoing the resource
+* `PUT /subscriptions/{subscriptionId}` → `UpdateNWDAFDataSubscription`
+* `NnwdafDataManagementNotif`: `required: [notifCorrId, notifTimestamp]`,
+  `oneOf: [dataNotification | dataReports | fetchInstruct]`
+* the callback is `'{$request.body#/notificURI}'`
+
+Members whose types come from yamls that are *also* absent (`DataSubscription` from TS 29.575,
+`FormattingInstruction` / `ProcessingInstruction` from TS 29.574) are passthrough
+`serde_json::Value` — the repo's established convention for a cross-spec leaf, because modelling a
+schema nobody can check against invents a contract.
+
+## The anchor: one character
+
+`notificURI` — `notific`, not `notif`, and `URI` uppercase. Note that `rename_all = "camelCase"`
+produces `notificUri`, which is *also* wrong, so the member needs an explicit
+`#[serde(rename = "notificURI")]`. That single character is the whole defect: a conformant consumer's
+URI was never captured, the stored URI stayed empty, and the empty-URI filter in the fan-out dropped
+that consumer from every notification. It subscribed, got a `201`, and was never told anything, with
+no error surface anywhere.
+
+## Decision 1: `serde(default)` on two members the yaml marks required
+
+Without it, an absent `notifCorrId` / `notificURI` is a **parse** error, which the handler can only
+report as `INVALID_MSG_FORMAT`. TS 29.500 wants `MANDATORY_IE_MISSING` for a missing mandatory IE, and
+that distinction is what tells a consumer whether its JSON is malformed or merely incomplete. So
+absence deserialises to an empty string and `validate()` names the offending member. Empty strings
+count as absent, because an empty callback URI is exactly the un-notifiable state being fixed.
+
+## Decision 2: the fan-out key, and what an indeterminate scope gets
+
+`SubscriptionScope { events, target }` replaces "any non-empty URI".
+
+* From `anaSub` the extraction is **exact**: `NnwdafEventsSubscription` is vendored, so
+  `eventSubscriptions[].event` is read directly.
+* From `dataSub` it is a documented **heuristic**: that schema is not vendored, so every string under
+  a key named `event`, `eventId` or `type`, at any depth, is collected. Depth-bounded at 16 —
+  `dataSub` is peer-supplied on the request path.
+* An inbound producer notification is scoped the same way, from
+  `eventNotifications[].event`.
+
+Matching requires an event intersection, and a `target` named on **both** sides must agree. A side
+that named no target does not constrain, because it constrained nothing.
+
+**A subscription whose scope cannot be determined matches nothing, not everything.** Delivering to it
+— the old behaviour — is the cross-consumer disclosure defect. It is logged at warn on create, naming
+the consequence and what to supply, so a scope-less subscriber is *visible*, which an over-broad
+delivery is not.
+
+## Decision 3: coordination is a runtime switch, not a cargo feature
+
+The issue suggests a cargo feature (`dccf-coordination`) and criterion 7 is marked
+"(Feature-gated)". **Deviation, deliberate:** it is a runtime switch (`--coordination` /
+`DCCF_COORDINATION`, default off) instead, because CI builds default features — a cargo feature would
+leave the coordination path **uncompiled in CI**, where it would rot unnoticed. A runtime switch means
+one `cargo test` run compiles and exercises **both** states, which is a stronger reading of criterion
+8 ("passes with the feature both off and on") than running the suite twice.
+
+Default **off**, honouring the issue's "keep the current registry as the default until the new path is
+validated": coordination makes `subscribe` perform outbound signalling that can fail or stall, and
+nothing in this stack exercises dccfd end to end. `coordination_off_creates_no_producer_subscription`
+guards that default with the same request the ON test uses.
+
+## Decision 4: coordination requires the consumer to name its producer
+
+`targetNfId` present → `GET {nrf}/nnrf-nfm/v1/nf-instances/{targetNfId}` (TS 29.510 NF profile
+retrieval, which nrfd serves), pick that profile's event-exposure service, POST the **consumer's own**
+subscription body with `notificationURI`/`notifCorrId` rewritten to this DCCF.
+
+Forwarding the consumer's body rather than synthesising one matters: the DCCF is subscribing *on its
+behalf*, not inventing a subscription.
+
+`targetNfId` absent → coordination is skipped with a log line. Doing otherwise needs an
+event→producer-NF-type table (TS 23.288 §6.2), and for most NWDAF events that mapping is genuinely
+ambiguous — `SERVICE_EXPERIENCE` can come from an AF or the NEF, `NF_LOAD` from OAM or the NRF.
+Guessing would create producer subscriptions on the wrong NF. The consumer subscription still
+succeeds: its contract is with the DCCF, and refusing it would make an unresolvable producer look
+like a malformed request.
+
+The event-exposure service is found by **name** (`eventexposure` / `evts` / `eventssubscription`)
+rather than from a hardcoded list of NF types, so a producer family this DCCF has never heard of still
+works.
+
+Producer subscriptions are **refcounted** by consumer: the last consumer to unsubscribe deletes the
+producer resource, so one consumer's unsubscribe cannot cut off another's data.
+
+## What was added / changed
+
+| area | change |
+|---|---|
+| `data_mgmt.rs` (new) | `DataManagementSubsc` + `validate()`, `SubscValidationError` with per-member details, `DataManagementNotif`, `SubscriptionScope` (`from_subsc`, `from_notification`, `matches`), the depth-bounded event sweep |
+| `coordination.rs` (new) | `enable_coordination`, `CoordinationConfig`, `ensure_producer_subscription`, `delete_producer_subscription`, NF-profile retrieval, event-exposure endpoint selection, `split_uri` |
+| `context.rs` | `DccfSubscription` gains `notif_corr_id`, `scope`, `resource`; `ProducerSubscription`; `dccf_context_store_subscription` / `_get_subscription` / `_subscription_ids`; `dccf_context_fanout_notify_scoped`; producer claim/record/release/count; the crate-wide `GLOBAL_TEST_LOCK` |
+| `main.rs` | `handle_dm_subscribe` / `_update` / `_unsubscribe` / `_notify`, `parse_subsc`, `bad_request`, `rfc3339_now`, `DM_SUBSCRIPTIONS_PATH`; the PUT route arm; GET echoes the stored resource |
+| `Cargo.toml` | `serde` (the wire types are derived, not hand-built from `Value`) |
+
+The pre-#112 unkeyed `dccf_context_fanout_notify` is retained as `#[cfg(test)]` only, so it cannot be
+reintroduced into production by accident.
+
+## Verification
+
+Every guard revert-verified: undo the fix, watch the **named** test fail, restore.
+
+| guard | revert applied | result |
+|---|---|---|
+| `the_callback_member_is_spelled_notific_uri`, `a_conformant_subscription_receives_its_notifications` | `rename = "notifyUri"` | FAILED ✓ |
+| `fanout_is_keyed_on_the_subscribed_event` | filter on non-empty URI only | FAILED ✓ |
+| `invalid_subscribe_bodies_are_rejected_with_problem_details` | `validate()` call removed | FAILED ✓ |
+| `create_returns_location_and_the_spec_resource` | `Location` header removed | FAILED ✓ |
+| `put_updates_the_subscription_and_its_scope` | PUT stores the new body but keeps the OLD scope | FAILED ✓ |
+| `overlapping_consumers_share_one_producer_subscription` | reuse check dropped (always create) | FAILED ✓ |
+| `a_conformant_subscription_receives_its_notifications` | notify with the old `{"data": ...}` envelope | FAILED ✓ |
+
+The PUT revert is worth naming: storing the new body while leaving the stale scope in place passes a
+GET-only assertion, so the test also asserts the recomputed scope no longer contains the old event.
+
+### A flake I caused, and the fix the repo already knows
+
+`context::tests::test_subscription_lifecycle` — a **pre-existing** test — started failing
+intermittently: my new `clear_subscriptions()` helper wipes the process-global subscription map, and
+that test had its own private guard, so the two modules were two disjoint agreements about the same
+variable. One green run proved nothing; the failure was order-dependent.
+
+Fixed by hoisting **one** crate-wide `GLOBAL_TEST_LOCK` into `context.rs` and having both test modules
+take it — the same resolution recorded for seppd in #100, and the reason a second lock is not the fix.
+Every pre-existing test in `context::tests` now takes it too, not only the fan-out ones. 5 consecutive
+runs green.
+
+## Workspace state
+
+`6090 passed / 0 failed` (main: `6071`), `cargo clippy --workspace --all-targets` 0 errors,
+`cargo clippy -p nextgcore-dccfd --all-targets` **0 warnings** (criterion 8 asks for none, not just
+no errors — `result_large_err` on `parse_subsc` was fixed by boxing, as eesd's `parse_json_body`
+does), `cargo fmt --all --check` clean.
+
+## Ceilings
+
+* **Coordination is off by default, so the DCCF still de-duplicates nothing in a default
+  deployment.** The mechanism exists, is tested, and is one flag away; that flag is the operator's
+  call, not this change's.
+* **Coordination needs `targetNfId`.** A consumer that names no target gets no producer subscription,
+  by design (see Decision 4). The event→producer-NF-type mapping is deliberately absent.
+* **`dataSub` scope extraction is a heuristic** over an unvendored schema. A `dataSub` whose event
+  identifier sits under a key not named `event`/`eventId`/`type` yields an empty scope, and that
+  consumer receives nothing — logged at warn, but silent on the wire. Vendoring TS 29.575 would let
+  this become exact.
+* **Only `dataNotification` is produced.** `dataReports` and `fetchInstruct` are modelled but never
+  emitted; the DCCF forwards, it does not summarise or store-and-instruct.
+* **No ADRF interaction.** `adrfId` / `adrfSetId` are parsed and echoed but nothing is stored to an
+  ADRF, so a consumer asking for storage is not served — it is also not told that, which is the
+  weakest point left in the contract.
+* **`formatInstruct` / `procInstruct` are echoed, not applied.** Data is forwarded verbatim.
+* **The producer subscription is created but never refreshed**, and its expiry is not tracked. A
+  producer that expires the subscription silently stops the data.
+* **No user-consent enforcement.** `dataCollectPurposes` / `checkedConsentInd` are parsed and ignored;
+  TS 23.288 makes consent checking conditional on local policy, and there is no consent source here.
+* **No wire interop.** The coordination test uses loopback `SbiServer`s standing in for the NRF and
+  the producer — real HTTP and a real `SbiClient`, but this tree's own server on both ends.
+* GitNexus impact analysis unrunnable (no MCP server connected — 49th consecutive PR). Blast radius
+  by grep: `dccf_context_fanout_notify` had exactly one production caller (rewritten) and two test
+  callers (kept, now `cfg(test)`); `dccf_context_add_subscription_with_uri` keeps its signature for
+  the `Ndccf_ContextDocument` side; `DccfSubscription` is constructed in three places, all in this
+  crate; no crate outside `nextgcore-dccfd` names any type touched here.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
  "nextgcore-sbi",
  "p256",
  "proptest",
+ "serde",
  "serde_json",
  "serde_yaml",
  "tokio",

--- a/src/bins/nextgcore-dccfd/Cargo.toml
+++ b/src/bins/nextgcore-dccfd/Cargo.toml
@@ -19,6 +19,10 @@ log.workspace = true
 env_logger.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
+# #112: the Ndccf_DataManagement wire types are derived, not hand-built from
+# serde_json::Value, so the member spellings (notably notificURI) are pinned in
+# one place and checkable against the yaml.
+serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 uuid.workspace = true

--- a/src/bins/nextgcore-dccfd/src/context.rs
+++ b/src/bins/nextgcore-dccfd/src/context.rs
@@ -8,13 +8,47 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
-/// A registered data-management subscription with its notification callback URI.
+use crate::data_mgmt::{DataManagementSubsc, SubscriptionScope};
+
+/// A registered data-management subscription (#112).
+///
+/// Before this it was `(id, notify_uri)` and nothing else: the correlation id was
+/// never stored, and neither was what the consumer had actually subscribed TO —
+/// which is why the fan-out could not be keyed on anything.
 #[derive(Debug, Clone)]
 pub struct DccfSubscription {
-    /// Subscription ID (UUID)
+    /// Subscription ID (UUID), the resource key.
     pub id: String,
-    /// Consumer callback URI for Ndccf_DataManagement_Notify (may be empty)
+    /// Consumer callback URI (`notificURI`). Non-empty by construction: the
+    /// handler refuses a subscription without one.
     pub notify_uri: String,
+    /// `notifCorrId`, echoed on every notification delivered to this consumer so
+    /// it can correlate. Previously not parsed anywhere in the crate.
+    pub notif_corr_id: String,
+    /// What this subscription covers — the fan-out key.
+    pub scope: SubscriptionScope,
+    /// The subscription resource as received, echoed on `201`, `GET` and `PUT`.
+    /// Stored rather than re-synthesised so the echo cannot drift from what the
+    /// consumer sent.
+    pub resource: DataManagementSubsc,
+}
+
+/// A producer `EventExposure` subscription the DCCF created on consumers' behalf
+/// (#112, TS 23.288 §5A.2 — the coordination the DCCF exists to perform).
+#[derive(Debug, Clone)]
+pub struct ProducerSubscription {
+    /// The `(events, target)` scope this producer subscription covers. Two
+    /// consumers with the same scope share one producer subscription, which is
+    /// the de-duplication that reduces producer load.
+    pub scope: SubscriptionScope,
+    /// Producer NF instance the subscription was created on.
+    pub producer_id: String,
+    /// Resource URI returned by the producer, used to delete it later.
+    pub resource_uri: String,
+    /// Consumer subscription ids currently relying on it. The producer
+    /// subscription is removed when this empties — refcounting, so one
+    /// consumer's unsubscribe cannot cut off another's data.
+    pub consumers: HashSet<String>,
 }
 
 /// DCCF process-wide context
@@ -25,6 +59,9 @@ struct DccfContext {
     subscription_map: HashMap<String, DccfSubscription>,
     /// Active analytics context IDs (Ndccf_ContextDocument)
     analytics_contexts: HashSet<String>,
+    /// Producer subscriptions the DCCF holds on consumers' behalf, keyed by a
+    /// canonical form of their scope (#112).
+    producer_subs: HashMap<String, ProducerSubscription>,
     /// Maximum allowed subscriptions
     max_subscriptions: usize,
     /// Total notifications fanned out
@@ -32,6 +69,21 @@ struct DccfContext {
 }
 
 static CONTEXT: OnceLock<Mutex<DccfContext>> = OnceLock::new();
+
+/// The ONE lock serialising every test that touches process-global DCCF state
+/// (#112).
+///
+/// This module and `main.rs`'s `data_management_tests` both mutate the same
+/// `CONTEXT` singleton — the subscription map, the producer-subscription registry
+/// and `fanout_count`. They previously had a private guard each, which is two
+/// disjoint agreements about the same variable: `data_management_tests` clears the
+/// subscription map between cases and would do so while a `context::tests` case
+/// held a subscription it was about to assert on. One green run proved nothing;
+/// the failure was order-dependent.
+///
+/// A single lock is the fix, not a second one. `unwrap_or_else(|e| e.into_inner())`
+/// at every acquisition, so one panicking test does not poison the rest.
+pub static GLOBAL_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 fn ctx() -> &'static Mutex<DccfContext> {
     CONTEXT.get().expect("value expected")
@@ -44,6 +96,7 @@ pub fn dccf_context_init(max_subscriptions: usize) {
             subscriptions: HashSet::new(),
             subscription_map: HashMap::new(),
             analytics_contexts: HashSet::new(),
+            producer_subs: HashMap::new(),
             max_subscriptions,
             fanout_count: 0,
         })
@@ -62,24 +115,53 @@ pub fn dccf_context_add_subscription(sub_id: String) -> bool {
 
 /// Registers a new subscription with a consumer callback URI.
 /// Returns false if capacity is exhausted.
+///
+/// Kept for the `Ndccf_ContextDocument` side and the pre-#112 tests. A
+/// subscription registered this way has an EMPTY scope, so it receives nothing
+/// from the keyed fan-out — see [`dccf_context_fanout_notify`].
 pub fn dccf_context_add_subscription_with_uri(sub_id: String, notify_uri: String) -> bool {
+    dccf_context_store_subscription(DccfSubscription {
+        id: sub_id,
+        notify_uri,
+        notif_corr_id: String::new(),
+        scope: SubscriptionScope::default(),
+        resource: DataManagementSubsc::default(),
+    })
+}
+
+/// Store a fully-populated subscription record (#112). Returns false when
+/// capacity is exhausted; replaces an existing record with the same id, which is
+/// what `PUT` needs.
+pub fn dccf_context_store_subscription(sub: DccfSubscription) -> bool {
     let mut c = ctx().lock().unwrap();
-    if c.subscriptions.len() >= c.max_subscriptions {
+    let replacing = c.subscriptions.contains(&sub.id);
+    if !replacing && c.subscriptions.len() >= c.max_subscriptions {
         log::warn!(
             "[DCCF] subscription capacity exhausted ({})",
             c.max_subscriptions
         );
         return false;
     }
-    c.subscription_map.insert(
-        sub_id.clone(),
-        DccfSubscription {
-            id: sub_id.clone(),
-            notify_uri,
-        },
-    );
-    c.subscriptions.insert(sub_id);
+    if sub.scope.events.is_empty() {
+        // Not an error -- the schema permits a `dataSub` shape whose event scope
+        // this DCCF cannot determine -- but it IS the reason such a consumer
+        // receives nothing, so it must be visible rather than silent. Delivering
+        // to it anyway is the cross-consumer disclosure defect #112 names.
+        log::warn!(
+            "[DCCF] subscription {} has no determinable event scope: it will receive NO \
+             notifications. Supply anaSub.eventSubscriptions[].event, or a dataSub carrying an \
+             event identifier.",
+            sub.id
+        );
+    }
+    c.subscription_map.insert(sub.id.clone(), sub.clone());
+    c.subscriptions.insert(sub.id);
     true
+}
+
+/// The stored record for a subscription id.
+pub fn dccf_context_get_subscription(sub_id: &str) -> Option<DccfSubscription> {
+    ctx().lock().unwrap().subscription_map.get(sub_id).cloned()
 }
 
 /// Removes a subscription.  Returns true if it existed.
@@ -92,6 +174,22 @@ pub fn dccf_context_remove_subscription(sub_id: &str) -> bool {
 /// Returns true if the subscription exists.
 pub fn dccf_context_has_subscription(sub_id: &str) -> bool {
     ctx().lock().unwrap().subscriptions.contains(sub_id)
+}
+
+/// Every active subscription id.
+///
+/// Exists so a test can clear the process-global registry between cases: the
+/// context is a `OnceLock`, so one instance is shared across the whole test
+/// binary and a stale subscription from a sibling test changes another test's
+/// fan-out count.
+pub fn dccf_context_subscription_ids() -> Vec<String> {
+    ctx()
+        .lock()
+        .unwrap()
+        .subscriptions
+        .iter()
+        .cloned()
+        .collect()
 }
 
 /// Returns the number of active subscriptions.
@@ -122,11 +220,50 @@ pub fn dccf_context_remove_analytics_context(ctx_id: &str) {
 // Fan-out (Ndccf_DataManagement_Notify)
 // ---------------------------------------------------------------------------
 
-/// Fans out a notification body to all registered analytics consumers.
+/// Fans out a notification to the consumers whose scope MATCHES it (#112).
 ///
-/// Returns the list of (sub_id, notify_uri) pairs that have a non-empty
-/// callback URI.  The caller is responsible for making the HTTP POST requests
-/// (the context lock must not be held during network I/O).
+/// Returns `(sub_id, notify_uri, notif_corr_id)` per matching consumer; the
+/// caller performs the POSTs, because the context lock must not be held across
+/// network I/O.
+///
+/// This used to return every subscription with a non-empty callback URI,
+/// regardless of what it had subscribed to — so any consumer that got a URI
+/// stored received every other consumer's collected data. Matching is now on
+/// `(events, target)`; see [`SubscriptionScope::matches`] for the rules, including
+/// why an indeterminate scope matches nothing rather than everything.
+///
+/// `notif_corr_id` is returned alongside because each consumer's notification
+/// must echo ITS OWN correlation id — one broadcast body cannot serve them all.
+pub fn dccf_context_fanout_notify_scoped(
+    notif_scope: &SubscriptionScope,
+) -> Vec<(String, String, String)> {
+    let mut c = ctx().lock().unwrap();
+    let total = c.subscription_map.len();
+    let targets: Vec<(String, String, String)> = c
+        .subscription_map
+        .values()
+        .filter(|s| !s.notify_uri.is_empty() && s.scope.matches(notif_scope))
+        .map(|s| (s.id.clone(), s.notify_uri.clone(), s.notif_corr_id.clone()))
+        .collect();
+    c.fanout_count += targets.len() as u64;
+    log::debug!(
+        "[DCCF] fanout: {}/{} subscribers matched events={:?} target={:?}, total_fanout={}",
+        targets.len(),
+        total,
+        notif_scope.events,
+        notif_scope.target,
+        c.fanout_count,
+    );
+    targets
+}
+
+/// Pre-#112 unkeyed fan-out, retained only for the `Ndccf_ContextDocument`
+/// tests that predate scoping. Returns every subscriber with a callback URI.
+///
+/// Not used by the `Ndccf_DataManagement` notify path any more — that is
+/// [`dccf_context_fanout_notify_scoped`]. Left as `cfg(test)` so it cannot be
+/// reintroduced into production by accident.
+#[cfg(test)]
 pub fn dccf_context_fanout_notify(body: &str) -> Vec<(String, String)> {
     let mut c = ctx().lock().unwrap();
     let targets: Vec<(String, String)> = c
@@ -144,6 +281,110 @@ pub fn dccf_context_fanout_notify(body: &str) -> Vec<(String, String)> {
         c.fanout_count,
     );
     targets
+}
+
+// ---------------------------------------------------------------------------
+// #112: producer-subscription coordination (TS 23.288 §5A.2)
+// ---------------------------------------------------------------------------
+
+/// Canonical key for a scope, so two consumers asking for the same
+/// `(events, target)` map to one producer subscription.
+///
+/// The events are a `BTreeSet`, so the key is order-independent: two consumers
+/// naming the same events in a different order must share, not duplicate.
+pub fn scope_key(scope: &SubscriptionScope) -> String {
+    format!(
+        "{}|{}",
+        scope.events.iter().cloned().collect::<Vec<_>>().join(","),
+        scope.target.as_deref().unwrap_or("")
+    )
+}
+
+/// Outcome of claiming a producer subscription for a consumer.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ProducerClaim {
+    /// An existing producer subscription covers this scope; it was reused and no
+    /// producer signalling is needed. This is the de-duplication.
+    Reused {
+        /// The producer NF instance already subscribed to.
+        producer_id: String,
+    },
+    /// No producer subscription covers this scope; the caller must create one and
+    /// then record it with [`dccf_context_record_producer_sub`].
+    NeedsCreate,
+}
+
+/// Claim a producer subscription for `consumer_id` at `scope`.
+pub fn dccf_context_claim_producer_sub(
+    consumer_id: &str,
+    scope: &SubscriptionScope,
+) -> ProducerClaim {
+    let key = scope_key(scope);
+    let mut c = ctx().lock().unwrap();
+    match c.producer_subs.get_mut(&key) {
+        Some(existing) => {
+            existing.consumers.insert(consumer_id.to_string());
+            log::info!(
+                "[DCCF] reusing producer subscription on {} for scope {key} ({} consumers)",
+                existing.producer_id,
+                existing.consumers.len()
+            );
+            ProducerClaim::Reused {
+                producer_id: existing.producer_id.clone(),
+            }
+        }
+        None => ProducerClaim::NeedsCreate,
+    }
+}
+
+/// Record a producer subscription the caller has just created.
+pub fn dccf_context_record_producer_sub(
+    consumer_id: &str,
+    scope: SubscriptionScope,
+    producer_id: String,
+    resource_uri: String,
+) {
+    let key = scope_key(&scope);
+    let mut c = ctx().lock().unwrap();
+    let entry = c.producer_subs.entry(key.clone()).or_insert_with(|| {
+        log::info!("[DCCF] created producer subscription on {producer_id} for scope {key}");
+        ProducerSubscription {
+            scope,
+            producer_id,
+            resource_uri,
+            consumers: HashSet::new(),
+        }
+    });
+    entry.consumers.insert(consumer_id.to_string());
+}
+
+/// Release a consumer's claim. Returns the producer subscription to DELETE when
+/// this was its last consumer — refcounted, so one consumer's unsubscribe cannot
+/// cut off another's data.
+pub fn dccf_context_release_producer_sub(consumer_id: &str) -> Option<ProducerSubscription> {
+    let mut c = ctx().lock().unwrap();
+    let mut orphaned_key = None;
+    for (key, sub) in c.producer_subs.iter_mut() {
+        if sub.consumers.remove(consumer_id) && sub.consumers.is_empty() {
+            orphaned_key = Some(key.clone());
+            break;
+        }
+    }
+    let key = orphaned_key?;
+    let removed = c.producer_subs.remove(&key);
+    if let Some(sub) = &removed {
+        log::info!(
+            "[DCCF] last consumer for scope {key} released; deleting producer subscription {}",
+            sub.resource_uri
+        );
+    }
+    removed
+}
+
+/// How many producer subscriptions the DCCF currently holds. The de-duplication
+/// assertion: two overlapping consumers must leave this at 1.
+pub fn dccf_context_producer_sub_count() -> usize {
+    ctx().lock().unwrap().producer_subs.len()
 }
 
 /// Returns the total number of notification fan-outs performed.
@@ -167,12 +408,15 @@ pub fn dccf_context_final() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex as StdMutex;
 
-    /// Serialises tests that touch the global DCCF context. Without this
-    /// they race on subscriptions / fanout_count under cargo test's
-    /// default parallel runner.
-    static TEST_GUARD: StdMutex<()> = StdMutex::new(());
+    /// Serialises tests that touch the global DCCF context. Without this they
+    /// race on subscriptions / fanout_count under cargo test's default parallel
+    /// runner.
+    ///
+    /// #112: this is now the CRATE-WIDE lock, shared with `main.rs`'s
+    /// `data_management_tests`, which also mutates the same singleton. A guard
+    /// private to this module did not cover that.
+    use super::GLOBAL_TEST_LOCK as TEST_GUARD;
 
     fn init() {
         let _ = CONTEXT.get_or_init(|| {
@@ -180,6 +424,7 @@ mod tests {
                 subscriptions: HashSet::new(),
                 subscription_map: HashMap::new(),
                 analytics_contexts: HashSet::new(),
+                producer_subs: HashMap::new(),
                 max_subscriptions: 16,
                 fanout_count: 0,
             })
@@ -188,6 +433,7 @@ mod tests {
 
     #[test]
     fn test_subscription_lifecycle() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|p| p.into_inner());
         init();
         dccf_context_add_subscription("sub-1".into());
         assert!(dccf_context_has_subscription("sub-1"));
@@ -198,6 +444,7 @@ mod tests {
 
     #[test]
     fn test_analytics_context_lifecycle() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|p| p.into_inner());
         init();
         dccf_context_add_analytics_context("ctx-1".into());
         assert!(dccf_context_has_analytics_context("ctx-1"));

--- a/src/bins/nextgcore-dccfd/src/coordination.rs
+++ b/src/bins/nextgcore-dccfd/src/coordination.rs
@@ -1,0 +1,416 @@
+//! Producer-subscription coordination — the DCCF's defining function (#112).
+//!
+//! TS 23.288 §5A.2: the DCCF collects from a producer **once** and shares the
+//! data with every analytics consumer that asked for it, instead of each
+//! consumer subscribing to the producer directly. Without this the DCCF is a
+//! passive callback registry: it adds a hop and reduces no signalling.
+//!
+//! # Flow
+//!
+//! On a consumer subscribe, when a producer subscription for the same
+//! `(events, target)` scope already exists it is **reused** (the whole point);
+//! otherwise the DCCF:
+//!
+//! 1. resolves the named NF instance — `GET
+//!    {nrf}/nnrf-nfm/v1/nf-instances/{targetNfId}` (TS 29.510 NF profile
+//!    retrieval);
+//! 2. picks that profile's event-exposure service and builds its apiRoot;
+//! 3. POSTs the **consumer's own** subscription body with `notificationURI` and
+//!    `notifCorrId` rewritten to point at this DCCF, so the producer's data
+//!    arrives here;
+//! 4. records the resource URI, refcounted by consumer, so the last consumer to
+//!    unsubscribe deletes it.
+//!
+//! # Off by default
+//!
+//! Gated behind `--coordination` / `DCCF_COORDINATION`, default **off**, because
+//! it makes `subscribe` perform outbound signalling that can fail or stall — a
+//! behaviour change in an NF nothing in this stack exercises end to end yet. The
+//! issue asked for a *cargo feature*; a runtime switch is used instead so CI
+//! **compiles and tests both states in one run**. A cargo feature would leave the
+//! coordination path uncompiled in CI (which builds default features), where it
+//! would rot unnoticed.
+//!
+//! # What is deliberately not implemented
+//!
+//! Coordination requires the consumer to name its producer (`targetNfId`). A
+//! consumer that names none would need an event→producer-NF-type table (TS 23.288
+//! §6.2), and for most NWDAF events that mapping is genuinely ambiguous —
+//! `SERVICE_EXPERIENCE` can come from an AF or the NEF, `NF_LOAD` from OAM or the
+//! NRF. Guessing would create producer subscriptions on the wrong NF. Such a
+//! subscription is accepted and served by the consumer-facing contract; only the
+//! coordination step is skipped, with a log line saying so.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+
+use nextgcore_sbi::client::SbiClient;
+
+use crate::context::{
+    dccf_context_claim_producer_sub, dccf_context_record_producer_sub, ProducerClaim,
+};
+use crate::data_mgmt::{DataManagementSubsc, SubscriptionScope};
+
+/// Is coordination enabled for this process?
+static COORDINATION_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// The NRF to resolve producers through, and this DCCF's own notification URI.
+static COORDINATION_CONFIG: OnceLock<CoordinationConfig> = OnceLock::new();
+
+/// What the coordination path needs to reach the NRF and to be called back.
+#[derive(Debug, Clone)]
+pub struct CoordinationConfig {
+    /// NRF root, e.g. `http://127.0.0.1:7777`.
+    pub nrf_uri: String,
+    /// This DCCF's own notify URI, handed to producers as `notificationURI` so
+    /// their data arrives here rather than at the consumer.
+    pub own_notify_uri: String,
+}
+
+/// Enable coordination with the given config (called once at startup).
+pub fn enable_coordination(config: CoordinationConfig) {
+    let _ = COORDINATION_CONFIG.set(config);
+    COORDINATION_ENABLED.store(true, Ordering::SeqCst);
+    log::info!("[DCCF] producer-subscription coordination ENABLED (TS 23.288 §5A.2)");
+}
+
+/// Whether coordination is enabled.
+pub fn coordination_enabled() -> bool {
+    COORDINATION_ENABLED.load(Ordering::SeqCst)
+}
+
+/// Test-only: set the config and toggle without going through startup.
+#[cfg(test)]
+pub fn set_coordination_for_test(config: Option<CoordinationConfig>) {
+    match config {
+        Some(c) => {
+            // `OnceLock` cannot be re-set, so tests share one config; the NRF and
+            // notify URI are per-run values passed by the caller.
+            let _ = COORDINATION_CONFIG.set(c);
+            COORDINATION_ENABLED.store(true, Ordering::SeqCst);
+        }
+        None => COORDINATION_ENABLED.store(false, Ordering::SeqCst),
+    }
+}
+
+/// The current coordination config, when enabled.
+fn config() -> Option<&'static CoordinationConfig> {
+    coordination_enabled()
+        .then(|| COORDINATION_CONFIG.get())
+        .flatten()
+}
+
+/// Outcome of the coordination step, so the caller (and the tests) can see what
+/// happened rather than inferring it from logs.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CoordinationOutcome {
+    /// Coordination is switched off.
+    Disabled,
+    /// The subscription named no `targetNfId`, so no producer could be resolved
+    /// without guessing.
+    NoProducerNamed,
+    /// An existing producer subscription was reused — the de-duplication.
+    Reused { producer_id: String },
+    /// A new producer subscription was created.
+    Created { producer_id: String },
+    /// Something failed; the consumer subscription still stands.
+    Failed(String),
+}
+
+/// Ensure a producer subscription exists for `scope`, creating one only if no
+/// existing subscription already covers it.
+pub async fn ensure_producer_subscription(
+    consumer_id: &str,
+    scope: &SubscriptionScope,
+    sub: &DataManagementSubsc,
+) -> CoordinationOutcome {
+    let Some(cfg) = config() else {
+        return CoordinationOutcome::Disabled;
+    };
+    // Reuse first: this is the whole point of the DCCF, so it must be checked
+    // before any producer signalling.
+    if let ProducerClaim::Reused { producer_id } =
+        dccf_context_claim_producer_sub(consumer_id, scope)
+    {
+        return CoordinationOutcome::Reused { producer_id };
+    }
+
+    let Some(target) = sub.target_nf_id.as_deref() else {
+        log::info!(
+            "[DCCF] consumer subscription {consumer_id} names no targetNfId; skipping producer \
+             coordination (an event-to-producer mapping is deliberately not guessed)"
+        );
+        return CoordinationOutcome::NoProducerNamed;
+    };
+
+    let profile = match fetch_nf_profile(&cfg.nrf_uri, target).await {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("[DCCF] producer discovery for {target} failed: {e}");
+            return CoordinationOutcome::Failed(e);
+        }
+    };
+    let Some((api_root, service_name)) = event_exposure_endpoint(&profile) else {
+        let detail = format!("NF {target} advertises no event-exposure service");
+        log::warn!("[DCCF] {detail}");
+        return CoordinationOutcome::Failed(detail);
+    };
+
+    // Forward the CONSUMER'S own subscription body, with the callback rewritten
+    // to this DCCF. Rewriting rather than synthesising a body means the producer
+    // receives exactly what the consumer asked for -- the DCCF is subscribing on
+    // its behalf, not inventing a subscription.
+    let mut producer_body = match sub.ana_sub.clone().or_else(|| sub.data_sub.clone()) {
+        Some(b) => b,
+        None => return CoordinationOutcome::Failed("no anaSub/dataSub to forward".to_string()),
+    };
+    if let Some(obj) = producer_body.as_object_mut() {
+        obj.insert(
+            "notificationURI".to_string(),
+            serde_json::Value::String(cfg.own_notify_uri.clone()),
+        );
+        obj.insert(
+            "notifCorrId".to_string(),
+            serde_json::Value::String(format!("dccf-{consumer_id}")),
+        );
+    }
+
+    match post_producer_subscription(&api_root, &service_name, &producer_body).await {
+        Ok(resource_uri) => {
+            dccf_context_record_producer_sub(
+                consumer_id,
+                scope.clone(),
+                target.to_string(),
+                resource_uri,
+            );
+            CoordinationOutcome::Created {
+                producer_id: target.to_string(),
+            }
+        }
+        Err(e) => {
+            log::warn!("[DCCF] creating a producer subscription on {target} failed: {e}");
+            CoordinationOutcome::Failed(e)
+        }
+    }
+}
+
+/// Delete a producer subscription that has lost its last consumer.
+pub async fn delete_producer_subscription(resource_uri: &str) {
+    let Some((host, port, path)) = split_uri(resource_uri) else {
+        log::warn!("[DCCF] cannot delete producer subscription: unparseable URI {resource_uri}");
+        return;
+    };
+    let client = SbiClient::with_host_port(&host, port);
+    match client.delete(&path).await {
+        Ok(resp) => log::info!(
+            "[DCCF] deleted producer subscription {resource_uri} -> status={}",
+            resp.status
+        ),
+        Err(e) => log::warn!("[DCCF] deleting producer subscription {resource_uri} failed: {e}"),
+    }
+}
+
+/// `GET {nrf}/nnrf-nfm/v1/nf-instances/{nfInstanceId}` — TS 29.510 NF profile
+/// retrieval. Returns the profile JSON.
+async fn fetch_nf_profile(
+    nrf_uri: &str,
+    nf_instance_id: &str,
+) -> Result<serde_json::Value, String> {
+    let Some((host, port, _)) = split_uri(nrf_uri) else {
+        return Err(format!("unparseable NRF URI {nrf_uri}"));
+    };
+    let client = SbiClient::with_host_port(&host, port);
+    let path = format!("/nnrf-nfm/v1/nf-instances/{nf_instance_id}");
+    let resp = client.get(&path).await.map_err(|e| e.to_string())?;
+    if resp.status != 200 {
+        return Err(format!("NRF answered {} for {path}", resp.status));
+    }
+    serde_json::from_str(resp.http.content.as_deref().unwrap_or("{}"))
+        .map_err(|e| format!("unparseable NF profile: {e}"))
+}
+
+/// Pick an event-exposure service from an NF profile and build its apiRoot.
+///
+/// A service is taken to be event exposure when its `serviceName` contains
+/// `eventexposure` or `evts` — the two spellings 3GPP uses
+/// (`namf-evts`, `nsmf-event-exposure`, `nnwdaf-eventssubscription`,
+/// `npcf-eventexposure`). Matching on the name rather than a hardcoded list means
+/// a producer family this DCCF has never heard of still works.
+fn event_exposure_endpoint(profile: &serde_json::Value) -> Option<(String, String)> {
+    let services = profile.get("nfServices").and_then(|v| v.as_array())?;
+    let service = services.iter().find(|s| {
+        s.get("serviceName")
+            .and_then(|n| n.as_str())
+            .is_some_and(|n| {
+                let n = n.to_ascii_lowercase();
+                n.contains("eventexposure")
+                    || n.contains("evts")
+                    || n.contains("eventssubscription")
+            })
+    })?;
+    let service_name = service.get("serviceName")?.as_str()?.to_string();
+
+    // apiRoot: prefer the service's own ipEndPoints, then the profile's
+    // addresses. A profile with neither is not reachable and is skipped rather
+    // than dialled at a guessed port.
+    let scheme = service
+        .get("scheme")
+        .and_then(|s| s.as_str())
+        .unwrap_or("http");
+    if let Some(ep) = service
+        .get("ipEndPoints")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+    {
+        let addr = ep
+            .get("ipv4Address")
+            .and_then(|v| v.as_str())
+            .or_else(|| ep.get("fqdn").and_then(|v| v.as_str()))?;
+        let port = ep.get("port").and_then(|v| v.as_u64()).unwrap_or(80);
+        return Some((format!("{scheme}://{addr}:{port}"), service_name));
+    }
+    let addr = profile
+        .get("ipv4Addresses")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str())
+        .or_else(|| profile.get("fqdn").and_then(|v| v.as_str()))?;
+    Some((format!("{scheme}://{addr}:80"), service_name))
+}
+
+/// POST the subscription to the producer's event-exposure service. Returns the
+/// created resource URI, taken from `Location` when the producer supplies one.
+async fn post_producer_subscription(
+    api_root: &str,
+    service_name: &str,
+    body: &serde_json::Value,
+) -> Result<String, String> {
+    let Some((host, port, _)) = split_uri(api_root) else {
+        return Err(format!("unparseable producer apiRoot {api_root}"));
+    };
+    let client = SbiClient::with_host_port(&host, port);
+    let path = format!("/{service_name}/v1/subscriptions");
+    let resp = client
+        .post_json(&path, body)
+        .await
+        .map_err(|e| e.to_string())?;
+    if resp.status != 201 && resp.status != 200 {
+        return Err(format!("producer answered {} for {path}", resp.status));
+    }
+    Ok(resp
+        .http
+        .get_header("location")
+        .cloned()
+        .unwrap_or_else(|| format!("{api_root}{path}")))
+}
+
+/// Split `scheme://host:port/path` into `(host, port, path)`.
+///
+/// Shared by all three calls above so the parsing rule (and the default port per
+/// scheme) is stated once.
+fn split_uri(uri: &str) -> Option<(String, u16, String)> {
+    let (default_port, rest) = if let Some(r) = uri.strip_prefix("https://") {
+        (443u16, r)
+    } else if let Some(r) = uri.strip_prefix("http://") {
+        (80u16, r)
+    } else {
+        (80u16, uri)
+    };
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], rest[i..].to_string()),
+        None => (rest, "/".to_string()),
+    };
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((h, p)) => (h.to_string(), p.parse().unwrap_or(default_port)),
+        None => (authority.to_string(), default_port),
+    };
+    if host.is_empty() {
+        return None;
+    }
+    Some((host, port, path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_uri_handles_scheme_port_and_path() {
+        assert_eq!(
+            split_uri("http://10.0.0.1:7777/nnrf-nfm/v1/x"),
+            Some(("10.0.0.1".to_string(), 7777, "/nnrf-nfm/v1/x".to_string()))
+        );
+        // Default ports per scheme.
+        assert_eq!(
+            split_uri("http://nrf.example"),
+            Some(("nrf.example".to_string(), 80, "/".to_string()))
+        );
+        assert_eq!(
+            split_uri("https://nrf.example/x"),
+            Some(("nrf.example".to_string(), 443, "/x".to_string()))
+        );
+        assert_eq!(split_uri("http://"), None);
+    }
+
+    /// The event-exposure service is found by name across the spellings 3GPP
+    /// uses, and its own `ipEndPoints` win over the profile-level address.
+    #[test]
+    fn event_exposure_endpoint_prefers_the_service_endpoint() {
+        let profile = serde_json::json!({
+            "nfInstanceId": "amf-1",
+            "nfType": "AMF",
+            "ipv4Addresses": ["10.0.0.9"],
+            "nfServices": [
+                {"serviceName": "namf-comm", "scheme": "http"},
+                {"serviceName": "namf-evts", "scheme": "http",
+                 "ipEndPoints": [{"ipv4Address": "10.0.0.10", "port": 8080}]}
+            ]
+        });
+        assert_eq!(
+            event_exposure_endpoint(&profile),
+            Some(("http://10.0.0.10:8080".to_string(), "namf-evts".to_string()))
+        );
+
+        // Falls back to the profile address when the service has no endpoint.
+        let profile = serde_json::json!({
+            "ipv4Addresses": ["10.0.0.9"],
+            "nfServices": [{"serviceName": "npcf-eventexposure", "scheme": "http"}]
+        });
+        assert_eq!(
+            event_exposure_endpoint(&profile),
+            Some((
+                "http://10.0.0.9:80".to_string(),
+                "npcf-eventexposure".to_string()
+            ))
+        );
+
+        // A profile with no event-exposure service, and one with no address at
+        // all, are both skipped rather than dialled at a guessed port.
+        assert_eq!(
+            event_exposure_endpoint(&serde_json::json!({
+                "nfServices": [{"serviceName": "namf-comm"}]
+            })),
+            None
+        );
+        assert_eq!(
+            event_exposure_endpoint(&serde_json::json!({
+                "nfServices": [{"serviceName": "namf-evts"}]
+            })),
+            None
+        );
+    }
+
+    /// With coordination off, nothing is attempted — the guard on the default
+    /// posture.
+    #[tokio::test]
+    async fn coordination_is_off_by_default() {
+        set_coordination_for_test(None);
+        let outcome = ensure_producer_subscription(
+            "c1",
+            &SubscriptionScope::default(),
+            &DataManagementSubsc::default(),
+        )
+        .await;
+        assert_eq!(outcome, CoordinationOutcome::Disabled);
+    }
+}

--- a/src/bins/nextgcore-dccfd/src/data_mgmt.rs
+++ b/src/bins/nextgcore-dccfd/src/data_mgmt.rs
@@ -1,0 +1,605 @@
+//! `Ndccf_DataManagement` wire types and subscription scoping (issue #112).
+//!
+//! # Which schema is authoritative
+//!
+//! TS 29.574 defines `Ndccf_DataManagement`, and its OpenAPI file is **not
+//! vendored** in this tree. The service's data model is the same as
+//! `Nnwdaf_DataManagement`, whose file **is** vendored
+//! (`TS29520_Nnwdaf_DataManagement.yaml`), so every member name, requirement and
+//! `oneOf` below was read out of that file. Where a member's type comes from a
+//! yaml that is *also* absent (`DataSubscription` from TS 29.575,
+//! `FormattingInstruction` / `ProcessingInstruction` / `NotifSummaryReport` from
+//! TS 29.574) it is carried as passthrough [`serde_json::Value`] — the
+//! established convention in this repo for a cross-spec leaf, because modelling
+//! a schema nobody can check against invents a contract.
+//!
+//! # What was wrong before
+//!
+//! The subscribe handler read the callback URI from `"notifyUri"`. The required
+//! member is `notificURI` (yaml `required: [notifCorrId, notificURI]`), so a
+//! conformant consumer's URI was never captured, the stored URI stayed empty,
+//! and the empty-URI filter in the fan-out dropped that consumer from every
+//! notification. It subscribed successfully and was never told anything.
+//!
+//! `notifCorrId` was never parsed, stored or echoed anywhere in the crate, so
+//! even a delivered notification could not be correlated by the consumer.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// `NnwdafDataManagementSubsc` (`TS29520_Nnwdaf_DataManagement.yaml`) — the
+/// subscribe request body, the `201` echo, and the `PUT` update body.
+///
+/// `required: [notifCorrId, notificURI]` and `oneOf: [anaSub | dataSub]`, both
+/// enforced by [`Self::validate`] — serde cannot express either (it accepts an
+/// empty string for a required `String`, and has no `oneOf`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DataManagementSubsc {
+    /// Notification correlation identifier (REQUIRED). Echoed on every
+    /// notification so the consumer can tie it back to this subscription.
+    ///
+    /// `serde(default)` although the yaml marks it required: without it an absent
+    /// member is a *parse* error, which the handler can only report as
+    /// `INVALID_MSG_FORMAT`. TS 29.500 wants `MANDATORY_IE_MISSING` for a missing
+    /// mandatory IE, and that distinction is what tells a consumer whether its
+    /// JSON is malformed or merely incomplete. So absence deserialises to an
+    /// empty string and [`Self::validate`] names the member.
+    #[serde(default)]
+    pub notif_corr_id: String,
+    /// Consumer callback URI (REQUIRED).
+    ///
+    /// `notificURI` in the yaml — note the spelling: `notific`, not `notif`, and
+    /// `URI` uppercase. `rename_all = "camelCase"` would produce `notificUri`,
+    /// so this needs the explicit rename. That single character is the defect
+    /// this type exists to fix.
+    #[serde(rename = "notificURI", default)]
+    pub notific_uri: String,
+    /// Analytics subscription (`NnwdafEventsSubscription`) — one of the two
+    /// `oneOf` branches. Passthrough: the events are read out of it by
+    /// [`SubscriptionScope::from_subsc`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ana_sub: Option<serde_json::Value>,
+    /// Data subscription (`DataSubscription`, TS 29.575 — yaml not vendored) —
+    /// the other `oneOf` branch. Passthrough.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_sub: Option<serde_json::Value>,
+    /// ADRF instance the collected data should be stored in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adrf_id: Option<String>,
+    /// ADRF set, as an alternative to `adrfId`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adrf_set_id: Option<String>,
+    /// Target NF instance the data is collected about.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_nf_id: Option<String>,
+    /// Target NF set, as an alternative to `targetNfId`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_nf_set_id: Option<String>,
+    /// Formatting instruction (TS 29.574; passthrough).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format_instruct: Option<serde_json::Value>,
+    /// Processing instruction (TS 29.574; passthrough).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proc_instruct: Option<serde_json::Value>,
+    /// Time window the data is requested for (passthrough).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_period: Option<serde_json::Value>,
+    /// Data-collection purposes, when user consent applies (passthrough).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_collect_purposes: Option<serde_json::Value>,
+    /// The consumer has already checked user consent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checked_consent_ind: Option<bool>,
+    /// Supported features.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supp_feat: Option<String>,
+}
+
+/// Why a subscribe/update body was rejected. Each variant maps to a distinct
+/// `ProblemDetails` detail, because "invalid request" tells a consumer nothing
+/// about which member to fix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubscValidationError {
+    /// `notifCorrId` absent or empty.
+    MissingNotifCorrId,
+    /// `notificURI` absent or empty.
+    MissingNotificUri,
+    /// Neither `anaSub` nor `dataSub` was supplied.
+    NeitherAnaSubNorDataSub,
+    /// Both were supplied — `oneOf` means exactly one.
+    BothAnaSubAndDataSub,
+}
+
+impl SubscValidationError {
+    /// The `detail` for the `400` ProblemDetails.
+    pub fn detail(&self) -> &'static str {
+        match self {
+            Self::MissingNotifCorrId => {
+                "Missing mandatory IE notifCorrId (TS29520_Nnwdaf_DataManagement.yaml \
+                 NnwdafDataManagementSubsc required: [notifCorrId, notificURI])"
+            }
+            Self::MissingNotificUri => {
+                "Missing mandatory IE notificURI (TS29520_Nnwdaf_DataManagement.yaml \
+                 NnwdafDataManagementSubsc required: [notifCorrId, notificURI]). Note the \
+                 spelling: notificURI, not notifyUri"
+            }
+            Self::NeitherAnaSubNorDataSub => {
+                "Exactly one of anaSub / dataSub must be present \
+                 (NnwdafDataManagementSubsc oneOf); neither was supplied"
+            }
+            Self::BothAnaSubAndDataSub => {
+                "Exactly one of anaSub / dataSub must be present \
+                 (NnwdafDataManagementSubsc oneOf); both were supplied"
+            }
+        }
+    }
+}
+
+impl DataManagementSubsc {
+    /// Enforce the yaml's `required` and `oneOf` constraints.
+    ///
+    /// Empty strings count as absent. serde deserialises `{"notifCorrId": ""}`
+    /// into a present-but-empty `String`, and an empty callback URI is exactly
+    /// the state that made the old code silently un-notifiable — so accepting it
+    /// would reproduce the defect through a different door.
+    pub fn validate(&self) -> Result<(), SubscValidationError> {
+        if self.notif_corr_id.trim().is_empty() {
+            return Err(SubscValidationError::MissingNotifCorrId);
+        }
+        if self.notific_uri.trim().is_empty() {
+            return Err(SubscValidationError::MissingNotificUri);
+        }
+        match (self.ana_sub.is_some(), self.data_sub.is_some()) {
+            (false, false) => Err(SubscValidationError::NeitherAnaSubNorDataSub),
+            (true, true) => Err(SubscValidationError::BothAnaSubAndDataSub),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// `NnwdafDataManagementNotif` (`TS29520_Nnwdaf_DataManagement.yaml`) — the
+/// notification body delivered to a consumer's `notificURI`.
+///
+/// `required: [notifCorrId, notifTimestamp]`, `oneOf: [dataNotification |
+/// dataReports | fetchInstruct]`. The previous code sent `{"data": "<string>"}`,
+/// which satisfies none of that: no correlation id, no timestamp, and the
+/// producer's body stringified inside a member the schema does not define.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DataManagementNotif {
+    /// The subscription's `notifCorrId`, echoed (REQUIRED).
+    pub notif_corr_id: String,
+    /// RFC 3339 timestamp of this notification (REQUIRED).
+    pub notif_timestamp: String,
+    /// The collected data (`DataNotification`, TS 29.575; passthrough). This is
+    /// the `oneOf` branch the DCCF uses when forwarding producer data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_notification: Option<serde_json::Value>,
+    /// Summary reports of processed notifications (passthrough).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_reports: Option<serde_json::Value>,
+    /// Instruction to fetch the data from elsewhere (passthrough).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fetch_instruct: Option<serde_json::Value>,
+}
+
+impl DataManagementNotif {
+    /// A notification carrying forwarded producer data, which is the only
+    /// `oneOf` branch this DCCF produces.
+    pub fn with_data(
+        notif_corr_id: impl Into<String>,
+        notif_timestamp: impl Into<String>,
+        data: serde_json::Value,
+    ) -> Self {
+        Self {
+            notif_corr_id: notif_corr_id.into(),
+            notif_timestamp: notif_timestamp.into(),
+            data_notification: Some(data),
+            data_reports: None,
+            fetch_instruct: None,
+        }
+    }
+}
+
+/// What a subscription asked for: the set of event identifiers, and the target
+/// it is scoped to (#112).
+///
+/// This is the fan-out key. The old fan-out returned *every* subscriber with a
+/// non-empty URI, so a consumer that populated the non-standard `notifyUri`
+/// received every other such consumer's collected data — no keying on event or
+/// target at all.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SubscriptionScope {
+    /// Event identifiers this subscription covers. Empty means the scope could
+    /// not be determined — see [`Self::matches`] for what that implies.
+    pub events: BTreeSet<String>,
+    /// `targetNfId` / `targetNfSetId`, when the subscription named one.
+    pub target: Option<String>,
+}
+
+impl SubscriptionScope {
+    /// Derive the scope from a subscription.
+    ///
+    /// For `anaSub` the extraction is **exact**: `NnwdafEventsSubscription` is
+    /// vendored, so `eventSubscriptions[].event` is read directly.
+    ///
+    /// For `dataSub` it is a documented **heuristic**: `DataSubscription`
+    /// (TS 29.575) is not vendored, so its exact nesting cannot be verified
+    /// here. Every string under a key named `event`, `eventId` or `type`, at any
+    /// depth, is collected. That is deliberately conservative in the direction
+    /// that matters: an over-broad *extraction* can only ever make a
+    /// subscription's scope larger than intended for its own notifications,
+    /// whereas guessing wrong in the other direction would resurrect the
+    /// unkeyed fan-out this replaces.
+    pub fn from_subsc(sub: &DataManagementSubsc) -> Self {
+        let mut events = BTreeSet::new();
+        if let Some(ana) = &sub.ana_sub {
+            // Exact: the vendored NnwdafEventsSubscription shape.
+            if let Some(list) = ana.get("eventSubscriptions").and_then(|v| v.as_array()) {
+                for entry in list {
+                    if let Some(ev) = entry.get("event").and_then(|e| e.as_str()) {
+                        events.insert(ev.to_string());
+                    }
+                }
+            }
+        }
+        if let Some(data) = &sub.data_sub {
+            collect_event_strings(data, &mut events);
+        }
+        Self {
+            events,
+            target: sub
+                .target_nf_id
+                .clone()
+                .or_else(|| sub.target_nf_set_id.clone()),
+        }
+    }
+
+    /// Derive the scope of an inbound **producer notification**, so it can be
+    /// matched against subscriptions.
+    ///
+    /// Reads `eventNotifications[].event` (the vendored
+    /// `NnwdafEventsSubscriptionNotification` shape) and then applies the same
+    /// key-name sweep, so an event-exposure notification from another producer
+    /// family is still scoped rather than treated as unkeyed.
+    pub fn from_notification(body: &serde_json::Value) -> Self {
+        let mut events = BTreeSet::new();
+        if let Some(list) = body.get("eventNotifications").and_then(|v| v.as_array()) {
+            for entry in list {
+                if let Some(ev) = entry.get("event").and_then(|e| e.as_str()) {
+                    events.insert(ev.to_string());
+                }
+            }
+        }
+        if events.is_empty() {
+            collect_event_strings(body, &mut events);
+        }
+        Self {
+            events,
+            target: body
+                .get("targetNfId")
+                .or_else(|| body.get("nfInstanceId"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        }
+    }
+
+    /// Should a subscription with this scope receive a notification scoped
+    /// `notif`?
+    ///
+    /// Two rules, both deliberate:
+    ///
+    /// * **The event sets must intersect.** A subscription whose events are
+    ///   unknown (empty set) matches **nothing**. Delivering to it instead — the
+    ///   old behaviour — is the cross-consumer disclosure defect; and a
+    ///   scope-less subscriber is visible in the logs, which an over-broad
+    ///   delivery is not.
+    /// * **A target, if named on both sides, must match.** A subscription that
+    ///   named no target accepts any, because it constrained nothing. A
+    ///   notification that names no target is delivered to any matching event
+    ///   subscription, because a producer that did not say which NF the data is
+    ///   about cannot be filtered on that basis.
+    pub fn matches(&self, notif: &SubscriptionScope) -> bool {
+        if self.events.is_empty() || notif.events.is_empty() {
+            return false;
+        }
+        if !self.events.iter().any(|e| notif.events.contains(e)) {
+            return false;
+        }
+        match (&self.target, &notif.target) {
+            (Some(mine), Some(theirs)) => mine == theirs,
+            _ => true,
+        }
+    }
+}
+
+/// Recursively collect every string value under a key named `event`, `eventId`
+/// or `type`. Bounded by [`MAX_SCOPE_DEPTH`] so a deeply nested (or
+/// adversarially nested) body cannot recurse without limit.
+fn collect_event_strings(value: &serde_json::Value, out: &mut BTreeSet<String>) {
+    fn walk(value: &serde_json::Value, out: &mut BTreeSet<String>, depth: usize) {
+        if depth > MAX_SCOPE_DEPTH {
+            return;
+        }
+        match value {
+            serde_json::Value::Object(map) => {
+                for (key, val) in map {
+                    if matches!(key.as_str(), "event" | "eventId" | "type") {
+                        if let Some(s) = val.as_str() {
+                            out.insert(s.to_string());
+                        }
+                    }
+                    walk(val, out, depth + 1);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    walk(item, out, depth + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+    walk(value, out, 0);
+}
+
+/// Depth bound for the scope sweep. A `dataSub` is peer-supplied and this walk
+/// runs on the request path, so the recursion needs a ceiling; 16 is far deeper
+/// than any nesting in the TS 29.5xx models.
+const MAX_SCOPE_DEPTH: usize = 16;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid() -> DataManagementSubsc {
+        DataManagementSubsc {
+            notif_corr_id: "corr-1".into(),
+            notific_uri: "http://consumer/cb".into(),
+            ana_sub: Some(serde_json::json!({
+                "eventSubscriptions": [{"event": "SERVICE_EXPERIENCE"}]
+            })),
+            ..Default::default()
+        }
+    }
+
+    /// The member spelling is the anchor defect: `notificURI`, not `notifyUri`
+    /// and not the `notificUri` that `rename_all = "camelCase"` would produce.
+    ///
+    /// Asserted on the serialized TEXT and by deserialising a hand-written
+    /// spec-shaped body: a round trip of our own struct passes even when every
+    /// member name is wrong, because both directions use the same wrong name.
+    #[test]
+    fn the_callback_member_is_spelled_notific_uri() {
+        let json = serde_json::to_string(&valid()).expect("json");
+        assert!(
+            json.contains(r#""notificURI":"http://consumer/cb""#),
+            "expected the yaml spelling, got {json}"
+        );
+        assert!(
+            !json.contains("notifyUri") && !json.contains("notificUri"),
+            "neither the old bespoke key nor the camelCase default may appear: {json}"
+        );
+
+        // A body copied out of the yaml parses.
+        let parsed: DataManagementSubsc = serde_json::from_str(
+            r#"{"notifCorrId":"c1","notificURI":"http://x/cb",
+                "anaSub":{"eventSubscriptions":[{"event":"NF_LOAD"}]}}"#,
+        )
+        .expect("parses");
+        assert_eq!(parsed.notific_uri, "http://x/cb");
+        assert_eq!(parsed.notif_corr_id, "c1");
+
+        // The OLD key is NOT honoured by the type: a body using `notifyUri`
+        // leaves `notificURI` absent, so validation refuses it rather than
+        // silently accepting an un-notifiable subscription.
+        let old: DataManagementSubsc = serde_json::from_str(
+            r#"{"notifCorrId":"c1","notifyUri":"http://x/cb",
+                "anaSub":{"eventSubscriptions":[{"event":"NF_LOAD"}]}}"#,
+        )
+        .expect("unknown members are ignored");
+        assert!(old.notific_uri.is_empty());
+        assert_eq!(old.validate(), Err(SubscValidationError::MissingNotificUri));
+    }
+
+    /// Every `required` / `oneOf` violation is a distinct error, so the 400 can
+    /// say which member to fix.
+    #[test]
+    fn validation_covers_required_and_one_of() {
+        assert!(valid().validate().is_ok());
+
+        let mut s = valid();
+        s.notif_corr_id = String::new();
+        assert_eq!(s.validate(), Err(SubscValidationError::MissingNotifCorrId));
+        // Whitespace is not a value.
+        let mut s = valid();
+        s.notif_corr_id = "   ".into();
+        assert_eq!(s.validate(), Err(SubscValidationError::MissingNotifCorrId));
+
+        let mut s = valid();
+        s.notific_uri = String::new();
+        assert_eq!(s.validate(), Err(SubscValidationError::MissingNotificUri));
+
+        let mut s = valid();
+        s.ana_sub = None;
+        assert_eq!(
+            s.validate(),
+            Err(SubscValidationError::NeitherAnaSubNorDataSub)
+        );
+
+        let mut s = valid();
+        s.data_sub = Some(serde_json::json!({"dataSpec": {}}));
+        assert_eq!(
+            s.validate(),
+            Err(SubscValidationError::BothAnaSubAndDataSub),
+            "oneOf means exactly one, not at least one"
+        );
+
+        // Each detail names its own member.
+        assert!(SubscValidationError::MissingNotificUri
+            .detail()
+            .contains("notificURI"));
+        assert!(SubscValidationError::MissingNotifCorrId
+            .detail()
+            .contains("notifCorrId"));
+    }
+
+    /// `anaSub` events are read exactly, from the vendored schema's shape.
+    #[test]
+    fn scope_from_ana_sub_is_exact() {
+        let sub = DataManagementSubsc {
+            ana_sub: Some(serde_json::json!({
+                "eventSubscriptions": [
+                    {"event": "SERVICE_EXPERIENCE"},
+                    {"event": "NF_LOAD"}
+                ],
+                "notificationURI": "http://nwdaf/cb"
+            })),
+            ..valid()
+        };
+        let scope = SubscriptionScope::from_subsc(&sub);
+        assert_eq!(scope.events.len(), 2);
+        assert!(scope.events.contains("SERVICE_EXPERIENCE"));
+        assert!(scope.events.contains("NF_LOAD"));
+        assert_eq!(scope.target, None);
+    }
+
+    /// `dataSub` is swept heuristically, and the target is picked up from either
+    /// `targetNfId` or `targetNfSetId`.
+    #[test]
+    fn scope_from_data_sub_sweeps_nested_event_keys() {
+        let sub = DataManagementSubsc {
+            notif_corr_id: "c".into(),
+            notific_uri: "http://x".into(),
+            ana_sub: None,
+            data_sub: Some(serde_json::json!({
+                "dataSpec": {"nwdafEventsSub": {"eventSubscriptions": [{"event": "UE_MOBILITY"}]}}
+            })),
+            target_nf_set_id: Some("set-1".into()),
+            ..Default::default()
+        };
+        let scope = SubscriptionScope::from_subsc(&sub);
+        assert!(scope.events.contains("UE_MOBILITY"));
+        assert_eq!(scope.target.as_deref(), Some("set-1"));
+    }
+
+    /// The keying rules: intersect on events, and an unknown scope matches
+    /// nothing rather than everything.
+    #[test]
+    fn matching_requires_an_event_intersection() {
+        let a = SubscriptionScope {
+            events: ["NF_LOAD".to_string()].into_iter().collect(),
+            target: None,
+        };
+        let b = SubscriptionScope {
+            events: ["UE_MOBILITY".to_string()].into_iter().collect(),
+            target: None,
+        };
+        let notif_a = SubscriptionScope {
+            events: ["NF_LOAD".to_string()].into_iter().collect(),
+            target: None,
+        };
+
+        assert!(a.matches(&notif_a));
+        assert!(
+            !b.matches(&notif_a),
+            "a consumer subscribed to a different event must not receive this"
+        );
+
+        // An unknown scope on either side matches nothing -- NOT everything,
+        // which is the disclosure defect being fixed.
+        let unknown = SubscriptionScope::default();
+        assert!(!unknown.matches(&notif_a));
+        assert!(!a.matches(&SubscriptionScope::default()));
+    }
+
+    /// A target named on both sides must agree; a side that named none does not
+    /// constrain.
+    #[test]
+    fn matching_honours_a_target_named_on_both_sides() {
+        let events: BTreeSet<String> = ["NF_LOAD".to_string()].into_iter().collect();
+        let scoped = SubscriptionScope {
+            events: events.clone(),
+            target: Some("nf-1".into()),
+        };
+        let unscoped = SubscriptionScope {
+            events: events.clone(),
+            target: None,
+        };
+
+        assert!(scoped.matches(&SubscriptionScope {
+            events: events.clone(),
+            target: Some("nf-1".into())
+        }));
+        assert!(
+            !scoped.matches(&SubscriptionScope {
+                events: events.clone(),
+                target: Some("nf-2".into())
+            }),
+            "data about another NF must not be delivered"
+        );
+        // Either side unset: no target constraint.
+        assert!(scoped.matches(&unscoped));
+        assert!(unscoped.matches(&scoped));
+    }
+
+    /// The producer-notification scope is read from the vendored notification
+    /// shape.
+    #[test]
+    fn scope_from_a_producer_notification() {
+        let body = serde_json::json!({
+            "subscriptionId": "prod-sub-1",
+            "eventNotifications": [{"event": "NF_LOAD", "timeStamp": "2026-01-01T00:00:00Z"}]
+        });
+        let scope = SubscriptionScope::from_notification(&body);
+        assert!(scope.events.contains("NF_LOAD"));
+    }
+
+    /// The notification body uses the yaml member names, carries both required
+    /// members, and exactly one `oneOf` branch.
+    #[test]
+    fn notification_uses_the_yaml_member_names() {
+        let notif = DataManagementNotif::with_data(
+            "corr-1",
+            "2026-01-01T00:00:00Z",
+            serde_json::json!({"eventNotifications": []}),
+        );
+        let json = serde_json::to_string(&notif).expect("json");
+        assert!(json.contains(r#""notifCorrId":"corr-1""#), "got {json}");
+        assert!(json.contains(r#""notifTimestamp""#), "got {json}");
+        assert!(json.contains(r#""dataNotification""#), "got {json}");
+        // The old bespoke envelope must be gone.
+        assert!(!json.contains(r#""data":"#), "got {json}");
+        // Only one oneOf branch is present.
+        assert!(!json.contains("dataReports"), "got {json}");
+        assert!(!json.contains("fetchInstruct"), "got {json}");
+        // And it round-trips.
+        let parsed: DataManagementNotif = serde_json::from_str(&json).expect("parses");
+        assert_eq!(parsed, notif);
+    }
+
+    /// The scope sweep terminates on a deeply nested body rather than recursing
+    /// without bound: `dataSub` is peer-supplied on the request path.
+    #[test]
+    fn the_scope_sweep_is_depth_bounded() {
+        // Nest well past the ceiling.
+        let mut body = serde_json::json!({"event": "DEEP"});
+        for _ in 0..(MAX_SCOPE_DEPTH * 3) {
+            body = serde_json::json!({"nested": body});
+        }
+        let mut out = BTreeSet::new();
+        collect_event_strings(&body, &mut out);
+        // It returns (does not hang or overflow) and does not see past the bound.
+        assert!(
+            out.is_empty(),
+            "the sweep must stop at the depth ceiling, got {out:?}"
+        );
+
+        // ...while a shallow event is still found.
+        let mut out = BTreeSet::new();
+        collect_event_strings(&serde_json::json!({"a": {"event": "SHALLOW"}}), &mut out);
+        assert!(out.contains("SHALLOW"));
+    }
+}

--- a/src/bins/nextgcore-dccfd/src/main.rs
+++ b/src/bins/nextgcore-dccfd/src/main.rs
@@ -22,6 +22,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 mod context;
+mod coordination;
+mod data_mgmt;
 
 pub use context::*;
 
@@ -113,90 +115,30 @@ async fn dccf_request_handler(req: SbiRequest) -> SbiResponse {
 
         // POST /ndccf-datamanagement/v1/subscriptions
         ["ndccf-datamanagement", "v1", "subscriptions"] => match method {
-            "POST" => {
-                let sub_id = uuid::Uuid::new_v4().to_string();
-                // Extract notifyUri from the request body if present (TS 29.574 §5.2)
-                let notify_uri = req
-                    .http
-                    .content
-                    .as_deref()
-                    .and_then(|body| serde_json::from_str::<serde_json::Value>(body).ok())
-                    .and_then(|v| {
-                        v.get("notifyUri")
-                            .and_then(|u| u.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .unwrap_or_default();
-                log::info!(
-                    "[DCCF] DataManagement subscription created sub_id={sub_id} notify_uri={notify_uri}"
-                );
-                dccf_context_add_subscription_with_uri(sub_id.clone(), notify_uri);
-                let body = format!(r#"{{"subscriptionId":"{sub_id}","status":"ACTIVE"}}"#);
-                SbiResponse::created().with_body(body, "application/json")
-            }
+            "POST" => handle_dm_subscribe(&req).await,
             _ => send_method_not_allowed(method, "subscriptions"),
         },
 
-        // GET/DELETE /ndccf-datamanagement/v1/subscriptions/{subscriptionId}
+        // GET/PUT/DELETE /ndccf-datamanagement/v1/subscriptions/{subscriptionId}
         ["ndccf-datamanagement", "v1", "subscriptions", sub_id] => match method {
-            "GET" => {
-                if dccf_context_has_subscription(sub_id) {
-                    let body = format!(r#"{{"subscriptionId":"{sub_id}","status":"ACTIVE"}}"#);
-                    SbiResponse::ok().with_body(body, "application/json")
-                } else {
-                    send_not_found("subscription not found", None)
-                }
-            }
-            "DELETE" => {
-                if dccf_context_remove_subscription(sub_id) {
-                    log::info!("[DCCF] DataManagement subscription deleted sub_id={sub_id}");
-                    SbiResponse::no_content()
-                } else {
-                    send_not_found("subscription not found", None)
-                }
-            }
+            "GET" => match dccf_context_get_subscription(sub_id) {
+                // #112: echo the stored resource, not a bespoke
+                // `{"subscriptionId":..,"status":"ACTIVE"}` body that no schema
+                // defines and that a consumer cannot deserialise.
+                Some(stored) => SbiResponse::ok()
+                    .with_json_body(&stored.resource)
+                    .unwrap_or_else(|_| SbiResponse::ok()),
+                None => send_not_found("subscription not found", None),
+            },
+            // #112: `UpdateNWDAFDataSubscription` was absent and PUT answered 405.
+            "PUT" => handle_dm_update(sub_id, &req).await,
+            "DELETE" => handle_dm_unsubscribe(sub_id).await,
             _ => send_method_not_allowed(method, "subscriptions/{id}"),
         },
 
         // POST /ndccf-datamanagement/v1/notify — inbound data from producers
         ["ndccf-datamanagement", "v1", "notify"] => match method {
-            "POST" => {
-                let body = req.http.content.as_deref().unwrap_or("{}").to_string();
-                log::debug!("[DCCF] DataManagement notify received len={}", body.len());
-                // Get subscriber callback URIs (without holding the context lock)
-                let targets = dccf_context_fanout_notify(&body);
-                // Fan out: POST notification body to each subscriber's callback URI
-                for (sub_id, notify_uri) in targets {
-                    if let Some((host, port)) = parse_host_port(&notify_uri) {
-                        let body_clone = body.clone();
-                        let path = notify_uri
-                            .trim_start_matches("https://")
-                            .trim_start_matches("http://");
-                        // Strip host:port prefix to get the path component
-                        let path_only = path.find('/').map(|i| &path[i..]).unwrap_or("/");
-                        let path_owned = path_only.to_string();
-                        let client = SbiClient::with_host_port(&host, port);
-                        tokio::spawn(async move {
-                            match client
-                                .post_json(&path_owned, &serde_json::json!({"data": body_clone}))
-                                .await
-                            {
-                                Ok(resp) => log::debug!(
-                                    "[DCCF] fanout POST {} -> status={}",
-                                    sub_id,
-                                    resp.status
-                                ),
-                                Err(e) => log::warn!("[DCCF] fanout POST {sub_id} failed: {e}"),
-                            }
-                        });
-                    } else {
-                        log::warn!(
-                            "[DCCF] subscriber {sub_id} has unparseable notify_uri: {notify_uri}"
-                        );
-                    }
-                }
-                SbiResponse::no_content()
-            }
+            "POST" => handle_dm_notify(&req).await,
             _ => send_method_not_allowed(method, "notify"),
         },
 
@@ -472,6 +414,222 @@ async fn register_with_nrf(
     }
 }
 
+// ---------------------------------------------------------------------------
+// #112: Ndccf_DataManagement handlers (TS 29.574, schema-mirrored from
+// TS29520_Nnwdaf_DataManagement.yaml)
+// ---------------------------------------------------------------------------
+
+/// Resource collection path for data-management subscriptions; the `Location`
+/// header of a created subscription is built from it.
+const DM_SUBSCRIPTIONS_PATH: &str = "/ndccf-datamanagement/v1/subscriptions";
+
+/// A `400` with a conformant `application/problem+json` body (TS 29.500 §5.2.7).
+///
+/// The old subscribe path parsed the body with `unwrap_or_default()`, so a
+/// missing or unparseable body still answered `201` for a subscription that could
+/// never work.
+fn bad_request(detail: &str, cause: &str) -> SbiResponse {
+    nextgcore_sbi::server::send_bad_request(detail, Some(cause))
+}
+
+/// Parse and validate a subscribe/update body.
+///
+/// The error is boxed: `SbiResponse` is ~300 bytes, and a `Result` whose `Err`
+/// dwarfs its `Ok` makes every caller pay for the failure path
+/// (`clippy::result_large_err`). Same shape as eesd's `parse_json_body`.
+#[allow(clippy::result_large_err)]
+fn parse_subsc(req: &SbiRequest) -> Result<data_mgmt::DataManagementSubsc, Box<SbiResponse>> {
+    let Some(body) = req.http.content.as_deref().filter(|b| !b.trim().is_empty()) else {
+        return Err(Box::new(bad_request(
+            "A request body is required (NnwdafDataManagementSubsc)",
+            "MANDATORY_IE_MISSING",
+        )));
+    };
+    let sub: data_mgmt::DataManagementSubsc = serde_json::from_str(body).map_err(|e| {
+        Box::new(bad_request(
+            &format!("Unparseable NnwdafDataManagementSubsc: {e}"),
+            "INVALID_MSG_FORMAT",
+        ))
+    })?;
+    sub.validate()
+        .map_err(|e| Box::new(bad_request(e.detail(), "MANDATORY_IE_MISSING")))?;
+    Ok(sub)
+}
+
+/// `POST /ndccf-datamanagement/v1/subscriptions` — subscribe (#112).
+///
+/// Four defects fixed here at once: the callback is read from `notificURI`
+/// (not the bespoke `notifyUri`), the body is validated with a `400` +
+/// ProblemDetails instead of `unwrap_or_default()`, the `201` carries the
+/// mandatory `Location` header and echoes the resource, and the subscription's
+/// scope is recorded so the fan-out can be keyed on it.
+async fn handle_dm_subscribe(req: &SbiRequest) -> SbiResponse {
+    let sub = match parse_subsc(req) {
+        Ok(s) => s,
+        Err(resp) => return *resp,
+    };
+    let sub_id = uuid::Uuid::new_v4().to_string();
+    let scope = data_mgmt::SubscriptionScope::from_subsc(&sub);
+    log::info!(
+        "[DCCF] DataManagement subscribe sub_id={sub_id} notifCorrId={} notificURI={} events={:?}",
+        sub.notif_corr_id,
+        sub.notific_uri,
+        scope.events
+    );
+
+    let stored = dccf_context_store_subscription(context::DccfSubscription {
+        id: sub_id.clone(),
+        notify_uri: sub.notific_uri.clone(),
+        notif_corr_id: sub.notif_corr_id.clone(),
+        scope: scope.clone(),
+        resource: sub.clone(),
+    });
+    if !stored {
+        return nextgcore_sbi::server::send_error(
+            507,
+            "Insufficient Storage",
+            "Subscription capacity exhausted",
+            Some("INSUFFICIENT_RESOURCES"),
+        );
+    }
+
+    // TS 23.288 §5A.2: collect once, share to many. Off by default; see
+    // `coordination.rs` for why this is a runtime switch and not a cargo feature.
+    // A coordination failure does not fail the consumer's subscription: the
+    // consumer's contract is with the DCCF, and refusing it would make an
+    // unreachable producer look like a malformed request.
+    let outcome = coordination::ensure_producer_subscription(&sub_id, &scope, &sub).await;
+    log::debug!("[DCCF] coordination for {sub_id}: {outcome:?}");
+
+    SbiResponse::created()
+        .with_header("Location", format!("{DM_SUBSCRIPTIONS_PATH}/{sub_id}"))
+        .with_json_body(&sub)
+        .unwrap_or_else(|_| SbiResponse::created())
+}
+
+/// `PUT /ndccf-datamanagement/v1/subscriptions/{subscriptionId}` —
+/// `UpdateNWDAFDataSubscription` (#112). Previously answered `405`.
+///
+/// A full replace, which is what PUT means: the new body is validated exactly as
+/// on create, and the recorded scope is recomputed so a changed `anaSub` changes
+/// what the consumer receives. `404` when the resource does not exist — PUT here
+/// updates an existing subscription and does not create one at a
+/// consumer-chosen id.
+async fn handle_dm_update(sub_id: &str, req: &SbiRequest) -> SbiResponse {
+    if !dccf_context_has_subscription(sub_id) {
+        return send_not_found("subscription not found", None);
+    }
+    let sub = match parse_subsc(req) {
+        Ok(s) => s,
+        Err(resp) => return *resp,
+    };
+    let scope = data_mgmt::SubscriptionScope::from_subsc(&sub);
+    log::info!(
+        "[DCCF] DataManagement update sub_id={sub_id} events={:?}",
+        scope.events
+    );
+    dccf_context_store_subscription(context::DccfSubscription {
+        id: sub_id.to_string(),
+        notify_uri: sub.notific_uri.clone(),
+        notif_corr_id: sub.notif_corr_id.clone(),
+        scope,
+        resource: sub.clone(),
+    });
+    SbiResponse::ok()
+        .with_json_body(&sub)
+        .unwrap_or_else(|_| SbiResponse::ok())
+}
+
+/// `DELETE /ndccf-datamanagement/v1/subscriptions/{subscriptionId}` (#112).
+///
+/// Releases this consumer's claim on its producer subscription, and deletes that
+/// producer subscription when it was the last consumer — refcounted, so one
+/// consumer unsubscribing cannot cut off another's data.
+async fn handle_dm_unsubscribe(sub_id: &str) -> SbiResponse {
+    if !dccf_context_remove_subscription(sub_id) {
+        return send_not_found("subscription not found", None);
+    }
+    log::info!("[DCCF] DataManagement subscription deleted sub_id={sub_id}");
+    if let Some(orphaned) = dccf_context_release_producer_sub(sub_id) {
+        coordination::delete_producer_subscription(&orphaned.resource_uri).await;
+    }
+    SbiResponse::no_content()
+}
+
+/// `POST /ndccf-datamanagement/v1/notify` — inbound producer data (#112).
+///
+/// Two defects fixed: the fan-out is keyed on `(events, target)` instead of
+/// going to every subscriber with a callback URI, and each consumer receives a
+/// conformant `NnwdafDataManagementNotif` echoing **its own** `notifCorrId`
+/// instead of a bespoke `{"data": "<stringified body>"}` envelope.
+///
+/// Because each consumer's body differs (its own correlation id), the
+/// notification is built per target rather than once and broadcast.
+async fn handle_dm_notify(req: &SbiRequest) -> SbiResponse {
+    let raw = req.http.content.as_deref().unwrap_or("{}");
+    let body: serde_json::Value = match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(e) => {
+            return bad_request(
+                &format!("Unparseable producer notification: {e}"),
+                "INVALID_MSG_FORMAT",
+            )
+        }
+    };
+    let notif_scope = data_mgmt::SubscriptionScope::from_notification(&body);
+    log::debug!(
+        "[DCCF] notify received: events={:?} target={:?} len={}",
+        notif_scope.events,
+        notif_scope.target,
+        raw.len()
+    );
+
+    let targets = dccf_context_fanout_notify_scoped(&notif_scope);
+    let timestamp = rfc3339_now();
+    for (sub_id, notify_uri, notif_corr_id) in targets {
+        let Some((host, port)) = parse_host_port(&notify_uri) else {
+            log::warn!("[DCCF] subscriber {sub_id} has unparseable notificURI: {notify_uri}");
+            continue;
+        };
+        let path = notify_uri
+            .trim_start_matches("https://")
+            .trim_start_matches("http://");
+        let path_owned = path
+            .find('/')
+            .map(|i| path[i..].to_string())
+            .unwrap_or_else(|| "/".to_string());
+        let notif = data_mgmt::DataManagementNotif::with_data(
+            notif_corr_id,
+            timestamp.clone(),
+            body.clone(),
+        );
+        let client = SbiClient::with_host_port(&host, port);
+        tokio::spawn(async move {
+            match client.post_json(&path_owned, &notif).await {
+                Ok(resp) => {
+                    log::debug!("[DCCF] fanout POST {sub_id} -> status={}", resp.status)
+                }
+                Err(e) => log::warn!("[DCCF] fanout POST {sub_id} failed: {e}"),
+            }
+        });
+    }
+    SbiResponse::no_content()
+}
+
+/// Current time as an RFC 3339 UTC timestamp, for `notifTimestamp`.
+///
+/// Delegates to the shared SBI formatter rather than hand-rolling one: the
+/// per-daemon copies of this were consolidated for a reason (a copy that
+/// formats a pre-epoch instant wrongly, or omits the `Z`, produces a `DateTime`
+/// a conformant consumer rejects).
+fn rfc3339_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    nextgcore_sbi::datetime::epoch_to_rfc3339_signed(secs)
+}
+
 /// Parse host and port from a URI string
 fn parse_host_port(uri: &str) -> Option<(String, u16)> {
     let without_scheme = uri
@@ -631,5 +789,504 @@ mod oauth2_h8_tests {
         assert_ne!(resp.status, 401, "valid token must not be 401");
         assert_ne!(resp.status, 403, "valid token must not be 403");
         server.stop().await.expect("stop");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #112: Ndccf_DataManagement conformance and coordination
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod data_management_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    /// Serialises these tests: they share the process-global DCCF context (its
+    /// subscription map and producer-subscription registry) and the coordination
+    /// switch.
+    ///
+    /// The CRATE-WIDE lock from `context`, not a private one: `context::tests`
+    /// mutates the same singleton, and `clear_subscriptions` below would otherwise
+    /// wipe a subscription a `context::tests` case was mid-way through asserting
+    /// on.
+    use context::GLOBAL_TEST_LOCK as TEST_GUARD;
+
+    fn init() {
+        dccf_context_init(256);
+    }
+
+    /// Remove every subscription, so a test's assertions are about its own
+    /// subscriptions and not whatever a sibling left behind. The context is
+    /// process-global, and `GLOBAL` locks serialise but do not isolate.
+    fn clear_subscriptions() {
+        for id in context::dccf_context_subscription_ids() {
+            dccf_context_remove_subscription(&id);
+        }
+    }
+
+    fn subscribe_body(corr: &str, uri: &str, event: &str) -> String {
+        serde_json::json!({
+            "notifCorrId": corr,
+            "notificURI": uri,
+            "anaSub": {"eventSubscriptions": [{"event": event}]}
+        })
+        .to_string()
+    }
+
+    fn post(path: &str, body: &str) -> SbiResponse {
+        let req = SbiRequest::post(path).with_body(body.to_string(), "application/json");
+        futures_lite_block_on(dccf_request_handler(req))
+    }
+
+    /// Minimal block_on: this crate has tokio but these handler calls need no
+    /// reactor beyond what the runtime provides.
+    fn futures_lite_block_on<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(fut)
+    }
+
+    /// A loopback consumer that records the notification bodies it receives.
+    async fn spawn_consumer() -> (SbiServer, u16, Arc<StdMutex<Vec<serde_json::Value>>>) {
+        let seen: Arc<StdMutex<Vec<serde_json::Value>>> = Arc::new(StdMutex::new(Vec::new()));
+        let sink = seen.clone();
+        let port = nextgcore_sbi::test_support::free_port();
+        let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+            [127, 0, 0, 1],
+            port,
+        ))));
+        server
+            .start(move |req: SbiRequest| {
+                let sink = sink.clone();
+                async move {
+                    if let Some(body) = req.http.content.as_deref() {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+                            sink.lock().unwrap_or_else(|e| e.into_inner()).push(v);
+                        }
+                    }
+                    SbiResponse::no_content()
+                }
+            })
+            .await
+            .expect("consumer server start");
+        (server, port, seen)
+    }
+
+    /// #112 acceptance: a subscription supplying `notificURI` receives its
+    /// notifications.
+    ///
+    /// The anchor defect: the handler read `notifyUri`, so a conformant
+    /// consumer's URI was never stored, the empty-URI filter dropped it from
+    /// every fan-out, and it was never notified — with no error surface at all.
+    /// End to end over a real connection, because that is the only place the
+    /// whole chain (parse → store → key → deliver) is exercised.
+    #[test]
+    fn a_conformant_subscription_receives_its_notifications() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        init();
+        clear_subscriptions();
+
+        futures_lite_block_on(async {
+            let (consumer, port, seen) = spawn_consumer().await;
+
+            let resp = dccf_request_handler(
+                SbiRequest::post("/ndccf-datamanagement/v1/subscriptions").with_body(
+                    subscribe_body("corr-A", &format!("http://127.0.0.1:{port}/cb"), "NF_LOAD"),
+                    "application/json",
+                ),
+            )
+            .await;
+            assert_eq!(resp.status, 201);
+
+            // A producer notification for the subscribed event.
+            let resp = dccf_request_handler(
+                SbiRequest::post("/ndccf-datamanagement/v1/notify").with_body(
+                    serde_json::json!({
+                        "subscriptionId": "prod-1",
+                        "eventNotifications": [{"event": "NF_LOAD"}]
+                    })
+                    .to_string(),
+                    "application/json",
+                ),
+            )
+            .await;
+            assert_eq!(resp.status, 204);
+
+            // The fan-out POSTs are spawned, so wait for delivery.
+            for _ in 0..50 {
+                if !seen.lock().unwrap_or_else(|e| e.into_inner()).is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            let delivered = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            assert_eq!(
+                delivered.len(),
+                1,
+                "the conformant consumer must be notified exactly once, got {delivered:?}"
+            );
+
+            // #112 acceptance: the body is an NnwdafDataManagementNotif echoing
+            // this consumer's notifCorrId, not a bespoke {"data": "..."} envelope.
+            let notif: data_mgmt::DataManagementNotif =
+                serde_json::from_value(delivered[0].clone()).expect("parses as the spec type");
+            assert_eq!(notif.notif_corr_id, "corr-A", "the subscription's own id");
+            assert!(!notif.notif_timestamp.is_empty());
+            assert!(notif.data_notification.is_some());
+            assert!(
+                delivered[0].get("data").is_none(),
+                "the old bespoke envelope must be gone: {:?}",
+                delivered[0]
+            );
+
+            consumer.stop().await.expect("stop");
+        });
+        clear_subscriptions();
+    }
+
+    /// #112 acceptance: fan-out is keyed on the event — a notification for event
+    /// A reaches only the consumer subscribed to A.
+    ///
+    /// The old fan-out returned every subscriber with a callback URI, so any
+    /// consumer received every other consumer's collected data.
+    #[test]
+    fn fanout_is_keyed_on_the_subscribed_event() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        init();
+        clear_subscriptions();
+
+        futures_lite_block_on(async {
+            let (consumer_a, port_a, seen_a) = spawn_consumer().await;
+            let (consumer_b, port_b, seen_b) = spawn_consumer().await;
+
+            for (corr, port, event) in [
+                ("corr-A", port_a, "NF_LOAD"),
+                ("corr-B", port_b, "UE_MOBILITY"),
+            ] {
+                let resp = dccf_request_handler(
+                    SbiRequest::post("/ndccf-datamanagement/v1/subscriptions").with_body(
+                        subscribe_body(corr, &format!("http://127.0.0.1:{port}/cb"), event),
+                        "application/json",
+                    ),
+                )
+                .await;
+                assert_eq!(resp.status, 201);
+            }
+
+            // A notification for NF_LOAD only.
+            dccf_request_handler(
+                SbiRequest::post("/ndccf-datamanagement/v1/notify").with_body(
+                    serde_json::json!({"eventNotifications": [{"event": "NF_LOAD"}]}).to_string(),
+                    "application/json",
+                ),
+            )
+            .await;
+
+            for _ in 0..50 {
+                if !seen_a.lock().unwrap_or_else(|e| e.into_inner()).is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            // Give B a fair chance to be (wrongly) notified before asserting it
+            // was not: an absence assertion checked too early passes for the
+            // wrong reason.
+            tokio::time::sleep(Duration::from_millis(150)).await;
+
+            assert_eq!(
+                seen_a.lock().unwrap_or_else(|e| e.into_inner()).len(),
+                1,
+                "consumer A subscribed to NF_LOAD and must receive it"
+            );
+            assert!(
+                seen_b.lock().unwrap_or_else(|e| e.into_inner()).is_empty(),
+                "consumer B subscribed to UE_MOBILITY and must NOT receive NF_LOAD data"
+            );
+
+            consumer_a.stop().await.expect("stop");
+            consumer_b.stop().await.expect("stop");
+        });
+        clear_subscriptions();
+    }
+
+    /// #112 acceptance: every `required` / `oneOf` violation is a `400` with
+    /// `application/problem+json`. A missing or unparseable body used to answer
+    /// `201`.
+    #[test]
+    fn invalid_subscribe_bodies_are_rejected_with_problem_details() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        init();
+        clear_subscriptions();
+
+        let cases: &[(&str, &str)] = &[
+            ("", "no body at all"),
+            ("not json", "unparseable"),
+            (r#"{}"#, "no members"),
+            (
+                r#"{"notificURI":"http://c/cb","anaSub":{}}"#,
+                "missing notifCorrId",
+            ),
+            (r#"{"notifCorrId":"c","anaSub":{}}"#, "missing notificURI"),
+            (
+                r#"{"notifCorrId":"c","notifyUri":"http://c/cb","anaSub":{}}"#,
+                "the OLD bespoke key does not satisfy notificURI",
+            ),
+            (
+                r#"{"notifCorrId":"c","notificURI":"http://c/cb"}"#,
+                "neither anaSub nor dataSub",
+            ),
+            (
+                r#"{"notifCorrId":"c","notificURI":"http://c/cb","anaSub":{},"dataSub":{}}"#,
+                "both anaSub and dataSub (oneOf)",
+            ),
+        ];
+        for (body, why) in cases {
+            let resp = post("/ndccf-datamanagement/v1/subscriptions", body);
+            assert_eq!(resp.status, 400, "must be 400 for: {why}");
+            assert_eq!(
+                resp.http.get_header("content-type").map(String::as_str),
+                Some("application/problem+json"),
+                "a 400 must carry ProblemDetails for: {why}"
+            );
+            let problem: nextgcore_sbi::message::ProblemDetails =
+                serde_json::from_str(resp.http.content.as_deref().unwrap_or("{}"))
+                    .expect("parses as ProblemDetails");
+            assert_eq!(problem.status, Some(400));
+        }
+        clear_subscriptions();
+    }
+
+    /// #112 acceptance: the `201` carries the mandatory `Location` header and a
+    /// body that round-trips as the spec resource; `GET` returns the same
+    /// resource rather than a bespoke status object.
+    #[test]
+    fn create_returns_location_and_the_spec_resource() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        init();
+        clear_subscriptions();
+
+        let resp = post(
+            "/ndccf-datamanagement/v1/subscriptions",
+            &subscribe_body("corr-1", "http://consumer/cb", "NF_LOAD"),
+        );
+        assert_eq!(resp.status, 201);
+        let location = resp
+            .http
+            .get_header("location")
+            .cloned()
+            .expect("Location is required: true in the yaml");
+        assert!(
+            location.starts_with(DM_SUBSCRIPTIONS_PATH),
+            "Location must point at the individual resource, got {location}"
+        );
+        let sub_id = location.rsplit('/').next().unwrap().to_string();
+        assert!(!sub_id.is_empty());
+
+        let created: data_mgmt::DataManagementSubsc =
+            serde_json::from_str(resp.http.content.as_deref().unwrap())
+                .expect("the 201 body round-trips as NnwdafDataManagementSubsc");
+        assert_eq!(created.notif_corr_id, "corr-1");
+        assert_eq!(created.notific_uri, "http://consumer/cb");
+
+        // GET returns the resource, not {"subscriptionId":..,"status":"ACTIVE"}.
+        let req = SbiRequest::get(format!("{DM_SUBSCRIPTIONS_PATH}/{sub_id}"));
+        let resp = futures_lite_block_on(dccf_request_handler(req));
+        assert_eq!(resp.status, 200);
+        let fetched: data_mgmt::DataManagementSubsc =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).expect("spec resource");
+        assert_eq!(fetched, created);
+        clear_subscriptions();
+    }
+
+    /// #112 acceptance: `PUT` updates the subscription (no longer `405`), and the
+    /// change is observable on a later `GET` **and** in what the consumer
+    /// receives — the scope must be recomputed, not just the stored body.
+    #[test]
+    fn put_updates_the_subscription_and_its_scope() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        init();
+        clear_subscriptions();
+
+        let resp = post(
+            "/ndccf-datamanagement/v1/subscriptions",
+            &subscribe_body("corr-1", "http://consumer/cb", "NF_LOAD"),
+        );
+        let sub_id = resp
+            .http
+            .get_header("location")
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap()
+            .to_string();
+
+        let put = SbiRequest::put(format!("{DM_SUBSCRIPTIONS_PATH}/{sub_id}")).with_body(
+            subscribe_body("corr-2", "http://consumer/other", "UE_MOBILITY"),
+            "application/json",
+        );
+        let resp = futures_lite_block_on(dccf_request_handler(put));
+        assert_ne!(resp.status, 405, "PUT must be implemented");
+        assert_eq!(resp.status, 200);
+
+        // Observable on GET.
+        let resp = futures_lite_block_on(dccf_request_handler(SbiRequest::get(format!(
+            "{DM_SUBSCRIPTIONS_PATH}/{sub_id}"
+        ))));
+        let fetched: data_mgmt::DataManagementSubsc =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(fetched.notif_corr_id, "corr-2");
+        assert_eq!(fetched.notific_uri, "http://consumer/other");
+
+        // ...and the SCOPE moved with it: the subscription now matches
+        // UE_MOBILITY and no longer matches NF_LOAD. Storing the new body while
+        // leaving the old scope in place would pass the GET assertion above.
+        let stored = dccf_context_get_subscription(&sub_id).expect("stored");
+        assert!(stored.scope.events.contains("UE_MOBILITY"));
+        assert!(
+            !stored.scope.events.contains("NF_LOAD"),
+            "the old event must not linger in the recomputed scope"
+        );
+        assert_eq!(stored.notif_corr_id, "corr-2");
+
+        // PUT on an unknown id is 404, not a create at a consumer-chosen id.
+        let put = SbiRequest::put(format!("{DM_SUBSCRIPTIONS_PATH}/no-such-id")).with_body(
+            subscribe_body("c", "http://c/cb", "NF_LOAD"),
+            "application/json",
+        );
+        assert_eq!(futures_lite_block_on(dccf_request_handler(put)).status, 404);
+        clear_subscriptions();
+    }
+
+    /// #112 acceptance (coordination): two consumers asking for the same
+    /// `(events, target)` share ONE producer subscription.
+    ///
+    /// Runs against a loopback NRF (serving `GET
+    /// /nnrf-nfm/v1/nf-instances/{id}`) and a loopback producer (counting
+    /// `POST /namf-evts/v1/subscriptions`), so the discovery and the producer
+    /// signalling are real HTTP, not a stubbed seam.
+    #[test]
+    fn overlapping_consumers_share_one_producer_subscription() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        init();
+        clear_subscriptions();
+
+        futures_lite_block_on(async {
+            // Producer: counts the subscriptions created on it.
+            let created = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let counter = created.clone();
+            let producer_port = nextgcore_sbi::test_support::free_port();
+            let producer = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+                [127, 0, 0, 1],
+                producer_port,
+            ))));
+            producer
+                .start(move |req: SbiRequest| {
+                    let counter = counter.clone();
+                    async move {
+                        if req.header.method == "POST" {
+                            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            return SbiResponse::created()
+                                .with_header("Location", "http://producer/sub/1");
+                        }
+                        SbiResponse::no_content()
+                    }
+                })
+                .await
+                .expect("producer start");
+
+            // NRF: answers the NF profile retrieval with an event-exposure service
+            // pointing at the producer above.
+            let nrf_port = nextgcore_sbi::test_support::free_port();
+            let nrf = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+                [127, 0, 0, 1],
+                nrf_port,
+            ))));
+            nrf.start(move |_req: SbiRequest| async move {
+                SbiResponse::ok()
+                    .with_json_body(&serde_json::json!({
+                        "nfInstanceId": "amf-1",
+                        "nfType": "AMF",
+                        "nfStatus": "REGISTERED",
+                        "nfServices": [{
+                            "serviceInstanceId": "amf-evts-1",
+                            "serviceName": "namf-evts",
+                            "scheme": "http",
+                            "ipEndPoints": [
+                                {"ipv4Address": "127.0.0.1", "port": producer_port}
+                            ]
+                        }]
+                    }))
+                    .unwrap_or_else(|_| SbiResponse::ok())
+            })
+            .await
+            .expect("nrf start");
+
+            coordination::set_coordination_for_test(Some(coordination::CoordinationConfig {
+                nrf_uri: format!("http://127.0.0.1:{nrf_port}"),
+                own_notify_uri: "http://dccf/ndccf-datamanagement/v1/notify".to_string(),
+            }));
+
+            // Two consumers, same event and same target NF.
+            let body = |corr: &str| {
+                serde_json::json!({
+                    "notifCorrId": corr,
+                    "notificURI": "http://consumer/cb",
+                    "targetNfId": "amf-1",
+                    "anaSub": {"eventSubscriptions": [{"event": "UE_MOBILITY"}]}
+                })
+                .to_string()
+            };
+            for corr in ["corr-1", "corr-2"] {
+                let resp = dccf_request_handler(
+                    SbiRequest::post("/ndccf-datamanagement/v1/subscriptions")
+                        .with_body(body(corr), "application/json"),
+                )
+                .await;
+                assert_eq!(resp.status, 201);
+            }
+
+            assert_eq!(
+                created.load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "the second consumer must REUSE the producer subscription, not create a second"
+            );
+            assert_eq!(
+                dccf_context_producer_sub_count(),
+                1,
+                "one producer subscription for the shared scope"
+            );
+
+            coordination::set_coordination_for_test(None);
+            producer.stop().await.expect("stop");
+            nrf.stop().await.expect("stop");
+        });
+        clear_subscriptions();
+    }
+
+    /// #112: with coordination OFF (the default) no producer signalling happens
+    /// at all — the guard on the default posture. Same request as the test above.
+    #[test]
+    fn coordination_off_creates_no_producer_subscription() {
+        let _g = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        init();
+        clear_subscriptions();
+        coordination::set_coordination_for_test(None);
+
+        let body = serde_json::json!({
+            "notifCorrId": "corr-1",
+            "notificURI": "http://consumer/cb",
+            "targetNfId": "amf-1",
+            "anaSub": {"eventSubscriptions": [{"event": "UE_MOBILITY"}]}
+        })
+        .to_string();
+        let resp = post("/ndccf-datamanagement/v1/subscriptions", &body);
+        assert_eq!(resp.status, 201, "the consumer subscription still succeeds");
+        assert_eq!(
+            dccf_context_producer_sub_count(),
+            0,
+            "coordination is off by default: no producer is dialled"
+        );
+        clear_subscriptions();
     }
 }


### PR DESCRIPTION
Closes #112. Spec: `specs/fix-dccfd-data-management-conformance-and-coordination.md`.

All eight acceptance criteria, one PR. Verified against `main` @ `08bd7ab` — every cite in the issue still held; dccfd had not been touched since `76ea248`.

TS 29.574's yaml is **not vendored**. Its data model is `Nnwdaf_DataManagement`'s, which **is**, so every member name, requirement and `oneOf` here was read out of `6g_docs/specs/TS29520_Nnwdaf_DataManagement.yaml` rather than from the issue text.

## The anchor is one character

`notificURI` — `notific`, not `notif`, and `URI` uppercase. Worth noting for review: `rename_all = "camelCase"` produces `notificUri`, which is *also* wrong, so the member needs an explicit `#[serde(rename = "notificURI")]`.

The consequence chain: a conformant consumer's URI was never captured → the stored URI stayed empty → the empty-URI filter in the fan-out dropped that consumer from every notification. It subscribed, received `201`, and was never told anything, with **no error surface anywhere**.

`notifCorrId` was never parsed, stored or echoed in the crate either, so even a delivered notification could not be correlated.

## `serde(default)` on two members the yaml marks required

Without it an absent `notifCorrId`/`notificURI` is a **parse** error, which the handler can only report as `INVALID_MSG_FORMAT`. TS 29.500 wants `MANDATORY_IE_MISSING` for a missing mandatory IE, and that distinction is what tells a consumer whether its JSON is malformed or merely incomplete. Absence deserialises to an empty string and `validate()` names the member. Empty strings count as absent — an empty callback URI is precisely the un-notifiable state being fixed.

## The fan-out key, and what an indeterminate scope gets

`SubscriptionScope { events, target }` replaces "any non-empty URI" (the mechanism by which one consumer could receive another's collected data).

- from `anaSub`: **exact** — `NnwdafEventsSubscription` is vendored, so `eventSubscriptions[].event` is read directly;
- from `dataSub`: a documented **heuristic** — TS 29.575 is not vendored, so every string under a key named `event`/`eventId`/`type` at any depth, **depth-bounded at 16** because `dataSub` is peer-supplied on the request path;
- matching needs an event intersection, and a `target` named on *both* sides must agree (a side that named none constrained nothing).

**A subscription whose scope cannot be determined matches nothing, not everything.** Delivering to it is the disclosure defect. It is logged at warn on create, naming the consequence and what to supply — a scope-less subscriber is *visible*, which an over-broad delivery is not.

## Two deviations from the suggested approach, both deliberate

**1. Coordination is a runtime switch, not a cargo feature.** The issue suggests `dccf-coordination` and marks criterion 7 "(Feature-gated)". CI builds default features, so a cargo feature would leave the coordination path **uncompiled in CI**, where it would rot. A runtime switch (`--coordination` / `DCCF_COORDINATION`, default off) means one `cargo test` run compiles and exercises **both** states — a stronger reading of criterion 8 than running the suite twice. Default off honours the issue's "keep the current registry as the default until the new path is validated"; `coordination_off_creates_no_producer_subscription` guards it with the same request the ON test uses.

**2. Coordination requires `targetNfId`.** Resolving a producer without one needs an event→producer-NF-type table (TS 23.288 §6.2), and for most NWDAF events that mapping is genuinely ambiguous — `SERVICE_EXPERIENCE` can come from an AF or the NEF, `NF_LOAD` from OAM or the NRF. Guessing would create producer subscriptions on the **wrong NF**. Without a target, coordination is skipped with a log line and the consumer subscription still succeeds: its contract is with the DCCF, and refusing it would make an unresolvable producer look like a malformed request.

When it does run: `GET {nrf}/nnrf-nfm/v1/nf-instances/{targetNfId}` (TS 29.510 profile retrieval, which nrfd serves) → pick the event-exposure service **by name** (`eventexposure`/`evts`/`eventssubscription`, so an unknown producer family still works) → POST the **consumer's own** subscription body with the callback rewritten to this DCCF. Forwarding rather than synthesising matters: the DCCF subscribes *on the consumer's behalf*, it does not invent a subscription. Producer subscriptions are **refcounted**, so one consumer's unsubscribe cannot cut off another's data.

## Criteria

| # | criterion | where |
|---|---|---|
| 1 | callback read from `notificURI`; such a subscription receives its notifications | `a_conformant_subscription_receives_its_notifications` (end to end over a real connection) |
| 2 | missing `notifCorrId`/`notificURI`/`oneOf` → `400` + ProblemDetails | `invalid_subscribe_bodies_are_rejected_with_problem_details` (8 cases incl. no body, unparseable, and the old `notifyUri` key; asserts `application/problem+json`) |
| 3 | `201` + `Location` + a body that round-trips as the resource | `create_returns_location_and_the_spec_resource` (also asserts GET echoes the resource, not the bespoke status object) |
| 4 | `PUT` updates and no longer `405` | `put_updates_the_subscription_and_its_scope` |
| 5 | fan-out keyed on `(event, target)`; B does not receive A's data | `fanout_is_keyed_on_the_subscribed_event` |
| 6 | notifications are `NnwdafDataManagementNotif` with the echoed `notifCorrId` | asserted inside criterion 1's test (parses as the spec type; asserts the old `data` key is gone) |
| 7 | two overlapping consumers ⇒ **one** producer subscription | `overlapping_consumers_share_one_producer_subscription` — loopback NRF + loopback producer counting `POST`s, real HTTP |
| 8 | tests pass with coordination off and on; clippy clean | one run covers both; `6090 passed / 0 failed` (main: `6071`); `clippy -p nextgcore-dccfd --all-targets` **0 warnings**, not just 0 errors |

## The PUT revert is the interesting one

Storing the new body while leaving the **stale scope** in place passes a GET-only assertion — the subscription would echo its new `anaSub` and still receive the old event's data. So the test also asserts the recomputed scope no longer contains the old event. All 7 reverts are tabulated in the spec.

## A flake I caused, and the fix this repo already knows

`context::tests::test_subscription_lifecycle` — **pre-existing** — started failing intermittently: my `clear_subscriptions()` helper wipes the process-global subscription map, and that test had its own private guard, so the two modules were two disjoint agreements about the same variable. One green run proved nothing; the failure was order-dependent.

Fixed by hoisting **one** crate-wide `GLOBAL_TEST_LOCK` and having both test modules take it — the same resolution recorded for seppd in #100, and the reason a second lock is not the fix. Every pre-existing case in that module now takes it, not only the fan-out ones. 5 consecutive runs green.

## Ceilings

- **Coordination is off by default**, so a default deployment still de-duplicates nothing. The mechanism exists, is tested, and is one flag away — that flag is the operator's call.
- **`dataSub` scope extraction is a heuristic.** A `dataSub` whose event identifier sits under a key not named `event`/`eventId`/`type` yields an empty scope and that consumer receives nothing — logged, but silent on the wire. Vendoring TS 29.575 would make it exact.
- **Only `dataNotification` is produced**; `dataReports`/`fetchInstruct` are modelled, never emitted.
- **No ADRF interaction** — `adrfId`/`adrfSetId` are parsed and echoed but nothing is stored, and the consumer is not told that. The weakest point left in the contract.
- **`formatInstruct`/`procInstruct` are echoed, not applied** — data is forwarded verbatim.
- **The producer subscription is never refreshed** and its expiry is not tracked; a producer that expires it silently stops the data.
- **No user-consent enforcement** — `dataCollectPurposes`/`checkedConsentInd` parsed and ignored; there is no consent source here.
- **No wire interop** — the coordination test's NRF and producer are loopback `SbiServer`s (real HTTP, this tree's own server on both ends).
- GitNexus impact analysis unrunnable (no MCP server connected — 49th consecutive PR); blast radius by grep, enumerated in the spec.