### PR TITLE
fix(pcrfd): react to reported Event-Triggers, RAT, QoS and rule failures, and give Gx sessions a restart story (#57)

### DIFF
--- a/docs-book/src/configuration/pcrf.md
+++ b/docs-book/src/configuration/pcrf.md
@@ -66,12 +66,55 @@ From the clap `Args` struct in `src/bins/nextgcore-pcrfd/src/main.rs`:
 | `--max-sess` | usize | `1024` | Maximum number of sessions. Stored in the context and logged at startup, but **no code path enforces it** — `gx_session_add` never checks it. |
 | `--db-uri` | string | unset | MongoDB URI — parsed but never wired to the DB layer. |
 | `--db-name` | string | `nextgcore` | Database name — parsed but never used. |
+| `--state-file` | path | unset | JSON snapshot file for the Gx/Rx session tables (#57). Falls back to `NEXTGCORE_PCRF_STATE_FILE`; an empty value is treated as unset. With neither set the PCRF is memory-only. |
 
 ## Behavior notes
 
 - **Peer handling (RFC 6733, per code comments):** CER/CEA (responder role), DWR/DWA and DPR/DPA are handled by the shared `nextgcore_diameter::peer::DiameterPeer`. The PCRF sends a device watchdog every 30 s (`timer_tc` default in `DiameterConfig`) and closes the connection after 3 consecutive missed watchdogs (`MAX_MISSED_WATCHDOGS` in `fd_path.rs`). Peers are registered by Origin-Host once the CER/CEA exchange completes.
-- **Gx CCR semantics (TS 29.212 §5.6 per code comments):** `INITIAL_REQUEST` creates the Gx session and indexes it by Session-Id and by Framed-IP-Address / Framed-IPv6-Prefix; `UPDATE_REQUEST` and `TERMINATION_REQUEST` for an unknown Session-Id are answered with Result-Code 5002 `DIAMETER_UNKNOWN_SESSION_ID`. A successful provisioning CCA carries Default-EPS-Bearer-QoS, QoS-Information (APN-AMBR), Event-Triggers (QoS/RAT change, UE IP allocate/release) and a Charging-Rule-Install. Termination clears the IP bindings and fires Rx ASRs toward any bound AF sessions. An *incoming* Gx RAR is rejected with 3001 `DIAMETER_COMMAND_UNSUPPORTED` (the PCRF only originates RAR); unknown applications get 3007 `DIAMETER_APPLICATION_UNSUPPORTED`.
+- **Gx CCR semantics (TS 29.212 §5.6 per code comments):** `INITIAL_REQUEST` creates the Gx session and indexes it by Session-Id and by Framed-IP-Address / Framed-IPv6-Prefix; `UPDATE_REQUEST` and `TERMINATION_REQUEST` for an unknown Session-Id are answered with Result-Code 5002 `DIAMETER_UNKNOWN_SESSION_ID`. An **initial** provisioning CCA carries Default-EPS-Bearer-QoS, QoS-Information (APN-AMBR), Event-Triggers (QoS/RAT change, UE IP allocate/release) and a Charging-Rule-Install. Termination clears the IP bindings and fires Rx ASRs toward any bound AF sessions. An *incoming* Gx RAR is rejected with 3001 `DIAMETER_COMMAND_UNSUPPORTED` (the PCRF only originates RAR); unknown applications get 3007 `DIAMETER_APPLICATION_UNSUPPORTED`.
+- **What an UPDATE answer carries is now a function of what the PCEF reported (#57).** Before #57 every CCR-U got the same static payload the initial request got, regardless of the request — TS 29.212 §4.5.1 makes the PCRF's decision a function of the reported Event-Trigger and its related data, so unconditional replay meant a consumer could not tell "policy changed" from "nothing happened".
+  - `RAT_CHANGE` re-authorizes: the CCA restates Default-EPS-Bearer-QoS and QoS-Information for the new access.
+  - `QOS_CHANGE` re-authorizes **only if** the QoS-Information the PCEF reports diverges from what was authorized. On agreement the CCA carries no QoS at all. On divergence it carries the **authorized** values, correcting the PCEF — never an echo of what was reported.
+  - `UE_IP_ADDRESS_ALLOCATE` / `UE_IP_ADDRESS_RELEASE` install and clear the IP→session mapping. The release takes the address from the *session*, not from the CCR, because a release report need not echo the address it releases.
+  - A CCR-U reporting **no** recognized trigger provisions nothing. Rules are never re-installed on an update; the PCEF holds them from the initial provisioning.
+  - `RAT-Type` is recorded on the session whenever reported. It was previously hardcoded to `0` and never populated.
+- **PCC rule failure reports are acted on (TS 29.212 §4.5.12, #57).** A `Charging-Rule-Report` with `PCC-Rule-Status = INACTIVE` withdraws the named rule from the PCRF's installed set and from every bound Rx session. If that leaves an Rx session with **no** installed rule, the AF is aborted with an ASR — the state where "the AF believes an unenforced service is active" is the harm §4.5.12 exists to prevent. Three deliberate limits: `TEMPORARILY INACTIVE` withdraws nothing (§5.3.19 says the rule is expected back, so aborting would tear down an AF session that is about to work); no `Charging-Rule-Remove` is sent back, per §4.5.12's own NOTE that the PCRF *"does not need request the PCEF to remove the inactive PCC rule"*; and `Charging-Rule-Base-Name` is logged but not resolved, because this PCRF provisions no base names and so has no membership list to expand one against. `PCRF_ASR_ON_RULE_FAILURE=0` keeps the bookkeeping update and suppresses the ASR; it defaults **on**, because off reproduces the defect.
+
+## Durable state (#57)
+
+Off by default. With `--state-file` (or `NEXTGCORE_PCRF_STATE_FILE`) the PCRF
+snapshots the Gx and Rx session tables on every mutation and reloads them at boot,
+so a restart no longer answers `DIAMETER_UNKNOWN_SESSION_ID` (5002) for every live
+PDN connection's CCR-U and CCR-T indefinitely. Uses the shared
+`nextgcore-core::state_store::StateStore` (atomic + fsynced + `0600` writes; a
+snapshot that cannot be read is never overwritten). An unreadable snapshot, or one
+from a newer build, **fails startup**.
+
+Two details specific to pcrfd:
+
+- **The index hashes ARE persisted**, unlike the other NFs in this tree.
+  `gx_session_remove` and `rx_session_remove` drop only the hash entry and leave a
+  **tombstone** in the vector, because a Gx session's `rx_sessions` and an Rx
+  session's `gx_session_idx` are positional indexes that compacting would
+  re-point. So the hash — not the vector — records which sessions are live, and it
+  is not derivable. Rebuilding it from every vector entry would resurrect every
+  session ever terminated. Only the live sid *set* is stored; the indexes
+  themselves are re-derived from position, so a persisted index cannot disagree
+  with the list it points into.
+- **The IP maps are derived on restore** from the session table under the same
+  `has_ipv4`/`has_ipv6` conditions the live path uses, and only for live sessions,
+  so a tombstone's old address does not come back resolving to a session that no
+  longer answers.
+
+Not enabled in the shipped Docker EPC compose, so the default E2E path is unchanged.
+
+**The restart-signalling alternative was not taken.** #57 offered either
+persistence or clean restart signalling via a fixed-at-start `Origin-State-Id`.
+`nextgcore-diameter`'s `origin_state_id()` returns `SystemTime::now()` seconds on
+every call, so it is not a stable per-instance restart indicator (RFC 6733 §8.16)
+and the signalling option has no working foundation today. That is filed as its own
+diameter-layer issue; persistence needs nothing from it.
 - **Policy is always the default profile in practice:** `build_subscriber_session_data` (`gx_path.rs`) tries `nextgcore_dbi_subscription_data`, but since this binary never initializes the Mongo client, the lookup always fails and it falls back to the built-in `default_profile` — QCI 9, ARP derived from the QCI table, APN-AMBR 100,000,000 bps down / 50,000,000 bps up, and one catch-all non-GBR PCC rule named `pcrf-<apn>-default` (precedence 100, bidirectional `permit ... ip from any to assigned` IPFilterRules).
 - **Rx session binding (TS 29.214 per code comments):** an AAR is bound to the Gx (IP-CAN) session via the UE IP address; if no Gx session matches, the AAA carries Experimental-Result 5065 `IP_CAN_SESSION_NOT_AVAILABLE` (vendor 10415). If pushing the derived PCC rules to the PCEF via Gx RAR fails, the AAA carries 5063 `REQUESTED_SERVICE_NOT_AUTHORIZED`. An STR triggers a Gx RAR with Charging-Rule-Remove and unbinds the Rx session.
 - **PCRF-initiated requests:** RAR/ASR are sent over the connection the target peer established (looked up by Origin-Host); the answer wait is capped at 5 s (`ANSWER_TIMEOUT` in `fd_path.rs`) with no application-level retransmission. If the peer is not connected the send fails immediately.
-- **Environment variables:** `OTEL_EXPORTER_OTLP_ENDPOINT` sets the OpenTelemetry OTLP trace endpoint (default `http://jaeger:4317`; export failure is silently ignored). Note that `RUST_LOG` is **not** read — `init_logging` builds `env_logger` without consulting the environment, so the `RUST_LOG: info` set in `docker-compose-epc.yml` has no effect on this daemon; only `-e/--log-level` does. There are no state files; Gx/Rx message counters are held in memory and logged as a summary line at shutdown.
+- **Environment variables:** `OTEL_EXPORTER_OTLP_ENDPOINT` sets the OpenTelemetry OTLP trace endpoint (default `http://jaeger:4317`; export failure is silently ignored). Note that `RUST_LOG` is **not** read — `init_logging` builds `env_logger` without consulting the environment, so the `RUST_LOG: info` set in `docker-compose-epc.yml` has no effect on this daemon; only `-e/--log-level` does. `NEXTGCORE_PCRF_STATE_FILE` supplies the durable-state path when `--state-file` is absent (the flag wins), and `PCRF_ASR_ON_RULE_FAILURE` (`0`/`false`/`no`/`off`) suppresses the §4.5.12 ASR. Gx/Rx message counters are held in memory and logged as a summary line at shutdown.

--- a/specs/fix-pcrfd-gx-dynamic-policy.md
+++ b/specs/fix-pcrfd-gx-dynamic-policy.md
@@ -1,0 +1,218 @@
+# nextgcore #57: pcrfd reacts to what the PCEF reports, and Gx sessions survive a restart
+
+Verified against `main` @ `96034a7`.
+
+Closes #57. The `origin_state_id()` defect #57 asked to track separately is filed
+as **#280**.
+
+## The defect
+
+Two independent halves.
+
+**(1) Gx was write-once provisioning.** `parse_ccr` read Session-Id,
+Auth-Application-Id, Origin-Host/Realm, Destination-Realm, CC-Request-Type/Number,
+Subscription-Id, Called-Station-Id, Framed-IP{v4,v6} and Network-Request-Support —
+and nothing else. Event-Trigger, RAT-Type, QoS-Information and
+Charging-Rule-Report were never parsed anywhere in the crate. The
+`UPDATE_REQUEST` branch checked only that the session existed and fell through to
+re-provisioning, so `build_cca_success` re-emitted the same static
+Default-EPS-Bearer-QoS, QoS-Information and armed Event-Triggers on every update
+irrespective of the request. The PCRF armed QOS_CHANGE, RAT_CHANGE,
+UE_IP_ADDRESS_ALLOCATE and UE_IP_ADDRESS_RELEASE and had no handler for any of
+them, and `PcrfGxSession::rat_type` was hardcoded `0` with no writer.
+
+**(2) No restart story.** All Gx/Rx state was in-memory with no persistence and no
+rebuild, so after a pcrfd restart every CCR-U and CCR-T was answered
+`DIAMETER_UNKNOWN_SESSION_ID` (5002) indefinitely.
+
+Both premises re-verified against `main` before starting.
+
+## Spec grounding, and one hypothesis that did not survive it
+
+TS 29.212 §4.5.1: *"the PCEF shall supply within the PCC rule request the specific
+event which caused the IP-CAN session modification (within the Event-Trigger AVP)
+and any related data affected by the IP-CAN session modification. Any change in PCC
+rule status shall be supplied to PCRF within the Charging-Rule-Report AVP."* The
+PCRF's decision is meant to be a function of that.
+
+Every AVP code was taken from the vendored `29212-j10.txt` §5.3 table rather than
+from memory: Charging-Rule-Report 1018 (M,V, grouped), PCC-Rule-Status 1019 (M,V),
+Rule-Failure-Code 1031 (M,V), RAT-Type 1032 (**V must, M may** — so the test builds
+it V-only, which is what a conformant PCEF sends and which the parser must not
+depend on).
+
+**A hypothesis that failed the check, recorded because it shaped the design:** I
+expected `Default-EPS-Bearer-QoS` to be EPS-only, which would have made a
+RAT_CHANGE to GERAN observably drop it — a clean, spec-derived difference. The §5.3
+table says its applicable access type is **All**. So the RAT dimension gives no
+per-RAT payload rule here, and the observable difference comes from *whether* the
+PCRF re-authorizes at all, not from a RAT-specific payload.
+
+## The change
+
+### What an update's answer carries
+
+New `GxProvisionDecision { qos, install_rules, triggers }`, threaded into
+`build_cca_success`. `GxProvisionDecision::for_update` derives it from the report:
+
+| Reported | Answer |
+|---|---|
+| `RAT_CHANGE` | re-authorize (Default-EPS-Bearer-QoS + QoS-Information + re-arm) |
+| `QOS_CHANGE`, reported QoS **diverges** from authorized | re-authorize with the **authorized** values |
+| `QOS_CHANGE`, reported QoS **agrees** | nothing — the PCEF already holds the right policy |
+| no recognized trigger | nothing |
+| anything, on an update | never `Charging-Rule-Install` |
+
+The authorized values are re-derived from the subscription on **every** request
+rather than replayed from the initial answer, so an administrative change between
+the initial CCR and an update is visible in the update's answer.
+
+`ReportedQos::diverges_from` treats an **absent** member as "not stated" rather
+than as a mismatch: otherwise every partial report would look like a violation and
+trigger a pointless re-authorization.
+
+### State the PCRF now keeps
+
+`apply_update_triggers` records the RAT (whenever reported, not only under
+RAT_CHANGE — a PCEF that reports the value without arming the trigger still told us
+where the UE is), installs the mapping on `UE_IP_ADDRESS_ALLOCATE`, and clears it
+on `UE_IP_ADDRESS_RELEASE`. The release takes the address from the **session**, not
+from the CCR: a release report need not echo the address it is releasing, and
+dropping only what the CCR happened to carry would leave the mapping behind — the
+stale-mapping half of the trigger being inert.
+
+`PcrfGxSession` gains `reported_rat` (so `0` = WLAN is distinguishable from "never
+reported") and `installed_rules` (so a failure report has something to act on).
+
+### Rule failure handling (§4.5.12)
+
+`apply_rule_reports` withdraws an `INACTIVE` rule from the installed set and from
+every bound Rx session; an Rx session left with **no** rule gets an ASR, reusing
+the existing `RxAbortTarget` → `pcrf_rx_send_asr_for_target` plumbing.
+
+Four choices, each with its reason in the code:
+
+* **`INACTIVE` only.** §5.3.19 defines `TEMPORARILY INACTIVE` as temporarily
+  disabled, e.g. loss of bearer, so the rule is expected back. Acting on it would
+  tear down an AF session that is about to work again.
+* **No `Charging-Rule-Remove` is sent back.** §4.5.12's own NOTE: *"When the PCRF
+  receives PCC-Rule-Status set to INACTIVE, the PCRF does not need request the PCEF
+  to remove the inactive PCC rule."*
+* **The AF is told only when its service has nothing left enforcing it.** An Rx
+  session still holding another rule is degraded, not dead. An Rx session with no
+  remaining rule is precisely the harm #57 names: "the AF believes an unenforced
+  service is active".
+* **`Charging-Rule-Base-Name` is logged, not resolved.** It names a
+  PCEF-preconfigured group, and this PCRF provisions no base names
+  (`build_charging_rule_install_avp` emits Charging-Rule-Definition only), so it has
+  no membership list. Guessing which local rules a base name covers could remove a
+  rule the PCEF never reported.
+
+Gated by `PCRF_ASR_ON_RULE_FAILURE`, a **runtime** switch (not a cargo feature, per
+this project's recorded convention, so CI compiles both states), defaulting **on**:
+off reproduces the defect.
+
+### Restoration model, and why persistence over signalling
+
+#57 offered either persistence or clean restart signalling. **Persistence**, using
+the shared `nextgcore-core::state_store::StateStore` — because the signalling option
+has no working foundation: `origin_state_id()` recomputes wall-clock on every call,
+so it is not a per-instance restart indicator at all (now #280). Choosing signalling
+would have meant fixing a diameter-layer defect #57 explicitly scoped out.
+
+**Deviation from the suggested approach:** #57 suggested persisting to "the existing
+MongoDB". This tree's established restoration model is `StateStore` (seven NFs use
+it), and pcrfd never initialises a Mongo client at all — `build_subscriber_session_data`'s
+DB lookup always fails and falls back to the default profile, which the docs already
+record. Persisting to a client the binary does not create would not have worked.
+
+**One thing pcrfd does differently from every other adopter, and it is load-bearing:
+the index hashes ARE persisted.** `gx_session_remove` and `rx_session_remove` drop
+only the hash entry and leave a **tombstone** in the vector, because a Gx session's
+`rx_sessions` and an Rx session's `gx_session_idx` are positional indexes that
+compacting would re-point. So the hash — not the vector — is the record of which
+sessions are live, and it is *not derivable from the list*. Rebuilding it from every
+vector entry would resurrect every session ever terminated and answer CCR-Us for
+them. Only the live sid **set** is stored; the indexes are re-derived from position,
+so a persisted index cannot disagree with the list it points into. The IP maps stay
+derived, and only from live sessions.
+
+For the same positional reason the vectors are deserialised **whole**, not
+per-record: skipping one malformed record would shift every later index. An
+unreadable table restores as empty (the pre-#57 behaviour) rather than as a silently
+re-indexed one.
+
+## Verification
+
+Every guard revert-verified: fix broken, **named** test watched to fail, file
+restored (`md5sum` checked against a pre-revert baseline). Three of these are worth
+stating rather than filing under "green".
+
+| Guard | Revert | Result |
+|---|---|---|
+| `a_rat_change_reauthorizes_and_a_triggerless_update_does_not` | `for_update` always re-authorizes (the pre-#57 replay) | FAILED ✓ |
+| same | `for_update` never re-authorizes | FAILED ✓ |
+| `a_qos_change_reauthorizes_only_when_the_report_diverges` | `diverges_from` always `false`; and always `true` | FAILED ✓ both ways |
+| `test_handle_ccr_lifecycle_initial_update_termination` | `for_update` always re-authorizes | FAILED ✓ |
+| `a_temporarily_inactive_report_withdraws_nothing` | `reports_removal` accepts any status | FAILED ✓ |
+| `an_inactive_rule_report_withdraws_the_rule_and_aborts_the_af` | `reports_removal` always `false` | FAILED ✓ |
+| `a_rule_report_leaving_another_rule_does_not_abort_the_af` | abort ignores surviving rules | FAILED ✓ |
+| `rat_type_is_populated_from_the_ccr` | RAT not recorded | FAILED ✓ |
+| `ue_ip_address_release_clears_the_mapping` | release branch inert | FAILED ✓ |
+| `parse_ccr_reads_every_modification_input` | only the first Event-Trigger instance read | FAILED ✓ |
+| `a_terminated_session_is_not_resurrected_by_a_restore` | tombstone filter removed; `gx_session_remove` persist removed | FAILED ✓ both |
+| `an_aborted_rx_session_stays_gone_across_a_restart` | `rx_session_remove` persist removed | FAILED ✓ |
+| `the_last_mutation_before_a_crash_is_durable` | `gx_session_update` persist removed | FAILED ✓ |
+| `an_rx_binding_added_and_nothing_else_is_durable` | `rx_session_add` persist removed | FAILED ✓ |
+| `a_newer_snapshot_is_refused_and_not_overwritten` | version comparison short-circuited | FAILED ✓ |
+
+### The revert pass found a real defect in my own work
+
+`a_pre_restart_session_still_resolves_after_a_simulated_restart` **passed with
+`gx_session_update`'s persist removed**, because the snapshot is a full-store
+document and the `rx_session_add` that followed captured the update's changes
+anyway. So that test proved "something persisted", not "this mutator persisted".
+Chasing it found that **`rx_session_add` had no persist at all** — an edit lost
+between two scripted patches — which the same test also masked, for the same
+reason. Both are now pinned by tests where the mutation in question is the *last*
+thing before the restore, so nothing else can cover for it. Without the revert pass
+this would have shipped as a silent durability hole behind a green test.
+
+### An existing test was inverted, with the spec checked first
+
+`test_handle_ccr_lifecycle_initial_update_termination` asserted that a CCR-U's CCA
+**carries** Default-EPS-Bearer-QoS. Per this project's rule that the old test is
+often right, I checked before touching it: TS 29.212 §4.5.5.9 says the PCRF *"**may**
+provision the authorized QoS for the default EPS bearer"* — permissive, not
+mandatory. The assertion was pinning this implementation's unconditional replay as
+if the spec demanded it. Inverted, with the reason and the two replacement tests
+named at the site.
+
+Workspace: 6140 passed / 0 failed, `cargo clippy --workspace` and
+`cargo fmt --all --check` clean.
+
+## Ceilings
+
+* **No wire interop.** All Gx behaviour is verified in-process against this tree's
+  own Diameter codec, with a real encode/decode round trip on every message
+  (`roundtrip()`), but no third-party PCEF. "Conformant" means "matches the vendored
+  TS 29.212 text and AVP table".
+* **The reacting policy is the default profile.** `build_subscriber_session_data`'s
+  Mongo lookup always fails in this binary (documented, pre-existing), so
+  "re-derived from the subscription" is exercised against the fallback profile.
+  What the tests pin is the *decision logic* and that the CCA carries authorized
+  rather than reported values — not a per-subscriber policy difference.
+* **RAT_CHANGE re-authorizes but applies no RAT-specific policy.** Nothing in the
+  subscription model is RAT-dependent, and inventing a per-RAT rule would be policy
+  this project has not decided. The trigger is now honoured in the sense §4.5.1
+  requires (the answer is a function of the report); a per-RAT authorization rule is
+  a separate product decision.
+* **No RAR is built for a rule change.** An update never re-installs rules; a
+  genuine PCRF-initiated rule change goes out as a RAR, which this path does not
+  build. Unchanged from before #57.
+* **Durable state is not enabled in the shipped Docker EPC compose**, so the E2E
+  path is unchanged and does not exercise it.
+* **GitNexus impact analysis unrunnable** (53rd consecutive PR): the MCP server is
+  not connected, so `CLAUDE.md`'s `gitnexus_impact` mandate could not be satisfied.
+  Blast radius established by grep; the only signature change is
+  `build_cca_success`, whose callers are `handle_ccr` and the tests.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2933,6 +2933,7 @@ dependencies = [
  "nextgcore-metrics",
  "proptest",
  "serde",
+ "serde_json",
  "serde_yaml",
  "thiserror 1.0.69",
  "tokio",

--- a/src/bins/nextgcore-pcrfd/Cargo.toml
+++ b/src/bins/nextgcore-pcrfd/Cargo.toml
@@ -27,6 +27,8 @@ tokio.workspace = true
 bytes.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
+# Issue #57: the durable session snapshot document.
+serde_json.workspace = true
 
 # Internal crates
 nextgcore-core = { path = "../../libs/nextgcore-core" }

--- a/src/bins/nextgcore-pcrfd/src/context.rs
+++ b/src/bins/nextgcore-pcrfd/src/context.rs
@@ -16,7 +16,8 @@ pub const NEXTGCORE_MAX_NUM_OF_PCC_RULE: usize = 8;
 pub const NEXTGCORE_IPV6_LEN: usize = 16;
 
 /// PCRF Rx Session State - represents an Rx session linked to a Gx session
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default = "PcrfRxSession::snapshot_default")]
 pub struct PcrfRxSession {
     /// Rx Session-Id
     pub sid: String,
@@ -38,10 +39,17 @@ impl PcrfRxSession {
             pcc_rules: Vec::new(),
         }
     }
+
+    /// Per-field fallback for deserialising a snapshot written before a member
+    /// existed (#57). Not a `Default` impl: an empty `sid` names no session.
+    fn snapshot_default() -> Self {
+        Self::new("", 0)
+    }
 }
 
 /// PCC Rule structure
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct PccRule {
     /// Rule name
     pub name: String,
@@ -56,7 +64,8 @@ pub struct PccRule {
 }
 
 /// PCRF Gx Session State - represents a Gx session with P-GW
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default = "PcrfGxSession::snapshot_default")]
 pub struct PcrfGxSession {
     /// Gx Session-Id
     pub sid: String,
@@ -74,8 +83,21 @@ pub struct PcrfGxSession {
     pub has_ipv6: bool,
     /// Framed IPv6 prefix
     pub ipv6_addr: Option<[u8; NEXTGCORE_IPV6_LEN]>,
-    /// RAT type
+    /// RAT type the PCEF reported (TS 29.212 §5.3.31). `0` = WLAN is a real
+    /// value, so `reported_rat` distinguishes "never reported" from "reported 0".
     pub rat_type: u32,
+    /// Whether `rat_type` came from a CCR rather than being the initial zero
+    /// (#57). Before #57 this field was hardcoded `0` and never populated, so a
+    /// reader could not tell an unreported RAT from a WLAN one.
+    pub reported_rat: bool,
+    /// Names of the PCC rules the PCRF believes are installed at the PCEF for the
+    /// session as a whole (#57).
+    ///
+    /// Maintained so a Charging-Rule-Report saying a rule went INACTIVE has
+    /// something to remove it from. Without it the PCRF has no record of what it
+    /// provisioned and so cannot act on a failure report at all
+    /// (TS 29.212 §4.5.12).
+    pub installed_rules: Vec<String>,
     /// List of Rx session indices
     pub rx_sessions: Vec<usize>,
 }
@@ -93,8 +115,34 @@ impl PcrfGxSession {
             has_ipv6: false,
             ipv6_addr: None,
             rat_type: 0,
+            reported_rat: false,
+            installed_rules: Vec::new(),
             rx_sessions: Vec::new(),
         }
+    }
+
+    /// Record the RAT-Type the PCEF reported (#57).
+    ///
+    /// Returns `true` when this is a *change* from a previously reported value —
+    /// the first report is not a change, so a session whose initial CCR carried a
+    /// RAT is not treated as having handed over.
+    pub fn set_rat_type(&mut self, rat_type: u32) -> bool {
+        let changed = self.reported_rat && self.rat_type != rat_type;
+        self.rat_type = rat_type;
+        self.reported_rat = true;
+        changed
+    }
+
+    /// Record the rule names the PCRF has provisioned to the PCEF (#57).
+    pub fn set_installed_rules(&mut self, names: Vec<String>) {
+        self.installed_rules = names;
+    }
+
+    /// Drop `name` from the installed set. `true` when it was there.
+    pub fn remove_installed_rule(&mut self, name: &str) -> bool {
+        let before = self.installed_rules.len();
+        self.installed_rules.retain(|n| n != name);
+        self.installed_rules.len() != before
     }
 
     /// Set peer host
@@ -134,6 +182,12 @@ impl PcrfGxSession {
     /// Remove Rx session
     pub fn remove_rx_session(&mut self, rx_idx: usize) {
         self.rx_sessions.retain(|&idx| idx != rx_idx);
+    }
+
+    /// Per-field fallback for deserialising a snapshot written before a member
+    /// existed (#57). Not a `Default` impl: an empty `sid` names no session.
+    fn snapshot_default() -> Self {
+        Self::new("")
     }
 }
 
@@ -180,6 +234,35 @@ pub struct PcrfContext {
     initialized: AtomicBool,
     /// Maximum sessions
     max_sess: AtomicUsize,
+
+    /// Durable snapshot of the Gx/Rx session tables and the IP maps (#57).
+    ///
+    /// Disabled unless a state file is configured, in which case behaviour is
+    /// byte-identical to before. `StateStore` rather than the
+    /// `read_snapshot`/`write_snapshot` free functions: it enforces "never
+    /// overwrite a snapshot you could not read" internally.
+    state: nextgcore_core::state_store::StateStore,
+}
+
+/// Why pcrfd durable state could not be loaded (#57).
+#[derive(Debug, thiserror::Error)]
+pub enum PcrfStateError {
+    /// The snapshot file itself could not be read or parsed.
+    #[error(transparent)]
+    Store(#[from] nextgcore_core::state_store::StateStoreError),
+    /// The snapshot was written by a newer build. Refused rather than partially
+    /// restored: restoring only what this build recognises and then persisting
+    /// would rewrite a newer-format file in the older format, discarding the rest.
+    #[error(
+        "state file {path} was written by a newer pcrfd (snapshot version {found}; this build \
+         understands {supported}). Refusing to restore or overwrite it. Run the newer build, or \
+         move the file aside to start fresh."
+    )]
+    UnsupportedVersion {
+        path: std::path::PathBuf,
+        found: u64,
+        supported: u64,
+    },
 }
 
 impl PcrfContext {
@@ -201,6 +284,7 @@ impl PcrfContext {
             rx_sid_hash: RwLock::new(HashMap::new()),
             initialized: AtomicBool::new(false),
             max_sess: AtomicUsize::new(1024),
+            state: nextgcore_core::state_store::StateStore::disabled(),
         }
     }
 
@@ -222,12 +306,239 @@ impl PcrfContext {
             return;
         }
 
+        // #57: DISABLE the store before clearing anything. The two removals below
+        // empty every table, and pcrfd has a Diameter listener that can still reach
+        // a mutation during shutdown -- so a persist reached afterwards would write
+        // an empty snapshot over a good one and lose every live session, which is
+        // the 5002-forever state this snapshot exists to prevent.
+        self.state = nextgcore_core::state_store::StateStore::disabled();
         // Clear all sessions
         self.gx_session_remove_all();
         self.rx_session_remove_all();
 
         self.initialized.store(false, Ordering::SeqCst);
         log::info!("PCRF context finalized");
+    }
+
+    // ── durable state (#57) ──────────────────────────────────────────────────
+
+    /// Snapshot document version. Bump ONLY for a change no `#[serde(default)]`
+    /// can absorb; a bump makes every older snapshot unreadable.
+    pub const SNAPSHOT_VERSION: u64 = 1;
+
+    /// Point this context at a snapshot file and restore any prior state,
+    /// returning how many sessions were installed.
+    ///
+    /// Call once at startup, **after** [`init`](Self::init) and **before** the
+    /// Diameter listener can accept a CCR, so a restored session is never shadowed
+    /// by a fresh one.
+    ///
+    /// An unreadable snapshot is an **error**: the caller should refuse to start
+    /// rather than answer `DIAMETER_UNKNOWN_SESSION_ID` for sessions that exist.
+    pub fn set_state_file(&mut self, path: std::path::PathBuf) -> Result<usize, PcrfStateError> {
+        use nextgcore_core::state_store::{Loaded, StateStore};
+        self.state = StateStore::new(Some(path.clone()));
+        match self.state.load()? {
+            Loaded::Snapshot(doc) => {
+                let restored = self.restore_from(&doc, &path);
+                if restored.is_err() {
+                    // The load itself succeeded, so the store is not poisoned; a
+                    // caller that logged and carried on could overwrite a snapshot
+                    // this build cannot fully read. Disable instead.
+                    self.state = StateStore::disabled();
+                }
+                restored
+            }
+            Loaded::Absent => Ok(0),
+        }
+    }
+
+    /// Whether durable state is armed. `false` is the shipped default.
+    pub fn state_is_enabled(&self) -> bool {
+        self.state.is_enabled()
+    }
+
+    /// Serialize the session tables to one snapshot document.
+    ///
+    /// **Takes one lock at a time.** `gx_session_remove` documents the canonical
+    /// order (primary list before the index and IP hashes); a function holding four
+    /// guards at once would be an inversion waiting to happen, so each table is
+    /// cloned out and its guard dropped before the next is taken.
+    ///
+    /// The **index hashes ARE persisted**, which is the opposite of what the other
+    /// NFs in this tree do, for a reason specific to pcrfd: `gx_session_remove` and
+    /// `rx_session_remove` drop only the hash entry and leave a **tombstone** in
+    /// the vector, because a Gx session's `rx_sessions` and an Rx session's
+    /// `gx_session_idx` are positional indexes that compacting would re-point. So
+    /// the hash — not the vector — is the record of which sessions are live, and it
+    /// is not derivable from the list. Rebuilding it from every vector entry would
+    /// resurrect every session ever removed. Only the sid→index key set is kept;
+    /// the indexes themselves are re-derived from position, so a persisted index
+    /// cannot disagree with the list it points into.
+    fn snapshot(&self) -> serde_json::Value {
+        let gx: Vec<PcrfGxSession> = self
+            .gx_sessions
+            .read()
+            .map(|v| v.clone())
+            .unwrap_or_default();
+        let live_gx: std::collections::BTreeSet<String> = self
+            .gx_sid_hash
+            .read()
+            .map(|h| h.keys().cloned().collect())
+            .unwrap_or_default();
+        let rx: Vec<PcrfRxSession> = self
+            .rx_sessions
+            .read()
+            .map(|v| v.clone())
+            .unwrap_or_default();
+        let live_rx: std::collections::BTreeSet<String> = self
+            .rx_sid_hash
+            .read()
+            .map(|h| h.keys().cloned().collect())
+            .unwrap_or_default();
+        serde_json::json!({
+            "version": Self::SNAPSHOT_VERSION,
+            // Positional: a Gx session's `rx_sessions` and an Rx session's
+            // `gx_session_idx` are INDEXES into these vectors, so the order is part
+            // of the data. Sorting or de-duplicating here would silently re-point
+            // every binding.
+            "gxSessions": gx,
+            "rxSessions": rx,
+            // BTreeSet so the file does not churn on hash iteration order.
+            "liveGxSids": live_gx,
+            "liveRxSids": live_rx,
+        })
+    }
+
+    /// Restore the session tables, re-index the **live** sessions, and rebuild both
+    /// IP maps.
+    ///
+    /// Liveness comes from the persisted sid sets (see [`snapshot`](Self::snapshot)
+    /// for why); the indexes themselves are re-derived from vector position, so
+    /// they cannot disagree with the list. The IP maps are rebuilt under the same
+    /// conditions the live path uses (`has_ipv4`/`has_ipv6` with an address
+    /// present) and only for live sessions, so the restored map has exactly the
+    /// entries the live one would — a tombstone's old address does not come back
+    /// pointing at a session that no longer answers.
+    fn restore_from(
+        &self,
+        doc: &serde_json::Value,
+        path: &std::path::Path,
+    ) -> Result<usize, PcrfStateError> {
+        let found = doc
+            .get("version")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(Self::SNAPSHOT_VERSION);
+        if found > Self::SNAPSHOT_VERSION {
+            return Err(PcrfStateError::UnsupportedVersion {
+                path: path.to_path_buf(),
+                found,
+                supported: Self::SNAPSHOT_VERSION,
+            });
+        }
+
+        // Whole-vector deserialise, NOT per-record: the vectors are positional and
+        // skipping one malformed record would shift every later index, re-pointing
+        // `gx_session_idx` and `rx_sessions` at the wrong sessions. An unreadable
+        // table restores as empty, which is the pre-#57 behaviour, rather than as a
+        // silently re-indexed one.
+        let gx: Vec<PcrfGxSession> = doc
+            .get("gxSessions")
+            .and_then(
+                |v| match serde_json::from_value::<Vec<PcrfGxSession>>(v.clone()) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        log::error!("PCRF gxSessions table unreadable, restoring none: {e}");
+                        None
+                    }
+                },
+            )
+            .unwrap_or_default();
+        let rx: Vec<PcrfRxSession> = doc
+            .get("rxSessions")
+            .and_then(
+                |v| match serde_json::from_value::<Vec<PcrfRxSession>>(v.clone()) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        log::error!("PCRF rxSessions table unreadable, restoring none: {e}");
+                        None
+                    }
+                },
+            )
+            .unwrap_or_default();
+        let live_gx: std::collections::HashSet<String> = doc
+            .get("liveGxSids")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+        let live_rx: std::collections::HashSet<String> = doc
+            .get("liveRxSids")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        if let (Ok(mut list), Ok(mut hash), Ok(mut v4), Ok(mut v6)) = (
+            self.gx_sessions.write(),
+            self.gx_sid_hash.write(),
+            self.ipv4_hash.write(),
+            self.ipv6_hash.write(),
+        ) {
+            for (idx, session) in gx.iter().enumerate() {
+                if !live_gx.contains(&session.sid) {
+                    // A tombstone left by `gx_session_remove`. Kept in the vector so
+                    // later indexes still resolve, but NOT re-indexed: doing so would
+                    // resurrect a terminated session and answer CCR-Us for it.
+                    continue;
+                }
+                hash.insert(session.sid.clone(), idx);
+                if session.has_ipv4 {
+                    if let Some(addr) = session.ipv4_addr {
+                        v4.insert(u32::from(addr), session.sid.clone());
+                    }
+                }
+                if session.has_ipv6 {
+                    if let Some(addr) = session.ipv6_addr {
+                        v6.insert(addr, session.sid.clone());
+                    }
+                }
+            }
+            *list = gx;
+        }
+        if let (Ok(mut list), Ok(mut hash)) = (self.rx_sessions.write(), self.rx_sid_hash.write()) {
+            for (idx, session) in rx.iter().enumerate() {
+                if !live_rx.contains(&session.sid) {
+                    continue;
+                }
+                hash.insert(session.sid.clone(), idx);
+            }
+            *list = rx;
+        }
+        let restored = self.gx_session_count() + self.rx_session_count();
+
+        log::info!(
+            "PCRF durable state restored: {} Gx session(s), {} Rx session(s); a CCR-U or CCR-T for \
+             any of them is answered instead of DIAMETER_UNKNOWN_SESSION_ID",
+            self.gx_session_count(),
+            self.rx_session_count(),
+        );
+        Ok(restored)
+    }
+
+    /// Write the snapshot after a mutation. A no-op with no state file, and
+    /// refused (loudly) when the previous load failed.
+    ///
+    /// **Every caller must have dropped its write guards first.** `persist` ->
+    /// `snapshot` takes read locks on the same tables and `std::sync::RwLock` is
+    /// not reentrant, so calling this while holding `gx_sessions.write()`
+    /// deadlocks the calling thread.
+    pub fn persist(&self) {
+        if !self.state.is_enabled() {
+            return;
+        }
+        let doc = self.snapshot();
+        if let Err(e) = self.state.persist(&doc) {
+            // The session exists in memory but not on disk: the CCR was answered
+            // and a restart will reject its updates with 5002.
+            log::error!("PCRF state was NOT persisted: {e}");
+        }
     }
 
     /// Check if context is initialized
