### PR TITLE
fix(smfd): give PFCP sessions, policy bindings and the IPv4 pool a durable store (#191)

### DIFF
--- a/docs-book/src/configuration/smf.md
+++ b/docs-book/src/configuration/smf.md
@@ -94,7 +94,53 @@ The N4/PFCP endpoints are configured by environment variables, **not** by the `s
 | `SMF_SBI_ADVERTISE_URI` | derived from SBI server address/port | Externally reachable base URI used in PCF callback (`notificationUri`) URIs. |
 | `UDM_SBI_ADDR` / `UDM_SBI_PORT` | unset / `7777` | UDM address for `Nudm_SDM_Get(smf-select-data)`, used only to resolve the **subscribed default DNN** (#204). Tried **after** NRF discovery, so it is the fallback for a deployment with no NRF. With neither available, a `SmContextCreateData` carrying no `dnn` is refused with `SUBSCRIPTION_DATA_NOT_AVAILABLE`. |
 | `NEXTGCORE_SBI_OAUTH2_REQUIRE` | unset | `1`/`true`/`yes` forces OAuth2 enforcement, taking precedence over the YAML knob. |
+| `NEXTGCORE_SMF_STATE_FILE` | unset | JSON snapshot file for PFCP sessions, policy bindings and IPv4-pool allocations (#191). Read only when `--state-file` is absent — the flag wins; an empty value is treated as unset. With neither set the SMF is memory-only, which is the shipped default. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://jaeger:4317` | OpenTelemetry OTLP trace exporter endpoint. |
+
+## Command-line flags
+
+`smfd` has no `clap` argument parser; it scans `argv` for the two flags it
+understands and ignores everything else.
+
+| Flag | Default | Description |
+|---|---|---|
+| `-c` / `--config` | `/etc/nextgcore/smf.yaml` | Config file path. Falls back to `SMF_CONFIG`. |
+| `--state-file` | unset | JSON snapshot file for durable state (#191). Falls back to `NEXTGCORE_SMF_STATE_FILE`; an empty value is treated as unset. |
+
+## Durable state (#191)
+
+Off by default. With `--state-file` (or `NEXTGCORE_SMF_STATE_FILE`) the SMF
+snapshots three things on every mutation and reloads them at boot:
+
+| Snapshotted | Why it matters on restart |
+|---|---|
+| PFCP sessions (`sm_context_ref` → UPF SEID) | Without it the UPF holds N4 sessions the SMF can no longer delete or modify. |
+| Policy bindings (PCF association, authorized QoS, GSM FSM state, EASDF DNS context) | Without it a restarted SMF cannot terminate or update policy for a live session. |
+| IPv4-pool allocations | **The one with a correctness consequence beyond lost state.** The pool is a bitmap; rebuilt empty, the next allocation returns an address a live UE still holds, and nothing logs the collision. |
+
+Uses the shared `nextgcore-core::state_store::StateStore`: atomic +
+fsynced + `0600` writes, and a snapshot that cannot be read is **never
+overwritten**. An unreadable snapshot, or one written by a newer build,
+**fails startup** rather than coming up with an empty pool.
+
+**The restored PFCP session map is checked, not trusted.** The snapshot also
+carries the last Recovery Time Stamp each UPF reported. That value is seeded
+back into each `PfcpClient` before the association loop starts, so the first
+Association Setup after a reload compares the UPF's reported stamp against it:
+a changed stamp means the UPF restarted while the SMF was down, and the restored
+sessions are flushed (TS 29.244 §5.22, TS 23.527 §4.2) instead of being believed
+in. An unchanged stamp means they are genuinely still valid.
+
+**Limits worth knowing:**
+
+- The flush is process-wide, not per-peer — `clear_pfcp_sessions` empties the
+  whole map, so with several UPFs configured one peer's restart discards the
+  session bookkeeping for all of them. The map has no peer column to do better.
+- Reconciling *which* sessions survived a restart, and signalling peers about
+  the ones that did not, is TS 23.527 restoration work tracked as #193. This
+  interlock is the minimum that makes restoring the map safe, not that work.
+- Not enabled in the shipped Docker compose (unlike `udrd`), so the default E2E
+  path is unchanged.
 
 ## Parsed-but-inert YAML sections
 

--- a/specs/fix-smfd-durable-state.md
+++ b/specs/fix-smfd-durable-state.md
@@ -1,0 +1,216 @@
+# nextgcore #191: smfd PFCP sessions, policy bindings and the IPv4 pool get a durable store
+
+Verified against `main` @ `f019c75`.
+
+Closes #191. Split out of #66 (criterion 2), which is already closed; the sibling
+per-NF persistence issues are #192 (done) and #193 (restoration signalling, open).
+
+## The defect
+
+`smfd` held every resource whose lifetime spans a PDU session in in-memory
+context maps with no durable store and no reload at boot:
+
+* `pfcp_sessions: RwLock<HashMap<String, u64>>` (`context.rs`) — `sm_context_ref`
+  → UPF SEID. Lost on restart, so the UPF holds N4 sessions the SMF can no longer
+  modify or delete.
+* `policy_bindings: RwLock<HashMap<String, PolicyBinding>>` — the PCF SM policy
+  association, authorized QoS, the GSM FSM state and the EASDF DNS context id.
+  Lost on restart, so a restarted SMF cannot terminate or update policy for a
+  live session.
+* `ipv4_pool: Ipv4Pool` — a 65536-bit bitmap plus a count. **This is the one with
+  a correctness consequence beyond "state is gone".** Rebuilt empty, the very
+  next `allocate()` returns `10.45.0.2` — an address a live UE still holds. That
+  is address *substitution*, and nothing logs it.
+
+Premise re-verified before starting: `grep -rn 'state_file\|StateStore\|state_store'
+src/bins/nextgcore-smfd/src/` returned nothing. The issue's "four NFs already use
+it" has drifted to seven (nrfd, nssfd, nsacfd, udrd, nwdafd, pcfd, nefd); the
+prior art it names is still correct.
+
+## The pre-check the issue demanded, and its answer
+
+> *"Confirm what the SMF actually keys sessions by, and whether a restored PFCP
+> session is usable without renegotiating with the UPF — a snapshot that restores
+> SMF-side bookkeeping the UPF has already discarded is worse than not restoring
+> it."*
+
+Keyed by `sm_context_ref` (the session index rendered as a decimal string), which
+is also the key `policy_bindings` uses, so one key spans both maps.
+
+The second half is the real question, and the answer is **no, not on its own** —
+so restoring the map alone would have shipped the harm the pre-check names. But
+the fix is small and already half-built in this tree, rather than being #193's
+restoration signalling:
+
+`pfcp_path.rs` already detects a UPF restart by comparing the peer's Recovery
+Time Stamp against a stored one (`check_peer_restart` → `teardown_association` →
+`clear_pfcp_sessions`, TS 29.244 §5.22 / TS 23.527 §4.2). It cannot fire across
+an *SMF* restart because a fresh process holds `None` and has nothing to compare
+against. So the snapshot carries `upfRecoveryTimeStamps` alongside the session
+map, and `main` seeds each `PfcpClient` with its peer's stored stamp **before the
+association loop is spawned**. The first Association Setup after a reload then
+either:
+
+* reports a **different** stamp — the UPF restarted while the SMF was down, the
+  association is torn down and exactly these restored sessions are flushed; or
+* reports the **same** stamp — the UPF did not restart, so the restored SEIDs are
+  genuinely valid.
+
+This is the minimum interlock that makes criterion 2 honest rather than harmful.
+It is deliberately **not** TS 23.527 restoration: it does not reconcile *which*
+sessions survived, and it signals no peer about the ones that did not. That
+remains #193.
+
+## The change
+
+### `session_extensions.rs` — the pool's snapshot surface
+
+* `Ipv4Pool::allocated_addrs()` — every set bit as an `Ipv4Addr`, ascending so
+  the same pool state serialises identically each write (a set-ordered result
+  would rewrite the whole file for no change).
+* `Ipv4Pool::reserve(addr)` — mark one address allocated, returning whether *this
+  call* marked it. That distinction is what stops the reserved `.0.0`/`.0.1`
+  (which `new()` marks without counting, and `allocated_addrs` reports) from
+  inflating `active_count` on restore.
+
+### `gsm_sm.rs` / `context.rs` — serialisable bindings
+
+`GsmState`, `gsm_sm::SmData`, `GsmFsm` and `PolicyBinding` gain serde derives.
+`GsmState` serialises **by variant name**, not discriminant, so inserting a state
+mid-enum cannot silently reinterpret an existing snapshot — a binding restored
+into `Initial` when it was `Operational` would re-run establishment for a live
+session. `serde(default)` throughout so a snapshot predating a member still loads.
+
+### `context.rs` — the store
+
+Mirrors pcfd's adoption (`SNAPSHOT_VERSION`, `set_state_file`, `snapshot`,
+`restore_from`, `persist`, poison-on-failed-load, disable-before-`fini`), using
+`StateStore` rather than the free functions so the never-overwrite-what-you-cannot-read
+guard is enforced rather than owned by the caller.
+
+Two properties worth naming:
+
+* **`snapshot` holds at most one lock at any instant.** It clones each map out and
+  drops the guard before taking the next. This file carries several documented
+  lock-ordering rules (`sess_remove`, `sess_update`, `sess_find_by_ipv4`); a
+  function holding three guards at once would be a new inversion waiting to
+  happen. The cost — the document is not one atomic instant — is paid back by
+  every mutation persisting immediately after its guards drop.
+* **`BTreeMap`, not `HashMap`, in the document.** A `HashMap` iterates differently
+  per process, so the file would churn wholesale on every write and a diff would
+  never show which record actually changed.
+
+`fini` disables the store **before** clearing anything: `ue_remove_all` empties
+every list and releases every address, and smfd has background tasks (the PFCP
+listener, the association loop, the timer loop) that can still reach a mutation
+during shutdown, so a persist reached afterwards would write an empty snapshot
+over a good one.
+
+### Persist call sites
+
+Every production mutation of the three concerns, each **after** its write guard
+closes (`persist` → `snapshot` re-reads the same locks and `RwLock`/`Mutex` are
+not reentrant):
+
+| Site | Mutation |
+|---|---|
+| `main.rs` create (`ipv4_pool.allocate`) | allocation |
+| `main.rs` create (`pfcp_sessions.insert`) | session |
+| `main.rs` create (`policy_bindings.insert`) | binding |
+| `main.rs` modify ×2 (`ambr`/`five_qi`) | binding |
+| `main.rs` EASDF report (`easdf_reported_eas`) | binding |
+| `main.rs` release (`pfcp_sessions.remove`, `ipv4_pool.release`) | session, allocation |
+| `context.rs` `sess_remove` (`ipv4_pool.release`) | allocation |
+| `pfcp_path.rs` `clear_pfcp_sessions` | session (the restart flush) |
+| `pfcp_path.rs` `associate` / `check_peer_restart` | peer stamp |
+
+The allocation is persisted **at allocate time**, before the session or binding
+exists, because the failure directions are not symmetric: a snapshot holding an
+address whose session never completed leaks one address, while a snapshot missing
+an address a UE is using hands that address to a second UE.
+
+The peer stamp persists **only on change** — the association loop re-reports the
+same stamp every heartbeat, and rewriting the snapshot every 10s per peer for an
+unchanged value is pure write amplification.
+
+`session_extensions.rs`'s `DualStackAllocator` owns a second `Ipv4Pool` and is
+**not** persisted: it is constructed only in its own unit tests
+(`grep DualStackAllocator` finds no production caller), so persisting it would be
+snapshotting a pool nothing allocates from.
+
+### Deviation from the issue's stated approach
+
+> *"`smfd` gains a `--state-file` flag plus `NEXTGCORE_SMF_STATE_FILE`, matching
+> the precedence the other four NFs use"*
+
+The precedence is matched exactly (flag wins over env var; empty value treated as
+unset), but the flag is parsed by the same hand-rolled `argv` scan smfd already
+uses for `-c`/`--config` rather than by clap. **smfd has no clap `Args` struct** —
+`main.rs` says so explicitly at the `SMF_EASDF` switch — and introducing one
+would turn every argument the daemon currently ignores into a hard startup error.
+Same substance, no new failure mode for existing deployments.
+
+## Verification
+
+Every guard below was revert-verified: the fix was broken, the **named** test was
+watched to fail, and the file was restored (checked by `md5sum -c` against a
+pre-revert baseline).
+
+| Guard | Revert applied | Result |
+|---|---|---|
+| `snapshot_restores_sessions_bindings_and_ip_allocations` | `restore_from` counts allocations without `reserve`-ing them | FAILED ✓ |
+| `a_restored_allocation_is_not_reissued` | same | FAILED ✓ |
+| `a_released_allocation_is_not_restored` | `sess_remove` does not `persist` | FAILED ✓ |
+| `a_newer_snapshot_is_refused_and_not_overwritten` | version comparison short-circuited to `false` | FAILED ✓ |
+| `without_a_state_file_nothing_is_persisted` | a state file armed in the watched directory | FAILED ✓ |
+| `a_seeded_recovery_time_stamp_makes_a_peer_restart_detectable` | `seed_peer_recovery_time_stamp` stores `None` | FAILED ✓ |
+| `an_unchanged_recovery_time_stamp_leaves_restored_sessions_alone` | same | **still passed** — see below |
+
+Two of these are worth stating plainly rather than filing under "green".
+
+**The negative control does not prove the seed works, by construction.** With no
+stamp stored, `matches!(None, Some(stored) if stored != rts)` is `false`, so "an
+unchanged stamp must not tear down" is satisfied by a build that stores no stamp
+at all. Its job is the *other* mutant — a version that flushes unconditionally,
+which would make the whole snapshot pointless — and it does catch that. The
+positive test is what pins the seed. Both are stated so a later reader does not
+mistake the pair for two independent proofs.
+
+**`without_a_state_file_nothing_is_persisted` carries a positive control**, added
+after noticing the absence assertion ("no files in this directory") would also
+pass if the scan were looking in the wrong place. An armed context now writes
+into the same directory first and the test asserts the file appears, before the
+memory-only context is checked to add nothing.
+
+### A race found in my own tests
+
+The two `pfcp_path` tests failed on the second run, not the first:
+`clear_pfcp_sessions` empties the **process-global** map, so the positive test's
+teardown was flushing the negative test's key mid-assertion. Fixed by purity where
+possible and one lock where not — `SESSION_MAP_LOCK`, taken by *every* test in the
+module that can reach a teardown (`test_heartbeat_detects_peer_restart`,
+`test_inbound_association_release`, `test_teardown_clears_load_state`, and the two
+new ones), so there is one agreement about that variable rather than two disjoint
+ones. Three consecutive full-crate runs green afterwards.
+
+## Ceilings
+
+* **No wire interop.** Everything is verified in-process against this tree's own
+  PFCP client and a fake UPF socket. The Docker E2E jobs are the only place a real
+  restart-with-UPF would be exercised, and durable state is deliberately **not**
+  enabled in the shipped compose file, so that path is unchanged and untested here.
+* **The restart flush is process-wide, not per-peer.** With several UPFs
+  configured, one peer's restart discards the session bookkeeping for all of them.
+  The map has no peer column, so fixing it means changing what `pfcp_sessions`
+  stores — no issue asks for that, and it is pre-existing behaviour.
+* **A restored session is bookkeeping, not a working session.** The interlock
+  proves the UPF did not restart; it does not prove any individual session
+  survived on it. That is #193.
+* **The `SmfSess` list itself is not persisted.** #191 names three concerns and
+  the session list is not one of them; `sess_add_by_psi`/`sess_add_by_apn` are
+  still only reached from tests on the SBI path, which is #78's defect, not this
+  one. Persisting a list nothing populates would be snapshot theatre.
+* **GitNexus impact analysis unrunnable** (52nd consecutive PR): the MCP server is
+  not connected in this session, so `nextgcore/CLAUDE.md`'s mandate to run
+  `gitnexus_impact` before editing could not be satisfied. Blast radius was
+  established by grep and is enumerated in the persist-call-sites table above.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3146,6 +3146,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
 ]

