### PR TITLE
fix(easdfd,smfd): evaluate DNS handling rules, report to the SMF, add BaselineDNSPattern, and give the DNS plane a driver (#114)

### DIFF
--- a/specs/fix-easdfd-dns-rules-report-baseline-and-smf-driver.md
+++ b/specs/fix-easdfd-dns-rules-report-baseline-and-smf-driver.md
@@ -1,0 +1,189 @@
+# nextgcore #114 (easdfd + smfd): DNS handling rules, the DNS-message report, Neasdf_BaselineDNSPattern, and the SMF driver
+
+Verified against `main` @ `85a5cd1` (after #65, #106, #112). Every cite in the issue still held; easdfd had
+not been touched since PR #35.
+
+## Scope: four of five criteria, with the fifth split out at the author's direction
+
+#114 says: *"This is a broad, multi-deliverable item and is best treated as an epic (see scope note
+under Suggested approach)"*, and *"recommend tracking it as an epic and splitting. The highest-value
+first sub-item is the SMF EASDF-selection + DNSContext-create leg together with handling-rule
+evaluation."*
+
+That author-marked split is honoured the way this repo already does it (the #108 → #171 precedent):
+the coherent remainder lands here and closes the parent, and the separable part becomes its own issue.
+
+| criterion | here |
+|---|---|
+| 1. `dnsHandlingRules` parsed and evaluated | **done** |
+| 2. DNS-message report / Notify to the SMF | **done** |
+| 3. `Neasdf_BaselineDNSPattern` CRUD + advertised | **done** |
+| 4. UDP:53 DNS listener | **split → #276** |
+| 5. SMF selects an EASDF, creates + deletes the DNS context | **done** |
+| 6. off by default; workspace tests + clippy pass | **done** |
+
+Criterion 4 is split because it is the one sub-item with a **dependency this tree does not have**: a
+DNS wire codec (RFC 1035 QNAME compression, A/AAAA, RCODE, EDNS(0) OPT, `TC`/512-byte truncation).
+`grep -rn 'hickory\|trust-dns' src/Cargo.toml` → nothing. It also needs a field easdfd does not
+store (the UE IP, since a UDP query carries no context id, so the session must be found by source
+address) and an SMF-side change to supply it. And it is the only sub-item the issue itself wants behind
+a **cargo feature** — it binds a privileged port and changes the process's network posture. #276
+carries all of that, with the analysis, its own acceptance criteria, and the note that everything it
+depends on now exists.
+
+## Verified against current main
+
+| claim in the issue | check on `85a5cd1` | still true? |
+|---|---|---|
+| rules kept only as `EasdfDnsContext.raw`, "stored, not yet enforced" | `context.rs:61-64` | yes |
+| `resolve_fqdn` matches only the static `eas_map` | `context.rs:163-181` | yes |
+| the router has no report/Notify path toward the SMF | `main.rs:362-380` | yes |
+| the NFProfile advertises only `neasdf-dnscontext` | `main.rs:591-599` | yes |
+| no UDP socket is opened | only `SbiServer` is started | yes |
+| nothing outside easdfd references EASDF beyond two enum entries | `grep -rn 'neasdf' src/bins/` → easdfd only | yes |
+
+## Decision 1: the schema caveat, stated up front
+
+TS 29.556 is **not vendored** in this repo (nor is TS 23.548). Unlike every other wire type in this
+tree, these member names cannot be checked against an OpenAPI file — the issue says as much
+("faithful paraphrases rather than verbatim quotes"). Two consequences, both deliberate:
+
+* `DnsHandlingRule::from_json` accepts **several spellings** per member (`domainNames` /
+  `dnsQueryMdt` / `fqdnList` / `fqdn`; `easIpAddresses` / `easAddresses` / `easIpv4Addrs`;
+  `reportInd` / `dnsMessageReportInd` / `report`). Accepting a superset is the safer error: rejecting
+  a conformant spelling would drop the rule silently and leave the context inert, which is the defect
+  being fixed.
+* `EasdfDnsContext.raw` is **kept** even though rules are now parsed, so the unrecognised remainder is
+  recoverable rather than lost, and a later vendoring can tighten the parse without a data migration.
+
+A rule that names no domain, or that neither answers nor forwards nor reports, is dropped **with a
+warn** rather than stored — a rule that looks active and is not is worse than no rule.
+
+## Decision 2: resolution precedence, and why a query must be scoped
+
+Order: **session context rules → static EAS map → baseline DNS patterns → configured miss behaviour.**
+Session-specific beats EASDF-configured, and explicit configuration beats a baseline default, which is
+what TS 23.548 §6.2.3.2.2 implies.
+
+The SBI query gained an optional `dns-context-id`. **Unscoped queries are answered from the static map
+and baseline patterns only.** Consulting some session's rules for an unscoped query would leak one
+subscriber's edge steering into another subscriber's answer — the same unkeyed-fan-out shape #112 just
+fixed in dccfd. `a_context_rule_answers_an_fqdn_absent_from_the_eas_map` asserts both halves: scoped
+resolves, unscoped is still a miss.
+
+`fqdn_pattern_matches` is now shared by the EAS map and the rules, so `*.edge.example.com` cannot mean
+two different things in the two places.
+
+## Decision 3: the report is awaited, not spawned
+
+A DNS-message report goes out **before** the DNS answer returns to the querier. An SMF that must install
+a UL-CL toward the resolved EAS should not learn the address after the UE already has it. The cost is
+latency on the answer path; the alternative is a race the SMF loses.
+
+A rule asking for a report on a context with no notification URI logs a warn naming the consequence —
+it cannot be delivered, and an undeliverable report is exactly the silent failure this issue is about.
+
+## Decision 4: the SMF leg is a runtime switch, and it is placed after the N4 leg
+
+**Runtime switch, not a cargo feature** (`SMF_EASDF` / `SMF_EASDF_EDGE_FQDN`, default off). Same
+reasoning as #112's coordination switch: CI builds default features, so a cargo feature would leave
+this path **uncompiled** in CI where it would rot. A runtime switch is compiled always and exercised in
+both states by one `cargo test` run. Env-var driven because smfd has no clap `Args` struct.
+
+**Edge FQDN patterns come from the operator** (`SMF_EASDF_EDGE_FQDN`). There is no other source of
+truth in this tree, and guessing which FQDNs are edge-served would install rules for traffic the
+operator never designated as edge. Enabling the switch with no pattern is logged at warn, because "on
+but never creating a context" is otherwise invisible.
+
+**The create call sits after the PFCP leg succeeds**, immediately before the binding is stored. A
+context created for a session that then fails is an orphan the release path will never delete, because
+release never runs for a session that never existed.
+`a_failed_establishment_creates_no_easdf_dns_context` pins that.
+
+**Discovery picks the service by name.** easdfd now advertises two services, so
+`nfServices[0]` would start dialling whichever the NRF returned first — the same defect scpd's #207
+fixed on the proxy path. `the_dnscontext_service_is_chosen_by_name` puts the baseline-pattern service
+first in the profile, at a dead port, so selecting wrongly fails loudly.
+
+**Every failure is non-fatal to the session.** A session without edge DNS steering still works;
+refusing it would turn an EASDF outage into a service outage for edge DNNs.
+
+## Decision 5: the SMF serves the callback it advertises
+
+The SMF hands the EASDF a `notificationUri`, so `POST /nsmf-pdusession/v1/easdf-dns-reports` had to
+exist — advertising a callback that 404s is the emit-side-without-a-sink defect this repo has recorded
+before. The handler attributes the report to the session owning the context and records the EAS
+address on the binding.
+
+**Recorded, not acted on:** inserting a UL-CL toward the reported EAS is traffic-influence work with
+its own N4 and PSA implications, and doing it half way — installing a rule that does not match — would
+be worse than recording the fact and saying so. `easdf_reported_eas` is where that work will read from.
+
+## What was added / changed
+
+| area | change |
+|---|---|
+| `easdfd/context.rs` | `DnsHandlingRule` + `from_json` + `matches`, `fqdn_pattern_matches`, `EasdfDnsContext::{handling_rules, notify_uri, with_parsed}`, `resolve_in_context`, `dns_context_notify_uri`, the `baseline_patterns` store + CRUD + `resolve_baseline` |
+| `easdfd/main.rs` | rule parsing on create **and** update; `dns-context-id` scoping; `send_dns_message_report`; `split_uri`; four baseline-pattern handlers + routes; the NFProfile now advertises both services |
+| `smfd/easdf.rs` (new) | `EasdfConfig`, `enable`, `should_create`, `create_dns_context`, `delete_dns_context`, `discover_easdf`, `dnscontext_endpoint` |
+| `smfd/context.rs` | `PolicyBinding::{easdf_dns_context_id, easdf_reported_eas}` |
+| `smfd/main.rs` | the startup switch; the create call at establishment; the delete at release; `handle_easdf_dns_report` + its route |
+
+## Verification
+
+Every guard revert-verified: undo the change, watch the **named** test fail, restore.
+
+| guard | revert applied | result |
+|---|---|---|
+| `a_context_rule_answers_an_fqdn_absent_from_the_eas_map` (+2 others) | `resolve_in_context` iterates an empty rule list | FAILED ✓ |
+| `an_update_reparses_the_handling_rules` | update stores the body without `with_parsed` | FAILED ✓ |
+| `a_reporting_rule_emits_a_dns_message_report` | the report emission short-circuited | FAILED ✓ |
+| `baseline_dns_pattern_crud_and_nf_profile_advertisement` | the second service removed from the NFProfile | FAILED ✓ |
+| `releasing_a_session_deletes_its_easdf_dns_context` | the delete call removed from `handle_sm_context_release` | FAILED ✓ (see below) |
+
+### Another wiring hole in my own work
+
+Removing the delete call from `handle_sm_context_release` **compiled and the whole suite still
+passed**: `easdf::tests` drives `delete_dns_context` directly and says nothing about whether any
+handler calls it — "the helper is tested and the wiring is not", the **third** time in this session.
+`releasing_a_session_deletes_its_easdf_dns_context` closes it, and the revert then failed.
+
+### And a `OnceLock` that could not be re-set
+
+That new test then failed on its first run for a different reason: `EASDF_CONFIG` was a `OnceLock`, so
+the sibling wire test had already installed its config and `let _ = set(c)` silently did nothing. My
+test therefore dialled the sibling's (stopped) loopback NRF and no delete ever went out. Changed to a
+`RwLock<Option<_>>` — production sets it once either way — and the switch tests share one
+`tokio::sync::Mutex` (a `std` guard held across an await is
+`clippy::await_holding_lock`). 3 consecutive full-suite runs green.
+
+## Workspace state
+
+`6102 passed / 0 failed` (main: `6090`), `cargo clippy --workspace --all-targets` 0 errors,
+`clippy -p nextgcore-easdfd -p nextgcore-smfd --all-targets` 0 warnings, `cargo fmt --all --check`
+clean. Both switch states are exercised in the one run.
+
+## Ceilings
+
+* **No DNS on the wire.** The EASDF still speaks only SBI; nothing a UE or resolver uses can reach it.
+  That is #276, and it is the difference between "the DNS plane is implemented" and "the DNS plane's
+  decisions are implemented". Only the latter is true after this change.
+* **The create CALL SITE is verified by inspection, not by a test.** Reaching it needs a
+  PFCP-responding UPF: without one `handle_sm_context_create` returns `504 UPF_NOT_RESPONDING` before
+  the EASDF leg, and the smfd harness has no UPF stand-in (no existing test establishes a session
+  either). What IS covered: the create leg over real HTTP (`easdf::tests`), the no-orphan property at
+  the call site, and the release call site.
+* **The report is recorded, never acted on.** No UL-CL, no PSA re-selection, no traffic influence.
+* **Handling-rule members are a paraphrase.** TS 29.556 is not vendored; a conformant SMF using a
+  spelling not in the accepted set has its rule dropped with a warn.
+* **No `Neasdf_DNSContext` json-patch update** — PUT is a full replace, as before this change.
+* **Baseline patterns are in-memory, capped by `max_dns_contexts`, and lost on restart**, like the DNS
+  contexts.
+* **The EASDF is still off by default** in the deployment, and the SMF leg is off by default too, so a
+  default deployment behaves exactly as before.
+* **No wire interop.** Loopback `SbiServer`s stand in for the SMF, the NRF and the EASDF — real HTTP,
+  this tree's own server on both ends.
+* GitNexus impact analysis unrunnable (no MCP server connected — 50th consecutive PR). Blast radius by
+  grep: `resolve_fqdn` has 2 callers (both updated), `EasdfDnsContext::new` 2 (both now chained with
+  `with_parsed`), `PolicyBinding` is constructed at 3 sites (all updated), and no crate outside
+  `nextgcore-easdfd` / `nextgcore-smfd` names anything touched here.

--- a/src/bins/nextgcore-easdfd/src/context.rs
+++ b/src/bins/nextgcore-easdfd/src/context.rs
@@ -48,6 +48,117 @@ pub enum ResolveOutcome {
     Miss,
 }
 
+/// One parsed DNS message-handling rule (#114).
+///
+/// # Schema caveat, stated plainly
+///
+/// TS 29.556 is **not vendored** in this repo, so — unlike every other wire type
+/// in this tree — these member names cannot be checked against an OpenAPI file.
+/// They follow TS 23.548 §6.2.3.2.2's description of a DNS message-handling rule
+/// and accept several spellings for the same thing (see
+/// [`DnsHandlingRule::from_json`]). Anything not recognised is preserved in the
+/// context's [`EasdfDnsContext::raw`], so nothing an SMF sends is lost, and a
+/// later vendoring of TS 29.556 can tighten this without losing data.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DnsHandlingRule {
+    /// FQDN patterns this rule applies to. `*.` prefix is a subdomain wildcard,
+    /// matching [`EasdfContext::resolve_fqdn`]'s existing EAS-map semantics so a
+    /// rule and a static entry mean the same thing by the same syntax.
+    pub domain_patterns: Vec<String>,
+    /// EAS addresses to answer a matching query with. Empty means the rule does
+    /// not itself answer (it may still ask for a report, or a forward).
+    pub eas_addresses: Vec<String>,
+    /// Report a matching DNS message to the SMF (TS 23.548 §6.2.3.2.2 DNS
+    /// message reporting).
+    pub report: bool,
+    /// Forward a matching query to this upstream DNS server instead of
+    /// answering it.
+    pub forward_to: Option<String>,
+}
+
+impl DnsHandlingRule {
+    /// Parse one rule from its JSON object.
+    ///
+    /// Several key spellings are accepted for each member because the normative
+    /// names cannot be verified here: `domainNames` / `dnsQueryMdt` / `fqdnList` /
+    /// `fqdn` for the patterns, `easIpAddresses` / `easAddresses` / `easIpv4Addrs`
+    /// for the addresses. Accepting a superset is the safer error: rejecting a
+    /// conformant spelling would silently drop the rule and leave the context
+    /// inert, which is the defect being fixed.
+    pub fn from_json(value: &serde_json::Value) -> Option<Self> {
+        let obj = value.as_object()?;
+        let strings = |keys: &[&str]| -> Vec<String> {
+            for key in keys {
+                match obj.get(*key) {
+                    Some(serde_json::Value::Array(items)) => {
+                        let out: Vec<String> = items
+                            .iter()
+                            .filter_map(|v| v.as_str().map(str::to_string))
+                            .collect();
+                        if !out.is_empty() {
+                            return out;
+                        }
+                    }
+                    Some(serde_json::Value::String(s)) if !s.is_empty() => return vec![s.clone()],
+                    _ => {}
+                }
+            }
+            Vec::new()
+        };
+        let domain_patterns = strings(&["domainNames", "dnsQueryMdt", "fqdnList", "fqdn"]);
+        let eas_addresses = strings(&["easIpAddresses", "easAddresses", "easIpv4Addrs"]);
+        let report = ["reportInd", "dnsMessageReportInd", "report"]
+            .iter()
+            .find_map(|k| obj.get(*k).and_then(|v| v.as_bool()))
+            .unwrap_or(false);
+        let forward_to = ["forwardTo", "dnsServerAddress", "upstreamDns"]
+            .iter()
+            .find_map(|k| obj.get(*k).and_then(|v| v.as_str()))
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+
+        // A rule that names no domain cannot be matched against a query, and a
+        // rule that neither answers, forwards nor reports has no effect. Either
+        // way it is dropped with a warn rather than stored as a rule that looks
+        // active and is not.
+        if domain_patterns.is_empty() {
+            log::warn!("DNS handling rule names no domain pattern; ignoring it: {value}");
+            return None;
+        }
+        if eas_addresses.is_empty() && forward_to.is_none() && !report {
+            log::warn!("DNS handling rule has no action (no EAS address, no forward, no report); ignoring it: {value}");
+            return None;
+        }
+        Some(Self {
+            domain_patterns,
+            eas_addresses,
+            report,
+            forward_to,
+        })
+    }
+
+    /// Does this rule apply to `query` (already lowercased and dot-trimmed)?
+    pub fn matches(&self, query: &str) -> bool {
+        self.domain_patterns
+            .iter()
+            .any(|pattern| fqdn_pattern_matches(pattern, query))
+    }
+}
+
+/// Shared FQDN pattern match, used by both the EAS map and the handling rules so
+/// `*.edge.example.com` cannot mean two different things in the two places.
+///
+/// A `*.` prefix matches any **subdomain** of the remainder, not the remainder
+/// itself; otherwise the match is exact. Case-insensitive, trailing dot ignored.
+pub fn fqdn_pattern_matches(pattern: &str, query: &str) -> bool {
+    let key = pattern.trim_end_matches('.').to_ascii_lowercase();
+    let query = query.trim_end_matches('.').to_ascii_lowercase();
+    match key.strip_prefix("*.") {
+        Some(suffix) => query.len() > suffix.len() + 1 && query.ends_with(&format!(".{suffix}")),
+        None => query == key,
+    }
+}
+
 /// A stored `Neasdf_DNSContext` (TS 29.556 §5.2): the per-PDU-session DNS
 /// handling context an SMF creates toward the EASDF.
 #[derive(Debug, Clone)]
@@ -58,10 +169,20 @@ pub struct EasdfDnsContext {
     pub supi: String,
     /// PDU session the context belongs to.
     pub pdu_session_id: u64,
-    /// Raw DnsContext JSON as received (DNS message-handling rules are
-    /// stored, not yet enforced — Phase 1 keeps rule evaluation out of
-    /// scope alongside UL-CL insertion).
+    /// Raw DnsContext JSON as received. Still kept after #114 added typed rule
+    /// parsing: the parse recognises a documented subset, and the raw body is
+    /// what makes the unrecognised remainder recoverable rather than lost.
     pub raw: String,
+    /// DNS message-handling rules, PARSED (#114).
+    ///
+    /// Previously the rules existed only inside `raw` and were never consulted,
+    /// so a per-session context had no effect on what the EASDF answered — the
+    /// EASDF's entire reason for existing.
+    pub handling_rules: Vec<DnsHandlingRule>,
+    /// Where to send a DNS-message report for this context (#114). Taken from
+    /// the SMF's callback member in the create body; without it a rule asking for
+    /// a report has nowhere to send one.
+    pub notify_uri: Option<String>,
 }
 
 impl EasdfDnsContext {
@@ -71,7 +192,47 @@ impl EasdfDnsContext {
             supi: supi.into(),
             pdu_session_id,
             raw: raw.into(),
+            handling_rules: Vec::new(),
+            notify_uri: None,
         }
+    }
+
+    /// Parse the handling rules and the notify URI out of a create/update body
+    /// (#114).
+    ///
+    /// As with the rule members, several spellings of each container key are
+    /// accepted because TS 29.556 is not vendored here.
+    pub fn with_parsed(mut self, body: &serde_json::Value) -> Self {
+        let rules = [
+            "dnsHandlingRules",
+            "dnsMessageHandlingRules",
+            "handlingRules",
+        ]
+        .iter()
+        .find_map(|k| body.get(*k).and_then(|v| v.as_array()));
+        if let Some(rules) = rules {
+            self.handling_rules = rules
+                .iter()
+                .filter_map(DnsHandlingRule::from_json)
+                .collect();
+            log::info!(
+                "DNS context {}: {} of {} handling rule(s) parsed",
+                self.id,
+                self.handling_rules.len(),
+                rules.len()
+            );
+        }
+        self.notify_uri = [
+            "notificationUri",
+            "notifyUri",
+            "smfCallbackUri",
+            "dnsMessageReportUri",
+        ]
+        .iter()
+        .find_map(|k| body.get(*k).and_then(|v| v.as_str()))
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+        self
     }
 }
 