@@ -239,19 +550,25 @@ impl PcrfContext {
 
     /// Add a new Gx session
     pub fn gx_session_add(&self, sid: &str) -> Option<usize> {
-        let mut sessions = self.gx_sessions.write().ok()?;
-        let mut hash = self.gx_sid_hash.write().ok()?;
+        // #57: scoped so both guards drop before `persist` re-reads them.
+        let (idx, added) = {
+            let mut sessions = self.gx_sessions.write().ok()?;
+            let mut hash = self.gx_sid_hash.write().ok()?;
 
-        if hash.contains_key(sid) {
-            return hash.get(sid).copied();
+            if let Some(&existing) = hash.get(sid) {
+                (existing, false)
+            } else {
+                let session = PcrfGxSession::new(sid);
+                let idx = sessions.len();
+                sessions.push(session);
+                hash.insert(sid.to_string(), idx);
+                log::debug!("Gx session added: {sid}");
+                (idx, true)
+            }
+        };
+        if added {
+            self.persist();
         }
-
-        let session = PcrfGxSession::new(sid);
-        let idx = sessions.len();
-        sessions.push(session);
-        hash.insert(sid.to_string(), idx);
-
-        log::debug!("Gx session added: {sid}");
         Some(idx)
     }
 
@@ -274,42 +591,61 @@ impl PcrfContext {
     where
         F: FnOnce(&mut PcrfGxSession),
     {
-        if let (Ok(mut sessions), Ok(hash)) = (self.gx_sessions.write(), self.gx_sid_hash.read()) {
-            if let Some(&idx) = hash.get(sid) {
-                if let Some(session) = sessions.get_mut(idx) {
-                    f(session);
-                    return true;
+        let updated = {
+            if let (Ok(mut sessions), Ok(hash)) =
+                (self.gx_sessions.write(), self.gx_sid_hash.read())
+            {
+                match hash.get(sid).and_then(|&idx| sessions.get_mut(idx)) {
+                    Some(session) => {
+                        f(session);
+                        true
+                    }
+                    None => false,
                 }
+            } else {
+                false
             }
+        };
+        if updated {
+            self.persist();
         }
-        false
+        updated
     }
 
     /// Remove Gx session
     pub fn gx_session_remove(&self, sid: &str) -> bool {
-        // AB-BA: primary list (gx_sessions) before index/IP hashes — canonical order
-        let sessions = self.gx_sessions.read();
-        let mut hash = self.gx_sid_hash.write().unwrap();
-        let mut ipv4_hash = self.ipv4_hash.write().unwrap();
-        let mut ipv6_hash = self.ipv6_hash.write().unwrap();
+        // #57: scoped so every guard drops before `persist` re-reads them.
+        let removed = {
+            // AB-BA: primary list (gx_sessions) before index/IP hashes — canonical order
+            let sessions = self.gx_sessions.read();
+            let mut hash = self.gx_sid_hash.write().unwrap();
+            let mut ipv4_hash = self.ipv4_hash.write().unwrap();
+            let mut ipv6_hash = self.ipv6_hash.write().unwrap();
 
-        if let Some(&idx) = hash.get(sid) {
-            // Remove IP mappings
-            if let Ok(ref sessions) = sessions {
-                if let Some(session) = sessions.get(idx) {
-                    if let Some(addr) = session.ipv4_addr {
-                        ipv4_hash.remove(&u32::from(addr));
+            match hash.get(sid).copied() {
+                Some(idx) => {
+                    // Remove IP mappings
+                    if let Ok(ref sessions) = sessions {
+                        if let Some(session) = sessions.get(idx) {
+                            if let Some(addr) = session.ipv4_addr {
+                                ipv4_hash.remove(&u32::from(addr));
+                            }
+                            if let Some(addr) = session.ipv6_addr {
+                                ipv6_hash.remove(&addr);
+                            }
+                        }
                     }
-                    if let Some(addr) = session.ipv6_addr {
-                        ipv6_hash.remove(&addr);
-                    }
+                    hash.remove(sid);
+                    log::debug!("Gx session removed: {sid}");
+                    true
                 }
+                None => false,
             }
-            hash.remove(sid);
-            log::debug!("Gx session removed: {sid}");
-            return true;
+        };
+        if removed {
+            self.persist();
         }
-        false
+        removed
     }
 
     /// Remove all Gx sessions
@@ -336,6 +672,10 @@ impl PcrfContext {
 
     /// Set IPv4 to Session-Id mapping
     pub fn set_ipv4_mapping(&self, addr: &[u8; 4], sid: Option<&str>) {
+        // Not persisted here: the IPv4 map is DERIVED from the session table on
+        // restore (see `restore_from`), so snapshotting on a map-only change would
+        // write a document whose map half is regenerated anyway. Every caller also
+        // updates the session's own address, and that path persists.
         let mut hash = self.ipv4_hash.write().unwrap();
         let key = u32::from_be_bytes(*addr);
 
@@ -378,26 +718,34 @@ impl PcrfContext {
 
     /// Add a new Rx session
     pub fn rx_session_add(&self, sid: &str, gx_session_idx: usize) -> Option<usize> {
-        let mut sessions = self.rx_sessions.write().ok()?;
-        let mut hash = self.rx_sid_hash.write().ok()?;
+        // #57: scoped so every guard drops before `persist` re-reads them.
+        let (idx, added) = {
+            let mut sessions = self.rx_sessions.write().ok()?;
+            let mut hash = self.rx_sid_hash.write().ok()?;
 
-        if hash.contains_key(sid) {
-            return hash.get(sid).copied();
-        }
+            match hash.get(sid).copied() {
+                Some(existing) => (existing, false),
+                None => {
+                    let session = PcrfRxSession::new(sid, gx_session_idx);
+                    let idx = sessions.len();
+                    sessions.push(session);
+                    hash.insert(sid.to_string(), idx);
 
-        let session = PcrfRxSession::new(sid, gx_session_idx);
-        let idx = sessions.len();
-        sessions.push(session);
-        hash.insert(sid.to_string(), idx);
+                    // Add to Gx session's rx_sessions list
+                    if let Ok(mut gx_sessions) = self.gx_sessions.write() {
+                        if let Some(gx_session) = gx_sessions.get_mut(gx_session_idx) {
+                            gx_session.add_rx_session(idx);
+                        }
+                    }
 
-        // Add to Gx session's rx_sessions list
-        if let Ok(mut gx_sessions) = self.gx_sessions.write() {
-            if let Some(gx_session) = gx_sessions.get_mut(gx_session_idx) {
-                gx_session.add_rx_session(idx);
+                    log::debug!("Rx session added: {sid} (gx_idx={gx_session_idx})");
+                    (idx, true)
+                }
             }
+        };
+        if added {
+            self.persist();
         }
-
-        log::debug!("Rx session added: {sid} (gx_idx={gx_session_idx})");
         Some(idx)
     }
 
@@ -427,15 +775,25 @@ impl PcrfContext {
     where
         F: FnOnce(&mut PcrfRxSession),
     {
-        if let (Ok(mut sessions), Ok(hash)) = (self.rx_sessions.write(), self.rx_sid_hash.read()) {
-            if let Some(&idx) = hash.get(sid) {
-                if let Some(session) = sessions.get_mut(idx) {
-                    f(session);
-                    return true;
+        let updated = {
+            if let (Ok(mut sessions), Ok(hash)) =
+                (self.rx_sessions.write(), self.rx_sid_hash.read())
+            {
+                match hash.get(sid).and_then(|&idx| sessions.get_mut(idx)) {
+                    Some(session) => {
+                        f(session);
+                        true
+                    }
+                    None => false,
                 }
+            } else {
+                false
             }
+        };
+        if updated {
+            self.persist();
         }
-        false
+        updated
     }
 
     /// Find Gx session by index (as referenced from an Rx session binding)
@@ -453,27 +811,36 @@ impl PcrfContext {
 
     /// Remove Rx session
     pub fn rx_session_remove(&self, sid: &str) -> bool {
-        // AB-BA: primary list (rx_sessions) before index (rx_sid_hash) — canonical order
-        let rx_sessions = self.rx_sessions.read();
-        let mut hash = self.rx_sid_hash.write().unwrap();
+        // #57: scoped so every guard drops before `persist` re-reads them.
+        let removed = {
+            // AB-BA: primary list (rx_sessions) before index (rx_sid_hash) — canonical order
+            let rx_sessions = self.rx_sessions.read();
+            let mut hash = self.rx_sid_hash.write().unwrap();
 
-        if let Some(&idx) = hash.get(sid) {
-            // Remove from Gx session's rx_sessions list
-            if let Ok(ref rx_sessions) = rx_sessions {
-                if let Some(rx_session) = rx_sessions.get(idx) {
-                    let gx_idx = rx_session.gx_session_idx;
-                    if let Ok(mut gx_sessions) = self.gx_sessions.write() {
-                        if let Some(gx_session) = gx_sessions.get_mut(gx_idx) {
-                            gx_session.remove_rx_session(idx);
+            match hash.get(sid).copied() {
+                Some(idx) => {
+                    // Remove from Gx session's rx_sessions list
+                    if let Ok(ref rx_sessions) = rx_sessions {
+                        if let Some(rx_session) = rx_sessions.get(idx) {
+                            let gx_idx = rx_session.gx_session_idx;
+                            if let Ok(mut gx_sessions) = self.gx_sessions.write() {
+                                if let Some(gx_session) = gx_sessions.get_mut(gx_idx) {
+                                    gx_session.remove_rx_session(idx);
+                                }
+                            }
                         }
                     }
+                    hash.remove(sid);
+                    log::debug!("Rx session removed: {sid}");
+                    true
                 }
+                None => false,
             }
-            hash.remove(sid);
-            log::debug!("Rx session removed: {sid}");
-            return true;
+        };
+        if removed {
+            self.persist();
         }
-        false
+        removed
     }
 
     /// Remove all Rx sessions
@@ -905,5 +1272,346 @@ mod tests {
             Some("conf.realm"),
             "what the YAML omits still comes from the .conf"
         );
+    }
+
+    // ── durable state (#57) ──────────────────────────────────────────────────
+    //
+    // Every test here builds its own `PcrfContext`, never `pcrf_self()`: arming a
+    // state file on the process-global context would make one test's snapshot the
+    // next test's restored state.
+
+    /// Unique snapshot path per test so parallel runs cannot collide.
+    fn temp_state_path(tag: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "nextgcore-pcrf-state-{}-{tag}-{nanos}.json",
+            std::process::id()
+        ))
+    }
+
+    fn ctx_with_state(path: &std::path::Path) -> PcrfContext {
+        let mut ctx = PcrfContext::new();
+        ctx.init(1024);
+        ctx.set_state_file(path.to_path_buf())
+            .expect("arming a fresh state file must succeed");
+        ctx
+    }
+
+    /// #57 criterion 5, the persistence path: after a simulated restart a CCR-U or
+    /// CCR-T for a pre-restart session resolves, so it is no longer answered
+    /// DIAMETER_UNKNOWN_SESSION_ID (5002) forever.
+    #[test]
+    fn a_pre_restart_session_still_resolves_after_a_simulated_restart() {
+        let path = temp_state_path("restart");
+        let sid = "gx-restart-1";
+        let rx_sid = "rx-restart-1";
+        {
+            let ctx = ctx_with_state(&path);
+            let gx_idx = ctx.gx_session_add(sid).expect("gx session");
+            ctx.gx_session_update(sid, |s| {
+                s.set_peer_host("pgw.example.com");
+                s.set_imsi("001010123456789");
+                s.set_apn("internet");
+                s.set_ipv4(Ipv4Addr::new(10, 45, 0, 2));
+                s.set_rat_type(1004);
+                s.set_installed_rules(vec!["pcrf-internet-default".to_string()]);
+            });
+            ctx.set_ipv4_mapping(&[10, 45, 0, 2], Some(sid));
+            ctx.rx_session_add(rx_sid, gx_idx).expect("rx session");
+            ctx.rx_session_update(rx_sid, |rx| {
+                rx.peer_host = Some("pcscf.example.com".to_string());
+                rx.pcc_rules.push(PccRule {
+                    name: "rx-voice-1".to_string(),
+                    qos_index: 1,
+                    flow_status: 2,
+                    precedence: 50,
+                    num_of_flow: 1,
+                });
+            });
+        }
+
+        // A cold rebuild from the same file: a different process would do exactly
+        // this, and nothing carries over except the snapshot.
+        let restored = ctx_with_state(&path);
+
+        let session = restored
+            .gx_session_find_by_sid(sid)
+            .expect("the CCR-U/CCR-T lookup that used to answer 5002 must resolve");
+        assert_eq!(session.peer_host.as_deref(), Some("pgw.example.com"));
+        assert_eq!(session.imsi_bcd.as_deref(), Some("001010123456789"));
+        assert_eq!(session.apn.as_deref(), Some("internet"));
+        assert_eq!(session.ipv4_addr, Some(Ipv4Addr::new(10, 45, 0, 2)));
+        assert_eq!(session.rat_type, 1004);
+        assert!(session.reported_rat);
+        assert_eq!(
+            session.installed_rules,
+            vec!["pcrf-internet-default".to_string()],
+            "without the installed set a post-restart rule report has nothing to act on"
+        );
+        // The IPv4 map is DERIVED on restore, so this also proves the derivation.
+        assert_eq!(
+            restored.find_sid_by_ipv4(&[10, 45, 0, 2]).as_deref(),
+            Some(sid)
+        );
+
+        // The Rx binding survives in both directions, or the PCRF could not abort
+        // the AF for a restored session.
+        let rx = restored
+            .rx_session_find_by_sid(rx_sid)
+            .expect("Rx session restored");
+        assert_eq!(rx.peer_host.as_deref(), Some("pcscf.example.com"));
+        assert_eq!(rx.pcc_rules.len(), 1);
+        assert_eq!(
+            session.rx_sessions,
+            vec![0],
+            "the Gx -> Rx index binding survives"
+        );
+        assert_eq!(
+            restored.rx_session_find_by_idx(0).map(|r| r.sid),
+            Some(rx_sid.to_string()),
+            "and resolves by index, which is how handle_ccr walks it"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Each mutator must persist on its own, not rely on a later one doing it.
+    ///
+    /// Written after noticing that
+    /// `a_pre_restart_session_still_resolves_after_a_simulated_restart` still
+    /// passed with `gx_session_update`'s persist removed: the snapshot is a
+    /// full-store document, so the `rx_session_add` that followed captured the
+    /// update's changes too. That test therefore proves "something persisted", not
+    /// "this mutator persisted". Here the update is the LAST thing that happens
+    /// before the restore, which is the crash-right-after-a-CCR case, so nothing
+    /// else can cover for it.
+    #[test]
+    fn the_last_mutation_before_a_crash_is_durable() {
+        let path = temp_state_path("last-write");
+        let sid = "gx-lastwrite-1";
+        {
+            let ctx = ctx_with_state(&path);
+            ctx.gx_session_add(sid).expect("gx session");
+            // The final mutation, with no later persist to cover for it.
+            ctx.gx_session_update(sid, |s| {
+                s.set_apn("ims");
+                s.set_rat_type(1001);
+            });
+        }
+
+        let restored = ctx_with_state(&path);
+        let session = restored
+            .gx_session_find_by_sid(sid)
+            .expect("session restored");
+        assert_eq!(
+            session.apn.as_deref(),
+            Some("ims"),
+            "the update itself must have reached the file"
+        );
+        assert_eq!(session.rat_type, 1001);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Same shape for the Rx side, and it found a real gap: `rx_session_add` was
+    /// the one mutator with no persist, and
+    /// `a_pre_restart_session_still_resolves_after_a_simulated_restart` did not
+    /// catch it because the `rx_session_update` that followed persisted the whole
+    /// store anyway.
+    #[test]
+    fn an_rx_binding_added_and_nothing_else_is_durable() {
+        let path = temp_state_path("rx-last-write");
+        let sid = "gx-rxlast-1";
+        let rx_sid = "rx-rxlast-1";
+        {
+            let ctx = ctx_with_state(&path);
+            let gx_idx = ctx.gx_session_add(sid).expect("gx session");
+            // The final mutation. No rx_session_update follows.
+            ctx.rx_session_add(rx_sid, gx_idx).expect("rx session");
+        }
+
+        let restored = ctx_with_state(&path);
+        assert!(
+            restored.rx_session_find_by_sid(rx_sid).is_some(),
+            "the Rx binding must have reached the file on its own"
+        );
+        assert_eq!(
+            restored
+                .gx_session_find_by_sid(sid)
+                .expect("gx session")
+                .rx_sessions,
+            vec![0],
+            "and so must the Gx -> Rx back-reference the add installed"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// An Rx session aborted by a rule report must stay gone across a restart.
+    ///
+    /// `withdraw_rule_from_rx_sessions` removes the Rx session it just told the AF
+    /// to abort; if that removal were not durable the restart would resurrect an Rx
+    /// session whose AF has already torn its own side down, and the next rule report
+    /// would try to abort it a second time.
+    #[test]
+    fn an_aborted_rx_session_stays_gone_across_a_restart() {
+        let path = temp_state_path("rx-abort");
+        let sid = "gx-rxabort-1";
+        let rx_sid = "rx-rxabort-1";
+        {
+            let ctx = ctx_with_state(&path);
+            let gx_idx = ctx.gx_session_add(sid).expect("gx session");
+            ctx.rx_session_add(rx_sid, gx_idx).expect("rx session");
+            // The final mutation.
+            assert!(ctx.rx_session_remove(rx_sid));
+        }
+
+        let restored = ctx_with_state(&path);
+        assert!(
+            restored.rx_session_find_by_sid(rx_sid).is_none(),
+            "an aborted Rx session must not come back"
+        );
+        assert_eq!(restored.rx_session_count(), 0);
+        assert!(
+            restored
+                .gx_session_find_by_sid(sid)
+                .expect("gx session")
+                .rx_sessions
+                .is_empty(),
+            "and the Gx side must not still point at it"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The tombstone hazard: `gx_session_remove` drops only the hash entry and
+    /// leaves the vector entry in place, so a restore that re-indexed every vector
+    /// entry would RESURRECT terminated sessions and answer CCR-Us for them.
+    #[test]
+    fn a_terminated_session_is_not_resurrected_by_a_restore() {
+        let path = temp_state_path("tombstone");
+        {
+            let ctx = ctx_with_state(&path);
+            ctx.gx_session_add("gx-tomb-live").expect("live");
+            ctx.gx_session_add("gx-tomb-dead").expect("dead");
+            ctx.gx_session_update("gx-tomb-dead", |s| {
+                s.set_ipv4(Ipv4Addr::new(10, 45, 9, 9));
+            });
+            ctx.set_ipv4_mapping(&[10, 45, 9, 9], Some("gx-tomb-dead"));
+            assert!(ctx.gx_session_remove("gx-tomb-dead"));
+        }
+
+        let restored = ctx_with_state(&path);
+        assert!(
+            restored.gx_session_find_by_sid("gx-tomb-live").is_some(),
+            "the live session must come back"
+        );
+        assert!(
+            restored.gx_session_find_by_sid("gx-tomb-dead").is_none(),
+            "a terminated session must NOT come back; answering its CCR-U would be worse \
+             than 5002"
+        );
+        assert_eq!(restored.gx_session_count(), 1);
+        assert_eq!(
+            restored.find_sid_by_ipv4(&[10, 45, 9, 9]),
+            None,
+            "and its address must not resolve to it either"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The shipped default: no state file means no file operations at all.
+    #[test]
+    fn without_a_state_file_nothing_is_persisted() {
+        let dir = std::env::temp_dir().join(format!(
+            "nextgcore-pcrf-nostate-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+
+        // Positive control FIRST, so the absence assertion below is known to be
+        // capable of failing: an armed context writing into this same directory
+        // must be visible to the scan.
+        {
+            let armed = ctx_with_state(&dir.join("armed.json"));
+            armed.gx_session_add("gx-control").expect("session");
+        }
+        assert!(
+            dir.join("armed.json").exists(),
+            "positive control: an armed store must write into the watched directory"
+        );
+        std::fs::remove_file(dir.join("armed.json")).expect("clear the control");
+
+        let mut ctx = PcrfContext::new();
+        ctx.init(1024);
+        assert!(!ctx.state_is_enabled());
+        let idx = ctx.gx_session_add("gx-nostate").expect("session");
+        ctx.gx_session_update("gx-nostate", |s| s.set_apn("internet"));
+        ctx.rx_session_add("rx-nostate", idx).expect("rx");
+        ctx.rx_session_update("rx-nostate", |r| r.peer_host = Some("af".to_string()));
+        ctx.set_ipv4_mapping(&[10, 45, 0, 3], Some("gx-nostate"));
+        ctx.rx_session_remove("rx-nostate");
+        ctx.gx_session_remove("gx-nostate");
+        ctx.fini();
+
+        let entries: Vec<_> = std::fs::read_dir(&dir)
+            .expect("read temp dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "a memory-only PCRF must touch no files, found {entries:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A snapshot from a newer build must be refused AND left alone, not partially
+    /// restored and then rewritten in the older format.
+    #[test]
+    fn a_newer_snapshot_is_refused_and_not_overwritten() {
+        let path = temp_state_path("newer");
+        let doc = serde_json::json!({
+            "version": PcrfContext::SNAPSHOT_VERSION + 1,
+            "gxSessions": [],
+            "rxSessions": [],
+            "liveGxSids": [],
+            "liveRxSids": [],
+        });
+        let before = serde_json::to_vec_pretty(&doc).expect("serialise");
+        std::fs::write(&path, &before).expect("write snapshot");
+
+        let mut ctx = PcrfContext::new();
+        ctx.init(1024);
+        let err = ctx
+            .set_state_file(path.clone())
+            .expect_err("a newer snapshot must be refused");
+        assert!(
+            matches!(err, PcrfStateError::UnsupportedVersion { .. }),
+            "got {err:?}"
+        );
+        assert!(
+            !ctx.state_is_enabled(),
+            "the store must be disabled so a later mutation cannot rewrite the file"
+        );
+
+        // Prove the refusal protects the file.
+        ctx.gx_session_add("gx-after-refusal");
+        assert_eq!(
+            std::fs::read(&path).expect("file still there"),
+            before,
+            "the newer-format file must be byte-identical after a refused load"
+        );
+
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/bins/nextgcore-pcrfd/src/gx_path.rs
+++ b/src/bins/nextgcore-pcrfd/src/gx_path.rs
@@ -12,7 +12,9 @@ use bytes::Bytes;
 
 use nextgcore_diameter::avp::{find_all_avps, find_avp, Avp, AvpData};
 use nextgcore_diameter::common::avp_code;
-use nextgcore_diameter::gx::{avp as gx_avp, cmd as gx_cmd, GX_APPLICATION_ID};
+use nextgcore_diameter::gx::{
+    avp as gx_avp, cmd as gx_cmd, pcc_rule_status as gx_pcc_rule_status, GX_APPLICATION_ID,
+};
 use nextgcore_diameter::message::DiameterMessage;
 use nextgcore_diameter::NEXTGCORE_3GPP_VENDOR_ID;
 
@@ -216,6 +218,68 @@ pub struct MediaSubComponent {
 // CCR parsing (TS 29.212 section 5.6.2)
 // ============================================================================
 
+/// QoS the PCEF reported in a CCR (TS 29.212 §5.3.16 QoS-Information).
+///
+/// This is what the PCEF says is currently in force, NOT what the PCRF
+/// authorized — the two diverging is exactly what a QOS_CHANGE report is for.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReportedQos {
+    /// APN-Aggregate-Max-Bitrate-UL (bps), when reported
+    pub ambr_uplink: Option<u64>,
+    /// APN-Aggregate-Max-Bitrate-DL (bps), when reported
+    pub ambr_downlink: Option<u64>,
+    /// QoS-Class-Identifier, when reported
+    pub qos_index: Option<u8>,
+}
+
+impl ReportedQos {
+    /// Nothing was reported at all.
+    pub fn is_empty(&self) -> bool {
+        self.ambr_uplink.is_none() && self.ambr_downlink.is_none() && self.qos_index.is_none()
+    }
+
+    /// Does what the PCEF reports differ from what the PCRF authorized?
+    ///
+    /// A member the PCEF did **not** report is not a divergence: absent means
+    /// "not stated", and treating it as a mismatch would make every partial
+    /// report look like a violation and trigger a pointless re-authorization.
+    pub fn diverges_from(&self, authorized: &GxSessionData) -> bool {
+        self.ambr_uplink
+            .is_some_and(|v| v != authorized.ambr_uplink)
+            || self
+                .ambr_downlink
+                .is_some_and(|v| v != authorized.ambr_downlink)
+            || self.qos_index.is_some_and(|v| v != authorized.qos_index)
+    }
+}
+
+/// One Charging-Rule-Report from a CCR (TS 29.212 §5.3.18).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChargingRuleReport {
+    /// Charging-Rule-Name instances (the individually named failed rules)
+    pub rule_names: Vec<String>,
+    /// Charging-Rule-Base-Name instances (named rule *groups*)
+    pub rule_base_names: Vec<String>,
+    /// PCC-Rule-Status, when present
+    pub pcc_rule_status: Option<i32>,
+    /// Rule-Failure-Code, when present
+    pub rule_failure_code: Option<i32>,
+}
+
+impl ChargingRuleReport {
+    /// Does this report say the named rules are gone (as opposed to temporarily
+    /// disabled, or successfully active)?
+    ///
+    /// `TEMPORARILY_INACTIVE` is deliberately **not** included: §5.3.19 defines it
+    /// as "already installed or activated PCC rules are temporarily disabled" for
+    /// a reason such as loss of bearer, so the rule is expected to return.
+    /// Treating it as removed would tear down an AF session that is about to work
+    /// again.
+    pub fn reports_removal(&self) -> bool {
+        self.pcc_rule_status == Some(gx_pcc_rule_status::INACTIVE)
+    }
+}
+
 /// Parsed CCR content
 #[derive(Debug, Clone, Default)]
 pub struct CcrInfo {
@@ -239,6 +303,22 @@ pub struct CcrInfo {
     pub framed_ipv6: Option<[u8; NEXTGCORE_IPV6_LEN]>,
     /// Network-Request-Support was present in the CCR
     pub network_request_support: bool,
+    /// Every Event-Trigger the PCEF reported (TS 29.212 §5.3.7). Repeated AVP:
+    /// one CCR-U can report several triggers at once, so all instances are kept.
+    pub event_triggers: Vec<u32>,
+    /// RAT-Type the PCEF reported (TS 29.212 §5.3.31)
+    pub rat_type: Option<u32>,
+    /// QoS the PCEF reported as currently in force
+    pub reported_qos: ReportedQos,
+    /// Charging-Rule-Report instances (TS 29.212 §5.3.18)
+    pub rule_reports: Vec<ChargingRuleReport>,
+}
+
+impl CcrInfo {
+    /// Did the PCEF report `trigger`?
+    pub fn has_trigger(&self, trigger: u32) -> bool {
+        self.event_triggers.contains(&trigger)
+    }
 }
 
 /// Errors detected while validating a CCR against the TS 29.212 message table
@@ -367,6 +447,33 @@ pub fn parse_ccr(msg: &DiameterMessage) -> Result<CcrInfo, GxRequestError> {
 
     let network_request_support = msg.find_avp(base_avp::NETWORK_REQUEST_SUPPORT).is_some();
 
+    // ---- The IP-CAN-session-modification inputs (#57) ----
+    //
+    // TS 29.212 §4.5.1: "the PCEF shall supply within the PCC rule request the
+    // specific event which caused the IP-CAN session modification (within the
+    // Event-Trigger AVP) and any related data". None of these were read before, so
+    // the PCRF's answer could not be a function of them.
+
+    // Repeated: every instance, not just the first.
+    let event_triggers: Vec<u32> = find_all_avps(&msg.avps, gx_avp::EVENT_TRIGGER)
+        .iter()
+        .filter_map(|a| a.as_u32())
+        .collect();
+
+    // Enumerated on the wire; carried as u32 here because the TS 29.212 value
+    // space is 0..2999 and the session field it lands in is u32.
+    let rat_type = msg
+        .find_avp(gx_avp::RAT_TYPE)
+        .and_then(|a| a.as_u32().or_else(|| a.as_i32().map(|v| v as u32)));
+
+    let reported_qos = parse_reported_qos(msg);
+
+    let rule_reports: Vec<ChargingRuleReport> =
+        find_all_avps(&msg.avps, gx_avp::CHARGING_RULE_REPORT)
+            .iter()
+            .filter_map(|a| parse_charging_rule_report(a))
+            .collect();
+
     Ok(CcrInfo {
         session_id,
         origin_host,
@@ -378,6 +485,78 @@ pub fn parse_ccr(msg: &DiameterMessage) -> Result<CcrInfo, GxRequestError> {
         framed_ipv4,
         framed_ipv6,
         network_request_support,
+        event_triggers,
+        rat_type,
+        reported_qos,
+        rule_reports,
+    })
+}
+
+/// Extract the QoS the PCEF reports as currently in force from a command-level
+/// QoS-Information AVP (TS 29.212 §5.3.16).
+///
+/// Only the command-level instance is read. A QoS-Information nested inside a
+/// Charging-Rule-Definition describes a *rule's* QoS, not the session's, and
+/// conflating the two would compare a rule MBR against the session AMBR.
+fn parse_reported_qos(msg: &DiameterMessage) -> ReportedQos {
+    let Some(qos) = msg.find_avp(gx_avp::QOS_INFORMATION) else {
+        return ReportedQos::default();
+    };
+    let Ok(members) = qos.parse_grouped() else {
+        return ReportedQos::default();
+    };
+    ReportedQos {
+        ambr_uplink: find_avp(&members, gx_avp::APN_AGGREGATE_MAX_BITRATE_UL)
+            .and_then(|a| a.as_u32())
+            .map(u64::from),
+        ambr_downlink: find_avp(&members, gx_avp::APN_AGGREGATE_MAX_BITRATE_DL)
+            .and_then(|a| a.as_u32())
+            .map(u64::from),
+        qos_index: find_avp(&members, gx_avp::QOS_CLASS_IDENTIFIER)
+            .and_then(|a| a.as_u32().or_else(|| a.as_i32().map(|v| v as u32)))
+            .and_then(|v| u8::try_from(v).ok()),
+    }
+}
+
+/// Read an AVP as a string whether it decoded as a UTF8String, a DiameterIdentity
+/// or an OctetString.
+///
+/// Charging-Rule-Name is an OctetString carrying a name (TS 29.212 §5.3.29), and
+/// `Avp::as_utf8_string` does not cover the `OctetString` variant — it covers
+/// `Raw`, which is what an AVP that crossed a socket decodes to. A rule name read
+/// only via `as_utf8_string` therefore works on the wire and silently returns
+/// `None` for a locally constructed message, which is the shape of an existing
+/// recorded defect in this tree. Handling both variants makes the reader
+/// independent of where the message came from.
+fn avp_as_string(avp: &Avp) -> Option<String> {
+    if let Some(s) = avp.as_utf8_string() {
+        return Some(s.to_string());
+    }
+    avp.as_octet_string()
+        .and_then(|b| std::str::from_utf8(b).ok())
+        .map(str::to_string)
+}
+
+/// Parse one Charging-Rule-Report grouped AVP (TS 29.212 §5.3.18).
+///
+/// `None` when the group cannot be decoded at all. A group that decodes but names
+/// no rule is still returned: the PCRF logs it rather than silently dropping a
+/// report the PCEF considered worth sending.
+fn parse_charging_rule_report(avp: &Avp) -> Option<ChargingRuleReport> {
+    let members = avp.parse_grouped().ok()?;
+    Some(ChargingRuleReport {
+        rule_names: find_all_avps(&members, gx_avp::CHARGING_RULE_NAME)
+            .iter()
+            .filter_map(|a| avp_as_string(a))
+            .collect(),
+        rule_base_names: find_all_avps(&members, gx_avp::CHARGING_RULE_BASE_NAME)
+            .iter()
+            .filter_map(|a| avp_as_string(a))
+            .collect(),
+        pcc_rule_status: find_avp(&members, gx_avp::PCC_RULE_STATUS)
+            .and_then(|a| a.as_i32().or_else(|| a.as_u32().map(|v| v as i32))),
+        rule_failure_code: find_avp(&members, gx_avp::RULE_FAILURE_CODE)
+            .and_then(|a| a.as_i32().or_else(|| a.as_u32().map(|v| v as i32))),
     })
 }
 
@@ -648,18 +827,89 @@ fn add_cca_base_avps(
     }
 }
 
+/// What the PCRF decided to provision in one CCA (#57).
+///
+/// Before #57 the answer was always "everything in `session_data`", on every
+/// CCR-U, regardless of what the PCEF reported — which is the static replay
+/// TS 29.212 §4.5.1 rules out. Now the shape of the answer is derived from the
+/// reported triggers and data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct GxProvisionDecision {
+    /// Emit Default-EPS-Bearer-QoS + QoS-Information (APN-AMBR).
+    pub qos: bool,
+    /// Emit Charging-Rule-Install.
+    pub install_rules: bool,
+    /// Emit the armed Event-Trigger set.
+    pub triggers: bool,
+}
+
+impl GxProvisionDecision {
+    /// Initial provisioning: the PCEF holds nothing, so everything is sent.
+    pub fn initial() -> Self {
+        Self {
+            qos: true,
+            install_rules: true,
+            triggers: true,
+        }
+    }
+
+    /// Nothing to provision.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Is any provisioning being sent at all?
+    pub fn is_empty(&self) -> bool {
+        !self.qos && !self.install_rules && !self.triggers
+    }
+
+    /// Decide what a CCR-**Update** answer must carry, as a function of what the
+    /// PCEF reported (TS 29.212 §4.5.1, §5.3.7).
+    ///
+    /// * **RAT_CHANGE** re-authorizes the QoS. A new serving RAT is a new IP-CAN
+    ///   condition, which is the whole reason the trigger is armed; re-stating the
+    ///   authorization is what the PCEF needs to enforce it on the new access.
+    /// * **QOS_CHANGE** re-authorizes **only if what the PCEF reports diverges
+    ///   from what was authorized.** When they agree, the PCEF already holds the
+    ///   right policy and re-sending it is exactly the static replay this issue is
+    ///   about. When they diverge, the CCA carries the authorized values, which
+    ///   corrects the PCEF.
+    /// * **A CCR-U with no recognized trigger provisions nothing.** This is a
+    ///   deliberate change to the previous default path: unconditional
+    ///   re-provisioning made the PCRF's answer independent of the request, so a
+    ///   consumer could not distinguish "policy changed" from "nothing happened".
+    ///
+    /// Rules are never re-installed on an update: the PCEF holds them from the
+    /// initial provisioning, and re-installing an unchanged rule set is the same
+    /// replay. A genuine rule change is pushed with a RAR, which this path does not
+    /// build.
+    pub fn for_update(info: &CcrInfo, authorized: &GxSessionData) -> Self {
+        let rat_change = info.has_trigger(event_trigger::RAT_CHANGE);
+        let qos_change = info.has_trigger(event_trigger::QOS_CHANGE);
+        let qos_diverged = qos_change && info.reported_qos.diverges_from(authorized);
+        Self {
+            qos: rat_change || qos_diverged,
+            install_rules: false,
+            // Re-arm alongside any re-authorization: TS 29.212 §5.3.7 triggers are
+            // provisioning state at the PCEF, and a PCEF that just re-applied a new
+            // authorization is the one case where confirming the armed set is not
+            // redundant.
+            triggers: rat_change || qos_diverged,
+        }
+    }
+}
+
 /// Build a successful CCA for the given CCR.
 ///
-/// For INITIAL_REQUEST the CCA provisions Charging-Rule-Install,
-/// Default-EPS-Bearer-QoS, QoS-Information (APN-AMBR) and Event-Trigger
-/// AVPs. For UPDATE_REQUEST the QoS and triggers are re-affirmed without
-/// re-installing rules. For TERMINATION_REQUEST only the mandatory AVPs
-/// are present.
+/// `decision` says which provisioning AVP groups to include; see
+/// [`GxProvisionDecision`]. `session_data` supplies the **authorized** values —
+/// always derived from the subscription, never from what the PCEF reported.
 pub fn build_cca_success(
     ccr: &DiameterMessage,
     info: &CcrInfo,
     local: &LocalIdentity,
     session_data: Option<&GxSessionData>,
+    decision: GxProvisionDecision,
 ) -> DiameterMessage {
     let mut cca = DiameterMessage::new_answer(ccr);
     add_cca_base_avps(
@@ -681,22 +931,27 @@ pub fn build_cca_success(
 
     if let Some(data) = session_data {
         // Event-Trigger AVPs (conditional: provisioning state)
-        for trigger in &data.event_triggers {
-            cca.add_avp(build_event_trigger_avp(*trigger));
+        if decision.triggers {
+            for trigger in &data.event_triggers {
+                cca.add_avp(build_event_trigger_avp(*trigger));
+            }
         }
-        // Default-EPS-Bearer-QoS (conditional: IP-CAN session provisioning)
-        cca.add_avp(build_default_eps_bearer_qos_avp(data));
-        // QoS-Information with APN-AMBR
-        cca.add_avp(build_session_qos_information_avp(
-            data.ambr_uplink,
-            data.ambr_downlink,
-        ));
-        // Charging-Rule-Install only at initial provisioning
-        if info.cc_request_type == cc_request_type::INITIAL_REQUEST && !data.pcc_rules.is_empty() {
+        if decision.qos {
+            // Default-EPS-Bearer-QoS (conditional: IP-CAN session provisioning)
+            cca.add_avp(build_default_eps_bearer_qos_avp(data));
+            // QoS-Information with APN-AMBR
+            cca.add_avp(build_session_qos_information_avp(
+                data.ambr_uplink,
+                data.ambr_downlink,
+            ));
+        }
+        if decision.install_rules && !data.pcc_rules.is_empty() {
             cca.add_avp(build_charging_rule_install_avp(&data.pcc_rules));
         }
         // Bearer-Control-Mode (conditional: only when the PCEF indicated
-        // Network-Request-Support, TS 29.212 section 4.5.1)
+        // Network-Request-Support, TS 29.212 section 4.5.1). Not part of the
+        // provisioning delta: it answers a capability the PCEF stated in THIS
+        // request, so it is echoed whenever it was stated.
         if info.network_request_support {
             cca.add_avp(Avp::vendor_mandatory(
                 gx_avp::BEARER_CONTROL_MODE,
@@ -826,10 +1081,23 @@ pub fn handle_ccr(
     };
 
     let mut abort_targets = Vec::new();
+    // The authorized policy for this session, re-derived from the subscription on
+    // every request rather than replayed from the initial answer (#57). An
+    // administrative change between the initial CCR and an update is therefore
+    // visible in the update's answer.
+    let authorized = build_subscriber_session_data(
+        info.imsi.as_deref().unwrap_or(""),
+        info.apn.as_deref().unwrap_or(""),
+    );
 
     let result = match info.cc_request_type {
         cc_request_type::INITIAL_REQUEST => {
             context.gx_session_add(&info.session_id);
+            let installed: Vec<String> = authorized
+                .pcc_rules
+                .iter()
+                .map(|r| r.name.clone())
+                .collect();
             context.gx_session_update(&info.session_id, |session| {
                 session.set_peer_host(&info.origin_host);
                 if let Some(ref imsi) = info.imsi {
@@ -844,6 +1112,14 @@ pub fn handle_ccr(
                 if let Some(addr) = info.framed_ipv6 {
                     session.set_ipv6(addr);
                 }
+                // #57: the RAT the PCEF reported, instead of leaving the field at
+                // its hardcoded 0.
+                if let Some(rat) = info.rat_type {
+                    session.set_rat_type(rat);
+                }
+                // #57: remember what is being provisioned, so a later
+                // Charging-Rule-Report has something to act on.
+                session.set_installed_rules(installed.clone());
             });
             if let Some(addr) = info.framed_ipv4 {
                 context.set_ipv4_mapping(&addr, Some(&info.session_id));
@@ -851,13 +1127,18 @@ pub fn handle_ccr(
             if let Some(addr) = info.framed_ipv6 {
                 context.set_ipv6_mapping(&addr, Some(&info.session_id));
             }
-            Ok(true)
+            Ok(GxProvisionDecision::initial())
         }
         cc_request_type::UPDATE_REQUEST => {
             if context.gx_session_find_by_sid(&info.session_id).is_none() {
                 Err(GxRequestError::UnknownSession)
             } else {
-                Ok(true)
+                // #57: react to what the PCEF actually reported. Previously this
+                // branch checked only that the session existed and fell through to
+                // unconditional re-provisioning.
+                apply_update_triggers(&context, &info);
+                abort_targets.extend(apply_rule_reports(&context, &info));
+                Ok(GxProvisionDecision::for_update(&info, &authorized))
             }
         }
         cc_request_type::TERMINATION_REQUEST => {
@@ -887,7 +1168,7 @@ pub fn handle_ccr(
                         context.rx_session_remove(&target.rx_sid);
                     }
                     context.gx_session_remove(&info.session_id);
-                    Ok(false)
+                    Ok(GxProvisionDecision::none())
                 }
             }
         }
@@ -897,18 +1178,15 @@ pub fn handle_ccr(
     drop(context);
 
     match result {
-        Ok(provision) => {
-            let session_data = if provision {
-                Some(build_subscriber_session_data(
-                    info.imsi.as_deref().unwrap_or(""),
-                    info.apn.as_deref().unwrap_or(""),
-                ))
-            } else {
+        Ok(decision) => {
+            let session_data = if decision.is_empty() {
                 None
+            } else {
+                Some(authorized)
             };
             pcrf_diam_stats().gx.inc_tx_cca();
             (
-                build_cca_success(msg, &info, local, session_data.as_ref()),
+                build_cca_success(msg, &info, local, session_data.as_ref(), decision),
                 abort_targets,
             )
         }
@@ -922,6 +1200,221 @@ pub fn handle_ccr(
             (build_cca_error(msg, local, &e), Vec::new())
         }
     }
+}
+
+/// Apply the state changes an update's reported Event-Triggers imply (#57,
+/// TS 29.212 §4.5.1 / §5.3.7).
+///
+/// Only state that the PCRF owns is touched here; what the *answer* carries is
+/// [`GxProvisionDecision::for_update`]'s job. Separating them keeps "what
+/// changed" from "what we tell the PCEF", which is the distinction the previous
+/// unconditional re-provisioning collapsed.
+fn apply_update_triggers(context: &crate::context::PcrfContext, info: &CcrInfo) {
+    // RAT-Type is recorded whenever reported, not only under RAT_CHANGE: a PCEF
+    // that reports the value without arming the trigger still told us where the UE
+    // is, and dropping that would leave the field at its pre-#57 zero.
+    if let Some(rat) = info.rat_type {
+        context.gx_session_update(&info.session_id, |session| {
+            if session.set_rat_type(rat) {
+                log::info!(
+                    "Gx session {}: RAT changed to {rat} (TS 29.212 §5.3.31)",
+                    info.session_id
+                );
+            }
+        });
+    }
+
+    if info.has_trigger(event_trigger::UE_IP_ADDRESS_ALLOCATE) {
+        if let Some(addr) = info.framed_ipv4 {
+            context.set_ipv4_mapping(&addr, Some(&info.session_id));
+            context.gx_session_update(&info.session_id, |session| {
+                session.set_ipv4(std::net::Ipv4Addr::from(addr));
+            });
+            log::info!(
+                "Gx session {}: UE IPv4 {} allocated",
+                info.session_id,
+                std::net::Ipv4Addr::from(addr)
+            );
+        }
+        if let Some(addr) = info.framed_ipv6 {
+            context.set_ipv6_mapping(&addr, Some(&info.session_id));
+            context.gx_session_update(&info.session_id, |session| {
+                session.set_ipv6(addr);
+            });
+        }
+    }
+
+    if info.has_trigger(event_trigger::UE_IP_ADDRESS_RELEASE) {
+        // The address to drop is taken from the SESSION, not from the CCR: a
+        // release report need not echo the address it is releasing, and dropping
+        // only what the CCR happened to carry would leave the mapping behind —
+        // which is the stale-mapping half of this trigger being inert.
+        let session = context.gx_session_find_by_sid(&info.session_id);
+        if let Some(session) = session {
+            if let Some(addr) = session.ipv4_addr {
+                context.set_ipv4_mapping(&addr.octets(), None);
+                log::info!("Gx session {}: UE IPv4 {addr} released", info.session_id);
+            }
+            if let Some(addr) = session.ipv6_addr {
+                context.set_ipv6_mapping(&addr, None);
+            }
+            context.gx_session_update(&info.session_id, |s| {
+                s.ipv4_addr = None;
+                s.has_ipv4 = false;
+                s.ipv6_addr = None;
+                s.has_ipv6 = false;
+            });
+        }
+    }
+}
+
+/// Whether an INACTIVE rule report may abort the bound AF session.
+///
+/// A runtime switch rather than a cargo feature, so CI compiles and exercises the
+/// path in both states. Defaults **ON**: leaving it off reproduces the defect
+/// TS 29.212 §4.5.12 exists to prevent — the AF keeps believing an unenforced
+/// service is active, which is a charging and QoS-integrity problem, not merely a
+/// missing notification. Set `PCRF_ASR_ON_RULE_FAILURE=0` to keep the
+/// bookkeeping update and suppress the ASR.
+fn asr_on_rule_failure_enabled() -> bool {
+    !matches!(
+        std::env::var("PCRF_ASR_ON_RULE_FAILURE")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+/// Act on the Charging-Rule-Reports in a CCR (TS 29.212 §4.5.12).
+///
+/// Returns the Rx sessions that must be aborted.
+///
+/// What this does, and why each choice:
+///
+/// * **INACTIVE only.** `ACTIVE` is a success confirmation and `TEMPORARILY
+///   INACTIVE` means the rule is expected back (§5.3.19), so only `INACTIVE`
+///   removes anything. Acting on a temporary loss of bearer would tear down an AF
+///   session that is about to work again.
+/// * **No Charging-Rule-Remove is sent back.** §4.5.12's own NOTE: *"When the
+///   PCRF receives PCC-Rule-Status set to INACTIVE, the PCRF does not need
+///   request the PCEF to remove the inactive PCC rule."* The rule is already gone
+///   at the PCEF; asking it to remove it again would be a message the spec says is
+///   unnecessary.
+/// * **The AF is told only when its service has nothing left enforcing it.** An Rx
+///   session that still holds another installed rule is degraded, not dead, and
+///   aborting it would be a bigger action than the report justifies. An Rx session
+///   with **no** remaining rule is precisely the state the issue names as the
+///   harm: "the AF believes an unenforced service is active".
+/// * **Base names are logged, not resolved.** `Charging-Rule-Base-Name` names a
+///   PCEF-preconfigured *group*, and this PCRF provisions no base names
+///   (`build_charging_rule_install_avp` emits Charging-Rule-Definition only), so it
+///   has no membership list to expand one against. Guessing which local rules a
+///   base name covers could remove a rule the PCEF never reported.
+fn apply_rule_reports(context: &crate::context::PcrfContext, info: &CcrInfo) -> Vec<RxAbortTarget> {
+    let mut aborts = Vec::new();
+    if info.rule_reports.is_empty() {
+        return aborts;
+    }
+
+    for report in &info.rule_reports {
+        if !report.rule_base_names.is_empty() {
+            log::warn!(
+                "Gx session {}: Charging-Rule-Report names base name(s) {:?} (status={:?}, \
+                 failure={:?}); this PCRF provisions no rule base names, so the group cannot be \
+                 resolved and is only recorded",
+                info.session_id,
+                report.rule_base_names,
+                report.pcc_rule_status,
+                report.rule_failure_code
+            );
+        }
+        if !report.reports_removal() {
+            if report.pcc_rule_status == Some(gx_pcc_rule_status::TEMPORARILY_INACTIVE) {
+                log::info!(
+                    "Gx session {}: rules {:?} TEMPORARILY INACTIVE (failure={:?}); retained, the \
+                     PCEF is expected to re-activate them",
+                    info.session_id,
+                    report.rule_names,
+                    report.rule_failure_code
+                );
+            }
+            continue;
+        }
+
+        for name in &report.rule_names {
+            log::warn!(
+                "Gx session {}: PCC rule '{name}' reported INACTIVE (Rule-Failure-Code={:?}) \
+                 (TS 29.212 §4.5.12)",
+                info.session_id,
+                report.rule_failure_code
+            );
+            context.gx_session_update(&info.session_id, |session| {
+                session.remove_installed_rule(name);
+            });
+            aborts.extend(withdraw_rule_from_rx_sessions(context, info, name));
+        }
+    }
+    aborts
+}
+
+/// Remove `rule_name` from every Rx session bound to this Gx session, and report
+/// which of them are left with nothing enforcing them.
+fn withdraw_rule_from_rx_sessions(
+    context: &crate::context::PcrfContext,
+    info: &CcrInfo,
+    rule_name: &str,
+) -> Vec<RxAbortTarget> {
+    let mut aborts = Vec::new();
+    let Some(gx) = context.gx_session_find_by_sid(&info.session_id) else {
+        return aborts;
+    };
+    for rx_idx in &gx.rx_sessions {
+        let Some(rx) = context.rx_session_find_by_idx(*rx_idx) else {
+            continue;
+        };
+        if !rx.pcc_rules.iter().any(|r| r.name == rule_name) {
+            continue;
+        }
+        let mut left = 0usize;
+        context.rx_session_update(&rx.sid, |session| {
+            session.pcc_rules.retain(|r| r.name != rule_name);
+            left = session.pcc_rules.len();
+        });
+        if left > 0 {
+            log::warn!(
+                "Rx session {}: rule '{rule_name}' withdrawn, {left} rule(s) still installed; the \
+                 AF is not aborted",
+                rx.sid
+            );
+            continue;
+        }
+        if !asr_on_rule_failure_enabled() {
+            log::warn!(
+                "Rx session {}: rule '{rule_name}' was its last installed rule, but \
+                 PCRF_ASR_ON_RULE_FAILURE is off so the AF is NOT told its service is unenforced",
+                rx.sid
+            );
+            continue;
+        }
+        log::warn!(
+            "Rx session {}: rule '{rule_name}' was its last installed rule — aborting the AF \
+             session (TS 29.212 §4.5.12, TS 29.214 §4.4.6)",
+            rx.sid
+        );
+        aborts.push(RxAbortTarget {
+            rx_sid: rx.sid.clone(),
+            peer_host: rx.peer_host.clone(),
+            peer_realm: Some(info.origin_realm.clone()),
+        });
+    }
+    // An aborted Rx session is gone: leaving the binding would make the next
+    // report try to abort it again.
+    for target in &aborts {
+        context.rx_session_remove(&target.rx_sid);
+    }
+    aborts
 }
 
 /// Resolve an Rx session by its index in the context list
@@ -1714,7 +2207,18 @@ mod tests {
             );
             assert!(session.has_ipv4);
         }
-        // UPDATE re-affirms QoS but does not reinstall rules
+        // UPDATE with no reported Event-Trigger provisions NOTHING.
+        //
+        // #57 INVERTED the Default-EPS-Bearer-QoS half of this assertion, which
+        // previously required it to be present. It was pinning this
+        // implementation's unconditional replay as if the spec demanded it: TS
+        // 29.212 §4.5.5.9 says the PCRF "**may** provision the authorized QoS for
+        // the default EPS bearer", and §4.5.1 makes the PCRF's answer a function of
+        // the event the PCEF reported. `build_test_ccr` reports no trigger, so
+        // there is nothing to react to and re-sending the initial payload is the
+        // static replay this issue is about. The reacting cases are covered by
+        // `a_rat_change_reauthorizes_and_a_triggerless_update_does_not` and
+        // `a_qos_change_reauthorizes_only_when_the_report_diverges`.
         let (cca, _) = handle_ccr(&roundtrip(&build_test_ccr(sid, 2, 1)), &local());
         let cca = roundtrip(&cca);
         assert_eq!(cca.result_code(), Some(result_code::DIAMETER_SUCCESS));
@@ -1723,7 +2227,7 @@ mod tests {
             .is_none());
         assert!(cca
             .find_vendor_avp(gx_avp::DEFAULT_EPS_BEARER_QOS, NEXTGCORE_3GPP_VENDOR_ID)
-            .is_some());
+            .is_none());
         // TERMINATION removes the session
         let (cca, aborts) = handle_ccr(&roundtrip(&build_test_ccr(sid, 3, 2)), &local());
         let cca = roundtrip(&cca);
@@ -2030,5 +2534,468 @@ mod tests {
     fn test_pcrf_gx_init_final() {
         assert!(pcrf_gx_init().is_ok());
         pcrf_gx_final();
+    }
+
+    // ====================================================================
+    // #57: the IP-CAN-session-modification loop
+    //
+    // Every test below uses a distinct Session-Id and asserts only about its own
+    // session, so the process-global `pcrf_self()` context these tests share
+    // cannot make one test's state another's.
+    // ====================================================================
+
+    fn add_event_trigger(ccr: &mut DiameterMessage, trigger: u32) {
+        ccr.add_avp(Avp::vendor_mandatory(
+            gx_avp::EVENT_TRIGGER,
+            NEXTGCORE_3GPP_VENDOR_ID,
+            AvpData::Enumerated(trigger as i32),
+        ));
+    }
+
+    /// RAT-Type with the V bit and **without** M, which is what the TS 29.212
+    /// §5.3 AVP table specifies (V must, M may). Built explicitly rather than with
+    /// `vendor_mandatory` so the parser is exercised against the flags a
+    /// conformant PCEF actually sends.
+    fn add_rat_type(ccr: &mut DiameterMessage, rat: u32) {
+        ccr.add_avp(Avp::new(
+            gx_avp::RAT_TYPE,
+            nextgcore_diameter::avp::avp_flags::VENDOR,
+            Some(NEXTGCORE_3GPP_VENDOR_ID),
+            AvpData::Enumerated(rat as i32),
+        ));
+    }
+
+    /// Command-level QoS-Information carrying what the PCEF says is in force.
+    fn add_reported_qos(ccr: &mut DiameterMessage, ambr_ul: u32, ambr_dl: u32, qci: u8) {
+        ccr.add_avp(Avp::vendor_mandatory(
+            gx_avp::QOS_INFORMATION,
+            NEXTGCORE_3GPP_VENDOR_ID,
+            AvpData::Grouped(vec![
+                Avp::vendor_mandatory(
+                    gx_avp::APN_AGGREGATE_MAX_BITRATE_UL,
+                    NEXTGCORE_3GPP_VENDOR_ID,
+                    AvpData::Unsigned32(ambr_ul),
+                ),
+                Avp::vendor_mandatory(
+                    gx_avp::APN_AGGREGATE_MAX_BITRATE_DL,
+                    NEXTGCORE_3GPP_VENDOR_ID,
+                    AvpData::Unsigned32(ambr_dl),
+                ),
+                Avp::vendor_mandatory(
+                    gx_avp::QOS_CLASS_IDENTIFIER,
+                    NEXTGCORE_3GPP_VENDOR_ID,
+                    AvpData::Enumerated(qci as i32),
+                ),
+            ]),
+        ));
+    }
+
+    fn add_rule_report(ccr: &mut DiameterMessage, rule_name: &str, status: i32, failure_code: i32) {
+        ccr.add_avp(Avp::vendor_mandatory(
+            gx_avp::CHARGING_RULE_REPORT,
+            NEXTGCORE_3GPP_VENDOR_ID,
+            AvpData::Grouped(vec![
+                Avp::vendor_mandatory(
+                    gx_avp::CHARGING_RULE_NAME,
+                    NEXTGCORE_3GPP_VENDOR_ID,
+                    AvpData::OctetString(Bytes::copy_from_slice(rule_name.as_bytes())),
+                ),
+                Avp::vendor_mandatory(
+                    gx_avp::PCC_RULE_STATUS,
+                    NEXTGCORE_3GPP_VENDOR_ID,
+                    AvpData::Enumerated(status),
+                ),
+                Avp::vendor_mandatory(
+                    gx_avp::RULE_FAILURE_CODE,
+                    NEXTGCORE_3GPP_VENDOR_ID,
+                    AvpData::Enumerated(failure_code),
+                ),
+            ]),
+        ));
+    }
+
+    /// Every modification input is read off the wire, not just the first
+    /// Event-Trigger instance.
+    #[test]
+    fn parse_ccr_reads_every_modification_input() {
+        let mut ccr = build_test_ccr("gx-parse-mod-1", 2, 1);
+        add_event_trigger(&mut ccr, event_trigger::QOS_CHANGE);
+        add_event_trigger(&mut ccr, event_trigger::RAT_CHANGE);
+        add_rat_type(&mut ccr, nextgcore_diameter::gx::rat_type::EUTRAN);
+        add_reported_qos(&mut ccr, 1_000, 2_000, 7);
+        add_rule_report(
+            &mut ccr,
+            "pcrf-internet-default",
+            gx_pcc_rule_status::INACTIVE,
+            8,
+        );
+
+        let info = parse_ccr(&roundtrip(&ccr)).expect("parse_ccr");
+
+        // Repeated AVP: BOTH instances, not just the first.
+        assert_eq!(
+            info.event_triggers,
+            vec![event_trigger::QOS_CHANGE, event_trigger::RAT_CHANGE]
+        );
+        assert!(info.has_trigger(event_trigger::RAT_CHANGE));
+        assert_eq!(
+            info.rat_type,
+            Some(nextgcore_diameter::gx::rat_type::EUTRAN)
+        );
+        assert_eq!(info.reported_qos.ambr_uplink, Some(1_000));
+        assert_eq!(info.reported_qos.ambr_downlink, Some(2_000));
+        assert_eq!(info.reported_qos.qos_index, Some(7));
+        assert_eq!(info.rule_reports.len(), 1);
+        let report = &info.rule_reports[0];
+        assert_eq!(report.rule_names, vec!["pcrf-internet-default".to_string()]);
+        assert_eq!(report.pcc_rule_status, Some(gx_pcc_rule_status::INACTIVE));
+        assert_eq!(report.rule_failure_code, Some(8));
+        assert!(report.reports_removal());
+    }
+
+    /// The session's RAT is populated from the CCR instead of staying at the
+    /// hardcoded 0 it had before #57.
+    #[test]
+    fn rat_type_is_populated_from_the_ccr() {
+        crate::context::pcrf_context_init(1024);
+        crate::fd_path::pcrf_fd_set_local_identity(local());
+        let sid = "gx-rat-1";
+
+        let mut initial = build_test_ccr(sid, 1, 0);
+        add_rat_type(&mut initial, nextgcore_diameter::gx::rat_type::EUTRAN);
+        let _ = handle_ccr(&roundtrip(&initial), &local());
+        {
+            let ctx = pcrf_self();
+            let session = ctx
+                .read()
+                .unwrap()
+                .gx_session_find_by_sid(sid)
+                .expect("session");
+            assert_eq!(
+                session.rat_type,
+                nextgcore_diameter::gx::rat_type::EUTRAN,
+                "the reported RAT, not the hardcoded 0"
+            );
+            assert!(session.reported_rat);
+        }
+
+        // A handover to GERAN is recorded.
+        let mut update = build_test_ccr(sid, 2, 1);
+        add_event_trigger(&mut update, event_trigger::RAT_CHANGE);
+        add_rat_type(&mut update, nextgcore_diameter::gx::rat_type::GERAN);
+        let _ = handle_ccr(&roundtrip(&update), &local());
+        {
+            let ctx = pcrf_self();
+            let session = ctx
+                .read()
+                .unwrap()
+                .gx_session_find_by_sid(sid)
+                .expect("session");
+            assert_eq!(session.rat_type, nextgcore_diameter::gx::rat_type::GERAN);
+        }
+    }
+
+    /// A reported RAT_CHANGE re-authorizes; an update reporting nothing does not.
+    /// The two CCAs must differ — before #57 they were identical, because neither
+    /// was a function of the request.
+    #[test]
+    fn a_rat_change_reauthorizes_and_a_triggerless_update_does_not() {
+        crate::context::pcrf_context_init(1024);
+        crate::fd_path::pcrf_fd_set_local_identity(local());
+        let sid = "gx-ratchange-1";
+        let _ = handle_ccr(&roundtrip(&build_test_ccr(sid, 1, 0)), &local());
+
+        // (a) no trigger reported -> nothing provisioned
+        let (quiet, _) = handle_ccr(&roundtrip(&build_test_ccr(sid, 2, 1)), &local());
+        let quiet = roundtrip(&quiet);
+        assert_eq!(quiet.result_code(), Some(result_code::DIAMETER_SUCCESS));
+        assert!(
+            quiet
+                .find_vendor_avp(gx_avp::QOS_INFORMATION, NEXTGCORE_3GPP_VENDOR_ID)
+                .is_none(),
+            "an update that reported no event must not re-provision"
+        );
+
+        // (b) RAT_CHANGE reported -> re-authorized
+        let mut update = build_test_ccr(sid, 2, 2);
+        add_event_trigger(&mut update, event_trigger::RAT_CHANGE);
+        add_rat_type(&mut update, nextgcore_diameter::gx::rat_type::GERAN);
+        let (reacted, _) = handle_ccr(&roundtrip(&update), &local());
+        let reacted = roundtrip(&reacted);
+        let qos = reacted
+            .find_vendor_avp(gx_avp::QOS_INFORMATION, NEXTGCORE_3GPP_VENDOR_ID)
+            .expect("RAT_CHANGE must re-authorize the session QoS");
+        // POSITIVE: the AUTHORIZED values, from the subscription profile — not an
+        // echo of whatever the PCEF reported.
+        let members = qos.parse_grouped().expect("grouped");
+        assert_eq!(
+            find_avp(&members, gx_avp::APN_AGGREGATE_MAX_BITRATE_DL).and_then(|a| a.as_u32()),
+            Some(default_profile::AMBR_DL as u32)
+        );
+        assert!(
+            reacted
+                .find_vendor_avp(gx_avp::DEFAULT_EPS_BEARER_QOS, NEXTGCORE_3GPP_VENDOR_ID)
+                .is_some(),
+            "the default bearer QoS is restated for the new access"
+        );
+        assert!(
+            reacted
+                .find_vendor_avp(gx_avp::CHARGING_RULE_INSTALL, NEXTGCORE_3GPP_VENDOR_ID)
+                .is_none(),
+            "rules are not re-installed on an update; the PCEF already holds them"
+        );
+    }
+
+    /// QOS_CHANGE re-authorizes ONLY when what the PCEF reports diverges from what
+    /// was authorized. Agreement means the PCEF already holds the right policy, and
+    /// re-sending it is the static replay #57 is about.
+    #[test]
+    fn a_qos_change_reauthorizes_only_when_the_report_diverges() {
+        crate::context::pcrf_context_init(1024);
+        crate::fd_path::pcrf_fd_set_local_identity(local());
+        let sid = "gx-qoschange-1";
+        let _ = handle_ccr(&roundtrip(&build_test_ccr(sid, 1, 0)), &local());
+
+        // (a) reported == authorized -> no re-provisioning
+        let mut agreeing = build_test_ccr(sid, 2, 1);
+        add_event_trigger(&mut agreeing, event_trigger::QOS_CHANGE);
+        add_reported_qos(
+            &mut agreeing,
+            default_profile::AMBR_UL as u32,
+            default_profile::AMBR_DL as u32,
+            default_profile::QCI,
+        );
+        let (cca, _) = handle_ccr(&roundtrip(&agreeing), &local());
+        let cca = roundtrip(&cca);
+        assert_eq!(cca.result_code(), Some(result_code::DIAMETER_SUCCESS));
+        assert!(
+            cca.find_vendor_avp(gx_avp::QOS_INFORMATION, NEXTGCORE_3GPP_VENDOR_ID)
+                .is_none(),
+            "the PCEF already enforces the authorized QoS; re-sending it is the replay"
+        );
+
+        // (b) reported != authorized -> the CCA corrects the PCEF
+        let mut diverging = build_test_ccr(sid, 2, 2);
+        add_event_trigger(&mut diverging, event_trigger::QOS_CHANGE);
+        add_reported_qos(&mut diverging, 1_000, 2_000, 5);
+        let (cca, _) = handle_ccr(&roundtrip(&diverging), &local());
+        let cca = roundtrip(&cca);
+        let qos = cca
+            .find_vendor_avp(gx_avp::QOS_INFORMATION, NEXTGCORE_3GPP_VENDOR_ID)
+            .expect("a divergent report must be corrected");
+        let members = qos.parse_grouped().expect("grouped");
+        assert_eq!(
+            find_avp(&members, gx_avp::APN_AGGREGATE_MAX_BITRATE_DL).and_then(|a| a.as_u32()),
+            Some(default_profile::AMBR_DL as u32),
+            "the CCA carries the AUTHORIZED value, not the 2000 the PCEF reported"
+        );
+    }
+
+    /// UE_IP_ADDRESS_RELEASE clears the IP -> session mapping. Before #57 the
+    /// trigger was armed and nothing reacted, so the mapping outlived the address.
+    #[test]
+    fn ue_ip_address_release_clears_the_mapping() {
+        crate::context::pcrf_context_init(1024);
+        crate::fd_path::pcrf_fd_set_local_identity(local());
+        let sid = "gx-iprelease-1";
+        let _ = handle_ccr(&roundtrip(&build_test_ccr(sid, 1, 0)), &local());
+        {
+            let ctx = pcrf_self();
+            assert_eq!(
+                ctx.read()
+                    .unwrap()
+                    .find_sid_by_ipv4(&[10, 45, 0, 2])
+                    .as_deref(),
+                Some(sid),
+                "the initial CCR installs the mapping"
+            );
+        }
+
+        let mut update = build_test_ccr(sid, 2, 1);
+        add_event_trigger(&mut update, event_trigger::UE_IP_ADDRESS_RELEASE);
+        let _ = handle_ccr(&roundtrip(&update), &local());
+
+        let ctx = pcrf_self();
+        let context = ctx.read().unwrap();
+        assert_eq!(
+            context.find_sid_by_ipv4(&[10, 45, 0, 2]),
+            None,
+            "a released address must not still resolve to the session"
+        );
+        let session = context.gx_session_find_by_sid(sid).expect("session");
+        assert!(!session.has_ipv4, "and the session must agree");
+    }
+
+    /// TS 29.212 §4.5.12: an INACTIVE rule report is acted on. The rule leaves the
+    /// PCRF's installed set and the bound Rx session, and because it was that Rx
+    /// session's last rule, the AF is aborted rather than left believing an
+    /// unenforced service is active.
+    #[test]
+    fn an_inactive_rule_report_withdraws_the_rule_and_aborts_the_af() {
+        crate::context::pcrf_context_init(1024);
+        crate::fd_path::pcrf_fd_set_local_identity(local());
+        let sid = "gx-rulereport-1";
+        let rx_sid = "rx-rulereport-1";
+        let rule = "pcrf-internet-default";
+
+        let _ = handle_ccr(&roundtrip(&build_test_ccr(sid, 1, 0)), &local());
+        {
+            let ctx = pcrf_self();
+            let context = ctx.read().unwrap();
+            let session = context.gx_session_find_by_sid(sid).expect("session");
+            assert_eq!(
+                session.installed_rules,
+                vec![rule.to_string()],
+                "the initial provisioning is recorded"
+            );
+            let gx_idx = context.gx_session_get_idx(sid).expect("gx idx");
+            context.rx_session_add(rx_sid, gx_idx).expect("rx session");
+            context.rx_session_update(rx_sid, |rx| {
+                rx.peer_host = Some("pcscf.example.com".to_string());
+                rx.pcc_rules.push(crate::context::PccRule {
+                    name: rule.to_string(),
+                    qos_index: 9,
+                    flow_status: flow_status::ENABLED,
+                    precedence: 100,
+                    num_of_flow: 2,
+                });
+            });
+        }
+
+        let mut update = build_test_ccr(sid, 2, 1);
+        add_rule_report(&mut update, rule, gx_pcc_rule_status::INACTIVE, 8);
+        let (cca, aborts) = handle_ccr(&roundtrip(&update), &local());
+        assert_eq!(
+            roundtrip(&cca).result_code(),
+            Some(result_code::DIAMETER_SUCCESS),
+            "the report is acted on, not rejected"
+        );
+
+        assert_eq!(aborts.len(), 1, "the AF must be told");
+        assert_eq!(aborts[0].rx_sid, rx_sid);
+        assert_eq!(aborts[0].peer_host.as_deref(), Some("pcscf.example.com"));
+
+        let ctx = pcrf_self();
+        let context = ctx.read().unwrap();
+        let session = context.gx_session_find_by_sid(sid).expect("session");
+        assert!(
+            session.installed_rules.is_empty(),
+            "the PCRF must stop believing the rule is installed"
+        );
+        assert!(
+            context.rx_session_find_by_sid(rx_sid).is_none(),
+            "an aborted Rx session is gone, so a second report cannot abort it again"
+        );
+    }
+
+    /// The other side of §4.5.12: TEMPORARILY INACTIVE means the rule is expected
+    /// back (§5.3.19), so nothing is withdrawn and no AF is aborted. Without this,
+    /// "acts on rule reports" would be satisfied by a version that tears down on any
+    /// report at all.
+    #[test]
+    fn a_temporarily_inactive_report_withdraws_nothing() {
+        crate::context::pcrf_context_init(1024);
+        crate::fd_path::pcrf_fd_set_local_identity(local());
+        let sid = "gx-rulereport-2";
+        let rx_sid = "rx-rulereport-2";
+        let rule = "pcrf-internet-default";
+
+        let _ = handle_ccr(&roundtrip(&build_test_ccr(sid, 1, 0)), &local());
+        {
+            let ctx = pcrf_self();
+            let context = ctx.read().unwrap();
+            let gx_idx = context.gx_session_get_idx(sid).expect("gx idx");
+            context.rx_session_add(rx_sid, gx_idx).expect("rx session");
+            context.rx_session_update(rx_sid, |rx| {
+                rx.peer_host = Some("pcscf.example.com".to_string());
+                rx.pcc_rules.push(crate::context::PccRule {
+                    name: rule.to_string(),
+                    qos_index: 9,
+                    flow_status: flow_status::ENABLED,
+                    precedence: 100,
+                    num_of_flow: 2,
+                });
+            });
+        }
+
+        let mut update = build_test_ccr(sid, 2, 1);
+        add_rule_report(
+            &mut update,
+            rule,
+            gx_pcc_rule_status::TEMPORARILY_INACTIVE,
+            8,
+        );
+        let (_, aborts) = handle_ccr(&roundtrip(&update), &local());
+
+        assert!(
+            aborts.is_empty(),
+            "a temporary loss of bearer must not abort the AF"
+        );
+        let ctx = pcrf_self();
+        let context = ctx.read().unwrap();
+        assert_eq!(
+            context
+                .gx_session_find_by_sid(sid)
+                .expect("session")
+                .installed_rules,
+            vec![rule.to_string()],
+            "the rule is retained"
+        );
+        assert!(
+            context.rx_session_find_by_sid(rx_sid).is_some(),
+            "and so is the Rx session"
+        );
+    }
+
+    /// An Rx session that still has another rule is degraded, not dead: it keeps
+    /// running and the AF is not aborted.
+    #[test]
+    fn a_rule_report_leaving_another_rule_does_not_abort_the_af() {
+        crate::context::pcrf_context_init(1024);
+        crate::fd_path::pcrf_fd_set_local_identity(local());
+        let sid = "gx-rulereport-3";
+        let rx_sid = "rx-rulereport-3";
+
+        let _ = handle_ccr(&roundtrip(&build_test_ccr(sid, 1, 0)), &local());
+        {
+            let ctx = pcrf_self();
+            let context = ctx.read().unwrap();
+            let gx_idx = context.gx_session_get_idx(sid).expect("gx idx");
+            context.rx_session_add(rx_sid, gx_idx).expect("rx session");
+            context.rx_session_update(rx_sid, |rx| {
+                rx.peer_host = Some("pcscf.example.com".to_string());
+                for name in ["pcrf-internet-default", "rx-voice-1"] {
+                    rx.pcc_rules.push(crate::context::PccRule {
+                        name: name.to_string(),
+                        qos_index: 9,
+                        flow_status: flow_status::ENABLED,
+                        precedence: 100,
+                        num_of_flow: 2,
+                    });
+                }
+            });
+        }
+
+        let mut update = build_test_ccr(sid, 2, 1);
+        add_rule_report(
+            &mut update,
+            "pcrf-internet-default",
+            gx_pcc_rule_status::INACTIVE,
+            8,
+        );
+        let (_, aborts) = handle_ccr(&roundtrip(&update), &local());
+
+        assert!(aborts.is_empty(), "one surviving rule means no abort");
+        let ctx = pcrf_self();
+        let context = ctx.read().unwrap();
+        let rx = context.rx_session_find_by_sid(rx_sid).expect("rx session");
+        assert_eq!(
+            rx.pcc_rules
+                .iter()
+                .map(|r| r.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["rx-voice-1"],
+            "only the reported rule is withdrawn"
+        );
     }
 }

--- a/src/bins/nextgcore-pcrfd/src/main.rs
+++ b/src/bins/nextgcore-pcrfd/src/main.rs
@@ -68,6 +68,17 @@ struct Args {
     #[arg(long, default_value = "1024")]
     max_sess: usize,
 
+    /// JSON snapshot file for the Gx/Rx session tables (#57).
+    ///
+    /// Falls back to `NEXTGCORE_PCRF_STATE_FILE`; an empty value is treated as
+    /// unset. With neither set the PCRF is memory-only, which is the shipped
+    /// default: a restart then answers `DIAMETER_UNKNOWN_SESSION_ID` (5002) for
+    /// every live session's CCR-U and CCR-T, indefinitely. An unreadable snapshot,
+    /// or one written by a newer build, FAILS STARTUP rather than coming up empty
+    /// and overwriting it.
+    #[arg(long)]
+    state_file: Option<String>,
+
     /// Database URI (MongoDB)
     #[arg(long)]
     db_uri: Option<String>,
@@ -165,6 +176,36 @@ fn main() -> Result<()> {
     // Initialize PCRF context
     pcrf_context_init(args.max_sess);
     log::info!("PCRF context initialized (max_sess={})", args.max_sess);
+
+    // #57: restore durable state AFTER the context knows its capacity cap and
+    // BEFORE the Diameter listener can accept a CCR, so a restored session is
+    // never shadowed by a fresh one. Precedence matches the other NFs: the flag
+    // wins over the env var, and an empty value is treated as unset.
+    let state_file = args
+        .state_file
+        .clone()
+        .or_else(|| std::env::var("NEXTGCORE_PCRF_STATE_FILE").ok())
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty());
+    if let Some(path) = state_file {
+        let ctx = nextgcore_pcrfd::context::pcrf_self();
+        let mut guard = ctx
+            .write()
+            .map_err(|_| anyhow::anyhow!("PCRF context lock poisoned"))?;
+        // Fail STARTUP on a snapshot that cannot be read or is from a newer build.
+        // Coming up empty is the failure this snapshot exists to prevent: every
+        // live PDN connection's CCR-U and CCR-T would be answered 5002 forever,
+        // and the store would then refuse each later write to protect the file, so
+        // the run would be silently non-durable too.
+        let restored = guard.set_state_file(std::path::PathBuf::from(&path))?;
+        log::info!("PCRF durable state: {path} ({restored} session(s) restored)");
+    } else {
+        log::info!(
+            "PCRF durable state disabled (no --state-file / NEXTGCORE_PCRF_STATE_FILE): Gx and Rx \
+             sessions are memory-only, and after a restart every CCR-U/CCR-T for a pre-restart \
+             session is answered DIAMETER_UNKNOWN_SESSION_ID (5002)"
+        );
+    }
 
     // Parse configuration file.
     //

--- a/src/libs/nextgcore-diameter/src/gx/mod.rs
+++ b/src/libs/nextgcore-diameter/src/gx/mod.rs
@@ -136,6 +136,51 @@ pub mod avp {
     pub const ACCESS_NETWORK_CHARGING_IDENTIFIER_VALUE: u32 = 503;
     /// AN-Trusted
     pub const AN_TRUSTED: u32 = 1503;
+    /// RAT-Type (TS 29.212 §5.3.31). Vendor-specific with the V bit set; the M
+    /// bit is **not** mandatory per the §5.3 AVP table.
+    pub const RAT_TYPE: u32 = 1032;
+    /// Charging-Rule-Report (TS 29.212 §5.3.18), grouped, M+V.
+    ///
+    /// How the PCEF tells the PCRF a PCC rule could not be installed or can no
+    /// longer be enforced. Multiple instances carry different status/failure
+    /// values for different groups of rules in one command.
+    pub const CHARGING_RULE_REPORT: u32 = 1018;
+    /// PCC-Rule-Status (TS 29.212 §5.3.19), enumerated, M+V.
+    pub const PCC_RULE_STATUS: u32 = 1019;
+    /// Rule-Failure-Code (TS 29.212 §5.3.38), enumerated, M+V.
+    pub const RULE_FAILURE_CODE: u32 = 1031;
+}
+
+/// PCC-Rule-Status values (TS 29.212 §5.3.19).
+pub mod pcc_rule_status {
+    /// Successfully installed (PCRF-provisioned) or activated (pre-provisioned).
+    pub const ACTIVE: i32 = 0;
+    /// Removed (PCRF-provisioned) or inactive (pre-provisioned). This is the
+    /// value the PCEF sets both when installation of a new rule fails and when a
+    /// previously installed rule can no longer be enforced.
+    pub const INACTIVE: i32 = 1;
+    /// Already installed rules temporarily disabled, e.g. loss of bearer. NOT the
+    /// same as INACTIVE: the rule is expected to come back, so the PCRF must not
+    /// treat it as removed.
+    pub const TEMPORARILY_INACTIVE: i32 = 2;
+}
+
+/// RAT-Type values (TS 29.212 §5.3.31).
+///
+/// 0-999 generic, 1000-1999 3GPP-specific, 2000-2999 3GPP2-specific.
+pub mod rat_type {
+    pub const WLAN: u32 = 0;
+    pub const VIRTUAL: u32 = 1;
+    pub const TRUSTED_N3GA: u32 = 2;
+    pub const WIRELINE: u32 = 3;
+    pub const WIRELINE_CABLE: u32 = 4;
+    pub const WIRELINE_BBF: u32 = 5;
+    pub const UTRAN: u32 = 1000;
+    pub const GERAN: u32 = 1001;
+    pub const GAN: u32 = 1002;
+    pub const HSPA_EVOLUTION: u32 = 1003;
+    pub const EUTRAN: u32 = 1004;
+    pub const EUTRAN_NB_IOT: u32 = 1005;
 }
 
 /// IP-CAN Type values


### PR DESCRIPTION
Closes #57. Filed **#280** for the `origin_state_id()` defect #57 asked to track separately.

Spec: `specs/fix-pcrfd-gx-dynamic-policy.md`. Verified against `main` @ `96034a7`.

## The defect

**Gx was write-once provisioning.** `parse_ccr` read none of the AVPs that describe an IP-CAN session modification — Event-Trigger, RAT-Type, QoS-Information, Charging-Rule-Report were never parsed anywhere in the crate. The `UPDATE_REQUEST` branch checked only that the session existed and fell through to re-provisioning, so `build_cca_success` re-emitted the same static payload on every CCR-U irrespective of the request. Four Event-Triggers were armed with no handler for any of them, and `PcrfGxSession::rat_type` was hardcoded `0` with no writer.

**And no restart story.** All state in-memory, so after a restart every CCR-U/CCR-T was answered `DIAMETER_UNKNOWN_SESSION_ID` (5002) forever.

## What an update's answer carries now

TS 29.212 §4.5.1 makes the PCRF's decision a function of the reported event and its related data. New `GxProvisionDecision`:

| Reported | Answer |
|---|---|
| `RAT_CHANGE` | re-authorize (Default-EPS-Bearer-QoS + QoS-Information + re-arm) |
| `QOS_CHANGE`, reported QoS **diverges** | re-authorize with the **authorized** values — correcting the PCEF, never echoing it |
| `QOS_CHANGE`, reported QoS **agrees** | nothing; the PCEF already holds the right policy |
| no recognized trigger | nothing |
| anything, on an update | never `Charging-Rule-Install` |

`UE_IP_ADDRESS_ALLOCATE`/`_RELEASE` install and clear the IP→session mapping; the release takes the address from the **session**, because a release report need not echo the address it releases. RAT-Type is recorded whenever reported.

## Rule failure handling (§4.5.12)

An `INACTIVE` report withdraws the rule from the installed set and from every bound Rx session; an Rx session left with **no** rule gets an ASR — that state is the harm the issue names ("the AF believes an unenforced service is active"). Four deliberate limits, each grounded:

- **`TEMPORARILY INACTIVE` withdraws nothing.** §5.3.19: the rule is temporarily disabled and expected back. Acting on it would tear down an AF session about to work again.
- **No `Charging-Rule-Remove` sent back**, per §4.5.12's own NOTE: *"the PCRF does not need request the PCEF to remove the inactive PCC rule."*
- **The AF is told only when nothing is left enforcing its service.** A surviving rule means degraded, not dead.
- **`Charging-Rule-Base-Name` is logged, not resolved** — this PCRF provisions no base names, so it has no membership list; guessing could remove a rule the PCEF never reported.

Gated by the runtime switch `PCRF_ASR_ON_RULE_FAILURE` (not a cargo feature, per this project's convention), default **on** because off reproduces the defect.

## Restoration model — and why not the one the issue suggested

Two deviations, both stated:

1. **Persistence, not restart signalling.** #57 offered either. `origin_state_id()` recomputes wall-clock on *every call*, so it is not a per-instance restart indicator and the signalling option has no foundation today. Filed as **#280**; persistence needs nothing from it.
2. **`StateStore`, not MongoDB.** The issue suggested "the existing MongoDB". This tree's established model is `StateStore` (seven NFs), and **pcrfd never initialises a Mongo client at all** — its own DB lookup always fails and falls back to the default profile, as the docs already record. Persisting to a client the binary does not create would not have worked.

**One thing pcrfd does differently from every other adopter, and it is load-bearing: the index hashes ARE persisted.** `gx_session_remove`/`rx_session_remove` drop only the hash entry and leave a **tombstone** in the vector, because `rx_sessions` and `gx_session_idx` are positional indexes that compacting would re-point. So the hash is the liveness record and is *not derivable from the list* — rebuilding it from every vector entry would resurrect every terminated session and answer CCR-Us for them. Only the live sid **set** is stored; indexes are re-derived from position, so a persisted index cannot disagree with the list it points into. Pinned by `a_terminated_session_is_not_resurrected_by_a_restore`.

## Spec checking that changed the design

- Every AVP code came from the vendored `29212-j10.txt` §5.3 table, not memory. RAT-Type is **V must, M may**, so the test builds it V-only — the flags a conformant PCEF sends, which the parser must not depend on.
- **A hypothesis that failed:** I expected `Default-EPS-Bearer-QoS` to be EPS-only, which would have given RAT_CHANGE a clean spec-derived payload difference. The table says applicable access type **All**. Recorded because it is why the RAT reaction is "whether we re-authorize" rather than a per-RAT payload.
- **An existing test was inverted, spec checked first.** `test_handle_ccr_lifecycle_initial_update_termination` required the CCR-U CCA to carry Default-EPS-Bearer-QoS. §4.5.5.9 says the PCRF *"**may** provision"* it — permissive. The assertion was pinning this implementation's unconditional replay as if the spec demanded it. Inverted, with the reason and the two replacement tests named at the site.

## Verification, and a real hole it found in my own work

15 guards revert-verified (fix broken → **named** test watched to fail → restored, `md5sum`-checked). Full table in the spec.

`a_pre_restart_session_still_resolves_after_a_simulated_restart` **passed with `gx_session_update`'s persist removed** — the snapshot is a full-store document, so the `rx_session_add` that followed captured the update anyway. That test proved "something persisted", not "this mutator persisted". Chasing it found **`rx_session_add` had no persist at all** (an edit lost between two scripted patches), which the same test masked for the same reason. Both are now pinned by tests where the mutation in question is the *last* thing before the restore. Without the revert pass this would have shipped as a silent durability hole behind a green test.

Workspace: **6140 passed / 0 failed**, `cargo clippy --workspace` and `cargo fmt --all --check` clean.

## Ceilings

- **No wire interop.** Every message does a real encode/decode round trip (`roundtrip()`), but against this tree's own codec, not a third-party PCEF.
- **The reacting policy is the default profile.** pcrfd's Mongo lookup always fails (documented, pre-existing), so "re-derived from the subscription" is exercised against the fallback. What the tests pin is the *decision logic* and that the CCA carries authorized rather than reported values.
- **RAT_CHANGE re-authorizes but applies no RAT-specific policy** — nothing in the subscription model is RAT-dependent, and inventing a per-RAT rule would be undecided product policy.
- **No RAR is built for a rule change** (unchanged from before #57).
- **Durable state is not enabled in the shipped Docker EPC compose**, so the E2E path is unchanged.
- **GitNexus impact analysis unrunnable** (53rd consecutive PR): MCP server not connected. Blast radius by grep; the only signature change is `build_cca_success`, whose callers are `handle_ccr` and the tests.
