### PR TITLE
fix(diameter): finish the Origin-State-Id verification §8.16 asks for (#280)

### DIFF
--- a/specs/fix-diameter-origin-state-id-verification.md
+++ b/specs/fix-diameter-origin-state-id-verification.md
@@ -1,0 +1,122 @@
+# nextgcore #280 (nextgcore-diameter): finish the Origin-State-Id verification §8.16 asks for
+
+Verified against `main` @ `3024f20`.
+
+**The issue is stale, and this is the headline.** #280 was filed on 2026-09-09 out of #57's
+text, which cited `peer.rs:588-594` returning `SystemTime::now().as_secs()` per call. That
+defect was already fixed on 2026-08-13 by `4eb7c49` (PR #148, slice 1 of #55), which latched
+the value in a `OnceLock`. #57's citation was carried forward without re-checking the code, so
+#280 describes a defect that had not existed for four weeks by the time it was written. This
+is the "a stated claim is a hypothesis, whoever stated it" rule applying to an issue *we*
+filed.
+
+What #280 asks for is nonetheless not all present. Its four acceptance criteria split cleanly:
+one was met by #148, three were not, and the three are the interesting ones.
+
+## Verified against current main
+
+| claim in the issue | site on `3024f20` | still true? |
+|---|---|---|
+| `origin_state_id()` computes seconds-since-epoch on every call | `libs/nextgcore-diameter/src/peer.rs:758` — `*ORIGIN_STATE_ID.get_or_init(...)` | **no — fixed by `4eb7c49`** |
+| the value is emitted in four places | `peer.rs:324` (CER), `:404` (CEA), `:484` (DWA), `:513` (DWR) | yes |
+| a test asserts stability across a sleep | `origin_state_id_is_stable_across_a_second_boundary` (added by `4eb7c49`) | yes — criterion 1 already met |
+| the ordering property is tested | nothing tested it | true, gap |
+| the four message paths are asserted to agree | nothing tested it | true, gap |
+| whether any in-tree peer consumes a received Origin-State-Id | never enumerated | true, gap |
+
+## Criterion-by-criterion, and what this PR adds
+
+1. **Stable for the process lifetime.** Already met by `4eb7c49`. Untouched.
+2. **The ordering property, not only the stability.** `origin_state_id()` is a latch, and one
+   process observes exactly one value — so *no* test inside one process can assert that a later
+   start yields a greater value. The derivation is therefore split into
+   `derive_origin_state_id(SystemTime)` and the property asserted against two synthetic start
+   instants. This is a refactor #280 does not ask for; it is here because without it the
+   criterion is not expressible at all rather than merely untested.
+3. **Every message-building path carries the latched value.** Four call sites each call
+   `origin_state_id()` independently, so the latch's own tests say nothing about them: a fifth
+   path added later could read the clock per call without disturbing either existing test.
+   `every_message_path_carries_the_latched_origin_state_id` drives all four over loopback — this
+   node is the raw transport twice, once facing a real responder (capturing its CEA and DWA)
+   and once facing a real initiator (capturing its CER and DWR) — and asserts all four AVPs
+   equal each other and equal `origin_state_id()`.
+4. **The receive-side enumeration.** Answered in full below and recorded at the latch in
+   `peer.rs`, so the next reader does not have to redo the grep.
+
+## Decision: the 1.1s sleeps are load-bearing, and the false-guard check proves it
+
+`every_message_path_carries_the_latched_origin_state_id` sleeps past a wall-clock second
+between the handshake and the watchdog in *both* directions. That is not padding. The defect
+being guarded against returned `now().as_secs()`, which yields the **same** value for every
+message sent inside one second — so an exchange run back to back agrees with itself even with
+the bug present.
+
+This was checked rather than assumed. With the defect restored and the two sleeps cut to 1ms,
+the test **passes** (see Verification). A version of this test without the sleeps would have
+been exactly the green-proves-nothing shape this repo keeps finding.
+
+## Criterion 4: what consumes a RECEIVED Origin-State-Id in this tree — nothing
+
+Enumerated across the whole workspace (`rg 'origin_state_id|OriginStateId|ORIGIN_STATE_ID'`):
+
+| site | direction | reads a received value? |
+|---|---|---|
+| `common.rs:37` | the AVP code constant `278` | n/a |
+| `peer.rs:324` `send_cer` | send | no |
+| `peer.rs:404` `handle_cer` → CEA | send | no |
+| `peer.rs:484` `handle_dwr` → DWA | send | no |
+| `peer.rs:513` `send_watchdog` → DWR | send | no |
+| `handle_cea` (`peer.rs:435`) | receive | **no** — reads Result-Code, Origin-Host, Origin-Realm only |
+| `hssd`, `pcrfd`, `mmed` | either | **no reference to the AVP at all** |
+
+So the behaviour change on the receive side that #280 asked to have "stated rather than
+discovered" is: **there is none**, because no in-tree peer acts on the value it receives.
+
+That is a clean answer to the criterion and a real gap underneath it. Diameter peer-restart
+detection (TS 23.007 restoration) exists in neither direction here: we now advertise a
+conformant value that no in-tree peer would notice changing. Closing that needs a per-NF
+decision about what to discard when a restart *is* detected — the same question #57 hit and
+answered with persistence instead. Filed separately rather than folded in: #280 asks for the
+enumeration, and adding unrequested outbound-behaviour change to a verification PR is how a
+reviewer stops being able to tell what was asked for.
+
+## Acceptance criteria
+
+- [x] `origin_state_id()` returns the same value for the process lifetime, with a test that
+      sleeps across a second boundary — met by `4eb7c49`, left as found.
+- [x] The value is derived once and a later start derives a greater one —
+      `a_later_process_start_derives_a_greater_origin_state_id`, covering an ordinary restart,
+      a same-second restart (equality, which §8.16's "non-decreasing" permits), and a pre-epoch
+      clock (floors at `0` rather than wrapping to `u32::MAX`).
+- [x] Every message-building path uses the stored value, asserted by comparing the AVP across
+      messages — `every_message_path_carries_the_latched_origin_state_id`, all four paths.
+- [x] Whether any in-tree peer consumes a received Origin-State-Id is enumerated — table above,
+      and recorded at `ORIGIN_STATE_ID` in `peer.rs`.
+
+## Verification
+
+Workspace `6209 passed / 0 failed` (baseline `6207` on `3024f20`; +2 tests). `cargo clippy
+--workspace --all-targets` and `cargo fmt --all -- --check` clean, and `nextgcore-diameter`
+itself carries zero clippy warnings.
+
+| revert | expected to break | result |
+|---|---|---|
+| `origin_state_id()` recomputes per call (the original defect) | `every_message_path_carries_the_latched_origin_state_id`, `origin_state_id_is_stable_across_a_second_boundary` | **2 failed** — CEA `1788993454` vs DWA `1788993455` |
+| `derive_origin_state_id` returns a constant | `a_later_process_start_derives_a_greater_origin_state_id` | **1 failed** |
+| **false-guard check**: defect restored *and* the two 1.1s sleeps cut to 1ms | nothing — the point is that it passes | **passed**, confirming the sleeps are the guard |
+
+## Ceilings
+
+* The ordering property is asserted on `derive_origin_state_id`, not on two real processes. A
+  genuine cross-restart assertion needs two process lifetimes, which no harness here provides;
+  what is verified is that the derivation is monotonic in its input and that the latch feeds it
+  the process-start instant.
+* `every_message_path_carries_the_latched_origin_state_id` proves the four paths agree *within
+  one process*. It cannot prove a fifth future path calls the latch — only that the four that
+  exist today do. A lint would be the general fix; four call sites did not justify one.
+* The receive side remains unimplemented and is now documented as such rather than left to be
+  rediscovered. See the enumeration above.
+* GitNexus impact analysis unrunnable (no MCP server connected). Blast radius by grep:
+  `origin_state_id` has four callers, all in `peer.rs`; `derive_origin_state_id` has one
+  production caller (the latch) and one test caller.
+

--- a/src/libs/nextgcore-diameter/src/peer.rs
+++ b/src/libs/nextgcore-diameter/src/peer.rs
@@ -751,18 +751,45 @@ impl Default for PeerTable {
 /// second reuses the value, which is acceptable -- the RFC only requires that it
 /// not decrease, and one second of ambiguity after a crash-restart is a far
 /// smaller problem than announcing a reboot every second.
+/// # What consumes a RECEIVED Origin-State-Id in this tree: nothing
+///
+/// Enumerated for #280 across the whole workspace: the only readers of AVP 278
+/// are the four senders below. `handle_cea` validates Result-Code, Origin-Host
+/// and Origin-Realm and never looks at the peer's Origin-State-Id; `handle_cer`,
+/// `handle_dwr` and `handle_dwa` likewise. No NF (`hssd`, `pcrfd`, `mmed`)
+/// references the AVP at all.
+///
+/// So this fix has **no receive-side behaviour change to declare**: making our
+/// own value stable cannot perturb an in-tree peer, because no in-tree peer acts
+/// on the value it receives. The corollary is a real gap rather than a
+/// reassurance -- Diameter peer-restart detection (TS 23.007 restoration) does
+/// not exist here in either direction, and closing it needs a per-NF decision
+/// about what to discard on a detected restart. Tracked separately; #280 asks
+/// for this enumeration, not for the receive side.
 static ORIGIN_STATE_ID: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
 
 /// This node's Origin-State-Id (RFC 6733 §8.16). Stable for the process
 /// lifetime; see [`ORIGIN_STATE_ID`].
 fn origin_state_id() -> u32 {
-    *ORIGIN_STATE_ID.get_or_init(|| {
-        use std::time::SystemTime;
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_secs() as u32)
-            .unwrap_or(0)
-    })
+    *ORIGIN_STATE_ID.get_or_init(|| derive_origin_state_id(std::time::SystemTime::now()))
+}
+
+/// Derive an Origin-State-Id from a process-start instant.
+///
+/// Split out of the latch so the property §8.16 actually requires -- that a
+/// LATER process start yields a GREATER value -- is testable. Inside the latch
+/// it was not: a single process observes exactly one value, so a test can only
+/// ever confirm stability, which is the weaker half of the requirement.
+///
+/// A clock reading before the epoch yields `0`. That is the floor rather than a
+/// wrap-around, so a node with a badly wrong clock advertises "oldest possible
+/// state" instead of a value a peer would read as newer than one from a healthy
+/// node.
+fn derive_origin_state_id(start: std::time::SystemTime) -> u32 {
+    start
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs() as u32)
+        .unwrap_or(0)
 }
 
 /// Generate a pseudo-random u32 for sequence initialization
@@ -780,7 +807,7 @@ fn rand_u32() -> u32 {
 mod tests {
     use super::*;
     use crate::config::DiameterConfig;
-    use crate::transport::{DiameterListener, DiameterTransport};
+    use crate::transport::{DiameterListener, DiameterTransport, DiameterTransportIo};
 
     fn test_config(host: &str, realm: &str) -> DiameterConfig {
         DiameterConfig {
@@ -825,6 +852,196 @@ mod tests {
         for _ in 0..1000 {
             assert_eq!(origin_state_id(), baseline);
         }
+    }
+
+    /// §8.16's requirement has TWO halves, and stability is only the first: the
+    /// value must also be *greater* after a restart, because that ordering is
+    /// what tells a peer which of two states is the newer one. A latched value
+    /// cannot be tested for that from inside one process -- one process observes
+    /// exactly one value -- which is why the derivation is a separate function.
+    ///
+    /// The three cases are the three a real deployment produces: an ordinary
+    /// restart minutes later, a restart inside the same second (§8.16 requires
+    /// non-decreasing, not strictly increasing, so equality is conformant), and
+    /// a clock that reads before the epoch.
+    #[test]
+    fn a_later_process_start_derives_a_greater_origin_state_id() {
+        use std::time::{Duration, SystemTime};
+
+        let first_boot = SystemTime::UNIX_EPOCH + Duration::from_secs(1_757_000_000);
+        let after_restart = first_boot + Duration::from_secs(600);
+
+        assert!(
+            derive_origin_state_id(after_restart) > derive_origin_state_id(first_boot),
+            "a process that started later must advertise a greater Origin-State-Id"
+        );
+
+        // Same second: non-decreasing is what §8.16 asks for, so equal is right.
+        assert_eq!(
+            derive_origin_state_id(first_boot + Duration::from_millis(400)),
+            derive_origin_state_id(first_boot),
+            "a restart inside one second reuses the value rather than decreasing"
+        );
+
+        // Pre-epoch clock: floored at 0 rather than wrapped, so a node with a
+        // broken clock claims the OLDEST state instead of the newest.
+        assert_eq!(
+            derive_origin_state_id(SystemTime::UNIX_EPOCH - Duration::from_secs(1)),
+            0,
+            "a pre-epoch clock must floor at 0, not wrap to u32::MAX"
+        );
+    }
+
+    /// Build a CER by hand for the raw side of the capture tests below. Only the
+    /// AVPs `handle_cer` actually reads (Origin-Host, Origin-Realm) plus an
+    /// Origin-State-Id of our own, so the responder answers 2001 and reaches
+    /// Open.
+    fn hand_built_cer(host: &str, realm: &str) -> DiameterMessage {
+        let mut cer =
+            DiameterMessage::new_request(base_cmd::CAPABILITIES_EXCHANGE, BASE_APPLICATION_ID);
+        cer.add_avp(Avp::mandatory(
+            avp_code::ORIGIN_HOST,
+            AvpData::DiameterIdentity(host.to_string()),
+        ));
+        cer.add_avp(Avp::mandatory(
+            avp_code::ORIGIN_REALM,
+            AvpData::DiameterIdentity(realm.to_string()),
+        ));
+        cer
+    }
+
+    fn received_origin_state_id(msg: &DiameterMessage, what: &str) -> u32 {
+        msg.find_avp(avp_code::ORIGIN_STATE_ID)
+            .unwrap_or_else(|| panic!("{what} carried no Origin-State-Id"))
+            .as_u32()
+            .unwrap_or_else(|| panic!("{what}'s Origin-State-Id was not a Unsigned32"))
+    }
+
+    /// #280 criterion 3: every message-building path must carry the LATCHED
+    /// value, not just the latch itself being stable. Four paths emit AVP 278 --
+    /// `send_cer`, `handle_cer`'s CEA, `send_watchdog`'s DWR and `handle_dwr`'s
+    /// DWA -- and each calls `origin_state_id()` on its own, so a fifth path
+    /// added later could reintroduce a per-call read without disturbing the
+    /// latch's own tests.
+    ///
+    /// **The 1.1s sleep is the whole test.** The defect was
+    /// `now().as_secs()` recomputed per call, which returns the SAME value for
+    /// every message sent inside one wall-clock second -- so a handshake and a
+    /// watchdog run back to back agree with each other even with the bug
+    /// present, and the assertion would prove nothing. Crossing a second
+    /// boundary between the handshake and the watchdog is the only arrangement
+    /// in which the old code fails this test.
+    ///
+    /// Both directions are captured, because the request paths and the answer
+    /// paths are different functions: this node is the raw side twice, once
+    /// facing a real responder (capturing its CEA and DWA) and once facing a
+    /// real initiator (capturing its CER and DWR).
+    #[tokio::test]
+    async fn every_message_path_carries_the_latched_origin_state_id() {
+        let latched = origin_state_id();
+
+        // ---- Direction 1: capture a real RESPONDER's CEA and DWA. ----
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let responder_addr = listener.local_addr().unwrap();
+        let responder_cfg = test_config("hss.example.org", "epc.example.org");
+
+        let responder = tokio::spawn(async move {
+            let transport = listener.accept().await.unwrap();
+            let mut peer = DiameterPeer::new_responder(transport, &responder_cfg);
+            peer.start().await.unwrap();
+            // CER -> CEA
+            assert!(matches!(
+                peer.next_event().await.unwrap(),
+                PeerEvent::Established { .. }
+            ));
+            // DWR -> DWA
+            assert!(matches!(
+                peer.next_event().await.unwrap(),
+                PeerEvent::WatchdogAck
+            ));
+        });
+
+        let mut raw = DiameterTransport::connect(responder_addr).await.unwrap();
+        raw.send_message(&hand_built_cer("mme.example.org", "epc.example.org"))
+            .await
+            .unwrap();
+        let cea = raw.recv_message().await.unwrap();
+        let cea_osi = received_origin_state_id(&cea, "CEA");
+
+        // Cross a second boundary before the second exchange.
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+
+        let mut dwr = DiameterMessage::new_request(base_cmd::DEVICE_WATCHDOG, BASE_APPLICATION_ID);
+        dwr.add_avp(Avp::mandatory(
+            avp_code::ORIGIN_HOST,
+            AvpData::DiameterIdentity("mme.example.org".to_string()),
+        ));
+        raw.send_message(&dwr).await.unwrap();
+        let dwa = raw.recv_message().await.unwrap();
+        let dwa_osi = received_origin_state_id(&dwa, "DWA");
+
+        responder.await.unwrap();
+
+        assert_eq!(
+            cea_osi, dwa_osi,
+            "handle_cer's CEA and handle_dwr's DWA disagreed across a second boundary"
+        );
+        assert_eq!(cea_osi, latched, "the CEA did not carry the latched value");
+
+        // ---- Direction 2: capture a real INITIATOR's CER and DWR. ----
+        let listener = DiameterListener::bind(([127, 0, 0, 1], 0).into())
+            .await
+            .unwrap();
+        let raw_addr = listener.local_addr().unwrap();
+
+        let raw_side = tokio::spawn(async move {
+            let mut raw = listener.accept().await.unwrap();
+            let cer = raw.recv_message().await.unwrap();
+            let cer_osi = received_origin_state_id(&cer, "CER");
+
+            // Answer a minimal successful CEA so the initiator reaches Open;
+            // `send_watchdog` refuses to build a DWR in any other state.
+            let mut cea = DiameterMessage::new_answer(&cer);
+            cea.add_avp(Avp::mandatory(
+                avp_code::RESULT_CODE,
+                AvpData::Unsigned32(crate::error::ResultCode::Success as u32),
+            ));
+            cea.add_avp(Avp::mandatory(
+                avp_code::ORIGIN_HOST,
+                AvpData::DiameterIdentity("hss.example.org".to_string()),
+            ));
+            cea.add_avp(Avp::mandatory(
+                avp_code::ORIGIN_REALM,
+                AvpData::DiameterIdentity("epc.example.org".to_string()),
+            ));
+            raw.send_message(&cea).await.unwrap();
+
+            let dwr = raw.recv_message().await.unwrap();
+            (cer_osi, received_origin_state_id(&dwr, "DWR"))
+        });
+
+        let transport = DiameterTransport::connect(raw_addr).await.unwrap();
+        let initiator_cfg = test_config("mme.example.org", "epc.example.org");
+        let mut initiator = DiameterPeer::new_initiator(transport, &initiator_cfg);
+        initiator.start().await.unwrap();
+        assert!(matches!(
+            initiator.next_event().await.unwrap(),
+            PeerEvent::Established { .. }
+        ));
+
+        // Same second boundary, this time between the CER and the DWR.
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+        initiator.send_watchdog().await.unwrap();
+
+        let (cer_osi, dwr_osi) = raw_side.await.unwrap();
+
+        assert_eq!(
+            cer_osi, dwr_osi,
+            "send_cer and send_watchdog disagreed across a second boundary"
+        );
+        assert_eq!(cer_osi, latched, "the CER did not carry the latched value");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #280. Spec: `specs/fix-diameter-origin-state-id-verification.md`.

## #280 is stale, and that is the headline

It was filed 2026-09-09 out of #57's text, which cited `peer.rs:588-594` recomputing
`SystemTime::now().as_secs()` per call. **That defect was fixed on 2026-08-13 by `4eb7c49`
(PR #148, slice 1 of #55)**, which latched the value in a `OnceLock`. #57's citation was
carried forward without re-checking the code, so #280 describes a defect that had not
existed for four weeks by the time it was written.

Three of its four acceptance criteria were nonetheless unmet, and they are the interesting
ones.

| criterion | state on `3024f20` | this PR |
|---|---|---|
| 1. stable for the process lifetime | **met** by `4eb7c49` | left as found |
| 2. a later start derives a greater value | untested | new test |
| 3. all four message paths carry the latched value | untested | new test |
| 4. receive-side consumers enumerated | never done | enumerated below + recorded in code |

## Criterion 2 — the ordering property

`origin_state_id()` is a latch, so one process observes exactly one value: no test inside one
process can assert that a later start yields a greater one, which is the half of §8.16 that
carries the information. The derivation is split into `derive_origin_state_id(SystemTime)` so
the property is expressible, then asserted over three cases a real deployment produces — an
ordinary restart, a same-second restart (equal, which §8.16's *non-decreasing* permits), and a
pre-epoch clock (floors at `0` rather than wrapping to `u32::MAX`, so a node with a broken
clock claims the *oldest* state rather than the newest).

The split is a refactor #280 does not ask for. It is here because without it the criterion
cannot be written at all, not for tidiness.

## Criterion 3 — and the 1.1s sleeps are the whole test

Four sites emit AVP 278 (`send_cer`, `handle_cer`'s CEA, `handle_dwr`'s DWA, `send_watchdog`'s
DWR) and each calls `origin_state_id()` independently, so the latch's own tests say nothing
about them. `every_message_path_carries_the_latched_origin_state_id` drives all four over
loopback: this node is the raw transport twice — once facing a real responder to capture its
CEA and DWA, once facing a real initiator to capture its CER and DWR — then asserts all four
AVPs equal each other and equal the latch.

**The sleeps are load-bearing, and this was checked rather than assumed.** The defect returned
the same value for every message sent inside one wall-clock second, so a back-to-back exchange
agrees with itself *with the bug present*. With the defect restored and the two sleeps cut to
1ms the test **passes** — the green-proves-nothing shape, caught before shipping it rather
than after.

## Criterion 4 — what consumes a received Origin-State-Id: nothing

| site | direction | reads a received value? |
|---|---|---|
| `peer.rs:324` `send_cer`, `:404` CEA, `:484` DWA, `:513` DWR | send | no |
| `handle_cea` (`peer.rs:435`) | receive | **no** — Result-Code, Origin-Host, Origin-Realm only |
| `hssd`, `pcrfd`, `mmed` | either | **no reference to the AVP at all** |

So the receive-side behaviour change #280 wanted *stated rather than discovered* is: there is
none. Recorded at the latch in `peer.rs` with the corollary, which is a real gap rather than a
reassurance — Diameter peer-restart detection (TS 23.007 restoration) exists in **neither**
direction here, and closing it needs a per-NF decision about what to discard on a detected
restart. Filed separately rather than folded in: adding unrequested outbound behaviour to a
verification PR is how a reviewer stops being able to tell what was asked for.

## Verification

Workspace **6209 passed / 0 failed** (baseline 6207 on `3024f20`, +2 tests). `cargo clippy
--workspace --all-targets` and `cargo fmt --all -- --check` clean; `nextgcore-diameter` carries
zero clippy warnings.

| revert | expected to break | result |
|---|---|---|
| `origin_state_id()` recomputes per call (the original defect) | the new path test + the existing stability test | **2 failed** — CEA `1788993454` vs DWA `1788993455` |
| `derive_origin_state_id` returns a constant | the ordering test | **1 failed** |
| false-guard check: defect restored *and* sleeps cut to 1ms | nothing — the point is it passes | **passed**, confirming the sleeps are the guard |

## Ceilings

- The ordering property is asserted on the derivation, not across two real processes; no
  harness here provides two process lifetimes.
- The path test proves the four paths agree *within one process*. It cannot prove a fifth
  future path calls the latch. A lint would be the general fix; four call sites did not
  justify one.
- The receive side stays unimplemented, now documented rather than left to be rediscovered.