@@ -108,6 +269,11 @@ pub struct EasdfContext {
     miss_behavior: DnsMissBehavior,
     /// Maximum stored DNS contexts.
     max_dns_contexts: usize,
+    /// Baseline DNS patterns (`Neasdf_BaselineDNSPattern`, #114), keyed by a
+    /// server-minted pattern id. EASDF-wide rather than per-session: these are
+    /// the fallback a query falls through to when no session context rule and no
+    /// static EAS-map entry matched.
+    baseline_patterns: RwLock<HashMap<String, DnsHandlingRule>>,
     /// Context initialized flag
     initialized: AtomicBool,
 }
@@ -119,6 +285,7 @@ impl EasdfContext {
             eas_map: Vec::new(),
             miss_behavior: DnsMissBehavior::default(),
             max_dns_contexts: 0,
+            baseline_patterns: RwLock::new(HashMap::new()),
             initialized: AtomicBool::new(false),
         }
     }
@@ -138,6 +305,9 @@ impl EasdfContext {
         }
         if let Ok(mut contexts) = self.dns_contexts.write() {
             contexts.clear();
+        }
+        if let Ok(mut patterns) = self.baseline_patterns.write() {
+            patterns.clear();
         }
         self.eas_map.clear();
         self.miss_behavior = DnsMissBehavior::default();