--- a/src/bins/nextgcore-eesd/src/context.rs
+++ b/src/bins/nextgcore-eesd/src/context.rs
@@ -1380,15 +1380,6 @@ impl EesContext {
         removed
     }
 
-    /// Build + enqueue an `AcrMgntEventsNotification` (yaml:537-554) for every
-    /// subscription whose `eventSubscs` include the fired `event` (and, when a
-    /// per-event `appGrpId` filter is present, only when it matches). Returns
-    /// the number of matched subscriptions (kept for testability).
-    ///
-    /// Delivery is fire-and-forget via the shared notifier (D6): the callback
-    /// `(uri, body)` pairs are collected UNDER the read lock and enqueued only
-    /// AFTER it is released — the documented NF-context AB-BA rule (the notifier
-    /// must never be invoked while holding the `EesContext` lock).
     // ---- eees-eel-acr — ACT status subscriptions (TS 29.558 §5.11, #106) ----
 
     /// Store an `ACTStatusSubsc`; mints and returns the server `subscriptionId`.
@@ -1569,6 +1560,15 @@ impl EesContext {
         notified
     }
 
+    /// Build + enqueue an `AcrMgntEventsNotification` (yaml:537-554) for every
+    /// subscription whose `eventSubscs` include the fired `event` (and, when a
+    /// per-event `appGrpId` filter is present, only when it matches). Returns
+    /// the number of matched subscriptions (kept for testability).
+    ///
+    /// Delivery is fire-and-forget via the shared notifier (D6): the callback
+    /// `(uri, body)` pairs are collected UNDER the read lock and enqueued only
+    /// AFTER it is released — the documented NF-context AB-BA rule (the notifier
+    /// must never be invoked while holding the `EesContext` lock).
     pub fn notify_acrmgnt_subscribers(&self, event: &str, app_grp_id: Option<&str>) -> usize {
         let mut pending: Vec<(String, serde_json::Value)> = Vec::new();
         {

--- a/src/bins/nextgcore-eesd/src/main.rs
+++ b/src/bins/nextgcore-eesd/src/main.rs
@@ -58,6 +58,7 @@
 //!   not 503, because a retry can never succeed; and refused rather than
 //!   accepted, because a stored session that actuates nothing, or a subscription
 //!   that can never notify, fails silently.
+//!
 //! Also #106: the `eees-eel-acr` ACT status subscription resource
 //! (`/subscriptions`, `/subscriptions/{subscriptionId}`) is served, and
 //! `ACTStatusNotif` is emitted when an ACR reaches a terminal ACT outcome.

--- a/src/bins/nextgcore-smfd/Cargo.toml
+++ b/src/bins/nextgcore-smfd/Cargo.toml
@@ -46,6 +46,9 @@ serde_yaml = { workspace = true }
 serde_json.workspace = true
 uuid.workspace = true
 base64.workspace = true
+# Issue #191: SmfStateError, so a snapshot from a newer build reports why it was
+# refused rather than being partially restored.
+thiserror.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/src/bins/nextgcore-smfd/src/context.rs
+++ b/src/bins/nextgcore-smfd/src/context.rs
@@ -1491,7 +1491,13 @@ impl MbsSession {
 /// Per-PDU-session policy binding: ties the SBI SM context to its PCF SM
 /// policy association, the UE-requested N1 parameters and the QoS the PCF
 /// authorized (applied to N1 NAS and N4 QERs/PDRs). Drives the GSM FSM.
-#[derive(Debug, Clone)]
+///
+/// Serialisable because it is one of the three things the durable snapshot
+/// carries (issue #191): without it a restarted SMF cannot terminate or update
+/// policy for a session that is still live. `serde(default)` throughout so a
+/// snapshot written before a member existed still loads.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default = "PolicyBinding::snapshot_default")]
 pub struct PolicyBinding {
     /// smPolicyId returned by the PCF (None = config-default fallback)
     pub sm_policy_id: Option<String>,
@@ -1531,6 +1537,35 @@ pub struct PolicyBinding {
     /// that work will read from, and keeping it empty-by-default means a session
     /// that never got a report is indistinguishable from the pre-#114 state.
     pub easdf_reported_eas: Vec<String>,
+}
+
+impl PolicyBinding {
+    /// Per-field fallback for deserialising a durable snapshot written before a
+    /// member existed (issue #191).
+    ///
+    /// Not a `Default` impl: an empty `supi` with `psi` 0 names no session, and a
+    /// binding is only ever created from a real SM context request. Only serde
+    /// reaches this, and only for a member the snapshot does not carry.
+    fn snapshot_default() -> Self {
+        Self {
+            sm_policy_id: None,
+            supi: String::new(),
+            psi: 0,
+            pti: 0,
+            pdu_session_type: 0,
+            ssc_mode: 0,
+            ue_ip: [0; 4],
+            dnn: String::new(),
+            qfi: 0,
+            five_qi: 0,
+            ambr_ul_bps: 0,
+            ambr_dl_bps: 0,
+            sm_context_status_uri: None,
+            fsm: crate::gsm_sm::GsmFsm::new(0),
+            easdf_dns_context_id: None,
+            easdf_reported_eas: Vec::new(),
+        }
+    }
 }
 
 pub struct SmfContext {
@@ -1626,6 +1661,48 @@ pub struct SmfContext {
 
     /// SM policy bindings: sm_context_ref -> PCF policy association + GSM FSM
     pub policy_bindings: RwLock<HashMap<String, PolicyBinding>>,
+
+    /// Last Recovery Time Stamp each UPF peer reported, keyed by the peer's
+    /// socket address (issue #191).
+    ///
+    /// Persisted with the session map because it is what makes restoring that map
+    /// safe: on the first Association Setup after a reload, `check_peer_restart`
+    /// compares the freshly reported value against this one and flushes the
+    /// restored sessions if the UPF restarted while the SMF was down (TS 29.244
+    /// §5.22, TS 23.527 §4.2). Without it the restored `peer_recovery_time_stamp`
+    /// is `None`, no restart is detectable, and the SMF believes in N4 sessions
+    /// the UPF has already discarded.
+    pub upf_recovery_time_stamps: RwLock<HashMap<String, u32>>,
+
+    /// Durable snapshot of the PFCP session map, the policy bindings and the
+    /// IPv4 pool's allocations (issue #191). Disabled unless a state file is
+    /// configured, in which case behaviour is byte-identical to before.
+    ///
+    /// `StateStore` rather than the `read_snapshot`/`write_snapshot` free
+    /// functions: it enforces "never overwrite a snapshot you could not read"
+    /// internally, and a new adopter has no reason to take that on manually.
+    state: nextgcore_core::state_store::StateStore,
+}
+
+/// Why smfd durable state could not be loaded (issue #191).
+#[derive(Debug, thiserror::Error)]
+pub enum SmfStateError {
+    /// The snapshot file itself could not be read or parsed.
+    #[error(transparent)]
+    Store(#[from] nextgcore_core::state_store::StateStoreError),
+    /// The snapshot was written by a newer build. Refused rather than partially
+    /// restored: restoring only what this build recognises and then persisting
+    /// would rewrite a newer-format file in the older format, discarding the rest.
+    #[error(
+        "state file {path} was written by a newer smfd (snapshot version {found}; this build \
+         understands {supported}). Refusing to restore or overwrite it. Run the newer build, or \
+         move the file aside to start fresh."
+    )]
+    UnsupportedVersion {
+        path: std::path::PathBuf,
+        found: u64,
+        supported: u64,
+    },
 }
 
 impl SmfContext {
@@ -1672,6 +1749,8 @@ impl SmfContext {
             initialized: AtomicBool::new(false),
             pfcp_sessions: RwLock::new(HashMap::new()),
             policy_bindings: RwLock::new(HashMap::new()),
+            upf_recovery_time_stamps: RwLock::new(HashMap::new()),
+            state: nextgcore_core::state_store::StateStore::disabled(),
         }
     }
 
@@ -1700,9 +1779,269 @@ impl SmfContext {
             return;
         }
 
+        // Issue #191: DISABLE the store before clearing anything. `ue_remove_all`
+        // empties every list and releases every IP, and smfd has background tasks
+        // (the PFCP listener, the association loop, the timer loop) that can still
+        // reach a mutation during shutdown -- so a persist reached afterwards would
+        // write an empty snapshot over a good one and lose every live session and
+        // its address. Disabling first is the only ordering that cannot lose data
+        // regardless of what runs next.
+        self.state = nextgcore_core::state_store::StateStore::disabled();
         self.ue_remove_all();
         self.initialized.store(false, Ordering::SeqCst);
         log::info!("SMF context finalized");
+    }
+
+    // ── durable state (issue #191) ───────────────────────────────────────────
+
+    /// Snapshot document version. Bump ONLY for a change no `#[serde(default)]`
+    /// can absorb; a bump makes every older snapshot unreadable.
+    pub const SNAPSHOT_VERSION: u64 = 1;
+
+    /// Point this context at a snapshot file and restore any prior state,
+    /// returning how many records were installed.
+    ///
+    /// Call once at startup, **after** [`init`](Self::init) and **before** the SBI
+    /// server or the PFCP association loop can run, so a restored session is never
+    /// shadowed by a fresh one and the restored peer Recovery Time Stamps are in
+    /// place for the first Association Setup.
+    ///
+    /// An unreadable snapshot is an **error**: the caller should refuse to start
+    /// rather than come up with an empty IPv4 pool that will re-issue addresses
+    /// live UEs still hold.
+    pub fn set_state_file(&mut self, path: std::path::PathBuf) -> Result<usize, SmfStateError> {
+        use nextgcore_core::state_store::{Loaded, StateStore};
+        self.state = StateStore::new(Some(path.clone()));
+        match self.state.load()? {
+            Loaded::Snapshot(doc) => {
+                let restored = self.restore_from(&doc, &path);
+                if restored.is_err() {
+                    // The store is not poisoned (the load itself succeeded), so a
+                    // caller that logged and carried on could otherwise overwrite a
+                    // snapshot this build cannot fully read. Disable instead.
+                    self.state = StateStore::disabled();
+                }
+                restored
+            }
+            Loaded::Absent => Ok(0),
+        }
+    }
+
+    /// Whether durable state is armed. `false` is the shipped default.
+    pub fn state_is_enabled(&self) -> bool {
+        self.state.is_enabled()
+    }
+
+    /// Serialize the three durable concerns to one snapshot document.
+    ///
+    /// **Takes one lock at a time, holding at most one at any instant.** This
+    /// file carries several documented lock-ordering rules (see `sess_remove`,
+    /// `sess_update`, `sess_find_by_ipv4`); a function holding three guards at
+    /// once would be a new inversion waiting to happen. Cloning each map out and
+    /// dropping its guard before taking the next means this function cannot
+    /// participate in any cycle, whatever order the mutators use.
+    ///
+    /// The cost is that the document is not one atomic instant across all three.
+    /// That is acceptable: every mutation persists immediately after its guards
+    /// drop, so the next write reconciles any skew -- and the alternative risks
+    /// wedging the NF, which no amount of snapshot precision is worth.
+    fn snapshot(&self) -> serde_json::Value {
+        // Each of these acquires and releases before the next begins.
+        let pfcp_sessions: std::collections::BTreeMap<String, u64> = self
+            .pfcp_sessions
+            .read()
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), *v)).collect())
+            .unwrap_or_default();
+        let policy_bindings: std::collections::BTreeMap<String, PolicyBinding> = self
+            .policy_bindings
+            .read()
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default();
+        let upf_rts: std::collections::BTreeMap<String, u32> = self
+            .upf_recovery_time_stamps
+            .read()
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), *v)).collect())
+            .unwrap_or_default();
+        // Ascending already (see `Ipv4Pool::allocated_addrs`), and as strings so
+        // the file is readable by an operator diagnosing a double assignment.
+        let ipv4_allocations: Vec<String> = self
+            .ipv4_pool
+            .allocated_addrs()
+            .into_iter()
+            .map(|a| a.to_string())
+            .collect();
+
+        // BTreeMap, not HashMap: a HashMap iterates in a different order on every
+        // process, so the file would churn wholesale on each write and a diff
+        // would never show which record actually changed.
+        serde_json::json!({
+            "version": Self::SNAPSHOT_VERSION,
+            "pfcpSessions": pfcp_sessions,
+            "policyBindings": policy_bindings,
+            "ipv4Allocations": ipv4_allocations,
+            "upfRecoveryTimeStamps": upf_rts,
+        })
+    }
+
+    /// Restore the three durable concerns.
+    ///
+    /// # Why the IPv4 pool is restored by re-marking, not by counting
+    ///
+    /// The pool is a bitmap plus a count. Restoring the count alone would leave
+    /// every bit clear, so the very next `allocate()` returns `10.45.0.2` — an
+    /// address a live UE is still using. Re-marking each snapshotted address is
+    /// the only restore that makes the pool's answer to "is this free?" agree with
+    /// reality. `reserve` reports whether it was this call that marked the bit, so
+    /// the reserved `.0.0`/`.0.1` that `allocated_addrs` also reports do not
+    /// double-count.
+    ///
+    /// # Why a restored PFCP session is not assumed usable
+    ///
+    /// A restored `sm_context_ref -> SEID` mapping is SMF-side bookkeeping about
+    /// state that lives on the UPF, and the UPF may have restarted while the SMF
+    /// was down. That is why `upfRecoveryTimeStamps` is part of the same document:
+    /// seeding it back into each `PfcpClient` (see `main`) makes the existing
+    /// `check_peer_restart` comparison fire on the first Association Setup after a
+    /// reload, which tears the association down and flushes exactly these restored
+    /// sessions. Reconciling *which* sessions survived, and telling peers about the
+    /// ones that did not, is TS 23.527 restoration signalling and belongs to #193.
+    fn restore_from(
+        &self,
+        doc: &serde_json::Value,
+        path: &std::path::Path,
+    ) -> Result<usize, SmfStateError> {
+        let found = doc
+            .get("version")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(Self::SNAPSHOT_VERSION);
+        if found > Self::SNAPSHOT_VERSION {
+            return Err(SmfStateError::UnsupportedVersion {
+                path: path.to_path_buf(),
+                found,
+                supported: Self::SNAPSHOT_VERSION,
+            });
+        }
+
+        let pfcp_sessions: HashMap<String, u64> = doc
+            .get("pfcpSessions")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+        // Per-record, so one binding whose schema moved does not discard the rest:
+        // the file was already validated as JSON by the store, so a bad record
+        // means a schema change, not corruption.
+        let policy_bindings: HashMap<String, PolicyBinding> = doc
+            .get("policyBindings")
+            .and_then(|v| v.as_object().cloned())
+            .map(|obj| {
+                obj.into_iter()
+                    .filter_map(|(k, v)| match serde_json::from_value::<PolicyBinding>(v) {
+                        Ok(b) => Some((k, b)),
+                        Err(e) => {
+                            log::warn!("skipping unreadable SMF policy binding {k}: {e}");
+                            None
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let ipv4_allocations: Vec<Ipv4Addr> = doc
+            .get("ipv4Allocations")
+            .and_then(|v| v.as_array().cloned())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .filter_map(|s| match s.parse::<Ipv4Addr>() {
+                        Ok(a) => Some(a),
+                        Err(e) => {
+                            log::warn!("skipping unreadable SMF IPv4 allocation {s}: {e}");
+                            None
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let upf_rts: HashMap<String, u32> = doc
+            .get("upfRecoveryTimeStamps")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        let n_sessions = pfcp_sessions.len();
+        let n_bindings = policy_bindings.len();
+        let n_rts = upf_rts.len();
+
+        // One lock at a time, as in `snapshot`.
+        if let Ok(mut map) = self.pfcp_sessions.write() {
+            map.extend(pfcp_sessions);
+        }
+        if let Ok(mut map) = self.policy_bindings.write() {
+            map.extend(policy_bindings);
+        }
+        if let Ok(mut map) = self.upf_recovery_time_stamps.write() {
+            map.extend(upf_rts);
+        }
+        let mut n_addrs = 0usize;
+        for addr in &ipv4_allocations {
+            if self.ipv4_pool.reserve(*addr) {
+                n_addrs += 1;
+            }
+        }
+
+        let restored = n_sessions + n_bindings + n_addrs;
+        log::info!(
+            "SMF durable state restored: {n_sessions} PFCP session(s), {n_bindings} policy \
+             binding(s), {n_addrs} IPv4 allocation(s) re-marked, {n_rts} UPF recovery time \
+             stamp(s). The PFCP sessions are UNRECONCILED: they are flushed on the first \
+             Association Setup if the UPF reports a changed Recovery Time Stamp."
+        );
+        Ok(restored)
+    }
+
+    /// Write the snapshot after a mutation. A no-op with no state file, and
+    /// refused (loudly) when the previous load failed.
+    ///
+    /// **Every caller must have dropped its write guards first.** `persist` ->
+    /// `snapshot` takes read locks on the same maps and `std::sync::RwLock` is not
+    /// reentrant, so calling this while still holding `pfcp_sessions.write()` or
+    /// `policy_bindings.write()` deadlocks the calling thread. Every call site
+    /// closes its `if let Ok(mut …) = ….write()` block first.
+    pub fn persist(&self) {
+        if !self.state.is_enabled() {
+            return;
+        }
+        let doc = self.snapshot();
+        if let Err(e) = self.state.persist(&doc) {
+            // The session exists in memory but not on disk: the request was
+            // answered and will not survive a restart.
+            log::error!("SMF state was NOT persisted: {e}");
+        }
+    }
+
+    /// Record the Recovery Time Stamp a UPF peer reported, and persist it.
+    ///
+    /// Keyed by the peer socket address as `PfcpClient::peer()` renders it, which
+    /// is what `main` uses to seed the value back after a restart.
+    pub fn note_upf_recovery_time_stamp(&self, peer: &str, rts: u32) {
+        let changed = {
+            match self.upf_recovery_time_stamps.write() {
+                Ok(mut map) => map.insert(peer.to_string(), rts) != Some(rts),
+                Err(_) => false,
+            }
+        };
+        // Only on a change: the association loop re-reports the same stamp on
+        // every heartbeat, and rewriting the whole snapshot every 10s per peer
+        // for an unchanged value is pure write amplification.
+        if changed {
+            self.persist();
+        }
+    }
+
+    /// The Recovery Time Stamp last recorded for `peer`, if any.
+    pub fn upf_recovery_time_stamp(&self, peer: &str) -> Option<u32> {
+        self.upf_recovery_time_stamps
+            .read()
+            .ok()?
+            .get(peer)
+            .copied()
     }
 
     /// Check if context is initialized
@@ -1967,38 +2306,53 @@ impl SmfContext {
         // First, remove all bearers for this session (must be done before acquiring session locks)
         self.bearer_remove_all_for_sess(id);
 
-        // Now remove the session itself
-        let mut sess_list = self.sess_list.write().ok()?;
-        let mut smf_n4_seid_hash = self.smf_n4_seid_hash.write().ok()?;
-        let mut ipv4_hash = self.ipv4_hash.write().ok()?;
-        let mut ipv6_hash = self.ipv6_hash.write().ok()?;
-        let mut n1n2message_hash = self.n1n2message_hash.write().ok()?;
-        let mut smf_ue_list = self.smf_ue_list.write().ok()?;
+        // Issue #191: scoped so every guard is dropped before `persist` runs --
+        // `persist` re-reads the IPv4 pool bitmap and neither `RwLock` nor `Mutex`
+        // is reentrant. The `?` operators inside still return early from
+        // `sess_remove`, which is the pre-#191 behaviour and needs no persist
+        // because nothing was removed.
+        let removed = {
+            // Now remove the session itself
+            let mut sess_list = self.sess_list.write().ok()?;
+            let mut smf_n4_seid_hash = self.smf_n4_seid_hash.write().ok()?;
+            let mut ipv4_hash = self.ipv4_hash.write().ok()?;
+            let mut ipv6_hash = self.ipv6_hash.write().ok()?;
+            let mut n1n2message_hash = self.n1n2message_hash.write().ok()?;
+            let mut smf_ue_list = self.smf_ue_list.write().ok()?;
 
-        if let Some(sess) = sess_list.remove(&id) {
-            smf_n4_seid_hash.remove(&sess.smf_n4_seid);
+            match sess_list.remove(&id) {
+                Some(sess) => {
+                    smf_n4_seid_hash.remove(&sess.smf_n4_seid);
 
-            if let Some(addr) = sess.ipv4_addr {
-                ipv4_hash.remove(&u32::from(addr));
-                self.ipv4_pool.release(addr);
-            }
-            if let Some((_, addr)) = sess.ipv6_prefix {
-                let prefix: [u8; 8] = addr.octets()[..8].try_into().unwrap_or([0; 8]);
-                ipv6_hash.remove(&prefix);
-            }
-            if let Some(ref location) = sess.paging_n1n2message_location {
-                n1n2message_hash.remove(location);
-            }
+                    if let Some(addr) = sess.ipv4_addr {
+                        ipv4_hash.remove(&u32::from(addr));
+                        self.ipv4_pool.release(addr);
+                    }
+                    if let Some((_, addr)) = sess.ipv6_prefix {
+                        let prefix: [u8; 8] = addr.octets()[..8].try_into().unwrap_or([0; 8]);
+                        ipv6_hash.remove(&prefix);
+                    }
+                    if let Some(ref location) = sess.paging_n1n2message_location {
+                        n1n2message_hash.remove(location);
+                    }
 
-            // Remove session ID from UE
-            if let Some(ue) = smf_ue_list.get_mut(&sess.smf_ue_id) {
-                ue.sess_ids.retain(|&sid| sid != id);
-            }
+                    // Remove session ID from UE
+                    if let Some(ue) = smf_ue_list.get_mut(&sess.smf_ue_id) {
+                        ue.sess_ids.retain(|&sid| sid != id);
+                    }
 
-            log::info!("[Removed] SMF session (id={}, psi={})", id, sess.psi);
-            return Some(sess);
+                    log::info!("[Removed] SMF session (id={}, psi={})", id, sess.psi);
+                    Some(sess)
+                }
+                None => None,
+            }
+        };
+        // Issue #191: a released address that is not persisted stays held in the
+        // snapshot forever, which leaks the pool across restarts.
+        if removed.is_some() {
+            self.persist();
         }
-        None
+        removed
     }
 
     /// Remove all sessions for a UE
@@ -2878,5 +3232,312 @@ mod tests {
         assert_eq!(ctx.sess_count(), 0);
         assert_eq!(ctx.bearer_count(), 0);
         assert_eq!(ctx.pf_count(), 0);
+    }
+
+    // ── durable state (issue #191) ───────────────────────────────────────────
+    //
+    // Every test here builds its own `SmfContext`, never `smf_self()`: arming a
+    // state file on the process-global context would make one test's snapshot the
+    // next test's restored state.
+
+    /// Unique snapshot path per test so parallel runs cannot collide.
+    fn temp_state_path(tag: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "nextgcore-smf-state-{}-{tag}-{nanos}.json",
+            std::process::id()
+        ))
+    }
+
+    fn ctx_with_state(path: &std::path::Path) -> SmfContext {
+        let mut ctx = SmfContext::new();
+        ctx.init(100, 200, 400);
+        ctx.set_state_file(path.to_path_buf())
+            .expect("arming a fresh state file must succeed");
+        ctx
+    }
+
+    fn binding(
+        supi: &str,
+        psi: u8,
+        ue_ip: [u8; 4],
+        state: crate::gsm_sm::GsmState,
+    ) -> PolicyBinding {
+        let mut b = PolicyBinding::snapshot_default();
+        b.sm_policy_id = Some(format!("pol-{supi}-{psi}"));
+        b.supi = supi.to_string();
+        b.psi = psi;
+        b.pti = 3;
+        b.pdu_session_type = 1;
+        b.ssc_mode = 1;
+        b.ue_ip = ue_ip;
+        b.dnn = "internet".to_string();
+        b.qfi = 1;
+        b.five_qi = 9;
+        b.ambr_ul_bps = 100_000_000;
+        b.ambr_dl_bps = 200_000_000;
+        b.sm_context_status_uri = Some("http://amf/status".to_string());
+        b.fsm.state = state;
+        b.easdf_dns_context_id = Some("dns-ctx-9".to_string());
+        b
+    }
+
+    /// The whole point of #191: a session created before a restart, and the
+    /// address it holds, are both still there afterwards.
+    #[test]
+    fn snapshot_restores_sessions_bindings_and_ip_allocations() {
+        let path = temp_state_path("roundtrip");
+        let addr = {
+            let ctx = ctx_with_state(&path);
+            let addr = ctx.ipv4_pool.allocate().expect("pool has addresses");
+            // The allocate call site persists; here the pool is driven directly, so
+            // the mutation is followed by the same explicit persist.
+            ctx.persist();
+            {
+                let mut sessions = ctx.pfcp_sessions.write().unwrap();
+                sessions.insert("ref-1".to_string(), 0x0102_0304_0506_0708);
+            }
+            ctx.persist();
+            {
+                let mut bindings = ctx.policy_bindings.write().unwrap();
+                bindings.insert(
+                    "ref-1".to_string(),
+                    binding(
+                        "imsi-001010000000001",
+                        5,
+                        addr.octets(),
+                        crate::gsm_sm::GsmState::Operational,
+                    ),
+                );
+            }
+            ctx.persist();
+            ctx.note_upf_recovery_time_stamp("127.0.0.1:8805", 4242);
+            addr
+        };
+
+        // A cold rebuild from the same file: a different process would do exactly
+        // this, and nothing carries over except the snapshot.
+        let restored_ctx = ctx_with_state(&path);
+
+        assert_eq!(
+            restored_ctx
+                .pfcp_sessions
+                .read()
+                .unwrap()
+                .get("ref-1")
+                .copied(),
+            Some(0x0102_0304_0506_0708),
+            "the UPF SEID must survive, or the SMF cannot delete the N4 session"
+        );
+        let b = restored_ctx
+            .policy_bindings
+            .read()
+            .unwrap()
+            .get("ref-1")
+            .cloned()
+            .expect("policy binding restored");
+        assert_eq!(b.supi, "imsi-001010000000001");
+        assert_eq!(b.psi, 5);
+        assert_eq!(b.ue_ip, addr.octets());
+        assert_eq!(b.ambr_dl_bps, 200_000_000);
+        assert_eq!(
+            b.sm_policy_id.as_deref(),
+            Some("pol-imsi-001010000000001-5")
+        );
+        assert_eq!(b.easdf_dns_context_id.as_deref(), Some("dns-ctx-9"));
+        assert_eq!(
+            b.fsm.state,
+            crate::gsm_sm::GsmState::Operational,
+            "a binding restored into Initial would re-run establishment for a live session"
+        );
+        assert_eq!(
+            restored_ctx.upf_recovery_time_stamp("127.0.0.1:8805"),
+            Some(4242),
+            "without the peer stamp the restored session map can never be checked"
+        );
+        // The allocation itself, not merely the copy of it inside the binding.
+        assert!(
+            restored_ctx.ipv4_pool.allocated_addrs().contains(&addr),
+            "the pool must know {addr} is held"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The consequence that makes this a correctness fix and not just resilience:
+    /// a restored allocation must not be handed to a second UE.
+    #[test]
+    fn a_restored_allocation_is_not_reissued() {
+        let path = temp_state_path("no-reissue");
+        let held = {
+            let ctx = ctx_with_state(&path);
+            let held: Vec<Ipv4Addr> = (0..3)
+                .map(|_| ctx.ipv4_pool.allocate().expect("pool has addresses"))
+                .collect();
+            ctx.persist();
+            held
+        };
+        // .0.0 and .0.1 are reserved, so the first three allocations are .0.2-.0.4.
+        assert_eq!(
+            held,
+            vec![
+                Ipv4Addr::new(10, 45, 0, 2),
+                Ipv4Addr::new(10, 45, 0, 3),
+                Ipv4Addr::new(10, 45, 0, 4)
+            ]
+        );
+
+        let restored_ctx = ctx_with_state(&path);
+        // POSITIVE assertion: the next free address is the one after the restored
+        // run, not merely "different from the three". A pool that restored nothing
+        // would answer .0.2 here, and a pool that restored the bits but lost the
+        // count would answer .0.5 too -- so the count is checked as well.
+        let fresh = restored_ctx
+            .ipv4_pool
+            .allocate()
+            .expect("pool has addresses");
+        assert_eq!(fresh, Ipv4Addr::new(10, 45, 0, 5));
+        assert_eq!(
+            restored_ctx.ipv4_pool.active_count(),
+            4,
+            "three restored plus one fresh; the reserved .0.0/.0.1 are not counted"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Releasing an address must reach the snapshot, or the pool leaks across
+    /// restarts -- the mirror of the double-assignment above.
+    #[test]
+    fn a_released_allocation_is_not_restored() {
+        let path = temp_state_path("release");
+        {
+            let ctx = ctx_with_state(&path);
+            let ue = ctx.ue_add_by_supi("imsi-001010000000009").expect("ue");
+            let mut sess = ctx.sess_add_by_psi(ue.id, 1).expect("sess");
+            let addr = ctx.ipv4_pool.allocate().expect("pool has addresses");
+            sess.ipv4_addr = Some(addr);
+            ctx.sess_update(&sess);
+            ctx.persist();
+            assert!(ctx.ipv4_pool.allocated_addrs().contains(&addr));
+            // sess_remove releases the address and persists.
+            ctx.sess_remove(sess.id).expect("session removed");
+            assert!(!ctx.ipv4_pool.allocated_addrs().contains(&addr));
+        }
+
+        let restored_ctx = ctx_with_state(&path);
+        assert_eq!(
+            restored_ctx.ipv4_pool.active_count(),
+            0,
+            "a released address must not come back as held"
+        );
+        assert_eq!(
+            restored_ctx.ipv4_pool.allocate(),
+            Some(Ipv4Addr::new(10, 45, 0, 2)),
+            "the released address is reusable again"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The shipped default: no state file means no file operations at all.
+    #[test]
+    fn without_a_state_file_nothing_is_persisted() {
+        let dir = std::env::temp_dir().join(format!(
+            "nextgcore-smf-nostate-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+
+        // Positive control FIRST, so the absence assertion below is known to be
+        // capable of failing: an armed context writing into this same directory
+        // must be visible to the scan. Without this the test would also pass if
+        // the scan were looking in the wrong place.
+        {
+            let armed = ctx_with_state(&dir.join("armed.json"));
+            let _ = armed.ipv4_pool.allocate();
+            armed.persist();
+        }
+        assert!(
+            dir.join("armed.json").exists(),
+            "positive control: an armed store must write into the watched directory"
+        );
+        std::fs::remove_file(dir.join("armed.json")).expect("clear the control");
+
+        let mut ctx = SmfContext::new();
+        ctx.init(100, 200, 400);
+        assert!(!ctx.state_is_enabled());
+        let _ = ctx.ipv4_pool.allocate();
+        {
+            let mut sessions = ctx.pfcp_sessions.write().unwrap();
+            sessions.insert("ref-x".to_string(), 7);
+        }
+        ctx.persist();
+        ctx.note_upf_recovery_time_stamp("127.0.0.1:8805", 11);
+        let ue = ctx.ue_add_by_supi("imsi-001010000000002").expect("ue");
+        let sess = ctx.sess_add_by_psi(ue.id, 1).expect("sess");
+        ctx.sess_remove(sess.id);
+        ctx.fini();
+
+        let entries: Vec<_> = std::fs::read_dir(&dir)
+            .expect("read temp dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "a memory-only SMF must touch no files, found {entries:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A snapshot from a newer build must be refused AND left alone, not
+    /// partially restored and then rewritten in the older format.
+    #[test]
+    fn a_newer_snapshot_is_refused_and_not_overwritten() {
+        let path = temp_state_path("newer");
+        let doc = serde_json::json!({
+            "version": SmfContext::SNAPSHOT_VERSION + 1,
+            "pfcpSessions": { "ref-future": 99 },
+            "policyBindings": {},
+            "ipv4Allocations": ["10.45.7.7"],
+            "upfRecoveryTimeStamps": {},
+        });
+        let before = serde_json::to_vec_pretty(&doc).expect("serialise");
+        std::fs::write(&path, &before).expect("write snapshot");
+
+        let mut ctx = SmfContext::new();
+        ctx.init(100, 200, 400);
+        let err = ctx
+            .set_state_file(path.clone())
+            .expect_err("a newer snapshot must be refused");
+        assert!(
+            matches!(err, SmfStateError::UnsupportedVersion { .. }),
+            "got {err:?}"
+        );
+        assert!(
+            !ctx.state_is_enabled(),
+            "the store must be disabled so a later mutation cannot rewrite the file"
+        );
+
+        // Prove the refusal protects the file: a mutation after the failed load
+        // must not rewrite it.
+        let _ = ctx.ipv4_pool.allocate();
+        ctx.persist();
+        assert_eq!(
+            std::fs::read(&path).expect("file still there"),
+            before,
+            "the newer-format file must be byte-identical after a refused load"
+        );
+
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/bins/nextgcore-smfd/src/gsm_sm.rs
+++ b/src/bins/nextgcore-smfd/src/gsm_sm.rs
@@ -9,7 +9,13 @@
 use crate::event::{SmfEvent, SmfEventId, SmfTimerId};
 
 /// GSM FSM states
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// Serialised by name (not by discriminant) into the smfd durable snapshot
+/// (issue #191), because a policy binding restored into `Initial` when it was
+/// `Operational` would re-run establishment for a live session. Naming the
+/// variants means inserting a state in the middle of this enum cannot silently
+/// reinterpret an existing snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum GsmState {
     /// Initial state
     #[default]
@@ -62,7 +68,11 @@ impl GsmState {
 }
 
 /// Session management data for tracking in-flight requests
-#[derive(Debug, Clone, Default)]
+///
+/// `serde(default)` on every member so a snapshot written before a member
+/// existed still loads (issue #191).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct SmData {
     /// S6b AAR in flight
     pub s6b_aar_in_flight: bool,
@@ -85,7 +95,8 @@ pub struct SmData {
 }
 
 /// GSM State Machine
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default = "GsmFsm::snapshot_default")]
 pub struct GsmFsm {
     /// Current state
     pub state: GsmState,
@@ -103,6 +114,17 @@ impl GsmFsm {
             sess_id,
             sm_data: SmData::default(),
         }
+    }
+
+    /// Per-field fallback for deserialising a durable snapshot written before a
+    /// member existed (issue #191).
+    ///
+    /// Deliberately not a `Default` impl: `sess_id` 0 names no session, so
+    /// offering `GsmFsm::default()` would invite constructing an FSM that belongs
+    /// to nothing. Only serde reaches this, and only for a member the snapshot
+    /// does not carry.
+    fn snapshot_default() -> Self {
+        Self::new(0)
     }
 
     /// Initialize the FSM

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -463,6 +463,43 @@ async fn main() -> Result<()> {
         config.max_bearer
     );
 
+    // ---- #191: durable state, OFF by default ----
+    //
+    // Restored AFTER the context knows its capacity caps and BEFORE the SBI server
+    // or the PFCP association loop can run, so a restored session is never
+    // shadowed by a fresh one and the restored peer Recovery Time Stamps are in
+    // place for the first Association Setup.
+    //
+    // Precedence matches the other NFs -- the flag wins over the env var, and an
+    // empty value is treated as unset -- but the flag is parsed by the same argv
+    // scan this daemon already uses for `-c`/`--config` rather than by clap:
+    // smfd has no clap `Args` struct, and introducing one would make every
+    // argument it currently ignores a hard startup error.
+    let state_file = std::env::args()
+        .zip(std::env::args().skip(1))
+        .find_map(|(a, b)| (a == "--state-file").then_some(b))
+        .or_else(|| std::env::var("NEXTGCORE_SMF_STATE_FILE").ok())
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty());
+    if let Some(path) = state_file {
+        let ctx = smf_self();
+        let mut guard = ctx
+            .write()
+            .map_err(|_| anyhow::anyhow!("SMF context lock poisoned"))?;
+        // Fail STARTUP on a snapshot that cannot be read or is from a newer build.
+        // Coming up with an empty IPv4 pool is the one failure mode here that is
+        // worse than not starting: it re-issues addresses live UEs still hold, and
+        // nothing logs the collision. The store would then also refuse every later
+        // write to protect the file, so the run would be silently non-durable too.
+        let restored = guard.set_state_file(std::path::PathBuf::from(&path))?;
+        log::info!("SMF durable state: {path} ({restored} record(s) restored)");
+    } else {
+        log::info!(
+            "SMF durable state disabled (no --state-file / NEXTGCORE_SMF_STATE_FILE): PFCP \
+             sessions, policy bindings and IPv4 allocations are memory-only and lost on restart"
+        );
+    }
+
     // Initialize SMF state machine
     let mut smf_sm = SmfFsm::new();
     smf_sm.init();
@@ -589,6 +626,22 @@ async fn main() -> Result<()> {
     // client (the legacy single-client paths keep working unchanged).
     pfcp_path::set_global_pool(pfcp_clients.clone());
     let pfcp_client = pfcp_clients[0].clone();
+
+    // #191: hand each client the Recovery Time Stamp the durable snapshot recorded
+    // for its peer, BEFORE the association loop is spawned. This is what turns the
+    // restored PFCP session map from a claim into a checked one: the first
+    // Association Setup compares the UPF's reported stamp against this seed and
+    // flushes the restored sessions if the UPF restarted while the SMF was down.
+    // A no-op when no state file is configured (the map has no entries).
+    for client in &pfcp_clients {
+        let stored = smf_self()
+            .read()
+            .ok()
+            .and_then(|ctx| ctx.upf_recovery_time_stamp(&client.peer().to_string()));
+        if let Some(rts) = stored {
+            client.seed_peer_recovery_time_stamp(rts).await;
+        }
+    }
 
     // PFCP receive/dispatch loop: responses complete pending transactions;
     // node-level requests (heartbeat, association release) are answered by
@@ -2492,6 +2545,12 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
         match context.ipv4_pool.allocate() {
             Some(addr) => {
                 ue_ip_octets = addr.octets();
+                // Issue #191: persist the allocation HERE, before the session or
+                // the binding exists, because the failure directions are not
+                // symmetric. A snapshot holding an address whose session never
+                // completed leaks one address; a snapshot missing an address a UE
+                // is using hands the same address to a second UE.
+                context.persist();
             }
             None => {
                 log::error!("IPv4 address pool exhausted");
@@ -2785,6 +2844,9 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
                     if let Ok(mut sessions) = ctx.pfcp_sessions.write() {
                         sessions.insert(sm_context_ref.to_string(), result.upf_seid);
                     }
+                    // Issue #191: after the write guard drops -- `persist` takes a
+                    // read lock on this same map and RwLock is not reentrant.
+                    ctx.persist();
                 }
                 // FSM: WaitPfcpEstablishment → Operational
                 fsm.dispatch(&event::SmfEvent::n4_message(0, 0, Vec::new()));
@@ -2856,6 +2918,8 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
                 },
             );
         }
+        // Issue #191: after the write guard drops (see `SmfContext::persist`).
+        context.persist();
     }
 
     // ---- N1: PDU Session Establishment Accept with authorized QoS ----
@@ -3254,6 +3318,8 @@ async fn handle_sm_context_update(sm_context_ref: &str, request: &SbiRequest) ->
                             b.ambr_dl_bps = ambr_dl;
                         }
                     }
+                    // Issue #191: durable too, not just in memory.
+                    ctx.persist();
                 }
             } else {
                 log::warn!("No PFCP session found for modification: ref={sm_context_ref}");
@@ -3933,6 +3999,11 @@ async fn handle_easdf_dns_report(request: &SbiRequest) -> SbiResponse {
                 }
             }
         }
+        if matched {
+            // Issue #191: the reported EAS list is part of the binding, so it is
+            // part of the snapshot.
+            ctx.persist();
+        }
     }
     if !matched {
         log::warn!(
@@ -4028,6 +4099,8 @@ async fn handle_sm_context_release(sm_context_ref: &str) -> SbiResponse {
             if let Ok(mut sessions) = ctx.pfcp_sessions.write() {
                 sessions.remove(sm_context_ref);
             }
+            // Issue #191: after the write guard drops (see `SmfContext::persist`).
+            ctx.persist();
         }
     } else {
         log::warn!("No PFCP session found for sm_context_ref={sm_context_ref}");
@@ -4037,6 +4110,10 @@ async fn handle_sm_context_release(sm_context_ref: &str) -> SbiResponse {
     if let Some(ref b) = binding {
         if let Ok(ctx) = smf_self().read() {
             ctx.ipv4_pool.release(std::net::Ipv4Addr::from(b.ue_ip));
+            // Issue #191: a release that is not persisted leaves the address held
+            // in the snapshot forever -- a pool leak across restarts, which is the
+            // mirror of the double-assignment the snapshot exists to prevent.
+            ctx.persist();
         }
     }
 
@@ -4235,6 +4312,8 @@ async fn handle_sm_policy_notify(sm_context_ref: &str, request: &SbiRequest) -> 
                 b.five_qi = dec.def_five_qi;
             }
         }
+        // Issue #191: durable too, not just in memory.
+        ctx.persist();
     }
 
     SbiResponse::with_status(204)

--- a/src/bins/nextgcore-smfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-smfd/src/pfcp_path.rs
@@ -445,6 +445,28 @@ impl PfcpClient {
         self.assoc.read().await.clone()
     }
 
+    /// Install a peer Recovery Time Stamp learned from a durable snapshot rather
+    /// than from the wire (issue #191).
+    ///
+    /// This is what makes restoring the PFCP session map safe across an SMF
+    /// restart. `check_peer_restart` can only detect a restart when it has a
+    /// stored stamp to compare against, and a fresh process has `None` — so
+    /// without this seed the first Association Setup after a reload accepts
+    /// whatever stamp the UPF reports and the restored sessions are never
+    /// questioned, even when the UPF restarted meanwhile and holds none of them.
+    ///
+    /// Deliberately does **not** set `associated`: the association still has to be
+    /// established on the wire. Only the restart-detection input is restored.
+    pub async fn seed_peer_recovery_time_stamp(&self, rts: u32) {
+        let mut assoc = self.assoc.write().await;
+        assoc.peer_recovery_time_stamp = Some(rts);
+        log::info!(
+            "PFCP {}: seeded peer Recovery Time Stamp {rts} from durable state; a different \
+             stamp at Association Setup will flush the restored sessions",
+            self.peer
+        );
+    }
+
     /// Test-only: force association/load state. Unit tests cannot run the
     /// full Association Setup handshake for every selection scenario.
     #[cfg(test)]
@@ -655,6 +677,9 @@ impl PfcpClient {
             self.teardown_association("peer restarted").await;
             // Remember the new incarnation so re-association succeeds
             self.assoc.write().await.peer_recovery_time_stamp = Some(rts);
+            // Issue #191: durably too, so a restart detected on a heartbeat is not
+            // re-detected (or worse, missed) after an SMF restart.
+            self.record_peer_recovery_time_stamp(rts);
         }
     }
 
@@ -708,20 +733,35 @@ impl PfcpClient {
         // Restart detection against any previously stored timestamp
         self.check_peer_restart(resp.recovery_time_stamp).await;
 
-        let mut assoc = self.assoc.write().await;
-        assoc.associated = true;
-        assoc.peer_recovery_time_stamp = Some(resp.recovery_time_stamp);
-        assoc.up_function_features = resp.up_function_features;
-        log::info!(
-            "PFCP association established with {} (peer RTS={}, UP features={:?})",
-            self.peer,
-            resp.recovery_time_stamp,
-            assoc
-                .up_function_features
-                .as_ref()
-                .map(|f| (f.ftup, f.empu, f.bucp))
-        );
+        {
+            let mut assoc = self.assoc.write().await;
+            assoc.associated = true;
+            assoc.peer_recovery_time_stamp = Some(resp.recovery_time_stamp);
+            assoc.up_function_features = resp.up_function_features;
+            log::info!(
+                "PFCP association established with {} (peer RTS={}, UP features={:?})",
+                self.peer,
+                resp.recovery_time_stamp,
+                assoc
+                    .up_function_features
+                    .as_ref()
+                    .map(|f| (f.ftup, f.empu, f.bucp))
+            );
+        }
+        // Issue #191: record the stamp durably so the NEXT process can compare
+        // against it. Scoped after the async guard drops, and the std lock is not
+        // held across an await.
+        self.record_peer_recovery_time_stamp(resp.recovery_time_stamp);
         Ok(())
+    }
+
+    /// Store the peer's Recovery Time Stamp in the SMF context so it reaches the
+    /// durable snapshot (issue #191). A no-op when persistence is disabled.
+    fn record_peer_recovery_time_stamp(&self, rts: u32) {
+        let peer = self.peer.to_string();
+        if let Ok(ctx) = smf_self().read() {
+            ctx.note_upf_recovery_time_stamp(&peer, rts);
+        }
     }
 
     /// Run the PFCP Association Release procedure (TS 29.244 6.2.9).
@@ -780,9 +820,22 @@ impl PfcpClient {
 /// Returns the number of sessions removed.
 pub fn clear_pfcp_sessions() -> usize {
     if let Ok(ctx) = smf_self().read() {
-        if let Ok(mut sessions) = ctx.pfcp_sessions.write() {
-            let n = sessions.len();
-            sessions.clear();
+        let n = {
+            match ctx.pfcp_sessions.write() {
+                Ok(mut sessions) => {
+                    let n = sessions.len();
+                    sessions.clear();
+                    Some(n)
+                }
+                Err(_) => None,
+            }
+        };
+        if let Some(n) = n {
+            // Issue #191: the flush must reach the snapshot too. This is the path
+            // that makes restoring the session map safe -- a UPF whose Recovery
+            // Time Stamp changed no longer holds these sessions, so a snapshot
+            // that kept them would re-restore them on every subsequent start.
+            ctx.persist();
             return n;
         }
     }
@@ -841,6 +894,19 @@ mod tests {
         assert!(!is_response_type(pfcp_message_type::HEARTBEAT_REQUEST));
         assert!(!is_response_type(pfcp_message_type::SESSION_REPORT_REQUEST));
     }
+
+    /// One agreement about the process-global `pfcp_sessions` map.
+    ///
+    /// `teardown_association` calls `clear_pfcp_sessions`, which clears the map
+    /// for the WHOLE process, not for the client that tore down. So any two tests
+    /// that can reach a teardown will flush each other's session entries if they
+    /// interleave — which is exactly how the #191 pair below first failed, one
+    /// clearing the other's key mid-assertion.
+    ///
+    /// Every test that can reach a teardown takes this, so there is one lock
+    /// rather than two disjoint agreements about the same variable. A test that
+    /// only reads client-local association state does not need it.
+    static SESSION_MAP_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
     async fn make_client_with_peer() -> (Arc<PfcpClient>, UdpSocket) {
         let peer_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -1021,6 +1087,9 @@ mod tests {
     /// Time Stamp must tear the association down (peer restarted).
     #[tokio::test]
     async fn test_heartbeat_detects_peer_restart() {
+        // Serialised: this test can reach a teardown, which flushes the
+        // process-global session map (see SESSION_MAP_LOCK).
+        let _map_guard = SESSION_MAP_LOCK.lock().await;
         let (client, upf) = make_client_with_peer().await;
         {
             let mut a = client.assoc.write().await;
@@ -1080,6 +1149,9 @@ mod tests {
     /// the association.
     #[tokio::test]
     async fn test_inbound_association_release() {
+        // Serialised: this test can reach a teardown, which flushes the
+        // process-global session map (see SESSION_MAP_LOCK).
+        let _map_guard = SESSION_MAP_LOCK.lock().await;
         let (client, upf) = make_client_with_peer().await;
         client.assoc.write().await.associated = true;
         let local_addr = client.socket.local_addr().unwrap();
@@ -1265,6 +1337,9 @@ mod tests {
     /// from 1) is not stuck behind the old high-watermark.
     #[tokio::test]
     async fn test_teardown_clears_load_state() {
+        // Serialised: this test can reach a teardown, which flushes the
+        // process-global session map (see SESSION_MAP_LOCK).
+        let _map_guard = SESSION_MAP_LOCK.lock().await;
         let (client, _upf) = make_client_with_peer().await;
         client
             .set_assoc_state_for_test(true, Some(40), Some(5000))
@@ -1278,6 +1353,99 @@ mod tests {
         assert_eq!(
             assoc.peer_load_seq, None,
             "a fresh low-seq post-restart report must be acceptable again"
+        );
+    }
+
+    // ── #191: a seeded stamp is what makes a restored session map checkable ──
+    //
+    // These two drive the process-global session map, as `test_teardown_clears_
+    // load_state` above already does via `teardown_association`. Safe because no
+    // smfd test asserts on the *contents* of the global `pfcp_sessions` map, and
+    // each of these asserts only about its own uniquely-named key rather than
+    // about the map being empty.
+
+    /// A stamp restored from a snapshot must participate in restart detection.
+    /// Without the seed a fresh process holds `None`, no restart is detectable,
+    /// and the restored sessions are never questioned.
+    #[tokio::test]
+    async fn a_seeded_recovery_time_stamp_makes_a_peer_restart_detectable() {
+        // Serialised: this test can reach a teardown, which flushes the
+        // process-global session map (see SESSION_MAP_LOCK).
+        let _map_guard = SESSION_MAP_LOCK.lock().await;
+        let (client, _upf) = make_client_with_peer().await;
+        client.seed_peer_recovery_time_stamp(100).await;
+        client.set_assoc_state_for_test(true, None, None).await;
+        if let Ok(ctx) = smf_self().read() {
+            ctx.pfcp_sessions
+                .write()
+                .unwrap()
+                .insert("seeded-restart-ref".to_string(), 0xabcd);
+        }
+
+        // The UPF comes back with a different incarnation: every session it held
+        // is gone (TS 29.244 §5.22, TS 23.527 §4.2).
+        client.check_peer_restart(200).await;
+
+        assert!(
+            !client.is_associated().await,
+            "a changed stamp must tear the association down"
+        );
+        let still_there = smf_self()
+            .read()
+            .unwrap()
+            .pfcp_sessions
+            .read()
+            .unwrap()
+            .contains_key("seeded-restart-ref");
+        assert!(
+            !still_there,
+            "the restored session must be flushed, not left believed-in"
+        );
+        assert_eq!(
+            client.association().await.peer_recovery_time_stamp,
+            Some(200),
+            "the new incarnation is remembered so re-association succeeds"
+        );
+    }
+
+    /// The other half of the interlock: an unchanged stamp means the UPF did NOT
+    /// restart, so the restored sessions are genuinely still valid and must be
+    /// left alone. Without this, "flush on restart" could be satisfied by a
+    /// version that flushes unconditionally — which would make the whole snapshot
+    /// pointless.
+    #[tokio::test]
+    async fn an_unchanged_recovery_time_stamp_leaves_restored_sessions_alone() {
+        // Serialised: this test can reach a teardown, which flushes the
+        // process-global session map (see SESSION_MAP_LOCK).
+        let _map_guard = SESSION_MAP_LOCK.lock().await;
+        let (client, _upf) = make_client_with_peer().await;
+        client.seed_peer_recovery_time_stamp(300).await;
+        client.set_assoc_state_for_test(true, None, None).await;
+        if let Ok(ctx) = smf_self().read() {
+            ctx.pfcp_sessions
+                .write()
+                .unwrap()
+                .insert("unchanged-stamp-ref".to_string(), 0x1234);
+        }
+
+        client.check_peer_restart(300).await;
+
+        assert!(
+            client.is_associated().await,
+            "the same stamp is not a restart"
+        );
+        let seid = smf_self()
+            .read()
+            .unwrap()
+            .pfcp_sessions
+            .read()
+            .unwrap()
+            .get("unchanged-stamp-ref")
+            .copied();
+        assert_eq!(
+            seid,
+            Some(0x1234),
+            "a session on a UPF that did not restart must survive"
         );
     }
 }

--- a/src/bins/nextgcore-smfd/src/session_extensions.rs
+++ b/src/bins/nextgcore-smfd/src/session_extensions.rs
@@ -221,6 +221,72 @@ impl Ipv4Pool {
         false
     }
 
+    /// Every host address currently marked allocated, including the reserved
+    /// network (`.0.0`) and gateway (`.0.1`) addresses.
+    ///
+    /// Ascending, so the same pool state serialises identically on every write.
+    /// A set-ordered result would rewrite the whole snapshot for no change and
+    /// make a diff useless for spotting a real one.
+    ///
+    /// Used by the durable snapshot (issue #191): the bitmap is the only record
+    /// of which addresses are held, and rebuilding it empty is what lets the pool
+    /// hand a live UE's address to a second UE after a restart.
+    pub fn allocated_addrs(&self) -> Vec<Ipv4Addr> {
+        let bm = match self.bitmap.lock() {
+            Ok(bm) => bm,
+            Err(_) => return Vec::new(),
+        };
+        let mut out = Vec::new();
+        for (word_idx, word) in bm.iter().enumerate() {
+            if *word == 0 {
+                continue;
+            }
+            for bit in 0..64u32 {
+                if *word & (1u64 << bit) == 0 {
+                    continue;
+                }
+                let host_idx = (word_idx as u32) * 64 + bit;
+                if host_idx >= self.pool_size {
+                    break;
+                }
+                let mut octets = self.base;
+                octets[2] = ((host_idx >> 8) & 0xFF) as u8;
+                octets[3] = (host_idx & 0xFF) as u8;
+                out.push(Ipv4Addr::from(octets));
+            }
+        }
+        out
+    }
+
+    /// Mark one specific address allocated, as when restoring a snapshot.
+    ///
+    /// `true` when this call is what marked it; `false` when it was already
+    /// marked — the reserved network/gateway addresses, or a duplicate — or when
+    /// it lies outside this pool. Only a newly-marked address moves
+    /// `active_count`, so restoring a snapshot that includes `.0.0`/`.0.1` (which
+    /// [`allocated_addrs`](Self::allocated_addrs) reports, and `new` already
+    /// marked without counting) does not inflate the count.
+    pub fn reserve(&self, addr: Ipv4Addr) -> bool {
+        let octets = addr.octets();
+        if octets[0] != self.base[0] || octets[1] != self.base[1] {
+            return false;
+        }
+        let host_idx = ((octets[2] as u32) << 8) | (octets[3] as u32);
+        if host_idx >= self.pool_size {
+            return false;
+        }
+        if let Ok(mut bm) = self.bitmap.lock() {
+            let word = (host_idx / 64) as usize;
+            let bit = host_idx % 64;
+            if bm[word] & (1u64 << bit) == 0 {
+                bm[word] |= 1u64 << bit;
+                self.allocated_count.fetch_add(1, Ordering::Relaxed);
+                return true;
+            }
+        }
+        false
+    }
+
     /// Number of currently allocated addresses (excluding reserved).
     pub fn active_count(&self) -> u32 {
         self.allocated_count.load(Ordering::Relaxed)


### PR DESCRIPTION
Closes #191.

Spec: `specs/fix-smfd-durable-state.md`. Verified against `main` @ `f019c75`.

## The defect

`smfd` held every resource whose lifetime spans a PDU session in in-memory maps with no snapshot and no reload:

- `pfcp_sessions` (`sm_context_ref` → UPF SEID) — lost on restart, so the UPF holds N4 sessions the SMF can no longer modify or delete.
- `policy_bindings` (PCF association, authorized QoS, GSM FSM state, EASDF DNS context) — lost, so a restarted SMF cannot terminate or update policy for a live session.
- `ipv4_pool` — **the one with a correctness consequence beyond "state is gone".** It is a bitmap plus a count; rebuilt empty, the very next `allocate()` returns `10.45.0.2`, an address a live UE still holds. That is address *substitution*, and nothing logs it.

Premise re-verified before starting: `grep -rn 'state_file\|StateStore' src/bins/nextgcore-smfd/src/` returned nothing. (The issue's "four NFs already use it" has drifted to seven; the prior art it names is still correct.)

## The pre-check the issue demanded, and its answer

> *"whether a restored PFCP session is usable without renegotiating with the UPF — a snapshot that restores SMF-side bookkeeping the UPF has already discarded is worse than not restoring it."*

**On its own, no** — so restoring the map alone would have shipped exactly that harm. But the fix is small and half-built in this tree already, rather than being #193's restoration signalling.

`pfcp_path.rs` already detects a UPF restart by comparing the peer's Recovery Time Stamp against a stored one (`check_peer_restart` → `teardown_association` → `clear_pfcp_sessions`, TS 29.244 §5.22 / TS 23.527 §4.2). It cannot fire across an **SMF** restart because a fresh process holds `None`. So the snapshot carries `upfRecoveryTimeStamps` too, and `main` seeds each `PfcpClient` with its peer's stored stamp **before the association loop is spawned**. The first Association Setup after a reload then either:

- reports a **different** stamp → the UPF restarted while the SMF was down; the association is torn down and exactly these restored sessions are flushed; or
- reports the **same** stamp → the UPF did not restart, so the restored SEIDs are genuinely valid.

That is the minimum interlock that makes criterion 2 honest rather than harmful. It is deliberately **not** TS 23.527 restoration — it reconciles no individual session and signals no peer. That remains #193.

## Acceptance criteria

| Criterion | Where |
|---|---|
| `--state-file` + `NEXTGCORE_SMF_STATE_FILE`, flag wins, empty = unset | `main.rs`; **deviation stated below** |
| Three concerns snapshotted on mutation, reloaded at boot | `context.rs` `snapshot`/`restore_from`/`persist`; 9 call sites tabulated in the spec |
| Create → rebuild from the same file → session **and** its IP allocation present | `snapshot_restores_sessions_bindings_and_ip_allocations` |
| A restored allocation is not re-issuable | `a_restored_allocation_is_not_reissued` |
| No state file ⇒ behaviour byte-identical | `without_a_state_file_nothing_is_persisted` |
| Documented in `docs-book/src/configuration/smf.md` | ✔, with the limits |

Extras the criteria did not ask for but the code needs: a released address must not come back as held (`a_released_allocation_is_not_restored`), a newer-format snapshot must be refused *and left byte-identical* (`a_newer_snapshot_is_refused_and_not_overwritten`), and the two halves of the restart interlock.

## Deviation from the suggested approach

The issue says "gains a `--state-file` **flag**… matching the precedence the other four NFs use". Precedence matches exactly, but the flag is parsed by the same hand-rolled `argv` scan smfd already uses for `-c`/`--config`, **not clap**: smfd has no clap `Args` struct (`main.rs` says so at the `SMF_EASDF` switch), and adding one would turn every argument the daemon currently ignores into a hard startup error. Same substance, no new failure mode for existing deployments.

## Verification

Every guard was revert-verified — fix broken, **named** test watched to fail, file restored (`md5sum -c` against a pre-revert baseline). Table in the spec. Two things stated rather than filed under "green":

- **The negative control does not prove the seed works, by construction.** With no stamp stored, `matches!(None, Some(s) if s != rts)` is `false`, so "an unchanged stamp must not tear down" is satisfied by a build that stores no stamp at all. Its job is the *other* mutant — a version that flushes unconditionally, which would make the snapshot pointless — and it catches that. The positive test pins the seed. Both are documented so the pair is not mistaken for two independent proofs.
- **A race in my own tests, found on the second run.** `clear_pfcp_sessions` empties the **process-global** map, so the positive test's teardown was flushing the negative test's key mid-assertion. Fixed with one `SESSION_MAP_LOCK` taken by *every* test in the module that can reach a teardown, so there is one agreement about that variable rather than two disjoint ones. Three consecutive full-crate runs green after.

Workspace: **6125 passed / 0 failed** (was 6118), `cargo clippy --workspace` and `cargo fmt --all --check` clean.

## Also in this PR

Three pre-existing clippy warnings in `eesd` from #106: a doc block that #106's section marker had orphaned from `notify_acrmgnt_subscribers` is moved back onto it, plus one missing `//!` blank line. Unrelated to #191, but workspace clippy was not clean and this project's bar is that it is. 4 lines, zero behaviour.

## Ceilings

- **No wire interop.** Verified in-process against this tree's PFCP client and a fake UPF socket. Durable state is deliberately **not** enabled in the shipped compose, so the Docker E2E path is unchanged and does not exercise it.
- **The restart flush is process-wide, not per-peer** — with several UPFs, one peer's restart discards the bookkeeping for all. Pre-existing; the map has no peer column.
- **A restored session is bookkeeping, not a working session.** The interlock proves the UPF did not restart; it does not prove any individual session survived. That is #193.
- **The `SmfSess` list is not persisted** — not one of #191's three concerns, and `sess_add_by_psi`/`by_apn` are still test-only on the SBI path (that is #78). Persisting a list nothing populates would be snapshot theatre.
- **GitNexus impact analysis unrunnable** (52nd consecutive PR): the MCP server is not connected, so `CLAUDE.md`'s `gitnexus_impact` mandate could not be satisfied. Blast radius established by grep and tabulated in the spec.
