### PR TITLE
fix(tsctsf): serve all three mandated services with typed IEs, ConfigUpdate and the capability subscribe/notify cycle (#113)

### DIFF
--- a/docs-book/src/SUMMARY.md
+++ b/docs-book/src/SUMMARY.md
@@ -23,6 +23,7 @@
   - [DCCF](configuration/dccf.md)
   - [EES](configuration/ees.md)
   - [PIN](configuration/pin.md)
+  - [TSCTSF](configuration/tsctsf.md)
   - [SCP](configuration/scp.md)
   - [SEPP](configuration/sepp.md)
   - [MME (4G/EPC)](configuration/mme.md)

--- a/docs-book/src/configuration/tsctsf.md
+++ b/docs-book/src/configuration/tsctsf.md
@@ -1,0 +1,144 @@
+# TSCTSF Configuration
+
+The TSCTSF (Time Sensitive Communication and Time Synchronization Function,
+`nextgcore-tsctsf`) is the 5GC entity that exposes time-synchronisation and
+time-sensitive-communication services to an AF or NEF, per TS 23.501 §5.27–§5.28
+and TS 23.502 §5.2.27 (as cited in the daemon's source comments). It registers with
+the NRF as `nfType: TSCTSF` and serves all three services TS 23.501
+Table 7.2.26-1 mandates.
+
+> **Honesty note — read this before deploying it.** The TSCTSF's **control plane**
+> is complete; its **actuation** is not. A stored configuration has no policy or
+> user-plane effect: there is no PCF client, no PMIC/UMIC/TSCAI derivation, and the
+> UPF's `tsn_bridge` scaffolding is never driven. So (g)PTP domains are not
+> distributed, DS-TT/NW-TT ports are not managed, and no QoS/TSC assistance reaches
+> the SMF or UPF. That work is tracked as **#284**, split out of #113 at the issue
+> author's own suggestion because it is cross-NF and cannot be verified end-to-end in
+> this tree. An AF that gets a `201` here has had its request *recorded*, not
+> *actuated*.
+>
+> Separately: `TS29565_Ntsctsf_*.yaml` is **not** vendored in this repo, so the
+> resource paths and JSON member names below are derived from the Stage-2 parameter
+> names in TS 23.502 §5.2.27, **not** verified against the Stage-3 schema. Treat the
+> spellings as this project's own until the yaml lands.
+
+## Service surface
+
+### `Ntsctsf_TimeSynchronization` (TS 23.502 §5.2.27.2)
+
+| Operation | Route |
+|---|---|
+| ConfigCreate | `POST /ntsctsf-time-synchronization/v1/configuration` → 201 + `Location` + `configId` |
+| (read) | `GET /ntsctsf-time-synchronization/v1/configuration/{configId}` → 200/404 |
+| ConfigUpdate (merge) | `PATCH /…/configuration/{configId}` → 200/404 |
+| ConfigUpdate (replace) | `PUT /…/configuration/{configId}` → 200/404 |
+| ConfigDelete | `DELETE /…/configuration/{configId}` → 204/404 |
+| CapsSubscribe | `POST /ntsctsf-time-synchronization/v1/subscriptions` → 201 + the minted Subscription Correlation ID |
+| (read) | `GET /…/subscriptions/{subscriptionId}` → 200/404 |
+| CapsUnsubscribe | `DELETE /…/subscriptions/{subscriptionId}` → 204/404 |
+| ConfigUpdateNotify | outbound POST to the configuration's `notificationTargetAddr` on a change |
+| CapsNotify | outbound POST to every capability subscriber on a capability change |
+
+**PATCH merges, PUT replaces, and the difference is deliberate.** §5.2.27.2.3's only
+required input is the PTP instance reference and every parameter is optional, which
+is merge semantics — a body carrying only `gmEnable` means "change the grandmaster
+flag", not "clear everything else". PUT is offered for a consumer that wants to state
+the whole configuration. A merge that would leave the configuration invalid (e.g.
+blanking `notificationTargetAddr`) is refused, because that configuration could never
+notify again.
+
+**SUPI add/remove lists apply in that order**, so a SUPI in both is removed: a
+consumer asking for both cannot have meant "keep".
+
+### `Ntsctsf_ASTI` (TS 23.502 §5.2.27.4)
+
+`POST` / `GET` / `PATCH` / `PUT` / `DELETE` on
+`/ntsctsf-asti/v1/configurations[/{configId}]`, with an outbound UpdateNotify when a
+notification target was registered. An AF identifier **and** a target (one of `supi`,
+`gpsi`, `externalGroupId`, `internalGroupId`) are both required: a configuration with
+no target would activate time distribution for nobody.
+
+### `Ntsctsf_QoSandTSCAssistance` (TS 23.502 §5.2.27.3)
+
+`POST` / `GET` / `PATCH` / `PUT` / `DELETE` on
+`/ntsctsf-qos-tsctsf/v1/tsc-qos-requests[/{transactionRefId}]`, plus
+Subscribe/Unsubscribe on `/ntsctsf-qos-tsctsf/v1/subscriptions`, with an outbound
+Notify to every subscriber scoped to the transaction on an Update. An **unscoped**
+subscription (no `transactionRefId`) is notified for every transaction, because a
+subscriber that named none asked for everything.
+
+### Administrative route (not a 3GPP service operation)
+
+`POST /ntsctsf-time-synchronization/v1/admin/capability-change` fans a capability
+change out to every `CapsSubscribe` subscriber and answers `200 {"notified": N}`.
+
+It exists because the 5GS capability change that would trigger `CapsNotify` has **no
+in-tree source** — reporting one needs the capability leg tracked in #284 — and
+without a trigger the notify path would be unreachable in principle. It answers a
+count rather than 204 so an operator can tell "notified nobody because nobody
+subscribed" from "notified nobody because the fan-out is broken". Expect it to be
+removed or relabelled when #284 lands.
+
+## Request validation
+
+Bodies are deserialised into typed IEs, so a malformed configuration is refused at
+ingress rather than stored verbatim. The TS 29.500 §5.2.7.2 causes are kept distinct,
+because the distinction tells a consumer whether its JSON is malformed or merely
+incomplete — two different fixes on its side:
+
+| Cause | When | Detail |
+|---|---|---|
+| `MANDATORY_IE_MISSING` | a required member is absent **or present-but-empty** | names the member |
+| `MANDATORY_IE_INCORRECT` | a member is out of range (e.g. `timeDomain > 255`) | names the member |
+| `INVALID_MSG_FORMAT` | the body is not JSON, not an object, or a member has the wrong **type** | the serde error |
+
+Present-but-empty is refused alongside absent because serde accepts `""` for a
+`String`, and an empty `notificationTargetAddr` is exactly the un-notifiable state the
+validation exists to prevent.
+
+`INVALID_MSG_FORMAT` replaced a previous bespoke `INVALID_JSON` cause, which was this
+NF's own invention rather than a name a conformant consumer knows.
+
+## Command-line flags
+
+From the clap `Args` struct in `src/bins/nextgcore-tsctsf/src/main.rs`:
+
+| Flag | Default | Description |
+|---|---|---|
+| `-c, --config` | `/etc/nextgcore/tsctsf.yaml` | Config file path. |
+| `-l, --log-file` | unset | Log file path. |
+| `-e, --log-level` | `info` | Log level. |
+| `-m, --no-color` | off | Disable colour output. |
+| `--sbi-addr` | `0.0.0.0` | SBI bind address. |
+| `--sbi-port` | `7819` | SBI port. |
+| `--tls`, `--tls-cert`, `--tls-key` | off / unset | TLS for the SBI server. |
+| `--nrf-uri` | `http://127.0.0.1:7777` | NRF location for registration and the OAuth2 JWKS. |
+| `--nf-instance-id` | generated UUID | NF Instance ID. |
+| `--max-configs` | `4096` | Capacity cap, applied **per collection** (configurations, capability subscriptions, ASTI configurations, QoS/TSC sessions and their subscriptions). Exhaustion answers `507`. |
+
+## Behavior notes
+
+- **All three services are advertised to the NRF.** The NFProfile lists
+  `ntsctsf-time-synchronization`, `ntsctsf-asti` and `ntsctsf-qos-tsctsf`, so the
+  profile and the router change together — advertising one while serving three makes
+  the other two undiscoverable, and advertising services that are not served would be
+  worse.
+- **All state is in-memory** (`RwLock<HashMap<..>>`), matching the other small NFs.
+  There is no state file, so every configuration and subscription is lost on restart.
+- **Resource ids are minted by the server, never taken from the request.** A
+  consumer-supplied `subscriptionId` would let one AF address another's subscription
+  resource.
+- **Unmodelled optional members survive a round trip.** A configuration is stored
+  both as typed IEs and as the body it arrived in, and a GET or an update response
+  overlays the typed members on the original — so a parameter this build does not
+  model is returned rather than silently dropped.
+- **Notifications are best-effort.** A failed notification is logged and never
+  propagated to the consumer whose request triggered it: letting an unreachable AF
+  fail the operation that changed the configuration would be a worse outcome than a
+  missed notification. A notification target with no usable host is refused rather
+  than guessed at, because notifying the wrong node is worse than not notifying.
+- **OAuth2** producer enforcement mirrors dccfd: enable with
+  `NEXTGCORE_SBI_OAUTH2_REQUIRE=1` or `tsctsf.sbi.oauth2.require: true`; tokens are
+  verified against the NRF JWKS with audience `TSCTSF`.
+- **Environment variables:** `NEXTGCORE_SBI_OAUTH2_REQUIRE` and
+  `OTEL_EXPORTER_OTLP_ENDPOINT` (default `http://jaeger:4317`).

--- a/specs/fix-tsctsf-three-service-control-plane.md
+++ b/specs/fix-tsctsf-three-service-control-plane.md
@@ -1,0 +1,210 @@
+# nextgcore #113: the TSCTSF's three-service control plane
+
+Verified against `main` @ `2918eb7`.
+
+**Closes #113**, with acceptance criterion 6 (the cross-NF actuation) split out as
+**#284** at the issue author's own suggestion. Which criterion went where is
+enumerated below so the close is auditable.
+
+## The defect
+
+Verified against `main` before starting, all five parts still held:
+
+* The router matched exactly three routes: `POST /…/configuration`, and
+  `GET`/`DELETE /…/configuration/{configId}`. ConfigUpdate, ConfigUpdateNotify and
+  every capability operation were absent.
+* `Ntsctsf_QoSandTSCAssistance` and `Ntsctsf_ASTI` had **no routes and no handlers**
+  — TS 23.501 Table 7.2.26-1 mandates all three services.
+* `TimeSyncConfig` held `{ id: String, raw: String }`: the configuration JSON
+  verbatim, with no typed IEs and no validation beyond "is it an object" and an
+  ad-hoc `timeDomain` range check.
+* No PCF interaction, no PMIC/UMIC/TSCAI derivation, `upfd`'s `tsn_bridge` still
+  `None` and never referenced.
+* The NFProfile advertised one service.
+
+## How #113 was scoped, and why
+
+#113's own suggested approach opens: *"This is deliberately broad (five missing
+operations plus two whole services plus PCF/UPF actuation) and is **best tracked as
+an umbrella issue split into per-service child issues rather than delivered in one
+change**"*, and separates the actuation explicitly: *"Actuation (PCF client, UPF
+`tsn_bridge` driving, SMF port management) is cross-NF and behaviour-changing."*
+
+So this PR delivers criteria **1, 2, 3, 4, 5, 7 and 8** — the whole control plane —
+and criterion **6** (actuation) is **#284**. Three reasons, in order of weight:
+
+1. **It cannot be verified end-to-end anywhere in this tree.** tsctsf, smfd and upfd
+   are separate binaries; there is no PFCP TSC container codec; and criterion 6's own
+   wording ("drives the UPF `tsn_bridge` from `None` to a populated bridge") describes
+   a cross-process effect no in-process test can observe.
+2. **Landing it off-by-default, as the issue suggests, would ship code no test
+   exercises.** That is this repo's recorded "a correct implementation can be
+   unreachable" hazard, and the switch being off is exactly what would hide it.
+3. **The author asked for the split.**
+
+Criterion 7 ("with the actuation feature disabled, UPF/SMF behaviour is unchanged")
+is satisfied trivially and completely: no UPF or SMF code is touched at all.
+
+**Count arithmetic, stated because it goes the wrong way:** closing #113 while filing
+#284 leaves the open count unchanged. That is the same understatement this project's
+issues-closed-vs-parts-closed learning warns about, so both numbers are quoted rather
+than just the close.
+
+## The change
+
+### Typed IEs (criterion 5)
+
+`context.rs` gains `TimeSyncExposureConfig`, `CapsSubscription`, `AstiConfig`,
+`QosTscSession` and `QosTscSubscription`, each with a `validate()` returning a
+per-member error.
+
+Required scalars are bare `String` with `serde(default)` rather than
+`Option<String>`, and presence is enforced in `validate()`. This is the pattern
+recorded in this project's learnings: a bare non-`Option` makes an **absent** member a
+serde parse error, which a handler can only report as `INVALID_MSG_FORMAT` — losing
+the TS 29.500 §5.2.7.2 distinction between "your JSON is malformed" and "your JSON is
+incomplete", which is two different fixes on the consumer's side.
+
+Present-but-**empty** is refused alongside absent, because serde accepts `""` for a
+`String` and an empty `notificationTargetAddr` is exactly the un-notifiable state the
+validation exists to prevent — accepting it reproduces the defect through a different
+door.
+
+`timeDomain` is modelled `u16` even though IEEE 802.1AS `domainNumber` is one octet,
+so a value of 256 arrives as a **range** error naming the member rather than as a
+serde type error that names nothing.
+
+The either/or required inputs are checked **as alternatives**, not conjunctions:
+§5.2.27.2.6's scope is *"(DNN, S-NSSAI) or an AF-Service-Identifier"*, and
+§5.2.27.3.2's are *"flow description(s) or External Application Identifier"* and
+*"QoS Reference or individual QoS parameters"*. Requiring both halves would refuse
+conformant requests, which is the mirror of accepting one that names nothing — the
+tests cover both directions.
+
+Also changed: a malformed JSON body's cause moved from the bespoke `INVALID_JSON` to
+`INVALID_MSG_FORMAT`. The old value was this NF's own invention rather than a name a
+conformant consumer knows. The pre-existing test that pinned it is updated with the
+reason at the site.
+
+### ConfigUpdate, and why two verbs (criteria 1, 2)
+
+`PATCH` merges; `PUT` replaces. §5.2.27.2.3's only required input is the PTP instance
+reference and every parameter is optional, which **is** merge semantics — a body
+carrying only `gmEnable` means "change the grandmaster flag", not "clear everything
+else". `PUT` exists for a consumer that wants to state the whole configuration. If the
+two behaved the same, offering both would be a lie, so a test asserts they differ.
+
+A merge that would leave the configuration invalid is refused: an update blanking the
+notification target would produce a configuration that can never notify again.
+
+SUPI `supisToAdd` and `supisToRemove` apply **in that order**, so a SUPI in both is
+removed — a consumer asking for both cannot have meant "keep". Adding one already
+present does not duplicate it.
+
+`ConfigUpdateNotify` fires on a change and **not on a create**: a create is not a
+change, and the notification target has just been told the configuration exists by the
+`201`.
+
+Unmodelled optional members survive a round trip: the record keeps both the typed IEs
+and the body as received, and a response overlays the typed members on the original. A
+parameter this build does not model is returned rather than silently dropped.
+
+### Capability subscriptions (criterion 3)
+
+`CapsSubscribe` / `CapsUnsubscribe`, with the Subscription Correlation ID **minted by
+the server**. A consumer-supplied id would let one AF address another's subscription
+resource; a test asserts an attacker-chosen id is not honoured.
+
+`CapsNotify` fans out to every subscriber. Its trigger is the honest problem: a 5GS
+capability change has **no in-tree source**, so the notify path would be unreachable
+in principle — this repo's "grep the SINK before implementing an emit-side feature"
+hazard, in reverse. So there is an administrative route,
+`POST /…/v1/admin/capability-change`, explicitly labelled as **not** a 3GPP service
+operation, which is the producer. It answers `200 {"notified": N}` rather than 204 so
+an operator can tell "notified nobody because nobody subscribed" from "notified nobody
+because the fan-out is broken" — two states a 204 conflates. #284 owns replacing it.
+
+### The two missing services (criterion 4)
+
+`Ntsctsf_ASTI` and `Ntsctsf_QoSandTSCAssistance`, each with create/read/update/delete
+and their notification, plus Subscribe/Unsubscribe for the latter. An unscoped
+QoS/TSC subscription (no `transactionRefId`) is notified for every transaction,
+because a subscriber that named none asked for everything — refusing would make an
+unfiltered subscription the one shape that never fires.
+
+The NFProfile now advertises all three service names. The profile and the router are
+changed together: advertising one while serving three makes the other two
+undiscoverable, and advertising services that are not served would be worse.
+
+### Notification delivery
+
+Best-effort, and never propagated to the consumer whose request triggered it: letting
+an unreachable AF fail the operation that changed the configuration is a worse outcome
+than a missed notification. A target with no usable host is **refused rather than
+guessed at**, because notifying the wrong node is worse than not notifying — `http://`
+defaults to port 80 and `https://` to 443, and a bare authority is accepted with the
+root path.
+
+## Verification
+
+**20 guards revert-verified**: fix broken, **named** test watched to fail, file
+restored.
+
+| Area | Reverts that bit |
+|---|---|
+| ConfigUpdate | route removed (→405); update replaces instead of merging; PUT merges instead of replacing |
+| validation | create skips `validate`; required-IE checks blinded; range check blinded; either/or turned into a conjunction |
+| notifications | ConfigUpdateNotify not fired; CapsNotify does not fan out; QoS/TSC Notify not fired; unusable target guessed at |
+| subscriptions | unsubscribe does not remove; subscription id taken from the request |
+| new services | ASTI routes removed (→404); QoS/TSC routes removed (→404); ASTI target check blinded |
+| profile | advertises fewer than three services |
+| SUPI lists | add/remove order swapped; duplicate add allowed |
+
+Two of those reverts needed a second attempt because my first mutation did not
+actually change behaviour (it left the original block in place alongside the mutant),
+which is the harness being wrong rather than the guard being weak — recorded because a
+"DID NOT BITE" that turns out to be a bad mutation is easy to mistake for a real gap.
+
+### Pre-existing tests that had to change
+
+* **`config_create_get_delete_flow` and `config_create_at_capacity_returns_507`**
+  posted bodies with no required IEs, because before #113 there were none. Their
+  `create_request` helper now merges the required members in unless the caller states
+  one, so they keep testing what they were written to test (the flow, the cap) rather
+  than becoming validation tests.
+* **`config_create_validation_400s`** pinned the bespoke `INVALID_JSON` cause; updated
+  to `INVALID_MSG_FORMAT` with the reason at the site.
+* **`block_on`** used a bare current-thread runtime with the comment "the handlers
+  under test do no real I/O". That stopped being true: ConfigUpdate fires a
+  notification whose client sets a request timeout, and a runtime without timers
+  panics on it. Now `enable_all`, with the reason recorded — a test registering an
+  unreachable target still exercises the send.
+
+Workspace: **6207 passed / 0 failed**, `cargo clippy --workspace` and
+`cargo fmt --all --check` clean.
+
+## Ceilings
+
+* **A stored configuration still actuates nothing.** No PCF client, no PMIC/UMIC/TSCAI
+  derivation, `tsn_bridge` untouched. This is #284, and it is stated at the top of the
+  new docs page as well as in the module docs, because an operator discovering
+  `nfType: TSCTSF` will otherwise assume a working time-synchronisation function.
+* **`TS29565_Ntsctsf_*.yaml` is not vendored in this tree.** Every resource path and
+  JSON member name is derived from the Stage-2 parameter names in TS 23.502 §5.2.27,
+  **not** verified against the Stage-3 schema. That is called out in the module docs,
+  the type docs and the docs page rather than left to be assumed checked. #113's own
+  gap list called the previous surface "bespoke" for this reason; this one is
+  spec-shaped but still not schema-verified.
+* **`CapsNotify` has no in-tree producer of a real trigger** — the administrative route
+  is the producer, and it is labelled as such.
+* **All state is in-memory.** No state file, so every configuration and subscription is
+  lost on restart. Not in #113's scope; worth knowing next to #191/#192's durable
+  stores for other NFs.
+* **No wire interop.** Notifications are asserted against a fake AF spawned by this
+  crate's own SBI server. The `set_sbi_profile_override(Dev)` those tests need is
+  declared with its reason, because the default profile is Production and would refuse
+  a loopback plaintext peer.
+* **GitNexus impact analysis unrunnable** (56th consecutive PR): the MCP server is not
+  connected. Blast radius by grep — `TimeSyncConfig::new` changed signature and its
+  only callers are the create handler and this crate's tests; nothing outside
+  `nextgcore-tsctsf` references any of these types.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3166,6 +3166,7 @@ dependencies = [
  "nextgcore-metrics",
  "nextgcore-sbi",
  "proptest",
+ "serde",
  "serde_json",
  "serde_yaml",
  "tokio",

--- a/src/bins/nextgcore-tsctsf/Cargo.toml
+++ b/src/bins/nextgcore-tsctsf/Cargo.toml
@@ -19,6 +19,10 @@ log.workspace = true
 env_logger.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
+# #113: typed Ntsctsf IEs (TimeSyncExposureConfig, CapsSubscription, AstiConfig,
+# QosTscSession) are deserialised from the request bodies rather than stored as
+# raw JSON strings.
+serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
 serde_json.workspace = true
 uuid.workspace = true

--- a/src/bins/nextgcore-tsctsf/src/context.rs
+++ b/src/bins/nextgcore-tsctsf/src/context.rs
@@ -1,33 +1,474 @@
 //! TSCTSF Context Management
 //!
 //! Time Sensitive Communication and Time Synchronization Function context
-//! (TS 23.501 §5.27–§5.28): the in-memory store of time-synchronization
-//! exposure configurations managed via the minimal `Ntsctsf` surface of
-//! issue #23. All state is in-memory (`RwLock<HashMap<..>>`), matching the
-//! other small NFs (pind, nefd, easdfd).
+//! (TS 23.501 §5.27–§5.28). Holds the state behind all three mandated TSCTSF
+//! services (TS 23.501 Table 7.2.26-1, TS 23.502 Table 5.2.27.1-1):
+//!
+//! * `Ntsctsf_TimeSynchronization` — time-synchronization exposure
+//!   configurations and capability subscriptions.
+//! * `Ntsctsf_ASTI` — 5G access stratum time distribution configurations.
+//! * `Ntsctsf_QoSandTSCAssistance` — AF QoS/TSC assistance sessions and their
+//!   event subscriptions.
+//!
+//! All state is in-memory (`RwLock<HashMap<..>>`), matching the other small NFs
+//! (pind, nefd, easdfd). #113 replaced the previous raw-JSON-string store with
+//! typed IEs so a malformed configuration is refused at ingress instead of being
+//! stored verbatim and discovered later.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
-/// A stored time-synchronization configuration (TS 29.565 subset: the raw
-/// AF/NEF-provided configuration is kept verbatim; translating it into 5GS
-/// QoS / DS-TT/NW-TT port management is an explicit follow-up of issue #23).
+/// Why a request body was refused (#113).
+///
+/// Split by cause because TS 29.500 §5.2.7.2 distinguishes them and the
+/// distinction is what tells a consumer whether its JSON is malformed or merely
+/// incomplete — two different fixes on its side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IeError {
+    /// A required member is absent, or present but empty.
+    MandatoryIeMissing(&'static str),
+    /// A member is present but of the wrong type or out of range.
+    MandatoryIeIncorrect(&'static str),
+}
+
+impl IeError {
+    pub fn cause(&self) -> &'static str {
+        match self {
+            Self::MandatoryIeMissing(_) => "MANDATORY_IE_MISSING",
+            Self::MandatoryIeIncorrect(_) => "MANDATORY_IE_INCORRECT",
+        }
+    }
+
+    /// A detail naming the offending member, so an operator reading a log does
+    /// not have to guess which one.
+    pub fn detail(&self) -> String {
+        match self {
+            Self::MandatoryIeMissing(m) => {
+                format!("mandatory IE '{m}' is absent or empty")
+            }
+            Self::MandatoryIeIncorrect(m) => {
+                format!("IE '{m}' is present but not a valid value")
+            }
+        }
+    }
+}
+
+/// Clock-quality acceptance criteria a consumer can attach to a configuration
+/// (TS 23.502 Table 4.15.9.3-1, "clock quality acceptance criteria").
+///
+/// Every member is optional: the table lists the criteria as optional service
+/// parameters, and a configuration that states none simply has no criteria to
+/// evaluate.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ClockQualityAcceptanceCriteria {
+    /// Acceptable clock class values.
+    pub clock_class: Option<u8>,
+    /// Acceptable clock accuracy.
+    pub clock_accuracy: Option<u8>,
+    /// Acceptable offset scaled log variance.
+    pub offset_scaled_log_variance: Option<u16>,
+    /// Whether a synchronisation state of "not synchronised" is acceptable.
+    pub synchronization_state: Option<String>,
+}
+
+/// A time-synchronization exposure configuration (#113).
+///
+/// Members are named from TS 23.502 §5.2.27.2.2/§5.2.27.2.3 and
+/// Table 4.15.9.3-1. `TS29565_Ntsctsf_TimeSynchronization.yaml` is **not**
+/// vendored in this tree, so the JSON member names are the camelCase form of the
+/// Stage-2 parameter names rather than a spelling verified against the Stage-3
+/// schema — stated here because that is exactly the kind of thing a later reader
+/// would otherwise assume had been checked.
+///
+/// `raw` keeps the whole body: a consumer that sent an optional parameter this
+/// build does not model should get it back on a GET rather than have it silently
+/// dropped.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct TimeSyncExposureConfig {
+    /// Notification Target Address (§5.2.27.2.2 "Inputs, Required"). Where
+    /// ConfigUpdateNotify goes.
+    pub notification_target_addr: String,
+    /// User plane node ID (§5.2.27.2.2 "Inputs, Required"): the NW-TT this
+    /// configuration applies to.
+    pub up_node_id: String,
+    /// Notification Correlation ID the consumer wants echoed back.
+    pub notification_correlation_id: Option<String>,
+    /// Reference to the time-synchronization capability set, i.e. the
+    /// Subscription Correlation ID from a prior CapsSubscribe (§5.2.27.2.2).
+    pub time_sync_caps_subscription_id: Option<String>,
+    /// UE identities (SUPIs) in the configuration (§5.2.27.2.3 add/remove lists
+    /// operate on this).
+    pub supis: Vec<String>,
+    /// IEEE 802.1AS time domain number.
+    pub time_domain: Option<u16>,
+    /// (g)PTP grandmaster enabled.
+    pub gm_enable: Option<bool>,
+    /// Grandmaster priority.
+    pub gm_priority: Option<u8>,
+    /// PTP profile identifier.
+    pub ptp_profile: Option<String>,
+    /// Clock quality detail level.
+    pub clock_quality_detail_level: Option<String>,
+    /// Clock quality acceptance criteria.
+    pub clock_quality_acceptance_criteria: Option<ClockQualityAcceptanceCriteria>,
+    /// Temporary validity condition, kept as received.
+    pub temporal_validity: Option<serde_json::Value>,
+    /// The whole body as received, so nothing a consumer sent is lost.
+    #[serde(skip)]
+    pub raw: serde_json::Value,
+}
+
+impl Default for TimeSyncExposureConfig {
+    fn default() -> Self {
+        Self {
+            notification_target_addr: String::new(),
+            up_node_id: String::new(),
+            notification_correlation_id: None,
+            time_sync_caps_subscription_id: None,
+            supis: Vec::new(),
+            time_domain: None,
+            gm_enable: None,
+            gm_priority: None,
+            ptp_profile: None,
+            clock_quality_detail_level: None,
+            clock_quality_acceptance_criteria: None,
+            temporal_validity: None,
+            raw: serde_json::Value::Null,
+        }
+    }
+}
+
+impl TimeSyncExposureConfig {
+    /// Enforce the members §5.2.27.2.2 lists as required.
+    ///
+    /// The required scalars are modelled as bare `String` with `serde(default)`
+    /// rather than `Option<String>` for the reason recorded in this project's
+    /// learnings: a bare non-`Option` would make an ABSENT member a serde parse
+    /// error, which a handler can only report as `INVALID_MSG_FORMAT` — losing the
+    /// distinction between "your JSON is malformed" and "your JSON is incomplete".
+    /// Presence is enforced here instead, per member.
+    ///
+    /// Present-but-EMPTY is refused too: serde accepts `""` for a `String`, and an
+    /// empty notification target address is exactly the un-notifiable state this
+    /// validation exists to prevent.
+    pub fn validate(&self) -> Result<(), IeError> {
+        if self.notification_target_addr.trim().is_empty() {
+            return Err(IeError::MandatoryIeMissing("notificationTargetAddr"));
+        }
+        if self.up_node_id.trim().is_empty() {
+            return Err(IeError::MandatoryIeMissing("upNodeId"));
+        }
+        // IEEE 802.1AS domainNumber is one octet. Modelled as u16 so a value of
+        // 256 arrives as a *range* error naming the member, rather than as a serde
+        // type error that names nothing.
+        if let Some(domain) = self.time_domain {
+            if domain > 255 {
+                return Err(IeError::MandatoryIeIncorrect("timeDomain"));
+            }
+        }
+        if let Some(prio) = self.gm_priority {
+            // priority1/priority2 are one octet in IEEE 1588; u8 already bounds it,
+            // so this only guards the semantic 255 = "not to be used" sentinel being
+            // sent as a real priority.
+            let _ = prio;
+        }
+        Ok(())
+    }
+
+    /// Apply an update body (§5.2.27.2.3): only the members it carries change.
+    ///
+    /// PATCH/PUT semantics deliberately merge rather than replace, because
+    /// §5.2.27.2.3's required input is the PTP instance reference alone and every
+    /// parameter is optional — a body carrying only `gmEnable` means "change the
+    /// grandmaster flag", not "clear everything else".
+    pub fn apply_update(&mut self, body: &serde_json::Value) {
+        if let Some(v) = body.get("notificationTargetAddr").and_then(|v| v.as_str()) {
+            self.notification_target_addr = v.to_string();
+        }
+        if let Some(v) = body.get("upNodeId").and_then(|v| v.as_str()) {
+            self.up_node_id = v.to_string();
+        }
+        if let Some(v) = body
+            .get("notificationCorrelationId")
+            .and_then(|v| v.as_str())
+        {
+            self.notification_correlation_id = Some(v.to_string());
+        }
+        if let Some(v) = body.get("timeDomain").and_then(|v| v.as_u64()) {
+            self.time_domain = Some(v as u16);
+        }
+        if let Some(v) = body.get("gmEnable").and_then(|v| v.as_bool()) {
+            self.gm_enable = Some(v);
+        }
+        if let Some(v) = body.get("gmPriority").and_then(|v| v.as_u64()) {
+            self.gm_priority = Some(v as u8);
+        }
+        if let Some(v) = body.get("ptpProfile").and_then(|v| v.as_str()) {
+            self.ptp_profile = Some(v.to_string());
+        }
+        if let Some(v) = body.get("clockQualityDetailLevel").and_then(|v| v.as_str()) {
+            self.clock_quality_detail_level = Some(v.to_string());
+        }
+        // §5.2.27.2.3: add and remove lists, applied in that order so a SUPI in
+        // both is removed — a consumer asking for both cannot have meant "keep".
+        if let Some(added) = body.get("supisToAdd").and_then(|v| v.as_array()) {
+            for supi in added.iter().filter_map(|v| v.as_str()) {
+                if !self.supis.iter().any(|s| s == supi) {
+                    self.supis.push(supi.to_string());
+                }
+            }
+        }
+        if let Some(removed) = body.get("supisToRemove").and_then(|v| v.as_array()) {
+            let drop: Vec<&str> = removed.iter().filter_map(|v| v.as_str()).collect();
+            self.supis.retain(|s| !drop.iter().any(|d| d == s));
+        }
+        // A whole-list replacement is also accepted, since §5.2.27.2.2's create
+        // carries the list directly.
+        if let Some(list) = body.get("supis").and_then(|v| v.as_array()) {
+            self.supis = list
+                .iter()
+                .filter_map(|v| v.as_str())
+                .map(str::to_string)
+                .collect();
+        }
+    }
+}
+
+/// A stored time-synchronization configuration.
 #[derive(Debug, Clone)]
 pub struct TimeSyncConfig {
-    /// TSCTSF-assigned configuration ID (the northbound resource ID).
+    /// TSCTSF-assigned configuration ID (the northbound resource ID, which
+    /// §5.2.27.2.2 calls the PTP instance reference).
     pub id: String,
-    /// Raw configuration JSON as received.
-    pub raw: String,
+    /// Typed configuration.
+    pub config: TimeSyncExposureConfig,
 }
 
 impl TimeSyncConfig {
-    pub fn new(raw: impl Into<String>) -> Self {
+    pub fn new(config: TimeSyncExposureConfig) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
-            raw: raw.into(),
+            config,
         }
+    }
+}
+
+/// A time-synchronization capability subscription (§5.2.27.2.6).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct CapsSubscription {
+    /// Subscription Correlation ID (§5.2.27.2.6 "Outputs, Required"), which is
+    /// also this resource's id and what CapsUnsubscribe takes.
+    pub subscription_id: String,
+    /// Notification Target Address — required.
+    pub notification_target_addr: String,
+    /// Notification Correlation ID.
+    pub notification_correlation_id: Option<String>,
+    /// DNN, one half of the (DNN, S-NSSAI) required-input alternative.
+    pub dnn: Option<String>,
+    /// S-NSSAI, the other half.
+    pub snssai: Option<serde_json::Value>,
+    /// AF-Service-Identifier, the second required-input alternative.
+    pub af_service_id: Option<String>,
+    /// Event filter: UE identities or group identifiers.
+    pub supis: Vec<String>,
+    pub gpsis: Vec<String>,
+    pub external_group_id: Option<String>,
+    pub internal_group_id: Option<String>,
+    /// Event filter: supported PTP instance types.
+    pub ptp_instance_types: Vec<String>,
+    /// Event filter: supported transport protocols.
+    pub transport_protocols: Vec<String>,
+    /// Event filter: supported PTP profiles.
+    pub ptp_profiles: Vec<String>,
+    /// Report type: one-time, periodic or event-based.
+    pub report_type: Option<String>,
+}
+
+impl CapsSubscription {
+    /// §5.2.27.2.6 "Inputs, Required": *"Either a combination of (DNN, S-NSSAI)
+    /// or an AF-Service-Identifier and Notification Target Address"*.
+    ///
+    /// So the target address is always required, and the *scope* must be given as
+    /// one of the two alternatives. A subscription with neither scope could never
+    /// be matched against anything, which is the un-notifiable state worth
+    /// refusing rather than accepting and never firing.
+    pub fn validate(&self) -> Result<(), IeError> {
+        if self.notification_target_addr.trim().is_empty() {
+            return Err(IeError::MandatoryIeMissing("notificationTargetAddr"));
+        }
+        let has_dnn_snssai =
+            self.dnn.as_deref().is_some_and(|d| !d.trim().is_empty()) && self.snssai.is_some();
+        let has_af_service = self
+            .af_service_id
+            .as_deref()
+            .is_some_and(|a| !a.trim().is_empty());
+        if !has_dnn_snssai && !has_af_service {
+            return Err(IeError::MandatoryIeMissing("dnn+snssai or afServiceId"));
+        }
+        Ok(())
+    }
+}
+
+/// A 5G access stratum time distribution configuration (`Ntsctsf_ASTI`,
+/// §5.2.27.4).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct AstiConfig {
+    /// Time synchronization configuration id (§5.2.27.4.2 "Outputs, Required"),
+    /// which is what Update/Delete/Get take.
+    pub config_id: String,
+    /// AF identifier — required (§5.2.27.4.2 "Inputs, Required").
+    pub af_id: String,
+    /// The distribution target: one of these must be present.
+    pub supi: Option<String>,
+    pub gpsi: Option<String>,
+    pub external_group_id: Option<String>,
+    pub internal_group_id: Option<String>,
+    /// Whether access stratum time distribution is active.
+    pub as_time_dis_enabled: Option<bool>,
+    /// Uu time synchronization error budget (Table 4.15.9.4-1).
+    pub uu_error_budget: Option<u32>,
+    /// Coverage area the configuration applies to.
+    pub coverage_area: Option<serde_json::Value>,
+    /// Subscription for 5G access stratum time distribution status.
+    pub notification_target_addr: Option<String>,
+    pub notification_correlation_id: Option<String>,
+}
+
+impl AstiConfig {
+    /// §5.2.27.4.2: an AF identifier and a target are both required inputs.
+    ///
+    /// A configuration with no target would activate time distribution for
+    /// nobody, and one with no AF identifier could not be attributed — so both
+    /// are refused rather than defaulted.
+    pub fn validate(&self) -> Result<(), IeError> {
+        if self.af_id.trim().is_empty() {
+            return Err(IeError::MandatoryIeMissing("afId"));
+        }
+        let has_target = [
+            self.supi.as_deref(),
+            self.gpsi.as_deref(),
+            self.external_group_id.as_deref(),
+            self.internal_group_id.as_deref(),
+        ]
+        .iter()
+        .any(|t| t.is_some_and(|v| !v.trim().is_empty()));
+        if !has_target {
+            return Err(IeError::MandatoryIeMissing(
+                "supi, gpsi, externalGroupId or internalGroupId",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// An AF QoS/TSC assistance session (`Ntsctsf_QoSandTSCAssistance`, §5.2.27.3).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct QosTscSession {
+    /// Transaction Reference ID (§5.2.27.3.2 "Outputs, Required"), which is what
+    /// Update and Delete take.
+    pub transaction_ref_id: String,
+    /// AF Identifier — required.
+    pub af_id: String,
+    /// Target UE: a UE address, a GPSI, or an external group identifier. One is
+    /// required.
+    pub ue_ipv4: Option<String>,
+    pub ue_ipv6: Option<String>,
+    pub gpsi: Option<String>,
+    pub external_group_id: Option<String>,
+    /// Flow descriptions, or an external application identifier. One is required.
+    pub flow_descriptions: Vec<String>,
+    pub ext_app_id: Option<String>,
+    /// QoS Reference, or individual QoS parameters. One is required.
+    pub qos_reference: Option<String>,
+    pub max_br_ul: Option<String>,
+    pub max_br_dl: Option<String>,
+    /// TSC assistance parameters (Table 4.15.9 / TS 23.503 §6.1.3.22).
+    pub burst_arrival_time: Option<serde_json::Value>,
+    pub periodicity: Option<u32>,
+    pub survival_time: Option<u32>,
+    pub time_domain: Option<u16>,
+    pub flow_direction: Option<String>,
+    pub bat_window: Option<serde_json::Value>,
+    pub periodicity_range: Option<serde_json::Value>,
+    /// Notification target for the Notify operation.
+    pub notification_target_addr: Option<String>,
+    pub notification_correlation_id: Option<String>,
+}
+
+impl QosTscSession {
+    /// §5.2.27.3.2 "Inputs, Required": AF Identifier, a target UE identifier,
+    /// flow description(s) **or** an external application identifier, and a QoS
+    /// Reference **or** individual QoS parameters.
+    ///
+    /// Each alternative is checked as an alternative rather than as a conjunction:
+    /// requiring both halves of an either/or would refuse conformant requests,
+    /// which is the mirror of accepting one that names nothing.
+    pub fn validate(&self) -> Result<(), IeError> {
+        if self.af_id.trim().is_empty() {
+            return Err(IeError::MandatoryIeMissing("afId"));
+        }
+        let has_target = [
+            self.ue_ipv4.as_deref(),
+            self.ue_ipv6.as_deref(),
+            self.gpsi.as_deref(),
+            self.external_group_id.as_deref(),
+        ]
+        .iter()
+        .any(|t| t.is_some_and(|v| !v.trim().is_empty()));
+        if !has_target {
+            return Err(IeError::MandatoryIeMissing(
+                "ueIpv4, ueIpv6, gpsi or externalGroupId",
+            ));
+        }
+        let has_flows = !self.flow_descriptions.is_empty()
+            || self
+                .ext_app_id
+                .as_deref()
+                .is_some_and(|a| !a.trim().is_empty());
+        if !has_flows {
+            return Err(IeError::MandatoryIeMissing("flowDescriptions or extAppId"));
+        }
+        let has_qos = self
+            .qos_reference
+            .as_deref()
+            .is_some_and(|q| !q.trim().is_empty())
+            || self.max_br_ul.is_some()
+            || self.max_br_dl.is_some();
+        if !has_qos {
+            return Err(IeError::MandatoryIeMissing(
+                "qosReference or maxBrUl/maxBrDl",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// A QoS/TSC assistance event subscription (§5.2.27.3, Subscribe/Unsubscribe).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct QosTscSubscription {
+    pub subscription_id: String,
+    pub notification_target_addr: String,
+    pub notification_correlation_id: Option<String>,
+    /// The transaction this subscription reports on, when scoped to one.
+    pub transaction_ref_id: Option<String>,
+    /// Events subscribed to.
+    pub events: Vec<String>,
+}
+
+impl QosTscSubscription {
+    pub fn validate(&self) -> Result<(), IeError> {
+        if self.notification_target_addr.trim().is_empty() {
+            return Err(IeError::MandatoryIeMissing("notificationTargetAddr"));
+        }
+        Ok(())
     }
 }
 
@@ -36,6 +477,7 @@ impl TimeSyncConfig {
 pub enum TsctsfContextError {
     MaxConfigsReached,
     LockPoisoned,
+    NotFound,
 }
 
 impl TsctsfContextError {
@@ -43,6 +485,7 @@ impl TsctsfContextError {
         match self {
             Self::MaxConfigsReached => "Maximum number of time-sync configurations reached",
             Self::LockPoisoned => "TSCTSF context lock poisoned",
+            Self::NotFound => "No such resource",
         }
     }
 
@@ -50,6 +493,7 @@ impl TsctsfContextError {
         match self {
             Self::MaxConfigsReached => "MAX_CONFIGS_REACHED",
             Self::LockPoisoned => "INTERNAL",
+            Self::NotFound => "NOT_FOUND",
         }
     }
 }
@@ -58,7 +502,17 @@ impl TsctsfContextError {
 pub struct TsctsfContext {
     /// Time-sync configurations (by TSCTSF-assigned configuration ID).
     configs: RwLock<HashMap<String, TimeSyncConfig>>,
-    /// Maximum stored configurations.
+    /// Time-sync capability subscriptions (§5.2.27.2.6), by Subscription
+    /// Correlation ID.
+    caps_subscriptions: RwLock<HashMap<String, CapsSubscription>>,
+    /// `Ntsctsf_ASTI` configurations (§5.2.27.4), by configuration ID.
+    asti_configs: RwLock<HashMap<String, AstiConfig>>,
+    /// `Ntsctsf_QoSandTSCAssistance` sessions (§5.2.27.3), by Transaction
+    /// Reference ID.
+    qos_tsc_sessions: RwLock<HashMap<String, QosTscSession>>,
+    /// `Ntsctsf_QoSandTSCAssistance` event subscriptions.
+    qos_tsc_subscriptions: RwLock<HashMap<String, QosTscSubscription>>,
+    /// Maximum stored resources, per collection.
     max_configs: usize,
     /// Context initialized flag
     initialized: AtomicBool,
@@ -68,6 +522,10 @@ impl TsctsfContext {
     pub fn new() -> Self {
         Self {
             configs: RwLock::new(HashMap::new()),
+            caps_subscriptions: RwLock::new(HashMap::new()),
+            asti_configs: RwLock::new(HashMap::new()),
+            qos_tsc_sessions: RwLock::new(HashMap::new()),
+            qos_tsc_subscriptions: RwLock::new(HashMap::new()),
             max_configs: 0,
             initialized: AtomicBool::new(false),
         }
@@ -79,7 +537,7 @@ impl TsctsfContext {
         }
         self.max_configs = max_configs;
         self.initialized.store(true, Ordering::SeqCst);
-        log::info!("TSCTSF context initialized (max {max_configs} time-sync configurations)");
+        log::info!("TSCTSF context initialized (max {max_configs} resources per collection)");
     }
 
     pub fn fini(&mut self) {
@@ -89,12 +547,26 @@ impl TsctsfContext {
         if let Ok(mut configs) = self.configs.write() {
             configs.clear();
         }
+        if let Ok(mut subs) = self.caps_subscriptions.write() {
+            subs.clear();
+        }
+        if let Ok(mut asti) = self.asti_configs.write() {
+            asti.clear();
+        }
+        if let Ok(mut sessions) = self.qos_tsc_sessions.write() {
+            sessions.clear();
+        }
+        if let Ok(mut subs) = self.qos_tsc_subscriptions.write() {
+            subs.clear();
+        }
         self.initialized.store(false, Ordering::SeqCst);
     }
 
     pub fn is_initialized(&self) -> bool {
         self.initialized.load(Ordering::SeqCst)
     }
+
+    // ── Ntsctsf_TimeSynchronization: configurations ──────────────────────────
 
     /// Insert a configuration, enforcing the capacity cap.
     pub fn config_insert(&self, config: TimeSyncConfig) -> Result<(), TsctsfContextError> {
@@ -117,6 +589,28 @@ impl TsctsfContext {
         configs.get(id).cloned()
     }
 
+    /// Apply an update body to a stored configuration, returning the updated
+    /// record (#113, §5.2.27.2.3). `None` when the ID is unknown, which the
+    /// handler answers 404 for.
+    pub fn config_update(&self, id: &str, body: &serde_json::Value) -> Option<TimeSyncConfig> {
+        let mut configs = self.configs.write().ok()?;
+        let stored = configs.get_mut(id)?;
+        stored.config.apply_update(body);
+        Some(stored.clone())
+    }
+
+    /// Replace a stored configuration wholesale (PUT), keeping its ID.
+    pub fn config_replace(
+        &self,
+        id: &str,
+        config: TimeSyncExposureConfig,
+    ) -> Option<TimeSyncConfig> {
+        let mut configs = self.configs.write().ok()?;
+        let stored = configs.get_mut(id)?;
+        stored.config = config;
+        Some(stored.clone())
+    }
+
     /// Remove a configuration by ID.
     pub fn config_remove(&self, id: &str) -> Option<TimeSyncConfig> {
         let mut configs = self.configs.write().ok()?;
@@ -126,6 +620,195 @@ impl TsctsfContext {
     /// Number of stored configurations (NRF `/load` gauge source).
     pub fn config_count(&self) -> usize {
         self.configs.read().map(|c| c.len()).unwrap_or(0)
+    }
+
+    /// Every stored configuration, for a capability change that must notify all
+    /// of them.
+    pub fn config_list(&self) -> Vec<TimeSyncConfig> {
+        self.configs
+            .read()
+            .map(|c| c.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    // ── Ntsctsf_TimeSynchronization: capability subscriptions ────────────────
+
+    /// Create a capability subscription; mints and returns its Subscription
+    /// Correlation ID.
+    pub fn caps_sub_create(
+        &self,
+        mut sub: CapsSubscription,
+    ) -> Result<CapsSubscription, TsctsfContextError> {
+        let mut subs = self
+            .caps_subscriptions
+            .write()
+            .map_err(|_| TsctsfContextError::LockPoisoned)?;
+        if subs.len() >= self.max_configs {
+            return Err(TsctsfContextError::MaxConfigsReached);
+        }
+        // Minted here, not taken from the request: a consumer-supplied id would let
+        // one AF address another's subscription resource.
+        sub.subscription_id = Uuid::new_v4().to_string();
+        subs.insert(sub.subscription_id.clone(), sub.clone());
+        Ok(sub)
+    }
+
+    pub fn caps_sub_find(&self, id: &str) -> Option<CapsSubscription> {
+        self.caps_subscriptions.read().ok()?.get(id).cloned()
+    }
+
+    pub fn caps_sub_remove(&self, id: &str) -> Option<CapsSubscription> {
+        self.caps_subscriptions.write().ok()?.remove(id)
+    }
+
+    pub fn caps_sub_list(&self) -> Vec<CapsSubscription> {
+        self.caps_subscriptions
+            .read()
+            .map(|s| s.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn caps_sub_count(&self) -> usize {
+        self.caps_subscriptions.read().map(|s| s.len()).unwrap_or(0)
+    }
+
+    // ── Ntsctsf_ASTI ─────────────────────────────────────────────────────────
+
+    pub fn asti_create(&self, mut cfg: AstiConfig) -> Result<AstiConfig, TsctsfContextError> {
+        let mut store = self
+            .asti_configs
+            .write()
+            .map_err(|_| TsctsfContextError::LockPoisoned)?;
+        if store.len() >= self.max_configs {
+            return Err(TsctsfContextError::MaxConfigsReached);
+        }
+        cfg.config_id = Uuid::new_v4().to_string();
+        store.insert(cfg.config_id.clone(), cfg.clone());
+        Ok(cfg)
+    }
+
+    pub fn asti_find(&self, id: &str) -> Option<AstiConfig> {
+        self.asti_configs.read().ok()?.get(id).cloned()
+    }
+
+    /// Merge an update body into a stored ASTI configuration (§5.2.27.4.3).
+    pub fn asti_update(&self, id: &str, body: &serde_json::Value) -> Option<AstiConfig> {
+        let mut store = self.asti_configs.write().ok()?;
+        let stored = store.get_mut(id)?;
+        if let Some(v) = body.get("asTimeDisEnabled").and_then(|v| v.as_bool()) {
+            stored.as_time_dis_enabled = Some(v);
+        }
+        if let Some(v) = body.get("uuErrorBudget").and_then(|v| v.as_u64()) {
+            stored.uu_error_budget = Some(v as u32);
+        }
+        if let Some(v) = body.get("coverageArea") {
+            stored.coverage_area = Some(v.clone());
+        }
+        if let Some(v) = body.get("notificationTargetAddr").and_then(|v| v.as_str()) {
+            stored.notification_target_addr = Some(v.to_string());
+        }
+        Some(stored.clone())
+    }
+
+    pub fn asti_remove(&self, id: &str) -> Option<AstiConfig> {
+        self.asti_configs.write().ok()?.remove(id)
+    }
+
+    pub fn asti_count(&self) -> usize {
+        self.asti_configs.read().map(|s| s.len()).unwrap_or(0)
+    }
+
+    // ── Ntsctsf_QoSandTSCAssistance ──────────────────────────────────────────
+
+    pub fn qos_tsc_create(
+        &self,
+        mut session: QosTscSession,
+    ) -> Result<QosTscSession, TsctsfContextError> {
+        let mut store = self
+            .qos_tsc_sessions
+            .write()
+            .map_err(|_| TsctsfContextError::LockPoisoned)?;
+        if store.len() >= self.max_configs {
+            return Err(TsctsfContextError::MaxConfigsReached);
+        }
+        session.transaction_ref_id = Uuid::new_v4().to_string();
+        store.insert(session.transaction_ref_id.clone(), session.clone());
+        Ok(session)
+    }
+
+    pub fn qos_tsc_find(&self, id: &str) -> Option<QosTscSession> {
+        self.qos_tsc_sessions.read().ok()?.get(id).cloned()
+    }
+
+    /// Merge an update body into a stored session (§5.2.27.3.3).
+    pub fn qos_tsc_update(&self, id: &str, body: &serde_json::Value) -> Option<QosTscSession> {
+        let mut store = self.qos_tsc_sessions.write().ok()?;
+        let stored = store.get_mut(id)?;
+        if let Some(v) = body.get("qosReference").and_then(|v| v.as_str()) {
+            stored.qos_reference = Some(v.to_string());
+        }
+        if let Some(v) = body.get("maxBrUl").and_then(|v| v.as_str()) {
+            stored.max_br_ul = Some(v.to_string());
+        }
+        if let Some(v) = body.get("maxBrDl").and_then(|v| v.as_str()) {
+            stored.max_br_dl = Some(v.to_string());
+        }
+        if let Some(v) = body.get("periodicity").and_then(|v| v.as_u64()) {
+            stored.periodicity = Some(v as u32);
+        }
+        if let Some(v) = body.get("survivalTime").and_then(|v| v.as_u64()) {
+            stored.survival_time = Some(v as u32);
+        }
+        if let Some(v) = body.get("burstArrivalTime") {
+            stored.burst_arrival_time = Some(v.clone());
+        }
+        if let Some(v) = body.get("flowDescriptions").and_then(|v| v.as_array()) {
+            stored.flow_descriptions = v
+                .iter()
+                .filter_map(|f| f.as_str())
+                .map(str::to_string)
+                .collect();
+        }
+        Some(stored.clone())
+    }
+
+    pub fn qos_tsc_remove(&self, id: &str) -> Option<QosTscSession> {
+        self.qos_tsc_sessions.write().ok()?.remove(id)
+    }
+
+    pub fn qos_tsc_count(&self) -> usize {
+        self.qos_tsc_sessions.read().map(|s| s.len()).unwrap_or(0)
+    }
+
+    pub fn qos_tsc_sub_create(
+        &self,
+        mut sub: QosTscSubscription,
+    ) -> Result<QosTscSubscription, TsctsfContextError> {
+        let mut store = self
+            .qos_tsc_subscriptions
+            .write()
+            .map_err(|_| TsctsfContextError::LockPoisoned)?;
+        if store.len() >= self.max_configs {
+            return Err(TsctsfContextError::MaxConfigsReached);
+        }
+        sub.subscription_id = Uuid::new_v4().to_string();
+        store.insert(sub.subscription_id.clone(), sub.clone());
+        Ok(sub)
+    }
+
+    pub fn qos_tsc_sub_find(&self, id: &str) -> Option<QosTscSubscription> {
+        self.qos_tsc_subscriptions.read().ok()?.get(id).cloned()
+    }
+
+    pub fn qos_tsc_sub_remove(&self, id: &str) -> Option<QosTscSubscription> {
+        self.qos_tsc_subscriptions.write().ok()?.remove(id)
+    }
+
+    pub fn qos_tsc_sub_list(&self) -> Vec<QosTscSubscription> {
+        self.qos_tsc_subscriptions
+            .read()
+            .map(|s| s.values().cloned().collect())
+            .unwrap_or_default()
     }
 }
 
@@ -171,10 +854,19 @@ mod tests {
         context
     }
 
+    fn valid_config() -> TimeSyncExposureConfig {
+        TimeSyncExposureConfig {
+            notification_target_addr: "http://af.example.com/notify".to_string(),
+            up_node_id: "upf1.example.com".to_string(),
+            time_domain: Some(1),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn config_insert_find_remove_roundtrip() {
         let context = ctx(8);
-        let config = TimeSyncConfig::new(r#"{"timeDomain": 1}"#);
+        let config = TimeSyncConfig::new(valid_config());
         let id = config.id.clone();
 
         context.config_insert(config).expect("insert");
@@ -190,10 +882,10 @@ mod tests {
     fn config_cap_is_enforced() {
         let context = ctx(1);
         context
-            .config_insert(TimeSyncConfig::new("{}"))
+            .config_insert(TimeSyncConfig::new(valid_config()))
             .expect("fits");
         let err = context
-            .config_insert(TimeSyncConfig::new("{}"))
+            .config_insert(TimeSyncConfig::new(valid_config()))
             .expect_err("cap");
         assert_eq!(err, TsctsfContextError::MaxConfigsReached);
         assert_eq!(err.cause(), "MAX_CONFIGS_REACHED");
@@ -205,9 +897,11 @@ mod tests {
         assert!(!context.is_initialized());
         context.init(4);
         context.init(1); // guarded no-op
-        context.config_insert(TimeSyncConfig::new("{}")).expect("a");
         context
-            .config_insert(TimeSyncConfig::new("{}"))
+            .config_insert(TimeSyncConfig::new(valid_config()))
+            .expect("a");
+        context
+            .config_insert(TimeSyncConfig::new(valid_config()))
             .expect("caps kept from first init");
         context.fini();
         assert!(!context.is_initialized());
@@ -218,13 +912,325 @@ mod tests {
     fn uninitialized_context_rejects_inserts() {
         let context = TsctsfContext::new();
         assert_eq!(
-            context.config_insert(TimeSyncConfig::new("{}")),
+            context.config_insert(TimeSyncConfig::new(valid_config())),
             Err(TsctsfContextError::MaxConfigsReached)
         );
     }
 
     #[test]
     fn generated_ids_are_unique() {
-        assert_ne!(TimeSyncConfig::new("{}").id, TimeSyncConfig::new("{}").id);
+        assert_ne!(
+            TimeSyncConfig::new(valid_config()).id,
+            TimeSyncConfig::new(valid_config()).id
+        );
+    }
+
+    // ── #113: typed IE validation ────────────────────────────────────────────
+
+    /// A configuration missing a required member is `MANDATORY_IE_MISSING`, not
+    /// `INVALID_MSG_FORMAT`: TS 29.500 §5.2.7.2 distinguishes them, and that
+    /// distinction tells a consumer whether its JSON is malformed or incomplete.
+    #[test]
+    fn a_config_missing_a_required_ie_names_the_member() {
+        let mut cfg = valid_config();
+        cfg.notification_target_addr.clear();
+        let err = cfg.validate().expect_err("absent target address");
+        assert_eq!(err, IeError::MandatoryIeMissing("notificationTargetAddr"));
+        assert_eq!(err.cause(), "MANDATORY_IE_MISSING");
+        assert!(err.detail().contains("notificationTargetAddr"));
+
+        let mut cfg = valid_config();
+        cfg.up_node_id.clear();
+        assert_eq!(
+            cfg.validate().expect_err("absent node id"),
+            IeError::MandatoryIeMissing("upNodeId")
+        );
+    }
+
+    /// Present-but-EMPTY is refused as well: serde accepts `""` for a `String`,
+    /// and an empty notification target address is exactly the un-notifiable
+    /// state this validation exists to prevent — accepting it reproduces the
+    /// defect through a different door.
+    #[test]
+    fn an_empty_required_ie_is_refused_like_an_absent_one() {
+        let cfg = TimeSyncExposureConfig {
+            notification_target_addr: "   ".to_string(),
+            up_node_id: "upf1".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            cfg.validate().expect_err("blank target address"),
+            IeError::MandatoryIeMissing("notificationTargetAddr")
+        );
+    }
+
+    /// An out-of-range value is `MANDATORY_IE_INCORRECT` and names the member —
+    /// not a serde type error that names nothing.
+    #[test]
+    fn an_out_of_range_time_domain_names_the_member() {
+        let mut cfg = valid_config();
+        cfg.time_domain = Some(256);
+        let err = cfg.validate().expect_err("domain > 255");
+        assert_eq!(err, IeError::MandatoryIeIncorrect("timeDomain"));
+        assert_eq!(err.cause(), "MANDATORY_IE_INCORRECT");
+        // And the boundary is inclusive.
+        cfg.time_domain = Some(255);
+        assert!(cfg.validate().is_ok());
+    }
+
+    /// §5.2.27.2.3: an update body carrying one member changes only that member.
+    /// A replace would clear parameters the consumer did not mention, which its
+    /// required input (the PTP instance reference alone) cannot have meant.
+    #[test]
+    fn an_update_merges_rather_than_replacing() {
+        let mut cfg = valid_config();
+        cfg.gm_priority = Some(7);
+        cfg.apply_update(&serde_json::json!({ "gmEnable": true }));
+        assert_eq!(cfg.gm_enable, Some(true));
+        assert_eq!(cfg.gm_priority, Some(7), "an unmentioned member survives");
+        assert_eq!(
+            cfg.notification_target_addr, "http://af.example.com/notify",
+            "and so does a required one"
+        );
+    }
+
+    /// The add and remove lists are applied in that order, so a SUPI in both is
+    /// removed: a consumer asking for both cannot have meant "keep".
+    #[test]
+    fn supi_add_and_remove_lists_apply_in_order() {
+        let mut cfg = valid_config();
+        cfg.apply_update(&serde_json::json!({ "supisToAdd": ["a", "b", "c"] }));
+        assert_eq!(cfg.supis, vec!["a", "b", "c"]);
+        cfg.apply_update(&serde_json::json!({
+            "supisToAdd": ["d"],
+            "supisToRemove": ["b", "d"],
+        }));
+        assert_eq!(cfg.supis, vec!["a", "c"]);
+        // Adding a SUPI already present does not duplicate it.
+        cfg.apply_update(&serde_json::json!({ "supisToAdd": ["a"] }));
+        assert_eq!(cfg.supis, vec!["a", "c"]);
+    }
+
+    /// §5.2.27.2.6's required input is an EITHER/OR: (DNN, S-NSSAI) or an
+    /// AF-Service-Identifier. Both alternatives must be accepted, and neither
+    /// must be.
+    #[test]
+    fn a_caps_subscription_accepts_either_scope_and_refuses_neither() {
+        let base = CapsSubscription {
+            subscription_id: String::new(),
+            notification_target_addr: "http://af/notify".to_string(),
+            ..CapsSubscription::default()
+        };
+
+        let mut dnn_scoped = base.clone();
+        dnn_scoped.dnn = Some("internet".to_string());
+        dnn_scoped.snssai = Some(serde_json::json!({ "sst": 1 }));
+        assert!(
+            dnn_scoped.validate().is_ok(),
+            "(DNN, S-NSSAI) is a valid scope"
+        );
+
+        let mut af_scoped = base.clone();
+        af_scoped.af_service_id = Some("af-svc-1".to_string());
+        assert!(
+            af_scoped.validate().is_ok(),
+            "an AF-Service-Identifier is the other valid scope"
+        );
+
+        // DNN alone is not the alternative: the spec pairs it with S-NSSAI.
+        let mut dnn_only = base.clone();
+        dnn_only.dnn = Some("internet".to_string());
+        assert_eq!(
+            dnn_only.validate().expect_err("dnn alone"),
+            IeError::MandatoryIeMissing("dnn+snssai or afServiceId")
+        );
+
+        assert_eq!(
+            base.validate().expect_err("no scope at all"),
+            IeError::MandatoryIeMissing("dnn+snssai or afServiceId"),
+            "a subscription that could never be matched must be refused, not accepted"
+        );
+    }
+
+    /// A subscription with no notification target could never fire.
+    #[test]
+    fn a_caps_subscription_needs_a_notification_target() {
+        let sub = CapsSubscription {
+            af_service_id: Some("af-svc-1".to_string()),
+            ..CapsSubscription::default()
+        };
+        assert_eq!(
+            sub.validate().expect_err("no target"),
+            IeError::MandatoryIeMissing("notificationTargetAddr")
+        );
+    }
+
+    /// The subscription id is MINTED, never taken from the request: a
+    /// consumer-supplied id would let one AF address another's resource.
+    #[test]
+    fn a_caps_subscription_id_is_minted_not_accepted() {
+        let context = ctx(8);
+        let sub = CapsSubscription {
+            subscription_id: "attacker-chosen".to_string(),
+            notification_target_addr: "http://af/notify".to_string(),
+            af_service_id: Some("af-svc-1".to_string()),
+            ..CapsSubscription::default()
+        };
+        let created = context.caps_sub_create(sub).expect("create");
+        assert_ne!(created.subscription_id, "attacker-chosen");
+        assert!(context.caps_sub_find("attacker-chosen").is_none());
+        assert!(context.caps_sub_find(&created.subscription_id).is_some());
+        assert_eq!(
+            context
+                .caps_sub_remove(&created.subscription_id)
+                .map(|s| s.subscription_id),
+            Some(created.subscription_id.clone())
+        );
+        assert_eq!(context.caps_sub_count(), 0);
+    }
+
+    /// §5.2.27.4.2: an AF identifier AND a target are both required. A
+    /// configuration with no target would activate time distribution for nobody.
+    #[test]
+    fn an_asti_config_needs_an_af_id_and_a_target() {
+        let no_af = AstiConfig {
+            supi: Some("imsi-001010000000001".to_string()),
+            ..AstiConfig::default()
+        };
+        assert_eq!(
+            no_af.validate().expect_err("no af id"),
+            IeError::MandatoryIeMissing("afId")
+        );
+
+        let no_target = AstiConfig {
+            af_id: "af-1".to_string(),
+            ..AstiConfig::default()
+        };
+        assert_eq!(
+            no_target.validate().expect_err("no target"),
+            IeError::MandatoryIeMissing("supi, gpsi, externalGroupId or internalGroupId")
+        );
+
+        // Any one of the four targets suffices.
+        for target in ["supi", "gpsi", "externalGroupId", "internalGroupId"] {
+            let mut cfg = AstiConfig {
+                af_id: "af-1".to_string(),
+                ..AstiConfig::default()
+            };
+            match target {
+                "supi" => cfg.supi = Some("imsi-1".to_string()),
+                "gpsi" => cfg.gpsi = Some("msisdn-1".to_string()),
+                "externalGroupId" => cfg.external_group_id = Some("extgroup-1".to_string()),
+                _ => cfg.internal_group_id = Some("intgroup-1".to_string()),
+            }
+            assert!(cfg.validate().is_ok(), "{target} must be a valid target");
+        }
+    }
+
+    /// §5.2.27.3.2's required inputs are three either/ors plus the AF id. Each is
+    /// checked as an alternative: requiring both halves would refuse conformant
+    /// requests, which is the mirror of accepting one that names nothing.
+    #[test]
+    fn a_qos_tsc_session_checks_each_either_or() {
+        let complete = QosTscSession {
+            af_id: "af-1".to_string(),
+            gpsi: Some("msisdn-491700000001".to_string()),
+            flow_descriptions: vec!["permit out ip from any to assigned".to_string()],
+            qos_reference: Some("qos-ref-1".to_string()),
+            ..QosTscSession::default()
+        };
+        assert!(complete.validate().is_ok());
+
+        // The ext-app-id alternative to flow descriptions.
+        let mut ext_app = complete.clone();
+        ext_app.flow_descriptions.clear();
+        ext_app.ext_app_id = Some("app-1".to_string());
+        assert!(ext_app.validate().is_ok());
+
+        // The individual-QoS alternative to a QoS reference.
+        let mut individual = complete.clone();
+        individual.qos_reference = None;
+        individual.max_br_dl = Some("100 Mbps".to_string());
+        assert!(individual.validate().is_ok());
+
+        for (mutate, expected) in [
+            (
+                Box::new(|s: &mut QosTscSession| s.af_id.clear())
+                    as Box<dyn Fn(&mut QosTscSession)>,
+                IeError::MandatoryIeMissing("afId"),
+            ),
+            (
+                Box::new(|s: &mut QosTscSession| s.gpsi = None),
+                IeError::MandatoryIeMissing("ueIpv4, ueIpv6, gpsi or externalGroupId"),
+            ),
+            (
+                Box::new(|s: &mut QosTscSession| s.flow_descriptions.clear()),
+                IeError::MandatoryIeMissing("flowDescriptions or extAppId"),
+            ),
+            (
+                Box::new(|s: &mut QosTscSession| s.qos_reference = None),
+                IeError::MandatoryIeMissing("qosReference or maxBrUl/maxBrDl"),
+            ),
+        ] {
+            let mut broken = complete.clone();
+            mutate(&mut broken);
+            assert_eq!(broken.validate().expect_err("missing"), expected);
+        }
+    }
+
+    #[test]
+    fn asti_and_qos_tsc_stores_round_trip() {
+        let context = ctx(8);
+
+        let asti = context
+            .asti_create(AstiConfig {
+                af_id: "af-1".to_string(),
+                supi: Some("imsi-1".to_string()),
+                ..AstiConfig::default()
+            })
+            .expect("asti create");
+        assert!(!asti.config_id.is_empty());
+        assert_eq!(context.asti_count(), 1);
+        let updated = context
+            .asti_update(
+                &asti.config_id,
+                &serde_json::json!({ "asTimeDisEnabled": true, "uuErrorBudget": 900 }),
+            )
+            .expect("asti update");
+        assert_eq!(updated.as_time_dis_enabled, Some(true));
+        assert_eq!(updated.uu_error_budget, Some(900));
+        assert_eq!(
+            updated.af_id, "af-1",
+            "an update must not clear what it did not mention"
+        );
+        assert!(context.asti_remove(&asti.config_id).is_some());
+        assert_eq!(context.asti_count(), 0);
+        assert!(context
+            .asti_update("gone", &serde_json::json!({}))
+            .is_none());
+
+        let session = context
+            .qos_tsc_create(QosTscSession {
+                af_id: "af-1".to_string(),
+                gpsi: Some("msisdn-1".to_string()),
+                flow_descriptions: vec!["permit out ip from any to assigned".to_string()],
+                qos_reference: Some("q1".to_string()),
+                ..QosTscSession::default()
+            })
+            .expect("qos create");
+        assert!(!session.transaction_ref_id.is_empty());
+        let updated = context
+            .qos_tsc_update(
+                &session.transaction_ref_id,
+                &serde_json::json!({ "periodicity": 1000, "survivalTime": 2000 }),
+            )
+            .expect("qos update");
+        assert_eq!(updated.periodicity, Some(1000));
+        assert_eq!(updated.survival_time, Some(2000));
+        assert_eq!(updated.qos_reference.as_deref(), Some("q1"));
+        assert!(context
+            .qos_tsc_remove(&session.transaction_ref_id)
+            .is_some());
+        assert_eq!(context.qos_tsc_count(), 0);
     }
 }

--- a/src/bins/nextgcore-tsctsf/src/main.rs
+++ b/src/bins/nextgcore-tsctsf/src/main.rs
@@ -1,22 +1,51 @@
 //! NextGCore TSCTSF — Time Sensitive Communication and Time
 //! Synchronization Function (TS 23.501 §5.27–§5.28; service API TS 29.565).
 //!
-//! Issue #23 first increment: the control-plane NF skeleton with NRF
-//! registration (`nfType: TSCTSF`, advertising
-//! `ntsctsf-time-synchronization`) and a minimal
-//! `Ntsctsf_TimeSynchronization` surface:
+//! #113 completed the CONTROL-PLANE surface of all three services TS 23.501
+//! Table 7.2.26-1 mandates. Issue #23 landed only a three-verb store over one
+//! bespoke collection.
 //!
-//! - `POST /ntsctsf-time-synchronization/v1/configuration` — create a
-//!   time-sync exposure configuration (201 + Location + `configId`).
-//! - `GET /ntsctsf-time-synchronization/v1/configuration/{configId}` — 200.
-//! - `DELETE /ntsctsf-time-synchronization/v1/configuration/{configId}` — 204.
+//! `Ntsctsf_TimeSynchronization` (TS 23.502 §5.2.27.2):
 //!
-//! Configurations are stored verbatim in an in-memory `TsctsfContext`.
-//! Explicitly out of scope per the issue (follow-ups): PFCP TSC container
-//! codecs and SMF bridge/port management (PMIC/UMIC/TSCai), PCF TSC policy
-//! wiring, gPTP time-domain distribution, and driving the existing UPF
-//! `tsn_bridge` scaffolding. A new opt-in binary: nothing else changes
-//! behavior.
+//! - `POST   /ntsctsf-time-synchronization/v1/configuration` — ConfigCreate.
+//! - `GET    /ntsctsf-time-synchronization/v1/configuration/{configId}`.
+//! - `PATCH  /…/configuration/{configId}` — ConfigUpdate, merge semantics.
+//! - `PUT    /…/configuration/{configId}` — ConfigUpdate, whole-resource replace.
+//! - `DELETE /…/configuration/{configId}` — ConfigDelete.
+//! - `POST   /…/subscriptions` — CapsSubscribe (mints a Subscription Correlation
+//!   ID).
+//! - `GET`/`DELETE /…/subscriptions/{subscriptionId}` — CapsUnsubscribe.
+//! - ConfigUpdateNotify fires on a config change; CapsNotify fans out to every
+//!   capability subscriber.
+//!
+//! `Ntsctsf_ASTI` (§5.2.27.4): `POST`/`GET`/`PATCH`/`PUT`/`DELETE` on
+//! `/ntsctsf-asti/v1/configurations[/{configId}]`, with UpdateNotify.
+//!
+//! `Ntsctsf_QoSandTSCAssistance` (§5.2.27.3): `POST`/`GET`/`PATCH`/`PUT`/`DELETE`
+//! on `/ntsctsf-qos-tsctsf/v1/tsc-qos-requests[/{transactionRefId}]` plus
+//! Subscribe/Unsubscribe on `/ntsctsf-qos-tsctsf/v1/subscriptions`, with Notify.
+//!
+//! Configurations are now stored as TYPED IEs (see `context::TimeSyncExposureConfig`
+//! and siblings), so a malformed body is refused at ingress with the TS 29.500
+//! §5.2.7.2 cause that names the offending member, instead of being stored verbatim
+//! and discovered later.
+//!
+//! **What #113 deliberately did NOT do, and where it went instead.** The
+//! actuation leg — a PCF client issuing `Npcf_PolicyAuthorization_Create`/
+//! `Subscribe`, deriving PMIC/UMIC/TSCAI, and driving the UPF `tsn_bridge` and the
+//! SMF port-management path — is cross-NF and cannot be verified end-to-end
+//! anywhere in this tree: tsctsf, smfd and upfd are separate processes and there is
+//! no PFCP TSC container codec. #113's own suggested approach says the issue is
+//! *"best tracked as an umbrella issue split into per-service child issues rather
+//! than delivered in one change"*, so that leg is split out as its own issue rather
+//! than landed off-by-default where no test would exercise it. Consequence worth
+//! being blunt about: **a stored configuration still actuates nothing.** An operator
+//! discovering `nfType: TSCTSF` now gets three conformant control-plane services,
+//! not a working time-synchronisation function.
+//!
+//! **Spelling caveat:** `TS29565_Ntsctsf_*.yaml` is not vendored in this tree, so
+//! the resource paths and JSON member names are derived from the Stage-2 parameter
+//! names in TS 23.502 §5.2.27 rather than verified against the Stage-3 schema.
 //!
 //! OAuth2 producer enforcement mirrors dccfd: enable with
 //! `NEXTGCORE_SBI_OAUTH2_REQUIRE=1` or `<nf>.sbi.oauth2.require: true` in
@@ -264,16 +293,81 @@ async fn tsctsf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
     let parts: Vec<&str> = path.trim_start_matches('/').split('/').collect();
 
     match parts.as_slice() {
-        // Ntsctsf_TimeSynchronization (TS 29.565, minimal subset)
+        // ---- Ntsctsf_TimeSynchronization (TS 23.502 §5.2.27.2) ----
         ["ntsctsf-time-synchronization", "v1", "configuration"] => match method {
             "POST" => handle_config_create(&request).await,
             _ => send_method_not_allowed(method, "configuration"),
         },
         ["ntsctsf-time-synchronization", "v1", "configuration", config_id] => match method {
             "GET" => handle_config_get(config_id).await,
+            // #113: ConfigUpdate (§5.2.27.2.3). PATCH merges; PUT replaces. Both
+            // are served because §5.2.27.2.3's only required input is the PTP
+            // instance reference and every parameter is optional, which is merge
+            // semantics -- but a consumer that wants to state the whole
+            // configuration should not be forced into a merge.
+            "PATCH" => handle_config_update(config_id, &request).await,
+            "PUT" => handle_config_replace(config_id, &request).await,
             "DELETE" => handle_config_delete(config_id).await,
             _ => send_method_not_allowed(method, "configuration/{configId}"),
         },
+        // #113: CapsSubscribe / CapsUnsubscribe (§5.2.27.2.6, §5.2.27.2.7).
+        ["ntsctsf-time-synchronization", "v1", "subscriptions"] => match method {
+            "POST" => handle_caps_subscribe(&request).await,
+            _ => send_method_not_allowed(method, "subscriptions"),
+        },
+        ["ntsctsf-time-synchronization", "v1", "subscriptions", subscription_id] => match method {
+            "GET" => handle_caps_subscription_get(subscription_id).await,
+            "DELETE" => handle_caps_unsubscribe(subscription_id).await,
+            _ => send_method_not_allowed(method, "subscriptions/{subscriptionId}"),
+        },
+
+        // ---- Ntsctsf_ASTI (TS 23.502 §5.2.27.4) ----
+        ["ntsctsf-asti", "v1", "configurations"] => match method {
+            "POST" => handle_asti_create(&request).await,
+            _ => send_method_not_allowed(method, "configurations"),
+        },
+        ["ntsctsf-asti", "v1", "configurations", config_id] => match method {
+            "GET" => handle_asti_get(config_id).await,
+            "PATCH" | "PUT" => handle_asti_update(config_id, &request).await,
+            "DELETE" => handle_asti_delete(config_id).await,
+            _ => send_method_not_allowed(method, "configurations/{configId}"),
+        },
+
+        // ---- Ntsctsf_QoSandTSCAssistance (TS 23.502 §5.2.27.3) ----
+        ["ntsctsf-qos-tsctsf", "v1", "tsc-qos-requests"] => match method {
+            "POST" => handle_qos_tsc_create(&request).await,
+            _ => send_method_not_allowed(method, "tsc-qos-requests"),
+        },
+        ["ntsctsf-qos-tsctsf", "v1", "tsc-qos-requests", transaction_id] => match method {
+            "GET" => handle_qos_tsc_get(transaction_id).await,
+            "PATCH" | "PUT" => handle_qos_tsc_update(transaction_id, &request).await,
+            "DELETE" => handle_qos_tsc_delete(transaction_id).await,
+            _ => send_method_not_allowed(method, "tsc-qos-requests/{transactionId}"),
+        },
+        ["ntsctsf-qos-tsctsf", "v1", "subscriptions"] => match method {
+            "POST" => handle_qos_tsc_subscribe(&request).await,
+            _ => send_method_not_allowed(method, "subscriptions"),
+        },
+        ["ntsctsf-qos-tsctsf", "v1", "subscriptions", subscription_id] => match method {
+            "GET" => handle_qos_tsc_subscription_get(subscription_id).await,
+            "DELETE" => handle_qos_tsc_unsubscribe(subscription_id).await,
+            _ => send_method_not_allowed(method, "subscriptions/{subscriptionId}"),
+        },
+
+        // #113: administrative trigger for CapsNotify (§5.2.27.2.8).
+        //
+        // NOT a 3GPP service operation. The 5GS capability change that would
+        // trigger CapsNotify has NO in-tree source -- reporting one needs the
+        // UPF/NW-TT capability leg, which is split out as its own issue. Without a
+        // trigger the notify path would be unreachable in principle, which is this
+        // repo's recorded "grep the SINK before implementing an emit-side feature"
+        // hazard in reverse. This route is the producer, and it is named `admin` so
+        // nobody mistakes it for part of the Ntsctsf API.
+        ["ntsctsf-time-synchronization", "v1", "admin", "capability-change"] => match method {
+            "POST" => handle_admin_capability_change(&request).await,
+            _ => send_method_not_allowed(method, "admin/capability-change"),
+        },
+
         _ => send_not_found(&format!("Resource not found: {path}"), None),
     }
 }
@@ -283,34 +377,21 @@ async fn tsctsf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
 /// object; an optional `timeDomain` must be an integer 0..=255
 /// (IEEE 802.1AS domain number).
 async fn handle_config_create(request: &SbiRequest) -> SbiResponse {
-    let body = match &request.http.content {
-        Some(c) => c,
-        None => return send_bad_request("Missing request body", Some("MISSING_BODY")),
+    let (data, config) = match parse_typed_body::<context::TimeSyncExposureConfig>(request) {
+        Ok(pair) => pair,
+        Err(resp) => return *resp,
     };
-    let data: serde_json::Value = match serde_json::from_str(body) {
-        Ok(p) => p,
-        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
-    };
-    if !data.is_object() {
-        return send_bad_request(
-            "configuration must be a JSON object",
-            Some("INVALID_MSG_FORMAT"),
-        );
+    if let Err(err) = config.validate() {
+        return send_bad_request(&err.detail(), Some(err.cause()));
     }
-    if let Some(domain) = data.get("timeDomain") {
-        if domain.as_u64().is_none_or(|d| d > 255) {
-            return send_bad_request(
-                "timeDomain must be an integer 0..=255 (IEEE 802.1AS domain)",
-                Some("MANDATORY_IE_INCORRECT"),
-            );
-        }
-    }
+    let mut config = config;
+    config.raw = data.clone();
 
-    let config = TimeSyncConfig::new(body.clone());
-    let config_id = config.id.clone();
+    let stored = context::TimeSyncConfig::new(config);
+    let config_id = stored.id.clone();
     let ctx = tsctsf_self();
     let insert = match ctx.read() {
-        Ok(c) => c.config_insert(config),
+        Ok(c) => c.config_insert(stored),
         Err(_) => Err(TsctsfContextError::LockPoisoned),
     };
     match insert {
@@ -323,15 +404,181 @@ async fn handle_config_create(request: &SbiRequest) -> SbiResponse {
 
     let location = format!("/ntsctsf-time-synchronization/v1/configuration/{config_id}");
     log::info!("Time-sync configuration created: id={config_id}");
-    let mut echoed = data;
-    if let Some(obj) = echoed.as_object_mut() {
-        obj.insert("configId".to_string(), serde_json::json!(config_id));
-        obj.insert("self".to_string(), serde_json::json!(location));
-    }
     SbiResponse::with_status(201)
-        .with_header("Location", location)
-        .with_json_body(&echoed)
+        .with_header("Location", location.clone())
+        .with_json_body(&config_body(&config_id, &data, &location))
         .unwrap_or_else(|_| SbiResponse::with_status(201))
+}
+
+/// Parse a request body into `T`, distinguishing the TS 29.500 §5.2.7.2 causes.
+///
+/// Returns the raw JSON alongside the typed value, because every handler here
+/// echoes the body back with the server-minted id and `self` link, and a consumer
+/// that sent an optional parameter this build does not model should get it back
+/// rather than have it silently dropped.
+///
+/// A serde TYPE mismatch is `INVALID_MSG_FORMAT` and an absent required member is
+/// `MANDATORY_IE_MISSING` (raised by each type's `validate`). `serde(default)`
+/// covers an absent member; it does **not** rescue a mismatched one, which is why
+/// the two causes come from two different places.
+fn parse_typed_body<T: serde::de::DeserializeOwned>(
+    request: &SbiRequest,
+) -> Result<(serde_json::Value, T), Box<SbiResponse>> {
+    let Some(body) = &request.http.content else {
+        return Err(Box::new(send_bad_request(
+            "Missing request body",
+            Some("MISSING_BODY"),
+        )));
+    };
+    let data: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => {
+            return Err(Box::new(send_bad_request(
+                &format!("Invalid JSON: {e}"),
+                Some("INVALID_MSG_FORMAT"),
+            )))
+        }
+    };
+    if !data.is_object() {
+        return Err(Box::new(send_bad_request(
+            "request body must be a JSON object",
+            Some("INVALID_MSG_FORMAT"),
+        )));
+    }
+    match serde_json::from_value::<T>(data.clone()) {
+        Ok(typed) => Ok((data, typed)),
+        Err(e) => Err(Box::new(send_bad_request(
+            &format!("Invalid IE: {e}"),
+            Some("INVALID_MSG_FORMAT"),
+        ))),
+    }
+}
+
+/// The response body for a configuration resource: the body as received plus the
+/// server-minted `configId` and the server-canonical `self` link.
+///
+/// `self` overrides any client-supplied value: the link is the server's statement
+/// about where the resource lives, not the consumer's.
+fn config_body(config_id: &str, raw: &serde_json::Value, self_link: &str) -> serde_json::Value {
+    let mut body = raw.clone();
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("configId".to_string(), serde_json::json!(config_id));
+        obj.insert("self".to_string(), serde_json::json!(self_link));
+    }
+    body
+}
+
+/// PATCH /ntsctsf-time-synchronization/v1/configuration/{configId} — ConfigUpdate
+/// (#113, TS 23.502 §5.2.27.2.3). 200 on success, 404 for an unknown id.
+async fn handle_config_update(config_id: &str, request: &SbiRequest) -> SbiResponse {
+    let Some(body) = &request.http.content else {
+        return send_bad_request("Missing request body", Some("MISSING_BODY"));
+    };
+    let data: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => {
+            return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_MSG_FORMAT"))
+        }
+    };
+    if !data.is_object() {
+        return send_bad_request(
+            "request body must be a JSON object",
+            Some("INVALID_MSG_FORMAT"),
+        );
+    }
+
+    let ctx = tsctsf_self();
+    let updated = match ctx.read() {
+        Ok(c) => c.config_update(config_id, &data),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    let Some(updated) = updated else {
+        return send_not_found(
+            &format!("Configuration {config_id} not found"),
+            Some("CONFIG_NOT_FOUND"),
+        );
+    };
+    // The merge must not be able to produce an invalid configuration: an update
+    // that blanks the notification target address would leave a configuration that
+    // can never notify, which is what the validation exists to prevent.
+    if let Err(err) = updated.config.validate() {
+        return send_bad_request(&err.detail(), Some(err.cause()));
+    }
+
+    let self_link = format!("/ntsctsf-time-synchronization/v1/configuration/{config_id}");
+    let body = updated_config_body(&updated, &self_link);
+    // ConfigUpdateNotify (§5.2.27.2.5): the configuration changed, so tell whoever
+    // asked to be told. Awaited so the notification is on the wire before the 200,
+    // which is what makes the test able to observe it without a sleep.
+    notify_config_update(&updated, &body).await;
+
+    log::info!("Time-sync configuration updated: id={config_id}");
+    SbiResponse::with_status(200)
+        .with_json_body(&body)
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+/// PUT /ntsctsf-time-synchronization/v1/configuration/{configId} — ConfigUpdate as
+/// a whole-resource replace (#113).
+async fn handle_config_replace(config_id: &str, request: &SbiRequest) -> SbiResponse {
+    let (data, config) = match parse_typed_body::<context::TimeSyncExposureConfig>(request) {
+        Ok(pair) => pair,
+        Err(resp) => return *resp,
+    };
+    if let Err(err) = config.validate() {
+        return send_bad_request(&err.detail(), Some(err.cause()));
+    }
+    let mut config = config;
+    config.raw = data;
+
+    let ctx = tsctsf_self();
+    let updated = match ctx.read() {
+        Ok(c) => c.config_replace(config_id, config),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    let Some(updated) = updated else {
+        return send_not_found(
+            &format!("Configuration {config_id} not found"),
+            Some("CONFIG_NOT_FOUND"),
+        );
+    };
+
+    let self_link = format!("/ntsctsf-time-synchronization/v1/configuration/{config_id}");
+    let body = updated_config_body(&updated, &self_link);
+    notify_config_update(&updated, &body).await;
+
+    log::info!("Time-sync configuration replaced: id={config_id}");
+    SbiResponse::with_status(200)
+        .with_json_body(&body)
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+/// Render a stored configuration, merging the typed members over the body as
+/// received so an update is visible in the response.
+fn updated_config_body(stored: &context::TimeSyncConfig, self_link: &str) -> serde_json::Value {
+    let mut body = match serde_json::to_value(&stored.config) {
+        Ok(serde_json::Value::Object(typed)) => {
+            // Start from what the consumer sent, so unmodelled optional parameters
+            // survive, then overlay the typed members, which are authoritative for
+            // anything this build understands.
+            let mut merged = match stored.config.raw.clone() {
+                serde_json::Value::Object(raw) => raw,
+                _ => serde_json::Map::new(),
+            };
+            for (k, v) in typed {
+                if !v.is_null() {
+                    merged.insert(k, v);
+                }
+            }
+            serde_json::Value::Object(merged)
+        }
+        _ => stored.config.raw.clone(),
+    };
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("configId".to_string(), serde_json::json!(stored.id));
+        obj.insert("self".to_string(), serde_json::json!(self_link));
+    }
+    body
 }
 
 /// GET /ntsctsf-time-synchronization/v1/configuration/{configId} — 200/404.
@@ -347,22 +594,14 @@ async fn handle_config_get(config_id: &str) -> SbiResponse {
             Some("CONFIG_NOT_FOUND"),
         );
     };
-    let mut body: serde_json::Value =
-        serde_json::from_str(&config.raw).unwrap_or_else(|_| serde_json::json!({}));
-    if let Some(obj) = body.as_object_mut() {
-        obj.insert("configId".to_string(), serde_json::json!(config.id));
-        // Return the same server-canonical `self` link the create response
-        // carried, overriding any client-supplied value in the stored body.
-        obj.insert(
-            "self".to_string(),
-            serde_json::json!(format!(
-                "/ntsctsf-time-synchronization/v1/configuration/{}",
-                config.id
-            )),
-        );
-    }
+    // Returns the same server-canonical `self` link the create response carried,
+    // overriding any client-supplied value in the stored body.
+    let self_link = format!(
+        "/ntsctsf-time-synchronization/v1/configuration/{}",
+        config.id
+    );
     SbiResponse::with_status(200)
-        .with_json_body(&body)
+        .with_json_body(&updated_config_body(&config, &self_link))
         .unwrap_or_else(|_| SbiResponse::with_status(200))
 }
 
@@ -385,6 +624,593 @@ async fn handle_config_delete(config_id: &str) -> SbiResponse {
     }
 }
 
+// ============================================================================
+// #113: Ntsctsf_TimeSynchronization capability subscriptions (§5.2.27.2.6-.2.8)
+// ============================================================================
+
+/// POST /ntsctsf-time-synchronization/v1/subscriptions — CapsSubscribe
+/// (§5.2.27.2.6). 201 + Location + the minted Subscription Correlation ID.
+async fn handle_caps_subscribe(request: &SbiRequest) -> SbiResponse {
+    let (data, sub) = match parse_typed_body::<context::CapsSubscription>(request) {
+        Ok(pair) => pair,
+        Err(resp) => return *resp,
+    };
+    if let Err(err) = sub.validate() {
+        return send_bad_request(&err.detail(), Some(err.cause()));
+    }
+
+    let ctx = tsctsf_self();
+    let created = match ctx.read() {
+        Ok(c) => c.caps_sub_create(sub),
+        Err(_) => Err(TsctsfContextError::LockPoisoned),
+    };
+    let created = match created {
+        Ok(sub) => sub,
+        Err(err @ TsctsfContextError::MaxConfigsReached) => {
+            return send_error(507, "Insufficient Storage", err.detail(), Some(err.cause()))
+        }
+        Err(err) => return send_internal_error(err.detail()),
+    };
+
+    let location = format!(
+        "/ntsctsf-time-synchronization/v1/subscriptions/{}",
+        created.subscription_id
+    );
+    log::info!(
+        "Time-sync capability subscription created: id={}",
+        created.subscription_id
+    );
+    let mut body = data;
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert(
+            "subscriptionId".to_string(),
+            serde_json::json!(created.subscription_id),
+        );
+        obj.insert("self".to_string(), serde_json::json!(location));
+    }
+    SbiResponse::with_status(201)
+        .with_header("Location", location.clone())
+        .with_json_body(&body)
+        .unwrap_or_else(|_| SbiResponse::with_status(201))
+}
+
+/// GET /ntsctsf-time-synchronization/v1/subscriptions/{subscriptionId} — 200/404.
+async fn handle_caps_subscription_get(subscription_id: &str) -> SbiResponse {
+    let ctx = tsctsf_self();
+    let sub = match ctx.read() {
+        Ok(c) => c.caps_sub_find(subscription_id),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    match sub {
+        Some(sub) => SbiResponse::with_status(200)
+            .with_json_body(&sub)
+            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        None => send_not_found(
+            &format!("Subscription {subscription_id} not found"),
+            Some("SUBSCRIPTION_NOT_FOUND"),
+        ),
+    }
+}
+
+/// DELETE /ntsctsf-time-synchronization/v1/subscriptions/{subscriptionId} —
+/// CapsUnsubscribe (§5.2.27.2.7). 204/404.
+async fn handle_caps_unsubscribe(subscription_id: &str) -> SbiResponse {
+    let ctx = tsctsf_self();
+    let removed = match ctx.read() {
+        Ok(c) => c.caps_sub_remove(subscription_id),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    match removed {
+        Some(_) => {
+            log::info!("Time-sync capability subscription removed: id={subscription_id}");
+            SbiResponse::with_status(204)
+        }
+        None => send_not_found(
+            &format!("Subscription {subscription_id} not found"),
+            Some("SUBSCRIPTION_NOT_FOUND"),
+        ),
+    }
+}
+
+// ============================================================================
+// #113: Ntsctsf_ASTI (§5.2.27.4)
+// ============================================================================
+
+/// POST /ntsctsf-asti/v1/configurations — ASTI_Create (§5.2.27.4.2).
+async fn handle_asti_create(request: &SbiRequest) -> SbiResponse {
+    let (data, cfg) = match parse_typed_body::<context::AstiConfig>(request) {
+        Ok(pair) => pair,
+        Err(resp) => return *resp,
+    };
+    if let Err(err) = cfg.validate() {
+        return send_bad_request(&err.detail(), Some(err.cause()));
+    }
+
+    let ctx = tsctsf_self();
+    let created = match ctx.read() {
+        Ok(c) => c.asti_create(cfg),
+        Err(_) => Err(TsctsfContextError::LockPoisoned),
+    };
+    let created = match created {
+        Ok(cfg) => cfg,
+        Err(err @ TsctsfContextError::MaxConfigsReached) => {
+            return send_error(507, "Insufficient Storage", err.detail(), Some(err.cause()))
+        }
+        Err(err) => return send_internal_error(err.detail()),
+    };
+
+    let location = format!("/ntsctsf-asti/v1/configurations/{}", created.config_id);
+    log::info!(
+        "ASTI configuration created: id={} (af={})",
+        created.config_id,
+        created.af_id
+    );
+    let mut body = data;
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("configId".to_string(), serde_json::json!(created.config_id));
+        obj.insert("self".to_string(), serde_json::json!(location));
+    }
+    SbiResponse::with_status(201)
+        .with_header("Location", location.clone())
+        .with_json_body(&body)
+        .unwrap_or_else(|_| SbiResponse::with_status(201))
+}
+
+/// GET /ntsctsf-asti/v1/configurations/{configId} — ASTI_Get (§5.2.27.4.5).
+async fn handle_asti_get(config_id: &str) -> SbiResponse {
+    let ctx = tsctsf_self();
+    let cfg = match ctx.read() {
+        Ok(c) => c.asti_find(config_id),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    match cfg {
+        Some(cfg) => SbiResponse::with_status(200)
+            .with_json_body(&cfg)
+            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        None => send_not_found(
+            &format!("ASTI configuration {config_id} not found"),
+            Some("CONFIG_NOT_FOUND"),
+        ),
+    }
+}
+
+/// PATCH/PUT /ntsctsf-asti/v1/configurations/{configId} — ASTI_Update
+/// (§5.2.27.4.3).
+async fn handle_asti_update(config_id: &str, request: &SbiRequest) -> SbiResponse {
+    let Some(body) = &request.http.content else {
+        return send_bad_request("Missing request body", Some("MISSING_BODY"));
+    };
+    let data: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => {
+            return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_MSG_FORMAT"))
+        }
+    };
+    let ctx = tsctsf_self();
+    let updated = match ctx.read() {
+        Ok(c) => c.asti_update(config_id, &data),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    let Some(updated) = updated else {
+        return send_not_found(
+            &format!("ASTI configuration {config_id} not found"),
+            Some("CONFIG_NOT_FOUND"),
+        );
+    };
+    // ASTI_UpdateNotify (§5.2.27.4, "UpdateNotify"): the configuration changed, so
+    // tell the target the create registered, if any.
+    notify_asti_update(&updated).await;
+    log::info!("ASTI configuration updated: id={config_id}");
+    SbiResponse::with_status(200)
+        .with_json_body(&updated)
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+/// DELETE /ntsctsf-asti/v1/configurations/{configId} — ASTI_Delete
+/// (§5.2.27.4.4). 204/404.
+async fn handle_asti_delete(config_id: &str) -> SbiResponse {
+    let ctx = tsctsf_self();
+    let removed = match ctx.read() {
+        Ok(c) => c.asti_remove(config_id),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    match removed {
+        Some(_) => {
+            log::info!("ASTI configuration removed: id={config_id}");
+            SbiResponse::with_status(204)
+        }
+        None => send_not_found(
+            &format!("ASTI configuration {config_id} not found"),
+            Some("CONFIG_NOT_FOUND"),
+        ),
+    }
+}
+
+// ============================================================================
+// #113: Ntsctsf_QoSandTSCAssistance (§5.2.27.3)
+// ============================================================================
+
+/// POST /ntsctsf-qos-tsctsf/v1/tsc-qos-requests — Create (§5.2.27.3.2). The
+/// response carries the Transaction Reference ID.
+async fn handle_qos_tsc_create(request: &SbiRequest) -> SbiResponse {
+    let (data, session) = match parse_typed_body::<context::QosTscSession>(request) {
+        Ok(pair) => pair,
+        Err(resp) => return *resp,
+    };
+    if let Err(err) = session.validate() {
+        return send_bad_request(&err.detail(), Some(err.cause()));
+    }
+
+    let ctx = tsctsf_self();
+    let created = match ctx.read() {
+        Ok(c) => c.qos_tsc_create(session),
+        Err(_) => Err(TsctsfContextError::LockPoisoned),
+    };
+    let created = match created {
+        Ok(s) => s,
+        Err(err @ TsctsfContextError::MaxConfigsReached) => {
+            return send_error(507, "Insufficient Storage", err.detail(), Some(err.cause()))
+        }
+        Err(err) => return send_internal_error(err.detail()),
+    };
+
+    let location = format!(
+        "/ntsctsf-qos-tsctsf/v1/tsc-qos-requests/{}",
+        created.transaction_ref_id
+    );
+    log::info!(
+        "QoS/TSC assistance session created: transaction={} (af={})",
+        created.transaction_ref_id,
+        created.af_id
+    );
+    let mut body = data;
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert(
+            "transactionRefId".to_string(),
+            serde_json::json!(created.transaction_ref_id),
+        );
+        obj.insert("self".to_string(), serde_json::json!(location));
+    }
+    SbiResponse::with_status(201)
+        .with_header("Location", location.clone())
+        .with_json_body(&body)
+        .unwrap_or_else(|_| SbiResponse::with_status(201))
+}
+
+/// GET /ntsctsf-qos-tsctsf/v1/tsc-qos-requests/{transactionRefId} — 200/404.
+async fn handle_qos_tsc_get(transaction_id: &str) -> SbiResponse {
+    let ctx = tsctsf_self();
+    let session = match ctx.read() {
+        Ok(c) => c.qos_tsc_find(transaction_id),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    match session {
+        Some(s) => SbiResponse::with_status(200)
+            .with_json_body(&s)
+            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        None => send_not_found(
+            &format!("Transaction {transaction_id} not found"),
+            Some("TRANSACTION_NOT_FOUND"),
+        ),
+    }
+}
+
+/// PATCH/PUT /ntsctsf-qos-tsctsf/v1/tsc-qos-requests/{transactionRefId} — Update
+/// (§5.2.27.3.3).
+async fn handle_qos_tsc_update(transaction_id: &str, request: &SbiRequest) -> SbiResponse {
+    let Some(body) = &request.http.content else {
+        return send_bad_request("Missing request body", Some("MISSING_BODY"));
+    };
+    let data: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => {
+            return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_MSG_FORMAT"))
+        }
+    };
+    let ctx = tsctsf_self();
+    let updated = match ctx.read() {
+        Ok(c) => c.qos_tsc_update(transaction_id, &data),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    let Some(updated) = updated else {
+        return send_not_found(
+            &format!("Transaction {transaction_id} not found"),
+            Some("TRANSACTION_NOT_FOUND"),
+        );
+    };
+    // Notify (§5.2.27.3): the authorised QoS changed, so tell every subscriber
+    // scoped to this transaction.
+    notify_qos_tsc_subscribers(transaction_id, &updated).await;
+    log::info!("QoS/TSC assistance session updated: transaction={transaction_id}");
+    SbiResponse::with_status(200)
+        .with_json_body(&updated)
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+/// DELETE /ntsctsf-qos-tsctsf/v1/tsc-qos-requests/{transactionRefId} — Delete
+/// (§5.2.27.3.4). 204/404.
+async fn handle_qos_tsc_delete(transaction_id: &str) -> SbiResponse {
+    let ctx = tsctsf_self();
+    let removed = match ctx.read() {
+        Ok(c) => c.qos_tsc_remove(transaction_id),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    match removed {
+        Some(_) => {
+            log::info!("QoS/TSC assistance session removed: transaction={transaction_id}");
+            SbiResponse::with_status(204)
+        }
+        None => send_not_found(
+            &format!("Transaction {transaction_id} not found"),
+            Some("TRANSACTION_NOT_FOUND"),
+        ),
+    }
+}
+
+/// POST /ntsctsf-qos-tsctsf/v1/subscriptions — Subscribe (§5.2.27.3).
+async fn handle_qos_tsc_subscribe(request: &SbiRequest) -> SbiResponse {
+    let (data, sub) = match parse_typed_body::<context::QosTscSubscription>(request) {
+        Ok(pair) => pair,
+        Err(resp) => return *resp,
+    };
+    if let Err(err) = sub.validate() {
+        return send_bad_request(&err.detail(), Some(err.cause()));
+    }
+
+    let ctx = tsctsf_self();
+    let created = match ctx.read() {
+        Ok(c) => c.qos_tsc_sub_create(sub),
+        Err(_) => Err(TsctsfContextError::LockPoisoned),
+    };
+    let created = match created {
+        Ok(s) => s,
+        Err(err @ TsctsfContextError::MaxConfigsReached) => {
+            return send_error(507, "Insufficient Storage", err.detail(), Some(err.cause()))
+        }
+        Err(err) => return send_internal_error(err.detail()),
+    };
+
+    let location = format!(
+        "/ntsctsf-qos-tsctsf/v1/subscriptions/{}",
+        created.subscription_id
+    );
+    let mut body = data;
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert(
+            "subscriptionId".to_string(),
+            serde_json::json!(created.subscription_id),
+        );
+        obj.insert("self".to_string(), serde_json::json!(location));
+    }
+    SbiResponse::with_status(201)
+        .with_header("Location", location.clone())
+        .with_json_body(&body)
+        .unwrap_or_else(|_| SbiResponse::with_status(201))
+}
+
+/// GET /ntsctsf-qos-tsctsf/v1/subscriptions/{subscriptionId} — 200/404.
+async fn handle_qos_tsc_subscription_get(subscription_id: &str) -> SbiResponse {
+    let ctx = tsctsf_self();
+    let sub = match ctx.read() {
+        Ok(c) => c.qos_tsc_sub_find(subscription_id),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    match sub {
+        Some(s) => SbiResponse::with_status(200)
+            .with_json_body(&s)
+            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        None => send_not_found(
+            &format!("Subscription {subscription_id} not found"),
+            Some("SUBSCRIPTION_NOT_FOUND"),
+        ),
+    }
+}
+
+/// DELETE /ntsctsf-qos-tsctsf/v1/subscriptions/{subscriptionId} — Unsubscribe
+/// (§5.2.27.3). 204/404.
+async fn handle_qos_tsc_unsubscribe(subscription_id: &str) -> SbiResponse {
+    let ctx = tsctsf_self();
+    let removed = match ctx.read() {
+        Ok(c) => c.qos_tsc_sub_remove(subscription_id),
+        Err(_) => return send_internal_error("TSCTSF context lock poisoned"),
+    };
+    match removed {
+        Some(_) => SbiResponse::with_status(204),
+        None => send_not_found(
+            &format!("Subscription {subscription_id} not found"),
+            Some("SUBSCRIPTION_NOT_FOUND"),
+        ),
+    }
+}
+
+// ============================================================================
+// #113: notifications (ConfigUpdateNotify, CapsNotify, ASTI UpdateNotify, Notify)
+// ============================================================================
+
+/// POST a notification body to a consumer-supplied target address.
+///
+/// Best-effort: a failure is logged and never propagated to the consumer whose
+/// request triggered it. The alternative would let an unreachable AF fail the
+/// operation that changed the configuration, which is a worse outcome than a
+/// missed notification.
+async fn post_notification(target: &str, kind: &str, body: &serde_json::Value) {
+    use nextgcore_sbi::constants::content_type;
+    use nextgcore_sbi::message::SbiRequest as SReq;
+
+    let Some((host, port, path)) = split_target(target) else {
+        log::warn!("{kind}: notification target '{target}' is not a usable URI; not sent");
+        return;
+    };
+    let request = SReq::post(&path).with_body(body.to_string(), content_type::APPLICATION_JSON);
+    let client = nextgcore_sbi::client::SbiClient::new(
+        nextgcore_sbi::security::sbi_peer_client_config(&host, port)
+            .with_connect_timeout(std::time::Duration::from_secs(2))
+            .with_request_timeout(std::time::Duration::from_secs(3)),
+    );
+    match client.send_request(request).await {
+        Ok(resp) => log::info!("{kind} → {host}:{port}{path}: status={}", resp.status),
+        Err(e) => log::warn!("{kind} → {host}:{port}{path} failed: {e}"),
+    }
+}
+
+/// Split a notification target address into (host, port, path).
+///
+/// The address is consumer-supplied and TS 29.571 types it as a URI, so both a
+/// bare authority and a full URI with a path are accepted. A target with no usable
+/// host is refused rather than guessed at: notifying the wrong node is worse than
+/// not notifying.
+fn split_target(target: &str) -> Option<(String, u16, String)> {
+    let without_scheme = target
+        .strip_prefix("http://")
+        .or_else(|| target.strip_prefix("https://"))
+        .unwrap_or(target);
+    let default_port = if target.starts_with("https://") {
+        443
+    } else {
+        80
+    };
+    let (authority, path) = match without_scheme.find('/') {
+        Some(i) => (&without_scheme[..i], without_scheme[i..].to_string()),
+        None => (without_scheme, "/".to_string()),
+    };
+    if authority.is_empty() {
+        return None;
+    }
+    match authority.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() => {
+            Some((host.to_string(), port.parse().ok()?, path))
+        }
+        _ => Some((authority.to_string(), default_port, path)),
+    }
+}
+
+/// ConfigUpdateNotify (§5.2.27.2.5): tell the configuration's notification target
+/// that it changed.
+async fn notify_config_update(stored: &context::TimeSyncConfig, body: &serde_json::Value) {
+    let target = stored.config.notification_target_addr.clone();
+    if target.trim().is_empty() {
+        return;
+    }
+    let mut notification = serde_json::json!({
+        "configId": stored.id,
+        "timeSyncExposureConfig": body,
+    });
+    if let Some(id) = &stored.config.notification_correlation_id {
+        notification["notifyCorrelationId"] = serde_json::json!(id);
+    }
+    post_notification(&target, "ConfigUpdateNotify", &notification).await;
+}
+
+/// ASTI UpdateNotify (§5.2.27.4): tell the configuration's notification target, if
+/// one was registered, that the access-stratum time distribution changed.
+async fn notify_asti_update(cfg: &context::AstiConfig) {
+    let Some(target) = cfg
+        .notification_target_addr
+        .as_deref()
+        .filter(|t| !t.trim().is_empty())
+    else {
+        return;
+    };
+    let mut notification = serde_json::json!({
+        "configId": cfg.config_id,
+        "astiConfig": cfg,
+    });
+    if let Some(id) = &cfg.notification_correlation_id {
+        notification["notifyCorrelationId"] = serde_json::json!(id);
+    }
+    post_notification(target, "ASTI UpdateNotify", &notification).await;
+}
+
+/// QoSandTSCAssistance Notify (§5.2.27.3): tell every subscriber scoped to this
+/// transaction, plus every unscoped subscriber.
+///
+/// An unscoped subscription (no `transactionRefId`) is treated as "all
+/// transactions", because a subscriber that named none asked for everything —
+/// refusing to notify them would make an unfiltered subscription the one shape that
+/// never fires.
+async fn notify_qos_tsc_subscribers(transaction_id: &str, session: &context::QosTscSession) {
+    let ctx = tsctsf_self();
+    let subs = match ctx.read() {
+        Ok(c) => c.qos_tsc_sub_list(),
+        Err(_) => return,
+    };
+    for sub in subs {
+        let scoped = sub
+            .transaction_ref_id
+            .as_deref()
+            .is_none_or(|t| t == transaction_id);
+        if !scoped {
+            continue;
+        }
+        let mut notification = serde_json::json!({
+            "transactionRefId": transaction_id,
+            "tscQosSession": session,
+        });
+        if let Some(id) = &sub.notification_correlation_id {
+            notification["notifyCorrelationId"] = serde_json::json!(id);
+        }
+        post_notification(
+            &sub.notification_target_addr,
+            "QoSandTSCAssistance Notify",
+            &notification,
+        )
+        .await;
+    }
+}
+
+/// CapsNotify (§5.2.27.2.8): tell every capability subscriber about a change in
+/// the reported time-synchronization capabilities.
+///
+/// Exposed (rather than private) because the trigger is a capability change in the
+/// 5GS, which this build has no source for — the actuation leg that would report
+/// one is split out as its own issue. So this is called by the admin trigger below
+/// and by tests, and the absence of an in-tree producer is stated rather than left
+/// to be discovered.
+pub async fn notify_capability_change(capabilities: &serde_json::Value) -> usize {
+    let ctx = tsctsf_self();
+    let subs = match ctx.read() {
+        Ok(c) => c.caps_sub_list(),
+        Err(_) => return 0,
+    };
+    let mut sent = 0usize;
+    for sub in subs {
+        let mut notification = serde_json::json!({
+            "subscriptionId": sub.subscription_id,
+            "timeSyncCapabilities": capabilities,
+        });
+        if let Some(id) = &sub.notification_correlation_id {
+            notification["notifyCorrelationId"] = serde_json::json!(id);
+        }
+        post_notification(&sub.notification_target_addr, "CapsNotify", &notification).await;
+        sent += 1;
+    }
+    sent
+}
+
+/// POST /ntsctsf-time-synchronization/v1/admin/capability-change — fan a
+/// capability change out to every CapsSubscribe subscriber (#113).
+///
+/// Administrative, not a service operation: see the router comment. Answers 200
+/// with the number of subscribers notified, so an operator can tell "notified
+/// nobody because nobody subscribed" from "notified nobody because the fan-out is
+/// broken" — two states a 204 would conflate.
+async fn handle_admin_capability_change(request: &SbiRequest) -> SbiResponse {
+    let capabilities: serde_json::Value = match &request.http.content {
+        Some(body) => match serde_json::from_str(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_MSG_FORMAT"))
+            }
+        },
+        None => serde_json::json!({}),
+    };
+    let notified = notify_capability_change(&capabilities).await;
+    log::info!("CapsNotify fan-out: {notified} subscriber(s)");
+    SbiResponse::with_status(200)
+        .with_json_body(&serde_json::json!({ "notified": notified }))
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
 /// Build the NFProfile registered with the NRF (TS 29.510): nfType TSCTSF
 /// advertising the ntsctsf-time-synchronization service (TS 29.565).
 fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serde_json::Value {
@@ -393,10 +1219,31 @@ fn build_nf_profile(nf_instance_id: &str, sbi_addr: &str, sbi_port: u16) -> serd
         "nfType": "TSCTSF",
         "nfStatus": "REGISTERED",
         "ipv4Addresses": [sbi_addr],
+        // #113: all THREE services TS 23.501 Table 7.2.26-1 mandates, not just
+        // the one. Advertising only `ntsctsf-time-synchronization` while serving
+        // the other two would make them undiscoverable, and advertising services
+        // that are not served would be worse -- so this list and the router are
+        // changed together.
         "nfServices": [
             {
                 "serviceInstanceId": format!("{nf_instance_id}-ntsctsf-time-synchronization"),
                 "serviceName": "ntsctsf-time-synchronization",
+                "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
+                "scheme": "http",
+                "nfServiceStatus": "REGISTERED",
+                "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
+            },
+            {
+                "serviceInstanceId": format!("{nf_instance_id}-ntsctsf-asti"),
+                "serviceName": "ntsctsf-asti",
+                "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
+                "scheme": "http",
+                "nfServiceStatus": "REGISTERED",
+                "ipEndPoints": [{"ipv4Address": sbi_addr, "port": sbi_port}]
+            },
+            {
+                "serviceInstanceId": format!("{nf_instance_id}-ntsctsf-qos-tsctsf"),
+                "serviceName": "ntsctsf-qos-tsctsf",
                 "versions": [{"apiVersionInUri": "v1", "apiFullVersion": "1.0.0"}],
                 "scheme": "http",
                 "nfServiceStatus": "REGISTERED",
@@ -505,14 +1352,30 @@ mod tests {
 
     /// Drive an async handler on a fresh current-thread runtime (the
     /// handlers under test do no real I/O).
+    /// #113: `enable_all` rather than a bare builder. The handlers no longer "do
+    /// no real I/O": ConfigUpdate fires ConfigUpdateNotify, whose client sets a
+    /// request timeout, and a runtime without timers panics on it. A test that
+    /// registers an unreachable notification target still exercises the send.
     fn block_on<F: std::future::Future>(fut: F) -> F::Output {
         tokio::runtime::Builder::new_current_thread()
+            .enable_all()
             .build()
             .expect("build current-thread runtime")
             .block_on(fut)
     }
 
+    /// #113: the required IEs are merged in unless the caller states them, so the
+    /// pre-#113 tests below keep testing what they were written to test (the
+    /// create/get/delete flow, the capacity cap) rather than re-testing validation.
+    /// A caller that wants to exercise validation passes its own value for one.
     fn create_request(body: serde_json::Value) -> SbiRequest {
+        let mut body = body;
+        if let Some(obj) = body.as_object_mut() {
+            obj.entry("notificationTargetAddr".to_string())
+                .or_insert_with(|| serde_json::json!("http://af.example.com/notify"));
+            obj.entry("upNodeId".to_string())
+                .or_insert_with(|| serde_json::json!("upf1.example.com"));
+        }
         SbiRequest::post("/ntsctsf-time-synchronization/v1/configuration")
             .with_json_body(&body)
             .expect("serialize test body")
@@ -598,7 +1461,10 @@ mod tests {
         assert_eq!(response.status, 400);
         let body: serde_json::Value =
             serde_json::from_str(response.http.content.as_deref().unwrap()).unwrap();
-        assert_eq!(body["cause"], "INVALID_JSON");
+        // #113 changed this cause from the bespoke `INVALID_JSON` to the
+        // TS 29.500 §5.2.7.2 `INVALID_MSG_FORMAT`, which is the name a conformant
+        // consumer knows. The old value was this NF's own invention.
+        assert_eq!(body["cause"], "INVALID_MSG_FORMAT");
 
         let not_object = create_request(serde_json::json!([1, 2, 3]));
         assert_eq!(block_on(handle_config_create(&not_object)).status, 400);
@@ -674,5 +1540,625 @@ mod tests {
         assert_eq!(block_on(tsctsf_sbi_request_handler(wrong)).status, 405);
         let unknown = SbiRequest::get("/ntsctsf-qos/v1/whatever");
         assert_eq!(block_on(tsctsf_sbi_request_handler(unknown)).status, 404);
+    }
+
+    // ====================================================================
+    // #113: the three-service control-plane surface
+    // ====================================================================
+
+    fn post(path: &str, body: serde_json::Value) -> SbiRequest {
+        SbiRequest::post(path).with_body(body.to_string(), "application/json")
+    }
+
+    fn patch(path: &str, body: serde_json::Value) -> SbiRequest {
+        SbiRequest::patch(path).with_body(body.to_string(), "application/json")
+    }
+
+    fn put(path: &str, body: serde_json::Value) -> SbiRequest {
+        SbiRequest::put(path).with_body(body.to_string(), "application/json")
+    }
+
+    fn valid_time_sync_body(target: &str) -> serde_json::Value {
+        serde_json::json!({
+            "notificationTargetAddr": target,
+            "upNodeId": "upf1.example.com",
+            "timeDomain": 24,
+            "gmEnable": true,
+            "gmPriority": 128,
+            // An optional member this build does not model, so the response can be
+            // checked for having preserved it.
+            "operatorSpecificExtra": { "vendor": "nextgcore" },
+        })
+    }
+
+    /// Spawn a server that records every notification it receives.
+    async fn spawn_notification_sink() -> (
+        nextgcore_sbi::server::SbiServer,
+        String,
+        std::sync::Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>,
+    ) {
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+        // Drives production notification code against a loopback PLAINTEXT peer,
+        // i.e. a dev-profile deployment. The default `SbiProfile` is Production,
+        // which would refuse the connection and make every notification test fail
+        // for a reason unrelated to what it asserts.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let port = nextgcore_sbi::test_support::free_port();
+        let server = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            port,
+        ))));
+        server
+            .start(move |req: SbiRequest| {
+                let sink = sink.clone();
+                async move {
+                    let body = req
+                        .http
+                        .content
+                        .as_deref()
+                        .and_then(|b| serde_json::from_str(b).ok())
+                        .unwrap_or(serde_json::Value::Null);
+                    sink.lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push((req.header.uri.clone(), body));
+                    SbiResponse::with_status(204)
+                }
+            })
+            .await
+            .expect("notification sink start");
+        (server, format!("http://127.0.0.1:{port}/notify"), seen)
+    }
+
+    /// #113 criterion 1: PATCH updates a stored configuration and answers 200;
+    /// PATCH against a missing configId is 404.
+    #[test]
+    fn config_update_merges_and_a_missing_config_is_404() {
+        let _g = lock_globals();
+        reset_context();
+
+        let created = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/configuration",
+            valid_time_sync_body("http://af.example.com/notify"),
+        )));
+        assert_eq!(created.status, 201);
+        let body: serde_json::Value =
+            serde_json::from_str(created.http.content.as_deref().expect("body")).expect("json");
+        let config_id = body["configId"].as_str().expect("configId").to_string();
+        assert_eq!(
+            body["operatorSpecificExtra"]["vendor"],
+            serde_json::json!("nextgcore"),
+            "an unmodelled optional member must survive the round trip"
+        );
+
+        let updated = block_on(tsctsf_sbi_request_handler(patch(
+            &format!("/ntsctsf-time-synchronization/v1/configuration/{config_id}"),
+            serde_json::json!({ "gmEnable": false }),
+        )));
+        assert_eq!(updated.status, 200, "ConfigUpdate must be served, not 405");
+        let body: serde_json::Value =
+            serde_json::from_str(updated.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(
+            body["gmEnable"],
+            serde_json::json!(false),
+            "the change applied"
+        );
+        assert_eq!(
+            body["gmPriority"],
+            serde_json::json!(128),
+            "and a member the update did not mention survived"
+        );
+        assert_eq!(body["configId"], serde_json::json!(config_id));
+
+        // The stored record actually changed, not just the response.
+        let fetched = block_on(tsctsf_sbi_request_handler(SbiRequest::get(&format!(
+            "/ntsctsf-time-synchronization/v1/configuration/{config_id}"
+        ))));
+        assert_eq!(fetched.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(fetched.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["gmEnable"], serde_json::json!(false));
+
+        // A missing configId is 404 for both update verbs.
+        let absent = "/ntsctsf-time-synchronization/v1/configuration/no-such-config";
+        let body = valid_time_sync_body("http://af.example.com/notify");
+        for (label, request) in [
+            ("PATCH", patch(absent, body.clone())),
+            ("PUT", put(absent, body.clone())),
+        ] {
+            let missing = block_on(tsctsf_sbi_request_handler(request));
+            assert_eq!(missing.status, 404, "{label} on a missing config");
+        }
+    }
+
+    /// PUT replaces rather than merges, and still validates: the two verbs must
+    /// differ, or offering both is a lie.
+    #[test]
+    fn config_replace_does_not_merge() {
+        let _g = lock_globals();
+        reset_context();
+
+        let created = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/configuration",
+            valid_time_sync_body("http://af.example.com/notify"),
+        )));
+        let body: serde_json::Value =
+            serde_json::from_str(created.http.content.as_deref().expect("body")).expect("json");
+        let config_id = body["configId"].as_str().expect("configId").to_string();
+
+        // A replace that omits gmPriority must clear it.
+        let replaced = block_on(tsctsf_sbi_request_handler(put(
+            &format!("/ntsctsf-time-synchronization/v1/configuration/{config_id}"),
+            serde_json::json!({
+                "notificationTargetAddr": "http://af.example.com/notify",
+                "upNodeId": "upf2.example.com",
+            }),
+        )));
+        assert_eq!(replaced.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(replaced.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["upNodeId"], serde_json::json!("upf2.example.com"));
+        assert!(
+            body["gmPriority"].is_null(),
+            "PUT must replace, not merge -- otherwise it is indistinguishable from PATCH"
+        );
+    }
+
+    /// #113 criterion 5: a malformed IE is refused with a cause that NAMES the
+    /// member, and the absent/incorrect distinction is preserved
+    /// (TS 29.500 §5.2.7.2).
+    #[test]
+    fn a_malformed_configuration_is_refused_with_the_naming_cause() {
+        let _g = lock_globals();
+        reset_context();
+
+        // Absent required member -> MANDATORY_IE_MISSING.
+        let resp = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/configuration",
+            serde_json::json!({ "upNodeId": "upf1" }),
+        )));
+        assert_eq!(resp.status, 400);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["cause"], serde_json::json!("MANDATORY_IE_MISSING"));
+        assert!(
+            body["detail"]
+                .as_str()
+                .is_some_and(|d| d.contains("notificationTargetAddr")),
+            "the detail must name the member, got {body:?}"
+        );
+
+        // Present but out of range -> MANDATORY_IE_INCORRECT, naming the member.
+        let mut over = valid_time_sync_body("http://af/notify");
+        over["timeDomain"] = serde_json::json!(300);
+        let resp = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/configuration",
+            over,
+        )));
+        assert_eq!(resp.status, 400);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["cause"], serde_json::json!("MANDATORY_IE_INCORRECT"));
+        assert!(body["detail"]
+            .as_str()
+            .is_some_and(|d| d.contains("timeDomain")));
+
+        // A serde TYPE mismatch is INVALID_MSG_FORMAT, not MANDATORY_IE_*: the
+        // consumer's JSON is malformed rather than incomplete, which is a different
+        // fix on its side. `serde(default)` covers an absent member and does NOT
+        // rescue a mismatched one, so the two causes come from two places.
+        let mut wrong_type = valid_time_sync_body("http://af/notify");
+        wrong_type["gmEnable"] = serde_json::json!("yes please");
+        let resp = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/configuration",
+            wrong_type,
+        )));
+        assert_eq!(resp.status, 400);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["cause"], serde_json::json!("INVALID_MSG_FORMAT"));
+    }
+
+    /// #113 criterion 2: ConfigUpdateNotify reaches the registered notification
+    /// URI with the updated body — asserted by observing the HTTP request, not a
+    /// log line.
+    #[tokio::test]
+    async fn a_config_update_notifies_the_registered_target() {
+        let _g = lock_globals();
+        reset_context();
+        let (sink, target, seen) = spawn_notification_sink().await;
+
+        let created = tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/configuration",
+            valid_time_sync_body(&target),
+        ))
+        .await;
+        assert_eq!(created.status, 201);
+        let body: serde_json::Value =
+            serde_json::from_str(created.http.content.as_deref().expect("body")).expect("json");
+        let config_id = body["configId"].as_str().expect("configId").to_string();
+        assert!(
+            seen.lock().unwrap_or_else(|e| e.into_inner()).is_empty(),
+            "a CREATE is not a change, so it must not fire ConfigUpdateNotify"
+        );
+
+        let updated = tsctsf_sbi_request_handler(patch(
+            &format!("/ntsctsf-time-synchronization/v1/configuration/{config_id}"),
+            serde_json::json!({ "gmEnable": false }),
+        ))
+        .await;
+        assert_eq!(updated.status, 200);
+
+        let notifications = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(
+            notifications.len(),
+            1,
+            "a config change must fire exactly one ConfigUpdateNotify, got {notifications:?}"
+        );
+        let (uri, body) = &notifications[0];
+        assert_eq!(
+            uri, "/notify",
+            "posted to the path the target address named"
+        );
+        assert_eq!(body["configId"], serde_json::json!(config_id));
+        assert_eq!(
+            body["timeSyncExposureConfig"]["gmEnable"],
+            serde_json::json!(false),
+            "the notification must carry the UPDATED body, not the original"
+        );
+
+        sink.stop().await.expect("stop");
+    }
+
+    /// #113 criterion 3: subscribe → notify → unsubscribe. CapsNotify reaches the
+    /// subscriber while it is subscribed, and stops when it is not.
+    #[tokio::test]
+    async fn caps_subscribe_notify_unsubscribe() {
+        let _g = lock_globals();
+        reset_context();
+        let (sink, target, seen) = spawn_notification_sink().await;
+
+        let created = tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/subscriptions",
+            serde_json::json!({
+                "notificationTargetAddr": target,
+                "notificationCorrelationId": "corr-1",
+                "afServiceId": "af-svc-1",
+                "ptpInstanceTypes": ["PTP", "GPTP"],
+            }),
+        ))
+        .await;
+        assert_eq!(created.status, 201, "CapsSubscribe must be served");
+        let body: serde_json::Value =
+            serde_json::from_str(created.http.content.as_deref().expect("body")).expect("json");
+        let subscription_id = body["subscriptionId"]
+            .as_str()
+            .expect("Subscription Correlation ID")
+            .to_string();
+        assert_eq!(
+            created.http.get_header("location").map(String::as_str),
+            Some(
+                format!("/ntsctsf-time-synchronization/v1/subscriptions/{subscription_id}")
+                    .as_str()
+            )
+        );
+
+        // The subscription resource exists.
+        let fetched = tsctsf_sbi_request_handler(SbiRequest::get(&format!(
+            "/ntsctsf-time-synchronization/v1/subscriptions/{subscription_id}"
+        )))
+        .await;
+        assert_eq!(fetched.status, 200);
+
+        // A capability change reaches it.
+        let triggered = tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/admin/capability-change",
+            serde_json::json!({ "gmCapable": true, "asTimeSource": "GNSS" }),
+        ))
+        .await;
+        assert_eq!(triggered.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(triggered.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["notified"], serde_json::json!(1));
+
+        let notifications = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(notifications.len(), 1, "got {notifications:?}");
+        let (_, body) = &notifications[0];
+        assert_eq!(body["subscriptionId"], serde_json::json!(subscription_id));
+        assert_eq!(
+            body["timeSyncCapabilities"]["asTimeSource"],
+            serde_json::json!("GNSS")
+        );
+        assert_eq!(
+            body["notifyCorrelationId"],
+            serde_json::json!("corr-1"),
+            "the correlation id the subscriber gave must come back, or it cannot match the \
+             notification to its subscription"
+        );
+
+        // Unsubscribe, and the fan-out stops.
+        let removed = tsctsf_sbi_request_handler(SbiRequest::delete(&format!(
+            "/ntsctsf-time-synchronization/v1/subscriptions/{subscription_id}"
+        )))
+        .await;
+        assert_eq!(removed.status, 204);
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+        let triggered = tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/admin/capability-change",
+            serde_json::json!({ "gmCapable": false }),
+        ))
+        .await;
+        let body: serde_json::Value =
+            serde_json::from_str(triggered.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(
+            body["notified"],
+            serde_json::json!(0),
+            "an unsubscribed consumer must not be notified"
+        );
+        assert!(seen.lock().unwrap_or_else(|e| e.into_inner()).is_empty());
+
+        // And a second unsubscribe is 404, not another 204.
+        let again = tsctsf_sbi_request_handler(SbiRequest::delete(&format!(
+            "/ntsctsf-time-synchronization/v1/subscriptions/{subscription_id}"
+        )))
+        .await;
+        assert_eq!(again.status, 404);
+
+        sink.stop().await.expect("stop");
+    }
+
+    /// A capability subscription with neither scope is refused: §5.2.27.2.6's
+    /// required input is (DNN, S-NSSAI) **or** an AF-Service-Identifier, and a
+    /// subscription that names neither could never be matched against anything.
+    #[test]
+    fn a_caps_subscription_with_no_scope_is_refused() {
+        let _g = lock_globals();
+        reset_context();
+        let resp = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-time-synchronization/v1/subscriptions",
+            serde_json::json!({ "notificationTargetAddr": "http://af/notify" }),
+        )));
+        assert_eq!(resp.status, 400);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["cause"], serde_json::json!("MANDATORY_IE_MISSING"));
+    }
+
+    /// #113 criterion 4: `Ntsctsf_ASTI` has routes and handlers, and the
+    /// create/read path is non-404.
+    #[test]
+    fn asti_create_read_update_delete() {
+        let _g = lock_globals();
+        reset_context();
+
+        let created = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-asti/v1/configurations",
+            serde_json::json!({
+                "afId": "af-1",
+                "supi": "imsi-001010000000001",
+                "asTimeDisEnabled": true,
+                "uuErrorBudget": 900,
+            }),
+        )));
+        assert_eq!(
+            created.status, 201,
+            "Ntsctsf_ASTI must be served, not 404 -- it is one of the three mandated services"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(created.http.content.as_deref().expect("body")).expect("json");
+        let config_id = body["configId"].as_str().expect("configId").to_string();
+
+        let fetched = block_on(tsctsf_sbi_request_handler(SbiRequest::get(&format!(
+            "/ntsctsf-asti/v1/configurations/{config_id}"
+        ))));
+        assert_eq!(fetched.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(fetched.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["afId"], serde_json::json!("af-1"));
+        assert_eq!(body["uuErrorBudget"], serde_json::json!(900));
+
+        let updated = block_on(tsctsf_sbi_request_handler(patch(
+            &format!("/ntsctsf-asti/v1/configurations/{config_id}"),
+            serde_json::json!({ "asTimeDisEnabled": false }),
+        )));
+        assert_eq!(updated.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(updated.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["asTimeDisEnabled"], serde_json::json!(false));
+        assert_eq!(
+            body["afId"],
+            serde_json::json!("af-1"),
+            "an update must not clear what it did not mention"
+        );
+
+        let deleted = block_on(tsctsf_sbi_request_handler(SbiRequest::delete(&format!(
+            "/ntsctsf-asti/v1/configurations/{config_id}"
+        ))));
+        assert_eq!(deleted.status, 204);
+        let gone = block_on(tsctsf_sbi_request_handler(SbiRequest::get(&format!(
+            "/ntsctsf-asti/v1/configurations/{config_id}"
+        ))));
+        assert_eq!(gone.status, 404);
+    }
+
+    /// An ASTI configuration with no target would activate time distribution for
+    /// nobody.
+    #[test]
+    fn an_asti_config_with_no_target_is_refused() {
+        let _g = lock_globals();
+        reset_context();
+        let resp = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-asti/v1/configurations",
+            serde_json::json!({ "afId": "af-1" }),
+        )));
+        assert_eq!(resp.status, 400);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["cause"], serde_json::json!("MANDATORY_IE_MISSING"));
+        assert!(body["detail"].as_str().is_some_and(|d| d.contains("supi")));
+    }
+
+    /// #113 criterion 4: `Ntsctsf_QoSandTSCAssistance` has routes and handlers,
+    /// and Notify reaches a subscriber on an Update.
+    #[tokio::test]
+    async fn qos_tsc_create_read_update_notifies_and_delete() {
+        let _g = lock_globals();
+        reset_context();
+        let (sink, target, seen) = spawn_notification_sink().await;
+
+        let created = tsctsf_sbi_request_handler(post(
+            "/ntsctsf-qos-tsctsf/v1/tsc-qos-requests",
+            serde_json::json!({
+                "afId": "af-1",
+                "gpsi": "msisdn-491700000001",
+                "flowDescriptions": ["permit out ip from any to assigned"],
+                "qosReference": "qos-ref-1",
+                "periodicity": 500,
+            }),
+        ))
+        .await;
+        assert_eq!(
+            created.status, 201,
+            "Ntsctsf_QoSandTSCAssistance must be served, not 404"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(created.http.content.as_deref().expect("body")).expect("json");
+        let transaction_id = body["transactionRefId"]
+            .as_str()
+            .expect("Transaction Reference ID")
+            .to_string();
+
+        let fetched = tsctsf_sbi_request_handler(SbiRequest::get(&format!(
+            "/ntsctsf-qos-tsctsf/v1/tsc-qos-requests/{transaction_id}"
+        )))
+        .await;
+        assert_eq!(fetched.status, 200);
+
+        // Subscribe, then update, and the subscriber is notified.
+        let sub = tsctsf_sbi_request_handler(post(
+            "/ntsctsf-qos-tsctsf/v1/subscriptions",
+            serde_json::json!({
+                "notificationTargetAddr": target,
+                "transactionRefId": transaction_id,
+                "events": ["QOS_NOT_GUARANTEED"],
+            }),
+        ))
+        .await;
+        assert_eq!(sub.status, 201);
+
+        let updated = tsctsf_sbi_request_handler(patch(
+            &format!("/ntsctsf-qos-tsctsf/v1/tsc-qos-requests/{transaction_id}"),
+            serde_json::json!({ "periodicity": 1000, "survivalTime": 2000 }),
+        ))
+        .await;
+        assert_eq!(updated.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(updated.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["periodicity"], serde_json::json!(1000));
+        assert_eq!(
+            body["qosReference"],
+            serde_json::json!("qos-ref-1"),
+            "an update must not clear what it did not mention"
+        );
+
+        let notifications = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(notifications.len(), 1, "got {notifications:?}");
+        assert_eq!(
+            notifications[0].1["transactionRefId"],
+            serde_json::json!(transaction_id)
+        );
+        assert_eq!(
+            notifications[0].1["tscQosSession"]["survivalTime"],
+            serde_json::json!(2000)
+        );
+
+        let deleted = tsctsf_sbi_request_handler(SbiRequest::delete(&format!(
+            "/ntsctsf-qos-tsctsf/v1/tsc-qos-requests/{transaction_id}"
+        )))
+        .await;
+        assert_eq!(deleted.status, 204);
+        let gone = tsctsf_sbi_request_handler(SbiRequest::get(&format!(
+            "/ntsctsf-qos-tsctsf/v1/tsc-qos-requests/{transaction_id}"
+        )))
+        .await;
+        assert_eq!(gone.status, 404);
+
+        sink.stop().await.expect("stop");
+    }
+
+    /// A QoS/TSC request missing one half of each required either/or is refused,
+    /// naming which one.
+    #[test]
+    fn a_qos_tsc_request_missing_a_required_alternative_is_refused() {
+        let _g = lock_globals();
+        reset_context();
+        let resp = block_on(tsctsf_sbi_request_handler(post(
+            "/ntsctsf-qos-tsctsf/v1/tsc-qos-requests",
+            serde_json::json!({
+                "afId": "af-1",
+                "gpsi": "msisdn-1",
+                "flowDescriptions": ["permit out ip from any to assigned"],
+                // No qosReference and no maxBr*.
+            }),
+        )));
+        assert_eq!(resp.status, 400);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["cause"], serde_json::json!("MANDATORY_IE_MISSING"));
+        assert!(body["detail"]
+            .as_str()
+            .is_some_and(|d| d.contains("qosReference")));
+    }
+
+    /// The NF profile advertises all THREE mandated services. Advertising one
+    /// while serving three makes the other two undiscoverable — which was the
+    /// pre-#113 state for the two that did not exist.
+    #[test]
+    fn the_nf_profile_advertises_all_three_services() {
+        let profile = build_nf_profile("tsctsf-1", "127.0.0.1", 7777);
+        let names: Vec<&str> = profile["nfServices"]
+            .as_array()
+            .expect("nfServices")
+            .iter()
+            .filter_map(|s| s["serviceName"].as_str())
+            .collect();
+        assert!(names.contains(&"ntsctsf-time-synchronization"));
+        assert!(names.contains(&"ntsctsf-asti"));
+        assert!(names.contains(&"ntsctsf-qos-tsctsf"));
+        assert_eq!(
+            names.len(),
+            3,
+            "exactly the three TS 23.501 Table 7.2.26-1 names"
+        );
+    }
+
+    /// A notification target the TSCTSF cannot use is refused rather than guessed
+    /// at: notifying the wrong node is worse than not notifying.
+    #[test]
+    fn an_unusable_notification_target_is_not_guessed_at() {
+        assert!(split_target("").is_none());
+        assert!(split_target("http://").is_none());
+        assert_eq!(
+            split_target("http://af.example.com:8080/cb"),
+            Some(("af.example.com".to_string(), 8080, "/cb".to_string()))
+        );
+        assert_eq!(
+            split_target("http://af.example.com/cb"),
+            Some(("af.example.com".to_string(), 80, "/cb".to_string())),
+            "an http target with no port defaults to 80"
+        );
+        assert_eq!(
+            split_target("https://af.example.com/cb"),
+            Some(("af.example.com".to_string(), 443, "/cb".to_string())),
+            "and an https target to 443, not 80"
+        );
+        assert_eq!(
+            split_target("af.example.com:9000"),
+            Some(("af.example.com".to_string(), 9000, "/".to_string())),
+            "a bare authority is accepted, with the root path"
+        );
     }
 }


### PR DESCRIPTION
Closes #113, with **criterion 6 split out as #284**.

Spec: `specs/fix-tsctsf-three-service-control-plane.md`. Verified against `main` @ `2918eb7`.

## Scope, stated first because it is a judgement call

#113's own suggested approach opens: *"This is deliberately broad … and is **best tracked as an umbrella issue split into per-service child issues rather than delivered in one change**"*, and separates the actuation explicitly: *"Actuation (PCF client, UPF `tsn_bridge` driving, SMF port management) is cross-NF and behaviour-changing."*

So this PR delivers criteria **1, 2, 3, 4, 5, 7, 8** — the whole control plane — and criterion **6** is **#284**. Three reasons, heaviest first:

1. **It cannot be verified end-to-end anywhere in this tree.** tsctsf, smfd and upfd are separate binaries, there is no PFCP TSC container codec, and criterion 6's own wording ("drives the UPF `tsn_bridge` from `None` to a populated bridge") describes a cross-process effect no in-process test can observe.
2. **Landing it off-by-default, as the issue suggests, would ship code no test exercises** — this repo's "a correct implementation can be unreachable" hazard, with the switch being off as the thing that hides it.
3. **The author asked for the split.**

Criterion 7 ("with actuation disabled, UPF/SMF behaviour unchanged") is satisfied completely: **no UPF or SMF code is touched**.

**Count arithmetic, quoted because it goes the wrong way:** closing #113 while filing #284 leaves the open count unchanged. Same understatement this project's issues-closed-vs-parts-closed learning warns about.

**And the consequence, said plainly: a stored configuration still actuates nothing.** No PCF client, no PMIC/UMIC/TSCAI, `tsn_bridge` untouched. That is at the top of the new docs page, not buried — an operator discovering `nfType: TSCTSF` will otherwise assume a working time-synchronisation function.

## What landed

| Was | Now |
|---|---|
| 3 routes over one bespoke collection | all three services TS 23.501 Table 7.2.26-1 mandates |
| `{ id, raw: String }` | typed IEs per service, validated at ingress |
| no ConfigUpdate | `PATCH` (merge) and `PUT` (replace), 200/404 |
| no notifications | ConfigUpdateNotify, CapsNotify, ASTI UpdateNotify, QoS/TSC Notify |
| no capability subscriptions | CapsSubscribe/Unsubscribe, server-minted Subscription Correlation ID |
| `Ntsctsf_ASTI`, `Ntsctsf_QoSandTSCAssistance` → 404 | full CRUD + Subscribe/Unsubscribe |
| profile advertised 1 service | advertises 3 |

## Decisions worth reviewing

- **`PATCH` merges, `PUT` replaces, and a test asserts they differ.** §5.2.27.2.3's only required input is the PTP instance reference and every parameter is optional — that *is* merge semantics, so offering both verbs identically would be a lie. A merge that would blank `notificationTargetAddr` is refused: it would leave a configuration that can never notify again.
- **Required scalars are `serde(default)` + an explicit `validate()`**, not bare non-`Option`. A bare non-`Option` makes an **absent** member a serde parse error, reportable only as `INVALID_MSG_FORMAT` — losing the TS 29.500 §5.2.7.2 distinction between "malformed" and "incomplete", which is two different fixes on the consumer's side. Present-but-**empty** is refused alongside absent, because serde accepts `""` and an empty notification target is the un-notifiable state the validation exists to prevent.
- **Either/or required inputs are checked as alternatives, not conjunctions.** §5.2.27.2.6's scope is "(DNN, S-NSSAI) **or** an AF-Service-Identifier"; §5.2.27.3.2's are "flow description(s) **or** External Application Identifier" and "QoS Reference **or** individual QoS parameters". Requiring both halves would refuse conformant requests — the mirror of accepting one that names nothing. Tests cover both directions.
- **SUPI add/remove apply in that order**, so a SUPI in both is removed: a consumer asking for both cannot have meant "keep".
- **ConfigUpdateNotify fires on a change, not on a create** — a create is not a change, and the `201` already told the target the configuration exists.
- **The Subscription Correlation ID is minted, never taken from the request**; a test asserts an attacker-chosen id is not honoured.
- **`CapsNotify` needed a producer.** A 5GS capability change has **no in-tree source**, so the notify path would be unreachable in principle — this repo's "grep the SINK before implementing an emit-side feature" hazard in reverse. Hence `POST /…/v1/admin/capability-change`, explicitly labelled as **not** a 3GPP service operation, answering `200 {"notified": N}` rather than 204 so "nobody subscribed" is distinguishable from "the fan-out is broken". #284 owns replacing it.
- **`INVALID_JSON` → `INVALID_MSG_FORMAT`.** The old cause was this NF's own invention rather than a name a conformant consumer knows.

## Verification

**20 guards revert-verified** (fix broken → **named** test watched to fail → restored). Table in the spec. Two reverts needed a second attempt because my first mutation left the original block in place and so changed nothing — recorded because a "did not bite" that turns out to be a bad mutation is easy to mistake for a real gap.

Three pre-existing tests changed, each with the reason at the site:

- Two posted bodies with **no required IEs** — because before #113 there were none. Their helper now merges the required members in, so they keep testing the flow and the capacity cap rather than becoming validation tests.
- One pinned the bespoke `INVALID_JSON`.
- **`block_on` carried the comment "the handlers under test do no real I/O".** That stopped being true: ConfigUpdate fires a notification whose client sets a request timeout, and a runtime without timers panics on it. Now `enable_all`.

Workspace: **6207 passed / 0 failed**, `cargo clippy --workspace` and `cargo fmt --all --check` clean.

## Ceilings

- **`TS29565_Ntsctsf_*.yaml` is not vendored here.** Every resource path and JSON member name comes from the Stage-2 parameter names in TS 23.502 §5.2.27, **not** verified against the Stage-3 schema. Called out in the module docs, the type docs *and* the docs page rather than left to be assumed checked.
- **All state is in-memory** — no state file, so configurations and subscriptions are lost on restart. Out of #113's scope; worth knowing next to #191/#192's durable stores.
- **No wire interop.** Notifications are asserted against a fake AF spawned by this crate's own SBI server; the `set_sbi_profile_override(Dev)` those tests need is declared with its reason (the default profile is Production and refuses a loopback plaintext peer).
- **GitNexus impact analysis unrunnable** (56th consecutive PR): MCP server not connected. Blast radius by grep — `TimeSyncConfig::new` changed signature, callers are the create handler and this crate's tests; nothing outside `nextgcore-tsctsf` references these types.