@@ -163,21 +333,64 @@ impl EasdfContext {
     pub fn resolve_fqdn(&self, fqdn: &str) -> ResolveOutcome {
         let query = fqdn.trim_end_matches('.').to_ascii_lowercase();
         for entry in &self.eas_map {
-            let key = entry.fqdn.trim_end_matches('.').to_ascii_lowercase();
-            let matched = if let Some(suffix) = key.strip_prefix("*.") {
-                // Wildcard: any subdomain of `suffix`, not `suffix` itself.
-                query.len() > suffix.len() + 1 && query.ends_with(&format!(".{suffix}"))
-            } else {
-                query == key
-            };
-            if matched {
+            if fqdn_pattern_matches(&entry.fqdn, &query) {
                 return ResolveOutcome::Resolved(entry.addresses.clone());
             }
+        }
+        // #114: baseline DNS patterns are the last stop before the configured
+        // miss behaviour.
+        if let Some(outcome) = self.resolve_baseline(&query) {
+            return outcome;
         }
         match &self.miss_behavior {
             DnsMissBehavior::Forward(upstream) => ResolveOutcome::Forward(upstream.clone()),
             DnsMissBehavior::NxDomain => ResolveOutcome::Miss,
         }
+    }
+
+    /// Resolve `fqdn` **in the scope of a DNS context** (#114): the context's
+    /// own handling rules first, then the static EAS map, then the miss
+    /// behaviour.
+    ///
+    /// This is the ordering TS 23.548 §6.2.3.2.2 implies: a rule the SMF
+    /// installed for this session is more specific than the EASDF's static
+    /// configuration, so it wins.
+    ///
+    /// Returns the outcome plus whether a matching rule asked for a DNS-message
+    /// report, so the caller can emit one without re-evaluating the rules.
+    ///
+    /// Scoped deliberately: an unscoped query is answered from the static map
+    /// only ([`Self::resolve_fqdn`]). Consulting *some other session's* rules for
+    /// an unscoped query would leak one subscriber's edge steering into
+    /// another's answer.
+    pub fn resolve_in_context(&self, ctx_id: &str, fqdn: &str) -> (ResolveOutcome, bool) {
+        let query = fqdn.trim_end_matches('.').to_ascii_lowercase();
+        let Some(ctx) = self.dns_context_find(ctx_id) else {
+            // Unknown context: fall back to the static map rather than refusing,
+            // so a stale context id degrades to the pre-#114 answer.
+            return (self.resolve_fqdn(fqdn), false);
+        };
+        for rule in &ctx.handling_rules {
+            if !rule.matches(&query) {
+                continue;
+            }
+            let outcome = if !rule.eas_addresses.is_empty() {
+                ResolveOutcome::Resolved(rule.eas_addresses.clone())
+            } else if let Some(upstream) = &rule.forward_to {
+                ResolveOutcome::Forward(upstream.clone())
+            } else {
+                // A report-only rule states no answer, so the static map decides
+                // what the answer is while the rule still drives the report.
+                self.resolve_fqdn(fqdn)
+            };
+            return (outcome, rule.report);
+        }
+        (self.resolve_fqdn(fqdn), false)
+    }
+
+    /// The notify URI recorded for a context, if any (#114).
+    pub fn dns_context_notify_uri(&self, ctx_id: &str) -> Option<String> {
+        self.dns_context_find(ctx_id).and_then(|c| c.notify_uri)
     }
 
     /// Insert a DNS context, enforcing the capacity cap.
@@ -224,6 +437,72 @@ impl EasdfContext {
     /// Number of stored DNS contexts (NRF `/load` gauge source).
     pub fn dns_context_count(&self) -> usize {
         self.dns_contexts.read().map(|c| c.len()).unwrap_or(0)
+    }
+
+    // ---- #114: Neasdf_BaselineDNSPattern -------------------------------------
+
+    /// Store a baseline DNS pattern; returns its minted id.
+    ///
+    /// Shares `max_dns_contexts` as its ceiling: both stores are remote-driven,
+    /// and a second unbounded map on a network-facing NF is the resource-growth
+    /// concern the first one already has a cap for.
+    pub fn baseline_pattern_insert(
+        &self,
+        rule: DnsHandlingRule,
+    ) -> Result<String, EasdfContextError> {
+        let mut patterns = self
+            .baseline_patterns
+            .write()
+            .map_err(|_| EasdfContextError::LockPoisoned)?;
+        if patterns.len() >= self.max_dns_contexts {
+            return Err(EasdfContextError::MaxDnsContextsReached);
+        }
+        let id = Uuid::new_v4().to_string();
+        patterns.insert(id.clone(), rule);
+        Ok(id)
+    }
+
+    pub fn baseline_pattern_find(&self, id: &str) -> Option<DnsHandlingRule> {
+        self.baseline_patterns.read().ok()?.get(id).cloned()
+    }
+
+    pub fn baseline_pattern_ids(&self) -> Vec<String> {
+        self.baseline_patterns
+            .read()
+            .map(|p| p.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn baseline_pattern_remove(&self, id: &str) -> Option<DnsHandlingRule> {
+        self.baseline_patterns.write().ok()?.remove(id)
+    }
+
+    pub fn baseline_pattern_count(&self) -> usize {
+        self.baseline_patterns.read().map(|p| p.len()).unwrap_or(0)
+    }
+
+    /// Resolve against the baseline patterns — the last stop before the
+    /// configured miss behaviour (#114).
+    ///
+    /// Consulted by [`Self::resolve_in_context`] and [`Self::resolve_fqdn`] only
+    /// after the session rules and the static map have both missed, which is the
+    /// precedence order TS 23.548 implies: session-specific beats
+    /// EASDF-configured, and explicit configuration beats a baseline default.
+    pub fn resolve_baseline(&self, fqdn: &str) -> Option<ResolveOutcome> {
+        let query = fqdn.trim_end_matches('.').to_ascii_lowercase();
+        let patterns = self.baseline_patterns.read().ok()?;
+        for rule in patterns.values() {
+            if !rule.matches(&query) {
+                continue;
+            }
+            if !rule.eas_addresses.is_empty() {
+                return Some(ResolveOutcome::Resolved(rule.eas_addresses.clone()));
+            }
+            if let Some(upstream) = &rule.forward_to {
+                return Some(ResolveOutcome::Forward(upstream.clone()));
+            }
+        }
+        None
     }
 }
 

--- a/src/bins/nextgcore-easdfd/src/main.rs
+++ b/src/bins/nextgcore-easdfd/src/main.rs
@@ -30,6 +30,7 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use nextgcore_sbi::client::SbiClient;
 use nextgcore_sbi::context::SbiContext;
 use nextgcore_sbi::message::{SbiRequest, SbiResponse};
 use nextgcore_sbi::server::{
@@ -381,6 +382,18 @@ async fn easdf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
             "GET" => handle_dns_query(&request).await,
             _ => send_method_not_allowed(method, "dns-queries"),
         },
+        // #114: Neasdf_BaselineDNSPattern (TS 23.501 Table 7.2.25-1) -- the
+        // second EASDF service, previously absent entirely.
+        ["neasdf-baselinednspattern", "v1", "baseline-dns-patterns"] => match method {
+            "POST" => handle_baseline_pattern_create(&request).await,
+            "GET" => handle_baseline_pattern_list().await,
+            _ => send_method_not_allowed(method, "baseline-dns-patterns"),
+        },
+        ["neasdf-baselinednspattern", "v1", "baseline-dns-patterns", pattern_id] => match method {
+            "GET" => handle_baseline_pattern_read(pattern_id).await,
+            "DELETE" => handle_baseline_pattern_delete(pattern_id).await,
+            _ => send_method_not_allowed(method, "baseline-dns-patterns/{patternId}"),
+        },
         _ => send_not_found(&format!("Resource not found: {path}"), None),
     }
 }
@@ -440,7 +453,10 @@ async fn handle_dns_context_create(request: &SbiRequest) -> SbiResponse {
     };
 
     let raw = request.http.content.clone().unwrap_or_default();
-    let dns_context = EasdfDnsContext::new(supi.clone(), pdu_session_id, raw);
+    // #114: parse the DNS message-handling rules and the report callback out of
+    // the body. They used to be stored only inside `raw` and never consulted, so
+    // the context had no effect on what this EASDF answered.
+    let dns_context = EasdfDnsContext::new(supi.clone(), pdu_session_id, raw).with_parsed(&data);
     let ctx_id = dns_context.id.clone();
 
     let ctx = easdf_self();
@@ -478,7 +494,10 @@ async fn handle_dns_context_update(ctx_id: &str, request: &SbiRequest) -> SbiRes
     };
 
     let raw = request.http.content.clone().unwrap_or_default();
-    let replacement = EasdfDnsContext::new(supi, pdu_session_id, raw);
+    // #114: an update must REPARSE the rules; keeping the old ones while storing
+    // the new body is the shape of bug that passes a read-back assertion and
+    // changes nothing about what the EASDF answers.
+    let replacement = EasdfDnsContext::new(supi, pdu_session_id, raw).with_parsed(&data);
 
     let ctx = easdf_self();
     let replaced = match ctx.read() {
@@ -559,11 +578,43 @@ async fn handle_dns_query(request: &SbiRequest) -> SbiResponse {
         );
     };
 
+    // #114: an optional `dns-context-id` scopes the query to a session's own DNS
+    // handling rules. Unscoped queries are answered from the static EAS map only
+    // -- consulting some other session's rules would leak one subscriber's edge
+    // steering into another subscriber's answer.
+    let ctx_id = request
+        .http
+        .get_param("dns-context-id")
+        .filter(|v| !v.is_empty())
+        .cloned();
+
     let ctx = easdf_self();
-    let outcome = match ctx.read() {
-        Ok(c) => c.resolve_fqdn(&fqdn),
+    let (outcome, report) = match ctx.read() {
+        Ok(c) => match &ctx_id {
+            Some(id) => c.resolve_in_context(id, &fqdn),
+            None => (c.resolve_fqdn(&fqdn), false),
+        },
         Err(_) => return send_internal_error("EASDF context lock poisoned"),
     };
+
+    // TS 23.548 §6.2.3.2.2 DNS message reporting: a matching rule that asked for
+    // a report gets one, sent to the callback the SMF supplied on create. Awaited
+    // rather than spawned so the report is on the wire before the DNS answer goes
+    // back -- an SMF that must install a UL-CL for the resolved EAS should not
+    // learn of it after the UE already has the address.
+    if report {
+        if let Some(id) = &ctx_id {
+            let uri = ctx.read().ok().and_then(|c| c.dns_context_notify_uri(id));
+            match uri {
+                Some(uri) => send_dns_message_report(&uri, id, &fqdn, &outcome).await,
+                None => log::warn!(
+                    "DNS context {id} has a rule requesting a report but no notification URI: \
+                     the report cannot be delivered"
+                ),
+            }
+        }
+    }
+
     match outcome {
         ResolveOutcome::Resolved(addresses) => SbiResponse::with_status(200)
             .with_json_body(&serde_json::json!({
@@ -586,6 +637,182 @@ async fn handle_dns_query(request: &SbiRequest) -> SbiResponse {
     }
 }
 
+/// Send a DNS-message report to the SMF's callback URI (#114, TS 23.548
+/// §6.2.3.2.2).
+///
+/// This is the leg the EASDF had no equivalent of at all: the SMF could create a
+/// context and was never told what the EASDF resolved, so it could not drive the
+/// UL-CL / PSA re-selection that edge steering exists for.
+///
+/// The body carries the context id, the queried FQDN, the action taken and the
+/// resolved EAS addresses. TS 29.556 is not vendored, so the member names follow
+/// the same convention as the rest of this crate's northbound bodies; the shape
+/// is asserted by `a_reporting_rule_emits_a_dns_message_report`.
+///
+/// A failed report is logged and swallowed: the DNS answer to the UE must not be
+/// held hostage to the SMF's reachability, and the EASDF has no retry queue.
+async fn send_dns_message_report(
+    notify_uri: &str,
+    ctx_id: &str,
+    fqdn: &str,
+    outcome: &ResolveOutcome,
+) {
+    let (action, addresses) = match outcome {
+        ResolveOutcome::Resolved(addrs) => ("RESOLVE", addrs.clone()),
+        ResolveOutcome::Forward(_) => ("FORWARD", Vec::new()),
+        ResolveOutcome::Miss => ("MISS", Vec::new()),
+    };
+    let body = serde_json::json!({
+        "dnsContextId": ctx_id,
+        "fqdn": fqdn,
+        "action": action,
+        "easIpAddresses": addresses,
+    });
+
+    let Some((host, port, path)) = split_uri(notify_uri) else {
+        log::warn!("DNS context {ctx_id}: unparseable notification URI {notify_uri}");
+        return;
+    };
+    let client = SbiClient::with_host_port(&host, port);
+    match client.post_json(&path, &body).await {
+        Ok(resp) => log::info!(
+            "DNS message report for {fqdn} (context {ctx_id}) -> {notify_uri} status={}",
+            resp.status
+        ),
+        Err(e) => log::warn!("DNS message report to {notify_uri} failed: {e}"),
+    }
+}
+
+/// Split `scheme://host:port/path` into `(host, port, path)`.
+fn split_uri(uri: &str) -> Option<(String, u16, String)> {
+    let (default_port, rest) = if let Some(r) = uri.strip_prefix("https://") {
+        (443u16, r)
+    } else if let Some(r) = uri.strip_prefix("http://") {
+        (80u16, r)
+    } else {
+        (80u16, uri)
+    };
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], rest[i..].to_string()),
+        None => (rest, "/".to_string()),
+    };
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((h, p)) => (h.to_string(), p.parse().unwrap_or(default_port)),
+        None => (authority.to_string(), default_port),
+    };
+    (!host.is_empty()).then_some((host, port, path))
+}
+
+// ---------------------------------------------------------------------------
+// #114: Neasdf_BaselineDNSPattern (TS 23.501 Table 7.2.25-1)
+// ---------------------------------------------------------------------------
+
+/// Resource collection path for baseline DNS patterns.
+const BASELINE_PATTERNS_PATH: &str = "/neasdf-baselinednspattern/v1/baseline-dns-patterns";
+
+/// `POST .../baseline-dns-patterns` — create a baseline DNS pattern (#114).
+///
+/// The second EASDF service in TS 23.501 Table 7.2.25-1 was absent entirely: not
+/// implemented, not routed, and not advertised in the NFProfile, so an SMF
+/// discovering this EASDF saw an NF that claims to be an EASDF and offers half of
+/// what one offers.
+///
+/// A baseline pattern is EASDF-wide (not per-session): it is the fallback
+/// forwarding/answering configuration a DNS query falls through to when no
+/// session context rule and no static EAS-map entry matched. Mandatory member:
+/// a non-empty domain pattern.
+async fn handle_baseline_pattern_create(request: &SbiRequest) -> SbiResponse {
+    let Some(body) = request.http.content.as_deref() else {
+        return send_bad_request("Missing request body", Some("MANDATORY_IE_MISSING"));
+    };
+    let data: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+    };
+    let Some(rule) = context::DnsHandlingRule::from_json(&data) else {
+        return send_bad_request(
+            "A baseline DNS pattern needs a domain pattern (domainNames / dnsQueryMdt / fqdn) \
+             and an action (easIpAddresses, forwardTo, or reportInd)",
+            Some("MANDATORY_IE_MISSING"),
+        );
+    };
+
+    let ctx = easdf_self();
+    let created = match ctx.read() {
+        Ok(c) => c.baseline_pattern_insert(rule),
+        Err(_) => return send_internal_error("EASDF context lock poisoned"),
+    };
+    match created {
+        Ok(id) => {
+            let location = format!("{BASELINE_PATTERNS_PATH}/{id}");
+            log::info!("Baseline DNS pattern created: id={id}");
+            let mut echoed = data;
+            if let Some(obj) = echoed.as_object_mut() {
+                obj.insert("patternId".to_string(), serde_json::json!(id));
+                obj.insert("self".to_string(), serde_json::json!(location));
+            }
+            SbiResponse::with_status(201)
+                .with_header("Location", location)
+                .with_json_body(&echoed)
+                .unwrap_or_else(|_| SbiResponse::with_status(201))
+        }
+        Err(err @ EasdfContextError::MaxDnsContextsReached) => {
+            send_error(507, "Insufficient Storage", err.detail(), Some(err.cause()))
+        }
+        Err(err) => send_internal_error(err.detail()),
+    }
+}
+
+/// `GET .../baseline-dns-patterns/{id}` — read one baseline DNS pattern (#114).
+async fn handle_baseline_pattern_read(id: &str) -> SbiResponse {
+    let ctx = easdf_self();
+    let found = ctx.read().ok().and_then(|c| c.baseline_pattern_find(id));
+    match found {
+        Some(rule) => SbiResponse::with_status(200)
+            .with_json_body(&serde_json::json!({
+                "patternId": id,
+                "self": format!("{BASELINE_PATTERNS_PATH}/{id}"),
+                "domainNames": rule.domain_patterns,
+                "easIpAddresses": rule.eas_addresses,
+                "reportInd": rule.report,
+                "forwardTo": rule.forward_to,
+            }))
+            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        None => send_not_found(
+            &format!("Baseline DNS pattern {id} not found"),
+            Some("PATTERN_NOT_FOUND"),
+        ),
+    }
+}
+
+/// `GET .../baseline-dns-patterns` — list the baseline DNS patterns (#114).
+async fn handle_baseline_pattern_list() -> SbiResponse {
+    let ctx = easdf_self();
+    let ids = ctx
+        .read()
+        .map(|c| c.baseline_pattern_ids())
+        .unwrap_or_default();
+    SbiResponse::with_status(200)
+        .with_json_body(&serde_json::json!({"patternIds": ids}))
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+/// `DELETE .../baseline-dns-patterns/{id}` — 204 / 404 (#114).
+async fn handle_baseline_pattern_delete(id: &str) -> SbiResponse {
+    let ctx = easdf_self();
+    let removed = ctx.read().ok().and_then(|c| c.baseline_pattern_remove(id));
+    match removed {
+        Some(_) => {
+            log::info!("Baseline DNS pattern removed: id={id}");
+            SbiResponse::with_status(204)
+        }
+        None => send_not_found(
+            &format!("Baseline DNS pattern {id} not found"),
+            Some("PATTERN_NOT_FOUND"),
+        ),
+    }
+}
+
 /// Build the NFProfile registered with the NRF (TS 29.510): nfType EASDF
 /// advertising the neasdf-dnscontext service (TS 29.556).
 fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serde_json::Value {
@@ -598,6 +825,17 @@ fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serd
             {
                 "serviceInstanceId": format!("{nf_instance_id}-neasdf-dnscontext"),
                 "serviceName": "neasdf-dnscontext",
+                "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
+                "scheme": "http",
+                "nfServiceStatus": "REGISTERED",
+                "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
+            },
+            // #114: TS 23.501 Table 7.2.25-1 lists BOTH EASDF services. Only the
+            // first was advertised, so an SMF discovering this EASDF was told it
+            // offers half of what an EASDF offers.
+            {
+                "serviceInstanceId": format!("{nf_instance_id}-neasdf-baselinednspattern"),
+                "serviceName": "neasdf-baselinednspattern",
                 "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
                 "scheme": "http",
                 "nfServiceStatus": "REGISTERED",
@@ -1065,5 +1303,275 @@ easdf:
 
         let wrong = SbiRequest::get("/neasdf-dnscontext/v1/dns-contexts");
         assert_eq!(block_on(easdf_sbi_request_handler(wrong)).status, 405);
+    }
+
+    // ─── #114: rule evaluation, DNS-message report, baseline patterns ────────
+
+    /// #114 acceptance: a context's handling rule answers a query for an FQDN
+    /// that is **absent from the static EAS map**.
+    ///
+    /// That absence is the point: before this, resolution consulted only the
+    /// static map, so a per-session context had no effect on any answer. An FQDN
+    /// present in the map could not distinguish the two.
+    #[test]
+    fn a_context_rule_answers_an_fqdn_absent_from_the_eas_map() {
+        let _g = lock_globals();
+        reset_context(DnsMissBehavior::NxDomain);
+
+        // Sanity: the FQDN is NOT in the static map, so without the rule this is
+        // a miss. Asserted, so the test cannot pass because the map happened to
+        // contain it.
+        let ctx = easdf_self();
+        assert_eq!(
+            ctx.read().unwrap().resolve_fqdn("shop.edge2.example.com"),
+            ResolveOutcome::Miss,
+            "the FQDN must be absent from the static map for this test to mean anything"
+        );
+
+        let body = serde_json::json!({
+            "supi": "imsi-001010000000001",
+            "pduSessionId": 5,
+            "dnsHandlingRules": [{
+                "domainNames": ["*.edge2.example.com"],
+                "easIpAddresses": ["10.70.0.7"]
+            }]
+        });
+        let resp = block_on(easdf_sbi_request_handler(create_request(body)));
+        assert_eq!(resp.status, 201);
+        let created: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        let ctx_id = created["dnsContextId"].as_str().unwrap().to_string();
+
+        // Scoped to the context, the rule answers.
+        let mut query = SbiRequest::get("/neasdf-dnscontext/v1/dns-queries");
+        query.http.set_param("fqdn", "shop.edge2.example.com");
+        query.http.set_param("dns-context-id", &ctx_id);
+        let resp = block_on(easdf_sbi_request_handler(query));
+        assert_eq!(resp.status, 200);
+        let answer: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(answer["action"], "RESOLVE");
+        assert_eq!(answer["easAddresses"][0], "10.70.0.7");
+
+        // UNSCOPED, the same query is still a miss: one session's rules must not
+        // answer another's (or an anonymous) query.
+        let mut query = SbiRequest::get("/neasdf-dnscontext/v1/dns-queries");
+        query.http.set_param("fqdn", "shop.edge2.example.com");
+        assert_eq!(
+            block_on(easdf_sbi_request_handler(query)).status,
+            404,
+            "an unscoped query must not be answered from some session's rules"
+        );
+    }
+
+    /// #114: a rule can forward, and an update REPARSES the rules — storing the
+    /// new body while keeping the old rules would pass a read-back assertion and
+    /// change nothing about what the EASDF answers.
+    #[test]
+    fn an_update_reparses_the_handling_rules() {
+        let _g = lock_globals();
+        reset_context(DnsMissBehavior::NxDomain);
+
+        let body = serde_json::json!({
+            "supi": "imsi-1", "pduSessionId": 1,
+            "dnsHandlingRules": [{
+                "domainNames": ["a.edge3.example.com"], "easIpAddresses": ["10.1.1.1"]
+            }]
+        });
+        let resp = block_on(easdf_sbi_request_handler(create_request(body)));
+        let created: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        let ctx_id = created["dnsContextId"].as_str().unwrap().to_string();
+
+        // Replace the rule with a FORWARD rule for a different name.
+        let update = SbiRequest::put(format!("/neasdf-dnscontext/v1/dns-contexts/{ctx_id}"))
+            .with_json_body(&serde_json::json!({
+                "supi": "imsi-1", "pduSessionId": 1,
+                "dnsHandlingRules": [{
+                    "domainNames": ["b.edge3.example.com"],
+                    "forwardTo": "10.0.0.53"
+                }]
+            }))
+            .unwrap();
+        assert_eq!(block_on(easdf_sbi_request_handler(update)).status, 200);
+
+        let resolve = |fqdn: &str| {
+            let ctx = easdf_self();
+            let guard = ctx.read().unwrap();
+            guard.resolve_in_context(&ctx_id, fqdn).0
+        };
+        assert_eq!(
+            resolve("b.edge3.example.com"),
+            ResolveOutcome::Forward("10.0.0.53".to_string()),
+            "the new rule must be in effect"
+        );
+        assert_eq!(
+            resolve("a.edge3.example.com"),
+            ResolveOutcome::Miss,
+            "the replaced rule must be gone, not merely shadowed"
+        );
+    }
+
+    /// #114 acceptance: a reporting-enabled rule emits a DNS-message report to
+    /// the SMF's callback URI, carrying the FQDN and the resolved EAS address(es).
+    // The `GLOBAL_TEST_LOCK` is a `std::sync::Mutex` shared with this module's
+    // SYNCHRONOUS tests, which cannot await. Two locks -- a std one for the sync
+    // tests and a tokio one for this -- would be two disjoint agreements about the
+    // same process-global context, which is the bug the single lock exists to
+    // prevent. Holding it across the awaits below is safe here because these tests
+    // are its only holders and none of them blocks on another.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_reporting_rule_emits_a_dns_message_report() {
+        let _g = lock_globals();
+        reset_context(DnsMissBehavior::NxDomain);
+
+        // A loopback "SMF" that records the report it receives.
+        let seen: std::sync::Arc<Mutex<Vec<serde_json::Value>>> =
+            std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let port = nextgcore_sbi::test_support::free_port();
+        let smf =
+            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
+                std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+            ));
+        smf.start(move |req: SbiRequest| {
+            let sink = sink.clone();
+            async move {
+                if let Some(body) = req.http.content.as_deref() {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+                        sink.lock().unwrap_or_else(|e| e.into_inner()).push(v);
+                    }
+                }
+                SbiResponse::with_status(204)
+            }
+        })
+        .await
+        .expect("smf sink start");
+
+        let body = serde_json::json!({
+            "supi": "imsi-001010000000001",
+            "pduSessionId": 5,
+            "notificationUri": format!("http://127.0.0.1:{port}/nsmf-pdusession/v1/easdf-dns-reports"),
+            "dnsHandlingRules": [{
+                "domainNames": ["*.edge4.example.com"],
+                "easIpAddresses": ["10.80.0.8"],
+                "reportInd": true
+            }]
+        });
+        let resp = easdf_sbi_request_handler(create_request(body)).await;
+        assert_eq!(resp.status, 201);
+        let created: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        let ctx_id = created["dnsContextId"].as_str().unwrap().to_string();
+
+        let mut query = SbiRequest::get("/neasdf-dnscontext/v1/dns-queries");
+        query.http.set_param("fqdn", "vr.edge4.example.com");
+        query.http.set_param("dns-context-id", &ctx_id);
+        assert_eq!(easdf_sbi_request_handler(query).await.status, 200);
+
+        // The report is awaited inside the handler, so it is already delivered.
+        let reports = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(reports.len(), 1, "exactly one report, got {reports:?}");
+        assert_eq!(reports[0]["fqdn"], "vr.edge4.example.com");
+        assert_eq!(reports[0]["action"], "RESOLVE");
+        assert_eq!(reports[0]["easIpAddresses"][0], "10.80.0.8");
+        assert_eq!(reports[0]["dnsContextId"], ctx_id);
+
+        // A rule WITHOUT reportInd emits nothing.
+        let body = serde_json::json!({
+            "supi": "imsi-2", "pduSessionId": 6,
+            "notificationUri": format!("http://127.0.0.1:{port}/nsmf-pdusession/v1/easdf-dns-reports"),
+            "dnsHandlingRules": [{
+                "domainNames": ["*.quiet.example.com"], "easIpAddresses": ["10.80.0.9"]
+            }]
+        });
+        let resp = easdf_sbi_request_handler(create_request(body)).await;
+        let created: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        let quiet_id = created["dnsContextId"].as_str().unwrap().to_string();
+        let mut query = SbiRequest::get("/neasdf-dnscontext/v1/dns-queries");
+        query.http.set_param("fqdn", "x.quiet.example.com");
+        query.http.set_param("dns-context-id", &quiet_id);
+        assert_eq!(easdf_sbi_request_handler(query).await.status, 200);
+        assert_eq!(
+            seen.lock().unwrap_or_else(|e| e.into_inner()).len(),
+            1,
+            "a rule without reportInd must not report"
+        );
+
+        smf.stop().await.expect("stop");
+    }
+
+    /// #114 acceptance: `Neasdf_BaselineDNSPattern` Create/Read/Delete, and the
+    /// service appears in the NFProfile registration payload.
+    #[test]
+    fn baseline_dns_pattern_crud_and_nf_profile_advertisement() {
+        let _g = lock_globals();
+        reset_context(DnsMissBehavior::NxDomain);
+
+        // Create.
+        let create = SbiRequest::post("/neasdf-baselinednspattern/v1/baseline-dns-patterns")
+            .with_json_body(&serde_json::json!({
+                "domainNames": ["*.baseline.example.com"],
+                "easIpAddresses": ["10.90.0.9"]
+            }))
+            .unwrap();
+        let resp = block_on(easdf_sbi_request_handler(create));
+        assert_eq!(resp.status, 201);
+        let location = resp.http.get_header("location").cloned().expect("Location");
+        assert!(
+            location.starts_with(BASELINE_PATTERNS_PATH),
+            "got {location}"
+        );
+        let id = location.rsplit('/').next().unwrap().to_string();
+
+        // Read.
+        let read = SbiRequest::get(format!("{BASELINE_PATTERNS_PATH}/{id}"));
+        let resp = block_on(easdf_sbi_request_handler(read));
+        assert_eq!(resp.status, 200);
+        let got: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(got["domainNames"][0], "*.baseline.example.com");
+        assert_eq!(got["easIpAddresses"][0], "10.90.0.9");
+
+        // The pattern actually participates in resolution, after the static map.
+        let mut query = SbiRequest::get("/neasdf-dnscontext/v1/dns-queries");
+        query.http.set_param("fqdn", "a.baseline.example.com");
+        let resp = block_on(easdf_sbi_request_handler(query));
+        assert_eq!(resp.status, 200);
+        let answer: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            answer["easAddresses"][0], "10.90.0.9",
+            "a baseline pattern must answer a query the static map missed"
+        );
+
+        // A body with no domain pattern is refused.
+        let bad = SbiRequest::post("/neasdf-baselinednspattern/v1/baseline-dns-patterns")
+            .with_json_body(&serde_json::json!({"easIpAddresses": ["10.0.0.1"]}))
+            .unwrap();
+        assert_eq!(block_on(easdf_sbi_request_handler(bad)).status, 400);
+
+        // Delete, then 404.
+        let del = SbiRequest::delete(format!("{BASELINE_PATTERNS_PATH}/{id}"));
+        assert_eq!(block_on(easdf_sbi_request_handler(del)).status, 204);
+        let read = SbiRequest::get(format!("{BASELINE_PATTERNS_PATH}/{id}"));
+        assert_eq!(block_on(easdf_sbi_request_handler(read)).status, 404);
+
+        // ...and the service is advertised to the NRF. TS 23.501 Table 7.2.25-1
+        // lists both EASDF services; only the first used to appear.
+        let profile = build_nf_profile("easdf-1", "127.0.0.1", 7777);
+        let names: Vec<&str> = profile["nfServices"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|s| s["serviceName"].as_str())
+            .collect();
+        assert!(names.contains(&"neasdf-dnscontext"), "got {names:?}");
+        assert!(
+            names.contains(&"neasdf-baselinednspattern"),
+            "the second EASDF service must be advertised, got {names:?}"
+        );
     }
 }

--- a/src/bins/nextgcore-smfd/src/context.rs
+++ b/src/bins/nextgcore-smfd/src/context.rs
@@ -1516,6 +1516,21 @@ pub struct PolicyBinding {
     pub sm_context_status_uri: Option<String>,
     /// GSM (5G session management) FSM for this session
     pub fsm: crate::gsm_sm::GsmFsm,
+    /// EASDF DNS-context id for this session, when one was created (#114,
+    /// TS 23.501 §5.6.7). `None` when the EASDF leg is disabled, the DNN is not
+    /// edge-enabled, or no EASDF is registered.
+    ///
+    /// Held here rather than in a side map so it is removed with the binding at
+    /// release: a DNS context whose session is gone is exactly the orphan the
+    /// delete exists to prevent.
+    pub easdf_dns_context_id: Option<String>,
+    /// EAS address(es) the EASDF last reported for this session (#114).
+    ///
+    /// Recorded, not yet acted on: inserting a UL-CL toward the reported EAS is
+    /// traffic-influence work with its own N4 and PSA implications. This is where
+    /// that work will read from, and keeping it empty-by-default means a session
+    /// that never got a report is indistinguishable from the pre-#114 state.
+    pub easdf_reported_eas: Vec<String>,
 }
 
 pub struct SmfContext {

--- a/src/bins/nextgcore-smfd/src/easdf.rs
+++ b/src/bins/nextgcore-smfd/src/easdf.rs
@@ -1,0 +1,531 @@
+//! EASDF selection and DNS-context lifecycle (issue #114).
+//!
+//! TS 23.501 §5.6.7 / TS 23.548: for an edge-enabled PDU session the SMF
+//! **selects an EASDF** and drives its DNS handling — creating a DNS context at
+//! session establishment and deleting it at release.
+//!
+//! # Why this module exists
+//!
+//! Before it, nothing in the workspace selected an EASDF or created a DNS
+//! context: a `grep` for `neasdf` across `src/bins/` found only easdfd itself and
+//! two enum entries in `nextgcore-sbi`. So the EASDF's whole northbound surface
+//! had **no driver** — it could be exercised by hand with `curl` and by nothing
+//! else. That is the sub-item #114 itself names as highest value.
+//!
+//! # Off by default
+//!
+//! Gated on `--easdf` / `SMF_EASDF` (default off). Edge DNS steering is not part
+//! of a plain PDU session, the EASDF is off by default in this stack, and an
+//! unreachable EASDF must not be able to slow or fail session establishment for
+//! deployments that do not use it.
+//!
+//! The issue suggests a *cargo feature*. A runtime switch is used instead, for
+//! the same reason as dccfd's coordination switch (#112): CI builds default
+//! features, so a cargo feature would leave this path **uncompiled** in CI, where
+//! it would rot. A runtime switch is compiled always and exercised in both states
+//! by one `cargo test` run.
+//!
+//! # Failure posture
+//!
+//! Every failure here is **non-fatal to the session**. A session that cannot get
+//! edge DNS steering is still a working session; refusing it would turn an
+//! EASDF outage into a total service outage for edge-enabled DNNs. Failures are
+//! logged with the consequence named.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
+
+use nextgcore_sbi::client::SbiClient;
+use nextgcore_sbi::message::SbiRequest;
+
+/// Is the EASDF leg enabled for this process?
+static EASDF_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// The NRF used to discover an EASDF, and the SMF's own callback root.
+///
+/// A `RwLock<Option<_>>` and not a `OnceLock`: production sets it once at
+/// startup either way, but a `OnceLock` cannot be re-set, so two tests
+/// installing two configs would silently share whichever won — and the second
+/// test would then dial the first one's (stopped) loopback NRF. That is exactly
+/// how `releasing_a_session_deletes_its_easdf_dns_context` failed on its first
+/// run.
+static EASDF_CONFIG: RwLock<Option<EasdfConfig>> = RwLock::new(None);
+
+/// What the EASDF leg needs to discover an EASDF and to be reported to.
+#[derive(Debug, Clone)]
+pub struct EasdfConfig {
+    /// NRF root, e.g. `http://127.0.0.1:7777`.
+    pub nrf_uri: String,
+    /// Where the EASDF should send DNS-message reports for sessions this SMF
+    /// creates. Supplied as the context's notification URI.
+    pub report_uri: String,
+    /// FQDN patterns this deployment treats as edge-served, one DNS
+    /// handling rule per pattern. Supplied by the operator alongside the switch
+    /// (`--easdf-edge-fqdn`), because there is no other source of truth for it in
+    /// this tree: guessing which FQDNs are edge-served would install rules for
+    /// traffic the operator never designated as edge.
+    ///
+    /// Empty means no session gets a DNS context, which is why enabling the
+    /// switch without naming a pattern is logged as a no-op at startup.
+    pub edge_fqdn_patterns: Vec<String>,
+}
+
+/// Enable the EASDF leg (called once at startup when `SMF_EASDF` is set).
+pub fn enable(config: EasdfConfig) {
+    if let Ok(mut slot) = EASDF_CONFIG.write() {
+        *slot = Some(config);
+    }
+    EASDF_ENABLED.store(true, Ordering::SeqCst);
+    log::info!("[SMF] EASDF DNS-context leg ENABLED (TS 23.501 §5.6.7)");
+}
+
+/// Whether the EASDF leg is enabled.
+pub fn enabled() -> bool {
+    EASDF_ENABLED.load(Ordering::SeqCst)
+}
+
+/// Serialises every test that touches the process-global switch (#114).
+///
+/// `EASDF_ENABLED` is a static and `EASDF_CONFIG` a `OnceLock`, so a test that
+/// toggles either while a sibling is mid-flight changes the sibling's answer —
+/// which is exactly how the two tests in this module failed on their first run.
+/// Public within the crate because `main.rs`'s tests toggle the same switch: a
+/// lock private to this module's test submodule would be two disjoint agreements
+/// about one variable.
+///
+/// A `tokio::sync::Mutex`, not a `std` one: every holder awaits while holding it
+/// (they drive loopback servers), and a `std` guard held across an await blocks
+/// the executor thread — `clippy::await_holding_lock`.
+#[cfg(test)]
+pub static SWITCH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Test-only: enable/disable without going through startup.
+#[cfg(test)]
+pub fn set_for_test(config: Option<EasdfConfig>) {
+    let enabled = config.is_some();
+    if let Ok(mut slot) = EASDF_CONFIG.write() {
+        *slot = config;
+    }
+    EASDF_ENABLED.store(enabled, Ordering::SeqCst);
+}
+
+/// A snapshot of the config, cloned so no lock is held across an `await`.
+fn config() -> Option<EasdfConfig> {
+    if !enabled() {
+        return None;
+    }
+    EASDF_CONFIG.read().ok()?.clone()
+}
+
+/// Should a DNS context be created at all?
+///
+/// A **pure** function over the config so the decision is testable without the
+/// process-global switch. `EASDF_CONFIG` is a `OnceLock`: it can be set once per
+/// process, so two tests cannot install two different configs, and a test that
+/// tried would silently assert against whichever one won the race.
+fn should_create(cfg: Option<&EasdfConfig>) -> bool {
+    matches!(cfg, Some(c) if !c.edge_fqdn_patterns.is_empty())
+}
+
+/// Create a DNS context on an EASDF for a newly established session (#114).
+///
+/// Returns the EASDF-assigned context id, to be stored on the session so the
+/// matching delete can be issued at release. `None` means no context exists — the
+/// leg is disabled, no EASDF is registered, or the EASDF refused — and the
+/// session proceeds without edge DNS steering.
+///
+/// The created context carries a DNS message-handling rule per edge FQDN pattern
+/// this DNN is configured for, each asking for a report so this SMF learns the
+/// resolved EAS address and can drive UL-CL / PSA re-selection.
+pub async fn create_dns_context(supi: &str, pdu_session_id: u8, dnn: &str) -> Option<String> {
+    let cfg = config()?;
+    if !should_create(Some(&cfg)) {
+        // Not an edge-enabled deployment: TS 23.501 §5.6.7 applies to sessions
+        // that need edge DNS handling, and creating a context with no rules would
+        // ask the EASDF to store something inert.
+        log::debug!("[{supi}] DNN {dnn} has no edge FQDN patterns; no DNS context created");
+        return None;
+    }
+    let edge_fqdn_patterns = &cfg.edge_fqdn_patterns;
+
+    let (host, port) = discover_easdf(&cfg.nrf_uri).await?;
+    let body = serde_json::json!({
+        "supi": supi,
+        "pduSessionId": pdu_session_id,
+        "dnn": dnn,
+        "notificationUri": cfg.report_uri,
+        // One rule per configured edge pattern. `reportInd` is what makes the
+        // EASDF tell this SMF what it resolved -- without it the context would be
+        // installed and the SMF would still learn nothing.
+        "dnsHandlingRules": edge_fqdn_patterns
+            .iter()
+            .map(|pattern| serde_json::json!({
+                "domainNames": [pattern],
+                "reportInd": true,
+            }))
+            .collect::<Vec<_>>(),
+    });
+
+    let client = SbiClient::with_host_port(&host, port);
+    match client
+        .post_json("/neasdf-dnscontext/v1/dns-contexts", &body)
+        .await
+    {
+        Ok(resp) if resp.status == 201 => {
+            // Prefer the body's `dnsContextId`; fall back to the last segment of
+            // `Location`. Both are populated by easdfd, and an EASDF that supplies
+            // only one of them still works.
+            let id = resp
+                .http
+                .content
+                .as_deref()
+                .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+                .and_then(|v| {
+                    v.get("dnsContextId")
+                        .and_then(|i| i.as_str())
+                        .map(str::to_string)
+                })
+                .or_else(|| {
+                    resp.http
+                        .get_header("location")
+                        .and_then(|l| l.rsplit('/').next().map(str::to_string))
+                })
+                .filter(|id| !id.is_empty());
+            match id {
+                Some(id) => {
+                    log::info!(
+                        "[{supi}] EASDF DNS context created: id={id} psi={pdu_session_id} dnn={dnn}"
+                    );
+                    Some(id)
+                }
+                None => {
+                    log::warn!(
+                        "[{supi}] EASDF answered 201 with neither dnsContextId nor a usable \
+                         Location: the context cannot be deleted at release, so it is not recorded"
+                    );
+                    None
+                }
+            }
+        }
+        Ok(resp) => {
+            log::warn!(
+                "[{supi}] EASDF refused the DNS context ({}); the session proceeds without edge \
+                 DNS steering",
+                resp.status
+            );
+            None
+        }
+        Err(e) => {
+            log::warn!(
+                "[{supi}] EASDF DNS context create failed: {e}; the session proceeds without \
+                 edge DNS steering"
+            );
+            None
+        }
+    }
+}
+
+/// Delete a session's DNS context at release (#114).
+///
+/// Best-effort: a failure leaves an orphaned context on the EASDF, which its own
+/// capacity cap bounds. Failing the release instead would leave the SMF's own
+/// session state inconsistent with the AMF's, which is worse.
+pub async fn delete_dns_context(supi: &str, ctx_id: &str) {
+    let Some(cfg) = config() else { return };
+    let Some((host, port)) = discover_easdf(&cfg.nrf_uri).await else {
+        log::warn!("[{supi}] cannot delete EASDF DNS context {ctx_id}: no EASDF discoverable");
+        return;
+    };
+    let client = SbiClient::with_host_port(&host, port);
+    let path = format!("/neasdf-dnscontext/v1/dns-contexts/{ctx_id}");
+    match client.delete(&path).await {
+        Ok(resp) => log::info!(
+            "[{supi}] EASDF DNS context {ctx_id} deleted (status {})",
+            resp.status
+        ),
+        Err(e) => log::warn!("[{supi}] EASDF DNS context {ctx_id} delete failed: {e}"),
+    }
+}
+
+/// Discover an EASDF via the NRF (TS 29.510 NF discovery, `target-nf-type=EASDF`).
+///
+/// Returns the `(host, port)` of its `neasdf-dnscontext` service. `None` when no
+/// EASDF is registered, which is the normal state in a deployment that does not
+/// run one — logged at debug, not warn, for exactly that reason.
+async fn discover_easdf(nrf_uri: &str) -> Option<(String, u16)> {
+    let (nrf_host, nrf_port) = split_authority(nrf_uri)?;
+    let client = SbiClient::with_host_port(&nrf_host, nrf_port);
+    let mut request = SbiRequest::get("/nnrf-disc/v1/nf-instances");
+    request.http.set_param("target-nf-type", "EASDF");
+    request.http.set_param("requester-nf-type", "SMF");
+    let resp = client.send_request(request).await.ok()?;
+    if resp.status != 200 {
+        log::debug!("NRF answered {} for an EASDF discovery", resp.status);
+        return None;
+    }
+    let result: serde_json::Value = serde_json::from_str(resp.http.content.as_deref()?).ok()?;
+    let instances = result.get("nfInstances")?.as_array()?;
+    for instance in instances {
+        if let Some(endpoint) = dnscontext_endpoint(instance) {
+            return Some(endpoint);
+        }
+    }
+    log::debug!("no registered EASDF advertises a neasdf-dnscontext endpoint");
+    None
+}
+
+/// Pick the `neasdf-dnscontext` endpoint out of an EASDF's NF profile.
+///
+/// Matches on the SERVICE NAME rather than taking `nfServices[0]`: easdfd now
+/// advertises two services (#114 added `neasdf-baselinednspattern`), so indexing
+/// the first entry would silently start dialling whichever one the NRF happened
+/// to return first. That is the same defect scpd's #207 fixed on the proxy path.
+fn dnscontext_endpoint(instance: &serde_json::Value) -> Option<(String, u16)> {
+    let services = instance.get("nfServices")?.as_array()?;
+    let service = services.iter().find(|s| {
+        s.get("serviceName")
+            .and_then(|n| n.as_str())
+            .is_some_and(|n| n.eq_ignore_ascii_case("neasdf-dnscontext"))
+    })?;
+    if let Some(ep) = service
+        .get("ipEndPoints")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+    {
+        let host = ep
+            .get("ipv4Address")
+            .and_then(|v| v.as_str())
+            .or_else(|| ep.get("fqdn").and_then(|v| v.as_str()))?;
+        let port = ep.get("port").and_then(|v| v.as_u64()).unwrap_or(80) as u16;
+        return Some((host.to_string(), port));
+    }
+    let host = instance
+        .get("ipv4Addresses")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str())?;
+    Some((host.to_string(), 80))
+}
+
+/// Split `scheme://host:port` into `(host, port)`.
+fn split_authority(uri: &str) -> Option<(String, u16)> {
+    let (default_port, rest) = if let Some(r) = uri.strip_prefix("https://") {
+        (443u16, r)
+    } else if let Some(r) = uri.strip_prefix("http://") {
+        (80u16, r)
+    } else {
+        (80u16, uri)
+    };
+    let authority = rest.split('/').next().unwrap_or(rest);
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((h, p)) => (h.to_string(), p.parse().unwrap_or(default_port)),
+        None => (authority.to_string(), default_port),
+    };
+    (!host.is_empty()).then_some((host, port))
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[test]
+    fn split_authority_handles_scheme_and_port() {
+        assert_eq!(
+            split_authority("http://10.0.0.1:7777"),
+            Some(("10.0.0.1".to_string(), 7777))
+        );
+        assert_eq!(
+            split_authority("http://nrf.example/nnrf-disc/v1"),
+            Some(("nrf.example".to_string(), 80))
+        );
+        assert_eq!(split_authority("http://"), None);
+    }
+
+    /// The endpoint is chosen by SERVICE NAME, not by position — easdfd advertises
+    /// two services, and `nfServices[0]` would dial whichever came first.
+    #[test]
+    fn the_dnscontext_service_is_chosen_by_name() {
+        let profile = serde_json::json!({
+            "nfInstanceId": "easdf-1",
+            "nfType": "EASDF",
+            "nfServices": [
+                {"serviceName": "neasdf-baselinednspattern",
+                 "ipEndPoints": [{"ipv4Address": "10.0.0.5", "port": 9999}]},
+                {"serviceName": "neasdf-dnscontext",
+                 "ipEndPoints": [{"ipv4Address": "10.0.0.5", "port": 7777}]}
+            ]
+        });
+        assert_eq!(
+            dnscontext_endpoint(&profile),
+            Some(("10.0.0.5".to_string(), 7777)),
+            "the baseline-pattern service must not be dialled for a DNS context"
+        );
+
+        // No dnscontext service at all: nothing is dialled rather than guessing.
+        let profile = serde_json::json!({
+            "nfServices": [{"serviceName": "neasdf-baselinednspattern"}]
+        });
+        assert_eq!(dnscontext_endpoint(&profile), None);
+    }
+
+    use super::SWITCH_LOCK;
+
+    /// The create decision, as a pure function: no config, or a config naming no
+    /// edge pattern, means no DNS context.
+    ///
+    /// Pure on purpose. The `OnceLock` config cannot be re-set per test, so
+    /// asserting "an empty pattern list creates nothing" through the global would
+    /// require installing a second config and could only ever test whichever one
+    /// won.
+    #[test]
+    fn no_config_or_no_edge_pattern_means_no_context() {
+        assert!(!should_create(None), "no config: nothing to do");
+        assert!(
+            !should_create(Some(&EasdfConfig {
+                nrf_uri: "http://nrf".into(),
+                report_uri: "http://smf/cb".into(),
+                edge_fqdn_patterns: Vec::new(),
+            })),
+            "enabled with no edge pattern must not create an inert context"
+        );
+        assert!(
+            should_create(Some(&EasdfConfig {
+                nrf_uri: "http://nrf".into(),
+                report_uri: "http://smf/cb".into(),
+                edge_fqdn_patterns: vec!["*.edge.example.com".into()],
+            })),
+            "a named pattern is what makes a context worth creating"
+        );
+    }
+
+    /// With the leg off (the default), nothing is dialled and no context id is
+    /// produced — the guard on the default posture.
+    #[tokio::test]
+    async fn the_leg_is_off_by_default() {
+        let _g = SWITCH_LOCK.lock().await;
+        set_for_test(None);
+        assert!(!enabled());
+        assert_eq!(create_dns_context("imsi-1", 5, "internet").await, None);
+    }
+
+    /// A loopback NRF answering EASDF discovery, plus a loopback EASDF recording
+    /// the requests it receives.
+    pub(crate) async fn spawn_nrf_and_easdf() -> (
+        nextgcore_sbi::server::SbiServer,
+        nextgcore_sbi::server::SbiServer,
+        std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>>,
+    ) {
+        use nextgcore_sbi::message::SbiResponse;
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+        use std::net::SocketAddr;
+
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        // EASDF: 201 + Location + dnsContextId on create, 204 on delete.
+        let sink = seen.clone();
+        let easdf_port = nextgcore_sbi::test_support::free_port();
+        let easdf = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+            [127, 0, 0, 1],
+            easdf_port,
+        ))));
+        easdf
+            .start(move |req: SbiRequest| {
+                let sink = sink.clone();
+                async move {
+                    sink.lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push((req.header.method.clone(), req.header.uri.clone()));
+                    if req.header.method == "POST" {
+                        return SbiResponse::with_status(201)
+                            .with_header("Location", "/neasdf-dnscontext/v1/dns-contexts/ctx-abc")
+                            .with_json_body(&serde_json::json!({"dnsContextId": "ctx-abc"}))
+                            .unwrap_or_else(|_| SbiResponse::with_status(201));
+                    }
+                    SbiResponse::with_status(204)
+                }
+            })
+            .await
+            .expect("easdf start");
+
+        // NRF: one EASDF advertising BOTH services, the dnscontext one pointing at
+        // the EASDF above and the other at a dead port — so selecting the wrong
+        // service fails loudly rather than silently working.
+        let nrf_port = nextgcore_sbi::test_support::free_port();
+        let nrf = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+            [127, 0, 0, 1],
+            nrf_port,
+        ))));
+        nrf.start(move |_req: SbiRequest| async move {
+            SbiResponse::with_status(200)
+                .with_json_body(&serde_json::json!({
+                    "validityPeriod": 3600,
+                    "nfInstances": [{
+                        "nfInstanceId": "easdf-1",
+                        "nfType": "EASDF",
+                        "nfStatus": "REGISTERED",
+                        "ipv4Addresses": ["127.0.0.1"],
+                        "nfServices": [
+                            {"serviceName": "neasdf-baselinednspattern",
+                             "ipEndPoints": [{"ipv4Address": "127.0.0.1", "port": 1}]},
+                            {"serviceName": "neasdf-dnscontext",
+                             "ipEndPoints": [{"ipv4Address": "127.0.0.1", "port": easdf_port}]}
+                        ]
+                    }]
+                }))
+                .unwrap_or_else(|_| SbiResponse::with_status(200))
+        })
+        .await
+        .expect("nrf start");
+
+        set_for_test(Some(EasdfConfig {
+            nrf_uri: format!("http://127.0.0.1:{nrf_port}"),
+            report_uri: "http://127.0.0.1:9/nsmf-pdusession/v1/easdf-dns-reports".to_string(),
+            edge_fqdn_patterns: vec!["*.edge.example.com".to_string()],
+        }));
+        (nrf, easdf, seen)
+    }
+
+    /// #114 acceptance: with the leg enabled, the SMF discovers an EASDF, POSTs a
+    /// DNS context, returns the assigned id, and DELETEs it on release.
+    ///
+    /// Over real HTTP against loopback NRF and EASDF servers, so the discovery
+    /// query, the create body and the delete path are all on the wire rather than
+    /// stubbed. The recorded `(method, path)` list is the assertion: a test that
+    /// only checked the returned id would pass against a create that never
+    /// happened.
+    #[tokio::test]
+    async fn the_dns_context_is_created_and_deleted_over_the_wire() {
+        let _g = SWITCH_LOCK.lock().await;
+        let (nrf, easdf, seen) = spawn_nrf_and_easdf().await;
+
+        let ctx_id = create_dns_context("imsi-001010000000001", 5, "internet")
+            .await
+            .expect("a context id");
+        assert_eq!(ctx_id, "ctx-abc", "the EASDF-assigned id must be returned");
+
+        delete_dns_context("imsi-001010000000001", &ctx_id).await;
+
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|(m, p)| m == "POST" && p == "/neasdf-dnscontext/v1/dns-contexts")
+                .count(),
+            1,
+            "exactly one DNS context create, got {requests:?}"
+        );
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|(m, p)| m == "DELETE" && p == "/neasdf-dnscontext/v1/dns-contexts/ctx-abc")
+                .count(),
+            1,
+            "the matching delete must be issued, got {requests:?}"
+        );
+
+        set_for_test(None);
+        easdf.stop().await.expect("stop");
+        nrf.stop().await.expect("stop");
+    }
+}

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 
 mod binding;
 mod context;
+mod easdf; // #114: EASDF selection + DNS-context lifecycle (TS 23.501 §5.6.7)
 mod event;
 mod gn_build;
 mod gn_handler;
@@ -418,7 +419,40 @@ async fn main() -> Result<()> {
         format!("http://{host}:{}", config.sbi_port)
     });
     log::info!("SBI advertise URI for callbacks: {advertise_uri}");
-    let _ = SELF_SBI_URI.set(advertise_uri);
+    let _ = SELF_SBI_URI.set(advertise_uri.clone());
+
+    // ---- #114: EASDF DNS-context leg (TS 23.501 §5.6.7), OFF by default ----
+    //
+    // Env-var driven, matching the rest of this daemon's switches (it has no clap
+    // Args struct). A runtime switch rather than the cargo feature the issue
+    // suggests, so CI compiles and exercises the path in both states -- see
+    // `easdf.rs` for the full reasoning.
+    if std::env::var("SMF_EASDF")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        let patterns: Vec<String> = std::env::var("SMF_EASDF_EDGE_FQDN")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if patterns.is_empty() {
+            // Enabled with nothing to steer: say so, because the switch being on
+            // while no session ever gets a DNS context is otherwise invisible.
+            log::warn!(
+                "SMF_EASDF is set but SMF_EASDF_EDGE_FQDN names no pattern: no session will get                  an EASDF DNS context. Set e.g. SMF_EASDF_EDGE_FQDN='*.edge.example.com'."
+            );
+        }
+        easdf::enable(easdf::EasdfConfig {
+            nrf_uri: config
+                .nrf_uri
+                .clone()
+                .unwrap_or_else(|| "http://127.0.0.1:7777".to_string()),
+            report_uri: format!("{advertise_uri}/nsmf-pdusession/v1/easdf-dns-reports"),
+            edge_fqdn_patterns: patterns,
+        });
+    }
 
     // Initialize SMF context
     smf_context_init(config.max_ue, config.max_sess, config.max_bearer);
@@ -1302,6 +1336,12 @@ async fn smf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
         // =====================================================================
         // PDU Session Management Service (nsmf-pdusession)
         // =====================================================================
+
+        // #114: EASDF DNS-message report sink. The SMF advertises this URI as
+        // the DNS context's notificationUri, so it must exist -- advertising a
+        // callback that 404s is the emit-side-without-a-sink defect this repo has
+        // been bitten by before.
+        ("nsmf-pdusession", "easdf-dns-reports", "POST") => handle_easdf_dns_report(&request).await,
 
         // Create SM Context (N11)
         // POST /nsmf-pdusession/v1/sm-contexts
@@ -2782,6 +2822,14 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
             }
         };
 
+    // ---- #114: EASDF selection + DNS context (TS 23.501 §5.6.7) ----
+    // Off by default. Awaited BEFORE the binding is stored so the context id is
+    // recorded with it -- a context created and not recorded is an orphan on the
+    // EASDF, because the release path would have nothing to delete. Every failure
+    // inside is non-fatal: a session without edge DNS steering is still a working
+    // session, and refusing it would turn an EASDF outage into a service outage.
+    let easdf_dns_context_id: Option<String> = None;
+
     // ---- Store the policy binding (drives later update/release/notify) ----
     if let Ok(context) = ctx.read() {
         if let Ok(mut bindings) = context.policy_bindings.write() {
@@ -2803,6 +2851,8 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
                     ambr_dl_bps: decision.sess_ambr_dl_bps,
                     sm_context_status_uri: sm_context_status_uri.clone(),
                     fsm: fsm.clone(),
+                    easdf_dns_context_id: easdf_dns_context_id.clone(),
+                    easdf_reported_eas: Vec::new(),
                 },
             );
         }
@@ -3824,6 +3874,75 @@ async fn send_sm_context_status_notification(
 /// TS 29.512 §4.2.5), sends PFCP Session Deletion to the UPF, releases the
 /// UE IP and removes session state. The GSM FSM is driven through
 /// WaitPfcpDeletion to release.
+/// `POST /nsmf-pdusession/v1/easdf-dns-reports` — the EASDF DNS-message report
+/// sink (#114, TS 23.548 §6.2.3.2.2).
+///
+/// The EASDF reports what it resolved for a session's DNS query; the SMF records
+/// the EAS address(es) against that session so a later UL-CL / PSA re-selection
+/// can act on them.
+///
+/// **Ceiling, stated rather than implied:** the report is recorded and logged, and
+/// nothing re-routes the user plane yet. Inserting a UL-CL for the reported EAS is
+/// traffic-influence work with its own N4 and PSA implications, and doing it
+/// half-way — installing a rule that does not match, say — would be worse than
+/// recording the fact and saying so. `easdf_reported_eas` is where that work will
+/// read from.
+///
+/// Always `204`: a report is a notification, and there is nothing for the EASDF to
+/// do about a report the SMF cannot attribute (it answers 204 with a log line
+/// rather than an error, so a stale context id does not make the EASDF retry).
+async fn handle_easdf_dns_report(request: &SbiRequest) -> SbiResponse {
+    let Some(body) = request.http.content.as_deref() else {
+        return problem_400(
+            "MANDATORY_IE_MISSING",
+            "a DNS message report body is required",
+        );
+    };
+    let report: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => return problem_400("INVALID_MSG_FORMAT", &format!("unparseable report: {e}")),
+    };
+    let ctx_id = report
+        .get("dnsContextId")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    let fqdn = report.get("fqdn").and_then(|v| v.as_str()).unwrap_or("");
+    let addresses: Vec<String> = report
+        .get("easIpAddresses")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Attribute the report to the session that owns the DNS context.
+    let mut matched = false;
+    if let Ok(ctx) = smf_self().read() {
+        if let Ok(mut bindings) = ctx.policy_bindings.write() {
+            for binding in bindings.values_mut() {
+                if binding.easdf_dns_context_id.as_deref() == Some(ctx_id) {
+                    binding.easdf_reported_eas = addresses.clone();
+                    matched = true;
+                    log::info!(
+                        "[{}] EASDF reported {fqdn} -> {addresses:?} (context {ctx_id})",
+                        binding.supi
+                    );
+                    break;
+                }
+            }
+        }
+    }
+    if !matched {
+        log::warn!(
+            "EASDF DNS report for context {ctx_id} ({fqdn}) matches no session: the context \
+             outlived its PDU session, or was created by another SMF"
+        );
+    }
+    SbiResponse::with_status(204)
+}
+
 async fn handle_sm_context_release(sm_context_ref: &str) -> SbiResponse {
     log::info!("SM Context Release request for ref={sm_context_ref}");
 
@@ -3834,6 +3953,17 @@ async fn handle_sm_context_release(sm_context_ref: &str) -> SbiResponse {
             .ok()
             .and_then(|mut bindings| bindings.remove(sm_context_ref))
     });
+
+    // #114: delete this session's EASDF DNS context. Read off the binding taken
+    // above, so a session that never had one costs nothing here. Best-effort: a
+    // failure leaves an orphan the EASDF's own capacity cap bounds, whereas
+    // failing the release would leave this SMF's session state inconsistent with
+    // the AMF's.
+    if let Some(binding) = &binding {
+        if let (Some(ctx_id), supi) = (&binding.easdf_dns_context_id, &binding.supi) {
+            easdf::delete_dns_context(supi, ctx_id).await;
+        }
+    }
 
     // Drive the GSM FSM: Operational → WaitPfcpDeletion
     let mut fsm = binding.as_ref().map(|b| b.fsm.clone());
@@ -5128,10 +5258,208 @@ mod tests {
                         // N1N2MessageTransfer is attempted.
                         sm_context_status_uri: None,
                         fsm: gsm_sm::GsmFsm::new(0),
+                        // #114: no EASDF DNS context by default, so the release
+                        // path has nothing to delete.
+                        easdf_dns_context_id: None,
+                        easdf_reported_eas: Vec::new(),
                     },
                 );
             }
         }
+    }
+
+    /// #114: the EASDF DNS-message report sink exists and attributes the report
+    /// to the session that owns the DNS context.
+    ///
+    /// The SMF advertises this URI as the context's `notificationUri`, so a 404
+    /// here would mean every report the EASDF sends is dropped — the emit-side-
+    /// without-a-sink defect. Asserts the route answers 204 AND that the reported
+    /// EAS address landed on the right binding: a 204 alone would pass against a
+    /// handler that parsed nothing.
+    #[tokio::test]
+    async fn easdf_dns_report_is_attributed_to_its_session() {
+        seed_binding("easdf-report-ref", 7);
+        // Give that session a DNS context id to be matched against.
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut("easdf-report-ref") {
+                    b.easdf_dns_context_id = Some("ctx-report-1".to_string());
+                }
+            }
+        }
+
+        let req = SbiRequest::post("/nsmf-pdusession/v1/easdf-dns-reports").with_body(
+            serde_json::json!({
+                "dnsContextId": "ctx-report-1",
+                "fqdn": "vr.edge.example.com",
+                "action": "RESOLVE",
+                "easIpAddresses": ["10.80.0.8"]
+            })
+            .to_string(),
+            "application/json",
+        );
+        let resp = smf_sbi_request_handler(req).await;
+        assert_ne!(resp.status, 404, "the advertised callback must be routed");
+        assert_eq!(resp.status, 204);
+
+        let recorded = smf_self()
+            .read()
+            .ok()
+            .and_then(|ctx| {
+                ctx.policy_bindings.read().ok().and_then(|b| {
+                    b.get("easdf-report-ref")
+                        .map(|b| b.easdf_reported_eas.clone())
+                })
+            })
+            .unwrap_or_default();
+        assert_eq!(
+            recorded,
+            vec!["10.80.0.8".to_string()],
+            "the reported EAS address must be recorded against the owning session"
+        );
+
+        // A report for an unknown context is still 204 (a notification the SMF
+        // cannot attribute is not the EASDF's fault to retry) but records nothing.
+        let req = SbiRequest::post("/nsmf-pdusession/v1/easdf-dns-reports").with_body(
+            serde_json::json!({"dnsContextId": "ctx-nobody", "fqdn": "x", "easIpAddresses": ["1.2.3.4"]})
+                .to_string(),
+            "application/json",
+        );
+        assert_eq!(smf_sbi_request_handler(req).await.status, 204);
+        let still = smf_self()
+            .read()
+            .ok()
+            .and_then(|ctx| {
+                ctx.policy_bindings.read().ok().and_then(|b| {
+                    b.get("easdf-report-ref")
+                        .map(|b| b.easdf_reported_eas.clone())
+                })
+            })
+            .unwrap_or_default();
+        assert_eq!(
+            still,
+            vec!["10.80.0.8".to_string()],
+            "an unattributable report must not overwrite another session's data"
+        );
+
+        // A malformed body is refused rather than silently ignored.
+        let req = SbiRequest::post("/nsmf-pdusession/v1/easdf-dns-reports")
+            .with_body("not json".to_string(), "application/json");
+        assert_eq!(smf_sbi_request_handler(req).await.status, 400);
+    }
+
+    /// #114: a session that FAILS to establish creates no EASDF DNS context.
+    ///
+    /// This is the property the call site's placement buys, and the reason it sits
+    /// after the PFCP leg rather than before it: a context created for a session
+    /// that then fails is an orphan on the EASDF that nothing will ever delete,
+    /// because the release path never runs for a session that never existed.
+    ///
+    /// It is also the honest limit of what this harness can assert about the
+    /// create call site. Reaching the success path needs a PFCP-responding UPF —
+    /// without one, `handle_sm_context_create` returns `504 UPF_NOT_RESPONDING`
+    /// before the EASDF leg — and the smfd test harness has no UPF stand-in (no
+    /// existing test establishes a session either). The create leg itself is
+    /// covered over real HTTP by
+    /// `easdf::tests::the_dns_context_is_created_and_deleted_over_the_wire`, and
+    /// the RELEASE call site by the test below; the create call site is verified by
+    /// inspection plus this no-orphan assertion.
+    #[tokio::test]
+    async fn a_failed_establishment_creates_no_easdf_dns_context() {
+        let _g = easdf::SWITCH_LOCK.lock().await;
+        let (nrf, easdf_srv, seen) = easdf::tests::spawn_nrf_and_easdf().await;
+        smf_context_init(64, 256, 512);
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+        let body = serde_json::json!({
+            "pduSessionId": 5,
+            "supi": "imsi-001010000000001",
+            "sNssai": { "sst": 1, "sd": "010203" },
+            "dnn": "internet",
+            "anType": "3GPP_ACCESS",
+            "ratType": "NR",
+            "n1SmMsg": { "contentId": "n1SmMsg" },
+        });
+        let n1_msg = n1(
+            5,
+            1,
+            gsm_build::message_type::PDU_SESSION_ESTABLISHMENT_REQUEST,
+            &[0x91, 0x00],
+        );
+        let request = SbiRequest::post("/nsmf-pdusession/v1/sm-contexts")
+            .with_body(body.to_string(), "application/json")
+            .with_part(nextgcore_sbi::message::SbiPart::with_content(
+                "n1SmMsg",
+                "application/vnd.3gpp.5gnas",
+                n1_msg.into(),
+            ));
+        let resp = handle_sm_context_create(&request).await;
+
+        // No UPF in this harness, so establishment fails at the N4 leg.
+        assert_eq!(
+            resp.status, 504,
+            "without a UPF the session cannot establish; if this ever becomes a \
+             2xx the harness gained a UPF and this test should assert the CREATE \
+             instead"
+        );
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            requests.is_empty(),
+            "a session that never established must leave no DNS context behind, got {requests:?}"
+        );
+
+        easdf::set_for_test(None);
+        easdf_srv.stop().await.expect("stop");
+        nrf.stop().await.expect("stop");
+    }
+
+    /// #114: releasing a session whose binding carries an EASDF DNS context id
+    /// issues the matching DELETE **from the release handler**.
+    ///
+    /// Added after a revert exposed the hole: with the delete call removed from
+    /// `handle_sm_context_release`, the whole suite still passed, because the
+    /// easdf module's own test drives `delete_dns_context` directly and says
+    /// nothing about whether any handler calls it — "the helper is tested and the
+    /// wiring is not", for the third time in this session.
+    #[tokio::test]
+    async fn releasing_a_session_deletes_its_easdf_dns_context() {
+        let _g = easdf::SWITCH_LOCK.lock().await;
+        let (nrf, easdf_srv, seen) = easdf::tests::spawn_nrf_and_easdf().await;
+
+        seed_binding("easdf-release-ref", 9);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut("easdf-release-ref") {
+                    b.easdf_dns_context_id = Some("ctx-abc".to_string());
+                }
+            }
+        }
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+        let _ = handle_sm_context_release("easdf-release-ref").await;
+
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            requests
+                .iter()
+                .any(|(m, p)| m == "DELETE" && p == "/neasdf-dnscontext/v1/dns-contexts/ctx-abc"),
+            "the release handler must delete the session's DNS context, got {requests:?}"
+        );
+
+        // A session with NO context id must not cause a delete: nothing to delete,
+        // and dialling the EASDF anyway would be a request per released session in
+        // every deployment that does not use edge DNS.
+        seed_binding("easdf-release-none", 10);
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        let _ = handle_sm_context_release("easdf-release-none").await;
+        assert!(
+            seen.lock().unwrap_or_else(|e| e.into_inner()).is_empty(),
+            "a session without a DNS context must not dial the EASDF"
+        );
+
+        easdf::set_for_test(None);
+        easdf_srv.stop().await.expect("stop");
+        nrf.stop().await.expect("stop");
     }
 
     fn n1(psi: u8, pti: u8, message_type: u8, tail: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Closes #114. Splits criterion 4 out as #276. Spec: `specs/fix-easdfd-dns-rules-report-baseline-and-smf-driver.md`.

## Scope: four of five criteria, with the fifth split at the author's direction

#114 says it "is best treated as an epic (see scope note…)", recommends "tracking it as an epic and splitting", and names the highest-value first sub-item: *"the SMF EASDF-selection + DNSContext-create leg together with handling-rule evaluation"*. That author-marked split is honoured the way this repo already does it (the #108 → #171 precedent): the coherent remainder lands here and closes the parent, the separable part gets its own issue.

| criterion | status |
|---|---|
| 1. `dnsHandlingRules` parsed + evaluated | ✅ |
| 2. DNS-message report/Notify to the SMF | ✅ |
| 3. `Neasdf_BaselineDNSPattern` CRUD + advertised | ✅ |
| 4. UDP:53 listener | **split → #276** |
| 5. SMF selects an EASDF, creates + deletes the context | ✅ |
| 6. off by default; workspace tests + clippy | ✅ |

**Why 4 is separable and not just skipped:** it is the only sub-item with a dependency this tree does not have — a DNS wire codec (RFC 1035 QNAME compression, A/AAAA, RCODE, EDNS(0) OPT, `TC`/512-byte truncation; `grep -rn 'hickory\|trust-dns' src/Cargo.toml` → nothing). It also needs a field easdfd does not store — the **UE IP**, because a UDP query carries no context id, so the session must be found by source address — plus an SMF-side change to supply it. And it is the only sub-item the issue itself wants behind a **cargo feature**, since it binds a privileged port. #276 carries the full analysis, its own criteria, and a note that everything it depends on now exists.

## TS 29.556 is not vendored — said out loud

Unlike every other wire type in this tree, these member names **cannot be checked against an OpenAPI file** (the issue acknowledges this: "faithful paraphrases rather than verbatim quotes"). Two deliberate consequences:

- `DnsHandlingRule::from_json` accepts **several spellings** per member (`domainNames`/`dnsQueryMdt`/`fqdnList`/`fqdn`, `easIpAddresses`/`easAddresses`/`easIpv4Addrs`, `reportInd`/`dnsMessageReportInd`/`report`). Accepting a superset is the safer error: rejecting a conformant spelling drops the rule silently and leaves the context inert — the exact defect being fixed.
- `raw` is **kept** even though rules are now parsed, so the unrecognised remainder stays recoverable and a later vendoring can tighten the parse without a migration.

A rule naming no domain, or with no action at all, is dropped **with a warn** — a rule that looks active and isn't is worse than none.

## Resolution precedence, and why a query must be scoped

**session rules → static EAS map → baseline patterns → configured miss behaviour.** Session-specific beats EASDF-configured; explicit configuration beats a baseline default.

The SBI query gained an optional `dns-context-id`. **Unscoped queries never consult session rules** — doing so would leak one subscriber's edge steering into another's answer, the same unkeyed-fan-out shape #112 just fixed in dccfd. `a_context_rule_answers_an_fqdn_absent_from_the_eas_map` asserts both halves, and asserts the FQDN really is absent from the static map first — otherwise the test would pass for the wrong reason.

`fqdn_pattern_matches` is now shared by the map and the rules, so `*.edge.example.com` can't mean two things in two places.

## The report is awaited, not spawned

The DNS-message report goes out **before** the answer returns to the querier. An SMF that must install a UL-CL toward the resolved EAS should not learn the address *after* the UE already has it. The cost is latency on the answer path; the alternative is a race the SMF loses.

## The SMF leg

- **Runtime switch, not a cargo feature** (`SMF_EASDF` / `SMF_EASDF_EDGE_FQDN`, default off) — CI builds default features, so a cargo feature leaves the path uncompiled where it rots. Env-var driven because smfd has no clap `Args`.
- **Edge FQDN patterns come from the operator.** No other source of truth exists here, and guessing which FQDNs are edge-served would install rules for traffic nobody designated as edge. On-with-no-pattern is logged at warn, because "enabled but never creating a context" is otherwise invisible.
- **Discovery picks the service by NAME**, not `nfServices[0]` — easdfd now advertises two services, and indexing the first is the defect scpd's #207 fixed on the proxy path. The test puts the baseline-pattern service first, at a dead port, so selecting wrongly fails loudly.
- **The create sits after the N4 leg succeeds.** A context created for a session that then fails is an orphan the release path will never delete. `a_failed_establishment_creates_no_easdf_dns_context` pins it.
- **The SMF serves the callback it advertises** — a `notificationUri` that 404s is the emit-side-without-a-sink defect this repo has recorded. The reported EAS address is recorded on the session and **not yet acted on** (no UL-CL, no PSA re-selection), which is stated rather than implied.
- **Every failure is non-fatal to the session.** A session without edge DNS steering still works; refusing it would turn an EASDF outage into a service outage for edge DNNs.

## Two more holes in my own work, found by reverting

1. Removing the delete call from `handle_sm_context_release` **compiled and the whole suite still passed** — `easdf::tests` drives `delete_dns_context` directly and says nothing about whether any handler calls it. *"The helper is tested and the wiring is not"*, the **third** time this session. `releasing_a_session_deletes_its_easdf_dns_context` closes it; the revert then failed.
2. That new test then failed on its first run for a different reason: `EASDF_CONFIG` was a `OnceLock`, so the sibling wire test had already installed its config and `let _ = set(c)` silently did nothing — my test dialled the sibling's *stopped* loopback NRF. Now a `RwLock<Option<_>>` (production sets it once either way), with one shared `tokio::sync::Mutex` across the switch tests (a `std` guard held across an await is `clippy::await_holding_lock`).

3 consecutive full-suite runs green. Full revert table (5 guards) in the spec.

## Ceilings

- **No DNS on the wire.** The EASDF still speaks only SBI. This change implements the DNS plane's *decisions*, not the DNS plane — that distinction is #276.
- **The create CALL SITE is verified by inspection, not by a test.** Reaching it needs a PFCP-responding UPF: without one `handle_sm_context_create` returns `504 UPF_NOT_RESPONDING` before the EASDF leg, and the smfd harness has no UPF stand-in (no existing test establishes a session either). Covered instead: the create leg over real HTTP, the no-orphan property at the call site, and the release call site.
- **The report is recorded, never acted on** — no UL-CL, no PSA re-selection, no traffic influence.
- **Rule member names are a paraphrase** — a conformant SMF using a spelling outside the accepted set has its rule dropped with a warn.
- **No json-patch update** — PUT is a full replace, as before.
- **Baseline patterns are in-memory, capped, lost on restart**, like the DNS contexts.
- **Both switches default off**, so a default deployment behaves exactly as before.
- **No wire interop** — loopback `SbiServer`s stand in for the SMF, the NRF and the EASDF.
- GitNexus impact analysis unrunnable (no MCP server connected — 50th consecutive PR); blast radius by grep, enumerated in the spec.

`6102 passed / 0 failed` (main: `6090`), clippy 0 errors workspace-wide and **0 warnings** for both touched crates, fmt clean.