### PR TITLE
fix(easdfd,smfd): give the edge DNS plane a UDP/53 listener, a wire codec and source-address scoping (#276)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,14 @@ jobs:
         # (bind-and-keep ports + one cross-crate serialize lock).
         run: cd src && (cargo test --workspace || (echo '::warning::cargo test flaked, retrying once' && cargo test --workspace))
 
+      - name: cargo test (non-default features)
+        # Feature-gated paths are invisible to the default build, so a gated
+        # module rots uncompiled -- the reason this project normally prefers a
+        # runtime switch to a cargo feature. easdfd's `dns-udp` listener (#276)
+        # has to be a feature (it binds a privileged port), so it gets an
+        # explicit build+test here instead. Add a line per gated feature.
+        run: cd src && cargo test -p nextgcore-easdfd --features dns-udp
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -63,6 +71,11 @@ jobs:
         # Gate on errors only; warnings shown but don't fail CI until the
         # tail is cleaned up incrementally. See Phase 8 follow-ups.
         run: cd src && cargo clippy --workspace
+
+      - name: cargo clippy (non-default features)
+        # Same reasoning as the test job's non-default step: a gated module is
+        # invisible to a default-feature lint. One line per gated feature.
+        run: cd src && cargo clippy -p nextgcore-easdfd --features dns-udp --all-targets
 
   fmt:
     name: Format

--- a/docs-book/src/SUMMARY.md
+++ b/docs-book/src/SUMMARY.md
@@ -22,6 +22,7 @@
   - [MB-SMF](configuration/mbsmf.md)
   - [DCCF](configuration/dccf.md)
   - [EES](configuration/ees.md)
+  - [EASDF](configuration/easdf.md)
   - [PIN](configuration/pin.md)
   - [TSCTSF](configuration/tsctsf.md)
   - [SCP](configuration/scp.md)

--- a/docs-book/src/configuration/easdf.md
+++ b/docs-book/src/configuration/easdf.md
@@ -1,0 +1,172 @@
+# EASDF Configuration
+
+The EASDF (Edge Application Server Discovery Function, `nextgcore-easdfd`) performs DNS handling
+for Edge Computing per TS 23.501 §6.2.31 and TS 23.548 §6.2.3.2. It registers with the NRF as
+`nfType: EASDF` and serves two services — `neasdf-dnscontext` (the per-PDU-session DNS context an
+SMF creates, TS 29.556) and `neasdf-baselinednspattern` (the EASDF-wide fallback patterns) — plus
+edge DNS resolution over two transports:
+
+- **over SBI**: `GET /neasdf-dnscontext/v1/dns-queries?fqdn=<name>[&dns-context-id=<id>]`, always
+  available;
+- **over UDP/53**: a real DNS listener, behind the `dns-udp` cargo feature and **off by default**.
+
+> **Honesty note:** TS 29.556 is **not vendored** in this repository, so the `Neasdf_DNSContext`
+> member names are not schema-checked against an OpenAPI file — they follow TS 23.548 §6.2.3.2.2's
+> description and deliberately accept several spellings for the same thing (`domainNames` /
+> `dnsQueryMdt` / `fqdnList`, `ueIpv4Address` / `ueIpAddress`, …). Anything unrecognised is
+> preserved verbatim on the stored context, so nothing an SMF sends is lost. The DNS wire codec, by
+> contrast, is checked against RFC 1035 and RFC 6891, which are normative and public.
+
+## Off by default, twice over
+
+Two independent switches, for two different reasons:
+
+1. **The NF itself.** `nextgcore-easdfd` exits immediately unless `--enabled` or
+   `easdf.enabled: true` is set. Edge computing is an optional deployment feature.
+2. **The UDP listener.** Compiled only with `--features dns-udp`. Unlike everything else in this
+   crate it binds a privileged port and changes the process's network posture, so it is opt-in at
+   *build* time, not just at runtime. Without the feature the binary has no UDP socket at all and
+   the `easdf.dns.udp_*` keys below are ignored.
+
+## Example configuration
+
+```yaml
+easdf:
+  enabled: true
+  sbi:
+    server:
+      - address: 0.0.0.0
+        port: 7818
+    client:
+      nrf:
+        - uri: http://127.0.0.1:7777
+
+  # Static FQDN -> EAS address map. `*.` is a subdomain wildcard: it matches
+  # app.edge.example.com but NOT edge.example.com itself. Matching is
+  # case-insensitive and ignores a trailing dot.
+  eas_map:
+    - fqdn: "*.edge.example.com"
+      addresses: ["10.60.0.1", "2001:db8::60"]
+
+  dns:
+    # What to do with an FQDN no rule, no map entry and no baseline pattern
+    # matched: "forward" (needs `upstream`) or "nxdomain" (default).
+    miss_action: forward
+    upstream: "10.10.0.53"
+
+    # DNS/UDP listener (dns-udp feature only).
+    udp_address: 0.0.0.0
+    udp_port: 5353
+```
+
+## YAML parameters
+
+| Key | Default | Effect |
+|---|---|---|
+| `easdf.enabled` | `false` | Start the NF. Also settable with `--enabled`. |
+| `easdf.sbi.server[0].address` / `.port` | `0.0.0.0` / `7818` | SBI bind. Overrides `--sbi-addr` / `--sbi-port`. |
+| `easdf.sbi.client.nrf[0].uri` | `http://127.0.0.1:7777` | NRF for registration and heartbeat. Overrides `--nrf-uri`. |
+| `easdf.eas_map[].fqdn` / `.addresses` | *(empty)* | Static edge FQDN → EAS address map. |
+| `easdf.dns.miss_action` | `nxdomain` | `forward` or `nxdomain`. `forward` without `upstream` warns and falls back to `nxdomain`. |
+| `easdf.dns.upstream` | *(none)* | Upstream DNS server. Reported as `FORWARD` to SBI callers, and **dialled** by the UDP plane. |
+| `easdf.dns.udp_address` | `0.0.0.0` | UDP listener bind address. `dns-udp` only; overrides `--dns-udp-addr`. |
+| `easdf.dns.udp_port` | `53` | UDP listener port. `dns-udp` only; overrides `--dns-udp-port`. |
+
+`upstream` accepts a bare IP address (port 53 assumed) or `address:port`. A **hostname is
+refused**, with a warning: the EASDF would have to ask a resolver to find its own resolver.
+
+## Command-line flags
+
+`-c/--config` (default `/etc/nextgcore/easdf.yaml`), `-e/--log-level`, `-l/--log-file`,
+`-m/--no-color`, `--sbi-addr`, `--sbi-port`, `--tls`/`--tls-cert`/`--tls-key`, `--nrf-uri`,
+`--nf-instance-id`, `--enabled`, `--max-dns-contexts` (default 4096, and also the ceiling on stored
+baseline patterns), and — with `dns-udp` — `--dns-udp-addr` and `--dns-udp-port`.
+
+## Port 53 needs a capability
+
+Binding UDP/53 requires `CAP_NET_BIND_SERVICE` or root. A **bind failure is fatal**: the operator
+compiled the feature in and named the port, so starting without the listener would be an EASDF that
+reports healthy and answers nothing.
+
+For a container without the capability, set `udp_port` to an unprivileged port and redirect:
+
+```yaml
+# docker-compose
+services:
+  easdf:
+    cap_add: ["NET_BIND_SERVICE"]   # …or drop this and use the redirect below
+```
+
+```sh
+# host- or pod-side redirect when the capability is unavailable
+iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353
+```
+
+## How a query is resolved
+
+The same precedence for both transports, most specific first:
+
+1. **The querying session's own DNS handling rules**, when the query can be attributed to a session.
+2. **The static `eas_map`.**
+3. **The baseline DNS patterns** (`neasdf-baselinednspattern`).
+4. **The configured miss behaviour** — forward to `upstream`, or NXDOMAIN / `404 FQDN_NOT_FOUND`.
+
+Attribution differs by transport, and this is the part worth understanding:
+
+- Over **SBI**, the caller passes `dns-context-id` explicitly. A query without one is answered from
+  step 2 onward — never from some other session's rules.
+- Over **UDP**, a datagram carries no context id, so the query's **source address** is the only
+  correlator. The SMF therefore sends the UE's address (`ueIpv4Address`) when it creates the DNS
+  context, and the EASDF indexes it. A query from an address no context claims falls through to
+  step 2.
+
+If two live contexts claim one UE address, the **newer** wins and the collision is logged with both
+context ids: an SMF assigns a UE address to one live session at a time, so a collision means the
+older context's DELETE was lost.
+
+**Not implemented:** `ueIpv6Prefix`. Matching a source address against a prefix is a different
+operation from an exact lookup, and treating the network address as the UE's would answer for one
+address out of 2^64. A context carrying only a prefix logs a warning and its sessions fall through
+to the static map over UDP.
+
+## What the UDP plane answers
+
+| Query | Resolution | Answer |
+|---|---|---|
+| `A` / `AAAA` | edge-served, matching family | `NOERROR` + records, `AA` set, TTL 30s |
+| `A` / `AAAA` | edge-served, no address of that family | `NOERROR`, no records (NODATA) — **not** NXDOMAIN |
+| any other type (`MX`, `SVCB`, …) | edge-served | `NOERROR`, no records (NODATA) |
+| any | miss, `upstream` configured | the upstream's own reply, relayed **verbatim** |
+| any | miss, no upstream | `NXDOMAIN` |
+| any | `upstream` configured but unreachable | `SERVFAIL` — never NXDOMAIN |
+| class other than `IN`, or a non-`QUERY` opcode | — | `NOTIMP` |
+| malformed, ID readable | — | `FORMERR` |
+| malformed, too short to hold an ID | — | no reply |
+
+NODATA rather than NXDOMAIN for a wrong-family or unserved type is deliberate: the name
+demonstrably exists, and telling a dual-stack resolver it does not would stop it asking for the
+other family too.
+
+EDNS(0) is read and echoed: a response carries an `OPT` record only when the query did (RFC 6891
+§6.1.1), and the requestor's advertised payload size sets the truncation ceiling (clamped to
+512…4096). An answer set that does not fit is a `TC`-flagged prefix, never a silently short one.
+
+The TTL on an EASDF-authored answer is **30 seconds**, deliberately short: an EAS address is a
+steering decision the SMF may re-take on the next DNS message report, so a long-cached answer would
+keep a UE pointed at an EAS the network has moved away from.
+
+## DNS message reporting
+
+A handling rule with `reportInd: true` causes the EASDF to POST a DNS-message report to the
+context's notification URI (`notificationUri` on create) before answering the query — on both
+transports. That is how the SMF learns the resolved EAS address and can drive UL-CL / PSA
+re-selection. The report is awaited before the answer goes out, so the SMF is never told about an
+address the UE already has. A failed report is logged and swallowed: the UE's DNS answer is not held
+hostage to the SMF's reachability, and the EASDF has no retry queue.
+
+## Not in the shipped deployment
+
+The EASDF is not a service in `docker/rust/docker-compose.yml` and no `easdf.yaml` ships under
+`docker/rust/configs/5gc/`, so nothing above is exercised by the docker E2E gate. The DNS codec, the
+resolution precedence, the source-address scoping and the UDP listener are covered by the crate's
+own tests (including a real socket round trip); the deployment surface is not.

--- a/specs/fix-easdfd-dns-udp-listener.md
+++ b/specs/fix-easdfd-dns-udp-listener.md
@@ -1,0 +1,202 @@
+# nextgcore #276 (easdfd): give the DNS plane a socket a resolver can speak to
+
+Verified against `main` @ `6198a75`.
+
+#276 is the fifth criterion of #114, split out by that issue's own author because it is the one
+sub-item with a dependency this tree does not have (a DNS wire codec), a field easdfd does not
+store (the UE IP), and a gating requirement of its own.
+
+## Verified against current main
+
+| claim in the issue | site on `6198a75` | still true? |
+|---|---|---|
+| no UDP socket anywhere in the crate | `rg UdpSocket bins/nextgcore-easdfd/` → nothing | yes |
+| `resolve_in_context` is the engine a listener would call | `context.rs:366` | yes |
+| no DNS crate in the workspace | `rg 'hickory\|trust-dns\|domain =' Cargo.toml` → nothing | yes |
+| `EasdfDnsContext` stores `supi` + `pduSessionId` only, so the UE IP must be added | `context.rs:165` | yes |
+| the SMF creates DNS contexts (per #114) | **NO — see below** | **false** |
+
+## The thing this issue could not have been delivered honestly without
+
+#276's criterion 4 needs a UE's DNS context to be reachable from a UDP query, which needs the SMF
+to send the UE's address on create. Checking that led somewhere else first:
+
+**`easdf::create_dns_context` had no production caller.** At `main.rs:2961` the establishment path
+read
+
+```rust
+// ---- #114: EASDF selection + DNS context (TS 23.501 §5.6.7) ----
+// Off by default. Awaited BEFORE the binding is stored so the context id is
+// recorded with it -- ...
+let easdf_dns_context_id: Option<String> = None;
+```
+
+The comment describes an `await` that is not in the code. Introduced by `e9c823f` (PR #277,
+closing #114), whose own commit message says it "gives the DNS plane a driver". The driver exists,
+is 130 lines, and is tested over real HTTP by
+`easdf::tests::the_dns_context_is_created_and_deleted_over_the_wire` — and nothing in production
+ever called it. Because the id was permanently `None`, the release path's `delete_dns_context`
+(wired correctly, at `main.rs:4419`) could never fire either, so **both** legs were dead.
+
+This is "the helper is tested and the wiring is not — and the better the helper's test, the more
+convincing the illusion", with the additional twist that #114's spec *names* the ceiling and
+misjudges which side of it the call site fell on: it says "the create call site is verified **by
+inspection** plus this no-orphan assertion". The inspection did not notice the call was absent.
+
+Fixing it is a prerequisite here, not scope creep: with no context ever created, criterion 4's
+"a query from a UE whose session has a DNS context" describes a state the running system could
+never enter.
+
+## Decision 1: the codec is hand-rolled, and it is NOT behind the feature
+
+`dns_wire.rs` implements RFC 1035 message parse/build plus RFC 6891 EDNS(0) — header flags, QNAME
+with compression *reading*, QTYPE/QCLASS, `A`/`AAAA` RRs, RCODEs, `TC` truncation against the
+EDNS-negotiated or 512-byte ceiling. Hand-rolled rather than vendoring a DNS crate: this tree
+already hand-rolls NAS, NGAP, PFCP and Diameter, adding a third-party dependency is a decision of
+its own (as the issue notes), and the subset an EASDF needs is small because it answers address
+queries and forwards everything else verbatim.
+
+The codec is deliberately **outside** the `dns-udp` feature. It changes no network posture — the
+reason #276 gives for gating — and keeping it out means all the parsing logic is compiled and
+tested on every default CI run. That directly answers the project's recorded reason for preferring
+runtime switches to cargo features (a gated path rots uncompiled).
+
+Compression is read but only ever written as the one pointer to the question name at offset 12,
+which is the only compression a single-question answer has available.
+
+## Decision 2: the feature stands, and CI grew a step so it cannot rot
+
+The recorded house rule is a runtime switch, not a cargo feature. #276 asks for a feature and gives
+a reason specific to this sub-item: it binds a **privileged port**. That justification is accepted —
+but the rot risk is real, so `ci.yml` gained `cargo test -p nextgcore-easdfd --features dns-udp` in
+the test job and the matching `cargo clippy` in the lint job. The gated half is now built, linted
+and tested on every PR; what the feature controls is whether a *deployment* opens the socket.
+
+## Decision 3: a UDP query is attributed by source address, and by nothing else
+
+`EasdfDnsContext` gains `ue_addresses: Vec<IpAddr>`, and `EasdfContext` gains a `ue_ip_index`
+(UE address → context id) maintained by every mutation of the context map. `resolve_for_source`
+is the UDP plane's entry point and returns the outcome, the report flag and the context id in one
+lookup.
+
+Three sub-decisions worth stating:
+
+* **A collision goes to the newer context.** An SMF assigns a UE address to one live session at a
+  time, so two contexts claiming one address means the older one's DELETE was lost; steering the
+  live session with a dead session's rules is the worse error. The stale context itself is kept —
+  only its claim on the address is released — because removing a resource the SMF did not delete
+  would make its eventual DELETE answer 404. Both halves are pinned, including the subtle one:
+  deleting the stale context must **not** un-map the live session.
+* **An unknown source falls through to the static map**, never to another session's rules. Same
+  leak `resolve_in_context` already refuses for an unscoped SBI query.
+* **`ueIpv6Prefix` is refused, loudly.** Matching a source address against a prefix is a different
+  operation from an exact lookup, and treating the network address as the UE's would answer for one
+  address out of 2^64. It logs a warning and those sessions fall through to the static map.
+
+## Decision 4: NODATA, not NXDOMAIN, for a name we serve but a type we do not
+
+An `AAAA` query for an edge FQDN with only an `A` configured — or an `MX` query for one — answers
+`NOERROR` with zero records. `NXDOMAIN` would assert the name does not exist, and a dual-stack
+resolver told that would stop asking for the other family too. An unreachable upstream answers
+`SERVFAIL` for the same class of reason: "I could not find out" is a different and much less sticky
+statement than "it does not exist".
+
+## Decision 5: a forward is relayed verbatim in both directions
+
+The query bytes go to the upstream unchanged and its reply comes back unchanged, so the transaction
+ID, the question, the EDNS OPT and any option this codec does not model all survive. A
+parse-and-rebuild would silently drop the last of those. Replies from an address other than the one
+dialled are dropped. This is a forwarder, not a resolver: no cache, no validation.
+
+## Acceptance criteria
+
+- [x] A `dns_wire` module parses a real query and builds a response; tests cover a **compressed
+      name** (`a_compressed_name_is_followed_and_resumes_after_the_pointer`, plus
+      `multiple_answer_records_decode_after_their_compressed_names` for the production path), an
+      **unknown QTYPE** (`an_unknown_qtype_parses_and_is_answered_by_no_record`),
+      **malformed/truncated** input in five shapes
+      (`malformed_and_truncated_messages_are_rejected_distinguishably`) and an **EDNS(0) OPT**
+      (`an_edns0_query_gets_an_opt_in_its_response_and_a_larger_ceiling`,
+      `an_absurd_edns_payload_size_is_clamped_both_ways`).
+- [x] A UDP listener resolves via the existing context/EAS-map/baseline path; a test sends a **real
+      UDP query** and asserts an A-record answer — `a_real_udp_query_is_answered_with_an_a_record`,
+      over a real socket in both directions.
+- [x] A miss forwards when an upstream is configured and answers `NXDOMAIN` otherwise —
+      `a_miss_forwards_to_the_upstream_and_nxdomains_without_one`, asserting the UE receives the
+      *upstream's* address, not one the EASDF invented. Plus `an_unreachable_upstream_servfails`.
+- [x] A query from a UE with a DNS context is scoped to that context's rules; **two UEs with
+      different rules get different answers for the same FQDN** —
+      `two_ues_get_different_answers_for_the_same_fqdn` (and a third source that matches neither),
+      `resolve_for_source_scopes_to_the_sources_own_context`. Needed the UE IP on the context, the
+      SMF-side send, and the dead create wiring above.
+- [x] The listener is behind a `dns-udp` cargo feature, off by default; the workspace builds, tests
+      and clippy pass **both** with and without it — and CI now runs both, so the claim stays true.
+- [x] The `main.rs` module header no longer lists the UDP listener as deferred; it documents what
+      the plane does and points at `dns_udp` for why the split is where it is.
+
+Beyond the criteria: `docs-book/src/configuration/easdf.md` (new, in `SUMMARY.md`) documents the
+`CAP_NET_BIND_SERVICE` requirement and the port override, the resolution precedence per transport,
+and the answer table — the "say so in the docs" the suggested approach asks for. There was no EASDF
+page at all before.
+
+## Verification
+
+Workspace **6224 passed / 0 failed** (baseline 6209 on `6198a75`; +15 in the default build), and
+`cargo test -p nextgcore-easdfd --features dns-udp` **51 passed / 0 failed** (+9 more that exist
+only with the feature). `cargo clippy --workspace --all-targets`, `cargo clippy -p nextgcore-easdfd
+--features dns-udp --all-targets` and `cargo fmt --all -- --check` all clean, zero new warnings.
+
+| revert | expected to break | result |
+|---|---|---|
+| `resolve_for_source` ignores the source address | the two scoping tests | **2 failed** |
+| `ue_ip_index_remove` drops the mapping unconditionally | `a_colliding_ue_address_..._survives_the_stale_delete` | **1 failed** |
+| the listener binds but never serves | `a_real_udp_query_is_answered_with_an_a_record` | **1 failed** |
+| the `ueIpv4Address` member removed from the create body | `the_dns_context_is_created_and_deleted_over_the_wire` | **1 failed** |
+| an `OPT` emitted even when the query carried none | 3 tests | **3 failed** |
+| `TC` never set | `an_oversized_answer_set_is_truncated_with_the_tc_bit_set` | **1 failed** |
+| **the smfd create call removed (i.e. #114's state restored)** | — | **425 passed, 0 failed** |
+
+That last row is the honest one and is discussed under Ceilings.
+
+### A lock split that produced a hang, not a flake
+
+The UDP tests initially declared their own `tokio::Mutex` while `main.rs`'s tests already had a
+`std::Mutex` over the same process-global context — two disjoint agreements about one variable. The
+symptom was not a failed assertion: a UDP test called `easdf_context_final()` while a sibling
+handler test was mid-flight, that sibling's *miss* became a *hit*, so no forward was sent, so the
+fake upstream it was blocked on never received anything, and the run hung until the harness killed
+it. The single lock now lives in `context.rs` beside the global it protects, with both modules
+taking it, and the forward test's `upstream_task.await` is bounded by a timeout so a future
+regression fails instead of hanging. Eight consecutive feature-suite runs green afterwards, because
+one green run proves nothing about a process-global race.
+
+## Ceilings
+
+* **The smfd create CALL SITE is still not covered by a test, and the revert proves it.** Removing
+  the call leaves all 425 smfd tests green. Reaching it needs `handle_sm_context_create` to get
+  past its N4 leg, which needs an associated PFCP peer answering a Session Establishment Request,
+  and the smfd harness has no UPF stand-in — two existing tests
+  (`a_failed_establishment_creates_no_easdf_dns_context`, `a_failed_create_leaves_no_registered_sm_context`)
+  say so in as many words and both add "if this ever becomes a 2xx the harness gained a UPF".
+  Building one is a cross-module test-infrastructure change: `PFCP_CLIENT` is a `OnceLock`, so an
+  installed client is permanent for the process, and `release_association` clears the process-global
+  `pfcp_sessions` map that `pfcp_path`'s own `SESSION_MAP_LOCK` guards — a second disjoint lock
+  about the same variable, which is precisely the mistake this PR already made once and fixed.
+  Filed as its own issue rather than done here. What IS verified: the create body's contents over
+  real HTTP, and that a failed establishment creates no context.
+* **`ueIpv6Prefix` is unsupported**, so a v6-prefix-only session's UDP queries fall through to the
+  static map. Warned at runtime and documented.
+* **No TCP fallback.** A truncated answer is `TC`-flagged and a resolver that wants the rest must
+  retry against an upstream over TCP, not against the EASDF. RFC 1035 permits UDP-only; stated
+  because "supports DNS" would otherwise imply both.
+* **No DNSSEC.** The `DO` bit is read and echoed and nothing is signed. An EASDF answering for an
+  operator-configured edge FQDN is not the zone's signer.
+* **The deployment surface is untested.** The EASDF is not a service in
+  `docker/rust/docker-compose.yml` and ships no `easdf.yaml`, so nothing here is exercised by the
+  docker E2E gate. Unchanged by this PR and stated in the new docs page.
+* **TS 29.556 is still not vendored**, so `ueIpv4Address` and friends rest on the same
+  multiple-accepted-spellings stance #114 established, not on a schema. The DNS wire format, by
+  contrast, is checked against RFC 1035/6891.
+* GitNexus impact analysis unrunnable (no MCP server connected). Blast radius by grep:
+  `EasdfDnsContext` has 3 construction sites (2 handlers + tests), `resolve_for_source` has one
+  production caller (`handle_datagram`), `create_dns_context` now has one.

--- a/src/bins/nextgcore-easdfd/Cargo.toml
+++ b/src/bins/nextgcore-easdfd/Cargo.toml
@@ -10,6 +10,15 @@ description = "NextGCore EASDF (Edge Application Server Discovery Function, TS 2
 name = "nextgcore-easdfd"
 path = "src/main.rs"
 
+[features]
+# The UDP/53 DNS listener (#276). OFF by default: unlike the rest of the DNS
+# plane it binds a privileged port and changes the process's network posture, so
+# it is opt-in per the issue's own gating advice. The wire codec is NOT behind
+# this -- it is pure logic with no network posture, so it stays compiled and
+# tested in the default build. CI additionally builds and tests this crate WITH
+# the feature, so the gated half cannot rot uncompiled.
+dns-udp = []
+
 [dependencies]
 nextgcore-core = { workspace = true }
 nextgcore-sbi = { workspace = true }

--- a/src/bins/nextgcore-easdfd/src/context.rs
+++ b/src/bins/nextgcore-easdfd/src/context.rs
@@ -10,6 +10,7 @@
 //! from the YAML config.
 
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
@@ -183,6 +184,15 @@ pub struct EasdfDnsContext {
     /// the SMF's callback member in the create body; without it a rule asking for
     /// a report has nowhere to send one.
     pub notify_uri: Option<String>,
+    /// The UE's own IP address(es) for this PDU session (#276).
+    ///
+    /// Needed only by the UDP/53 plane, and needed absolutely there: a DNS query
+    /// arriving on a socket carries no context id, so the **source address** is
+    /// the only thing that can associate it with a session. Without this a UDP
+    /// query can be answered from the static EAS map and from nothing else, which
+    /// makes the per-session handling rules #114 added unreachable over the one
+    /// transport a resolver actually speaks.
+    pub ue_addresses: Vec<IpAddr>,
 }
 
 impl EasdfDnsContext {
@@ -194,6 +204,7 @@ impl EasdfDnsContext {
             raw: raw.into(),
             handling_rules: Vec::new(),
             notify_uri: None,
+            ue_addresses: Vec::new(),
         }
     }
 
@@ -232,8 +243,68 @@ impl EasdfDnsContext {
         .find_map(|k| body.get(*k).and_then(|v| v.as_str()))
         .filter(|s| !s.is_empty())
         .map(str::to_string);
+        self.ue_addresses = parse_ue_addresses(body);
         self
     }
+}
+
+/// Pull the UE's IP address(es) out of a DnsContext body (#276).
+///
+/// Same multi-spelling stance as the rules, and for the same reason: TS 29.556 is
+/// not vendored here, so `ueIpv4Address` / `ueIpv6Address` / `ueIpAddress` are all
+/// accepted, singly or as arrays. An unparseable address is **skipped with a
+/// warn** rather than failing the create: a context with no usable UE address is
+/// still a working context for the SBI shim, and refusing it would turn a
+/// cosmetic SMF bug into a session-establishment failure.
+///
+/// An IPv6 *prefix* (`ueIpv6Prefix`, e.g. `2001:db8::/64`) is deliberately NOT
+/// accepted. Matching a source address against a prefix is a different operation
+/// from an exact-address lookup, and implementing it as "take the network address
+/// and hope the UE uses ::1" would answer for one address out of 2^64. Stated
+/// here rather than silently dropped; the UDP plane's ceilings say the same.
+fn parse_ue_addresses(body: &serde_json::Value) -> Vec<IpAddr> {
+    let mut out = Vec::new();
+    let mut push = |raw: &str| {
+        if raw.is_empty() {
+            return;
+        }
+        match raw.parse::<IpAddr>() {
+            Ok(ip) => {
+                if !out.contains(&ip) {
+                    out.push(ip);
+                }
+            }
+            Err(_) => log::warn!(
+                "DNS context carries an unparseable UE address '{raw}'; \
+                 UDP queries from that UE will not be scoped to this context"
+            ),
+        }
+    };
+    for key in [
+        "ueIpv4Address",
+        "ueIpv6Address",
+        "ueIpAddress",
+        "ueIpAddresses",
+    ] {
+        match body.get(key) {
+            Some(serde_json::Value::String(s)) => push(s),
+            Some(serde_json::Value::Array(items)) => {
+                for item in items {
+                    if let Some(s) = item.as_str() {
+                        push(s);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(prefix) = body.get("ueIpv6Prefix").and_then(|v| v.as_str()) {
+        log::warn!(
+            "DNS context carries ueIpv6Prefix '{prefix}'; prefix matching is not \
+             implemented, so UDP queries from that session fall back to the static EAS map"
+        );
+    }
+    out
 }
 
 /// EASDF context errors.
@@ -274,6 +345,14 @@ pub struct EasdfContext {
     /// the fallback a query falls through to when no session context rule and no
     /// static EAS-map entry matched.
     baseline_patterns: RwLock<HashMap<String, DnsHandlingRule>>,
+    /// UE IP → DNS-context id (#276), the index the UDP plane resolves through.
+    ///
+    /// Derived from `dns_contexts` and maintained by every mutation of it, never
+    /// loaded from anywhere: this store is memory-only, so there is no snapshot
+    /// for a persisted index to disagree with. It exists because a UDP query
+    /// carries no context id and a linear scan of the context map per query would
+    /// put the cost of every DNS answer on the number of live sessions.
+    ue_ip_index: RwLock<HashMap<IpAddr, String>>,
     /// Context initialized flag
     initialized: AtomicBool,
 }
@@ -286,6 +365,7 @@ impl EasdfContext {
             miss_behavior: DnsMissBehavior::default(),
             max_dns_contexts: 0,
             baseline_patterns: RwLock::new(HashMap::new()),
+            ue_ip_index: RwLock::new(HashMap::new()),
             initialized: AtomicBool::new(false),
         }
     }
@@ -308,6 +388,9 @@ impl EasdfContext {
         }
         if let Ok(mut patterns) = self.baseline_patterns.write() {
             patterns.clear();
+        }
+        if let Ok(mut index) = self.ue_ip_index.write() {
+            index.clear();
         }
         self.eas_map.clear();
         self.miss_behavior = DnsMissBehavior::default();
@@ -403,9 +486,95 @@ impl EasdfContext {
             return Err(EasdfContextError::MaxDnsContextsReached);
         }
         let id = ctx.id.clone();
+        let addresses = ctx.ue_addresses.clone();
         contexts.insert(id.clone(), ctx);
+        self.ue_ip_index_add(&id, &addresses);
         log::debug!("EASDF DNS context inserted (id={id})");
         Ok(())
+    }
+
+    /// Point every one of `addresses` at `id` (#276).
+    ///
+    /// A collision means two contexts claim one UE address. The NEWER one wins
+    /// and the older mapping is dropped with a warn naming both ids: an SMF
+    /// assigns a UE address to exactly one live session at a time, so a collision
+    /// means the earlier context is stale (its delete was lost), and steering the
+    /// live session with a dead session's rules is the worse of the two errors.
+    /// The stale context itself is left in the map — only its claim on the address
+    /// is released — because removing a resource the SMF did not delete would make
+    /// its eventual DELETE 404.
+    fn ue_ip_index_add(&self, id: &str, addresses: &[IpAddr]) {
+        if addresses.is_empty() {
+            return;
+        }
+        let Ok(mut index) = self.ue_ip_index.write() else {
+            return;
+        };
+        for addr in addresses {
+            if let Some(previous) = index.insert(*addr, id.to_string()) {
+                if previous != id {
+                    log::warn!(
+                        "UE address {addr} was claimed by DNS context {previous} and is now \
+                         claimed by {id}; the newer context wins. The older one is stale -- \
+                         its DELETE was lost."
+                    );
+                }
+            }
+        }
+    }
+
+    /// Drop `id`'s claim on `addresses`, leaving claims another context has taken
+    /// over intact.
+    fn ue_ip_index_remove(&self, id: &str, addresses: &[IpAddr]) {
+        if addresses.is_empty() {
+            return;
+        }
+        let Ok(mut index) = self.ue_ip_index.write() else {
+            return;
+        };
+        for addr in addresses {
+            // Conditional: after a collision the address belongs to the newer
+            // context, and this one's removal must not un-map it.
+            if index.get(addr).map(String::as_str) == Some(id) {
+                index.remove(addr);
+            }
+        }
+    }
+
+    /// The DNS context a query from `source` belongs to, if any (#276).
+    pub fn dns_context_id_for_source(&self, source: IpAddr) -> Option<String> {
+        self.ue_ip_index.read().ok()?.get(&source).cloned()
+    }
+
+    /// Number of indexed UE addresses. Exposed so a test can assert the index
+    /// does not leak entries across a replace or a remove.
+    pub fn ue_ip_index_len(&self) -> usize {
+        self.ue_ip_index.read().map(|i| i.len()).unwrap_or(0)
+    }
+
+    /// Resolve `fqdn` for a query that arrived from `source` (#276): the UDP
+    /// plane's entry point.
+    ///
+    /// Returns the outcome, whether a matching rule asked for a report, and the
+    /// context id the answer was scoped to — the caller needs the id to send the
+    /// report, and returning it here means the source lookup happens once.
+    ///
+    /// A source with no context falls through to [`Self::resolve_fqdn`] (static
+    /// map, then baseline patterns, then the miss behaviour), which is the same
+    /// answer an unscoped SBI query gets. It does NOT consult some other
+    /// session's rules — the same leak `resolve_in_context` refuses.
+    pub fn resolve_for_source(
+        &self,
+        source: IpAddr,
+        fqdn: &str,
+    ) -> (ResolveOutcome, bool, Option<String>) {
+        match self.dns_context_id_for_source(source) {
+            Some(id) => {
+                let (outcome, report) = self.resolve_in_context(&id, fqdn);
+                (outcome, report, Some(id))
+            }
+            None => (self.resolve_fqdn(fqdn), false, None),
+        }
     }
 
     /// Find a DNS context by ID.
@@ -424,14 +593,32 @@ impl EasdfContext {
             return false;
         }
         ctx.id = id.to_string();
-        contexts.insert(id.to_string(), ctx);
+        let addresses = ctx.ue_addresses.clone();
+        let superseded = contexts.insert(id.to_string(), ctx);
+        // #276: an update that CHANGES the UE address must release the old claim,
+        // or a reassigned address keeps resolving through the session that no
+        // longer holds it. Old claims are dropped first, then the new ones added,
+        // so an address present in both survives.
+        if let Some(old) = superseded {
+            let dropped: Vec<IpAddr> = old
+                .ue_addresses
+                .into_iter()
+                .filter(|a| !addresses.contains(a))
+                .collect();
+            self.ue_ip_index_remove(id, &dropped);
+        }
+        self.ue_ip_index_add(id, &addresses);
         true
     }
 
     /// Remove a DNS context by ID.
     pub fn dns_context_remove(&self, id: &str) -> Option<EasdfDnsContext> {
-        let mut contexts = self.dns_contexts.write().ok()?;
-        contexts.remove(id)
+        let removed = {
+            let mut contexts = self.dns_contexts.write().ok()?;
+            contexts.remove(id)?
+        };
+        self.ue_ip_index_remove(id, &removed.ue_addresses);
+        Some(removed)
     }
 
     /// Number of stored DNS contexts (NRF `/load` gauge source).
@@ -527,6 +714,31 @@ pub fn easdf_context_init(max_dns_contexts: usize) {
     if let Ok(mut context) = ctx.write() {
         context.init(max_dns_contexts);
     };
+}
+
+/// The ONE agreement about the process-global EASDF context, for tests.
+///
+/// It lives here, beside the global it protects, rather than in whichever module
+/// happened to need it first. #276 learned that the hard way: the UDP plane's
+/// tests started with a `tokio::Mutex` of their own while `main.rs`'s tests
+/// already had a `std::Mutex`, and two locks are two disjoint agreements about
+/// one variable. The symptom was not a flaky assertion but a HANG -- a UDP test
+/// called `easdf_context_final()` while a sibling was mid-flight, the sibling's
+/// miss became a hit, and the fake upstream it was waiting on never received a
+/// forward.
+///
+/// A `std::sync::Mutex` even though async tests hold it across awaits (they carry
+/// `#[allow(clippy::await_holding_lock)]` and say why): every holder is a test in
+/// this crate, none blocks on another, and a second `tokio` lock for the async
+/// half would recreate exactly the split this comment exists to prevent.
+#[cfg(test)]
+pub(crate) static GLOBAL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Take [`GLOBAL_TEST_LOCK`], recovering from a poisoned guard so one failing
+/// test does not cascade into every sibling.
+#[cfg(test)]
+pub(crate) fn lock_globals() -> std::sync::MutexGuard<'static, ()> {
+    GLOBAL_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 pub fn easdf_context_final() {
@@ -693,5 +905,173 @@ mod tests {
     #[test]
     fn generated_ids_are_unique() {
         assert_ne!(dns_ctx("a").id, dns_ctx("a").id);
+    }
+
+    // ---- #276: the UE-address index the UDP plane resolves through -----------
+
+    fn ctx_for_ue(ue: &[&str], pattern: &str, eas: &str) -> EasdfDnsContext {
+        let mut c = EasdfDnsContext::new("imsi-1", 5, "{}");
+        c.handling_rules = vec![DnsHandlingRule {
+            domain_patterns: vec![pattern.to_string()],
+            eas_addresses: vec![eas.to_string()],
+            report: false,
+            forward_to: None,
+        }];
+        c.ue_addresses = ue
+            .iter()
+            .map(|a| a.parse().expect("test address"))
+            .collect();
+        c
+    }
+
+    /// A UE address is accepted in each spelling the SMF might use, singly or as
+    /// an array, and a malformed one is skipped rather than failing the create.
+    #[test]
+    fn ue_addresses_are_parsed_from_every_accepted_spelling() {
+        let both = parse_ue_addresses(&serde_json::json!({
+            "ueIpv4Address": "10.45.0.2",
+            "ueIpv6Address": "2001:db8::2",
+        }));
+        assert_eq!(
+            both,
+            vec![
+                "10.45.0.2".parse::<IpAddr>().expect("v4"),
+                "2001:db8::2".parse::<IpAddr>().expect("v6")
+            ]
+        );
+
+        assert_eq!(
+            parse_ue_addresses(&serde_json::json!({
+                "ueIpAddresses": ["10.45.0.3", "not-an-address", "10.45.0.3"]
+            })),
+            vec!["10.45.0.3".parse::<IpAddr>().expect("v4")],
+            "a malformed entry is skipped and a duplicate is not stored twice"
+        );
+
+        // An IPv6 PREFIX is deliberately not accepted: matching a source address
+        // against a prefix is a different operation, and taking the network
+        // address would answer for one address out of 2^64.
+        assert!(parse_ue_addresses(&serde_json::json!({
+            "ueIpv6Prefix": "2001:db8::/64"
+        }))
+        .is_empty());
+
+        assert!(parse_ue_addresses(&serde_json::json!({"supi": "imsi-1"})).is_empty());
+    }
+
+    /// The index is what the UDP plane resolves through, so an entry that
+    /// outlives its context would steer a reassigned UE address through a dead
+    /// session's rules. Remove and replace are both checked, because they are the
+    /// two ways an entry can be left behind.
+    #[test]
+    fn the_ue_address_index_does_not_outlive_its_context() {
+        let context = ctx_with_map(8);
+        let first = ctx_for_ue(&["10.45.0.2"], "*.edge.example.com", "10.60.0.201");
+        let id = first.id.clone();
+        context.dns_context_insert(first).expect("insert");
+        assert_eq!(context.ue_ip_index_len(), 1);
+        assert_eq!(
+            context.dns_context_id_for_source("10.45.0.2".parse().expect("v4")),
+            Some(id.clone())
+        );
+
+        // An update that MOVES the UE address must release the old claim.
+        let moved = ctx_for_ue(&["10.45.0.9"], "*.edge.example.com", "10.60.0.201");
+        assert!(context.dns_context_replace(&id, moved));
+        assert_eq!(
+            context.dns_context_id_for_source("10.45.0.2".parse().expect("v4")),
+            None,
+            "the old address must stop resolving to this context"
+        );
+        assert_eq!(
+            context.dns_context_id_for_source("10.45.0.9".parse().expect("v4")),
+            Some(id.clone())
+        );
+        assert_eq!(
+            context.ue_ip_index_len(),
+            1,
+            "the index must not grow on a move"
+        );
+
+        // Removal releases the claim.
+        assert!(context.dns_context_remove(&id).is_some());
+        assert_eq!(context.ue_ip_index_len(), 0);
+        assert_eq!(
+            context.dns_context_id_for_source("10.45.0.9".parse().expect("v4")),
+            None
+        );
+    }
+
+    /// Two contexts claiming one UE address: the newer wins, and removing the
+    /// STALE one must not un-map the live one.
+    ///
+    /// That second half is the subtle one. An unconditional `index.remove(addr)`
+    /// on delete would pass every other test here and silently break the live
+    /// session the moment the SMF got round to deleting the context whose delete
+    /// had been lost.
+    #[test]
+    fn a_colliding_ue_address_goes_to_the_newer_context_and_survives_the_stale_delete() {
+        let context = ctx_with_map(8);
+        let stale = ctx_for_ue(&["10.45.0.2"], "*.edge.example.com", "10.60.0.111");
+        let live = ctx_for_ue(&["10.45.0.2"], "*.edge.example.com", "10.60.0.222");
+        let stale_id = stale.id.clone();
+        let live_id = live.id.clone();
+        context.dns_context_insert(stale).expect("insert");
+        context.dns_context_insert(live).expect("insert");
+
+        let addr: IpAddr = "10.45.0.2".parse().expect("v4");
+        assert_eq!(
+            context.dns_context_id_for_source(addr),
+            Some(live_id.clone()),
+            "the newer context wins the address"
+        );
+
+        // The SMF finally deletes the stale context.
+        assert!(context.dns_context_remove(&stale_id).is_some());
+        assert_eq!(
+            context.dns_context_id_for_source(addr),
+            Some(live_id),
+            "deleting the STALE context must not un-map the live session"
+        );
+    }
+
+    /// End to end through the resolution entry point the UDP plane calls: the
+    /// context's rule wins for its own UE, and an unknown source gets the static
+    /// map rather than anyone's rules.
+    #[test]
+    fn resolve_for_source_scopes_to_the_sources_own_context() {
+        let context = ctx_with_map(8);
+        let a = ctx_for_ue(&["10.45.0.2"], "app.edge.example.com", "10.60.0.201");
+        let b = ctx_for_ue(&["10.45.0.3"], "app.edge.example.com", "10.60.0.202");
+        let a_id = a.id.clone();
+        context.dns_context_insert(a).expect("insert");
+        context.dns_context_insert(b).expect("insert");
+
+        let (outcome, _, id) =
+            context.resolve_for_source("10.45.0.2".parse().expect("v4"), "app.edge.example.com");
+        assert_eq!(
+            outcome,
+            ResolveOutcome::Resolved(vec!["10.60.0.201".into()])
+        );
+        assert_eq!(id.as_deref(), Some(a_id.as_str()));
+
+        let (outcome, _, id) =
+            context.resolve_for_source("10.45.0.3".parse().expect("v4"), "app.edge.example.com");
+        assert_eq!(
+            outcome,
+            ResolveOutcome::Resolved(vec!["10.60.0.202".into()])
+        );
+        assert!(id.is_some());
+
+        // No context for this source: the static map, and no context id -- so no
+        // report is attributed to a session that did not ask.
+        let (outcome, report, id) =
+            context.resolve_for_source("10.45.0.99".parse().expect("v4"), "app.edge.example.com");
+        assert_eq!(
+            outcome,
+            ResolveOutcome::Resolved(vec!["10.60.0.10".into(), "10.60.0.11".into()])
+        );
+        assert!(!report);
+        assert!(id.is_none());
     }
 }

--- a/src/bins/nextgcore-easdfd/src/dns_udp.rs
+++ b/src/bins/nextgcore-easdfd/src/dns_udp.rs
@@ -1,0 +1,885 @@
+//! The EASDF's DNS/UDP plane (issue #276): the socket a UE or stub resolver can
+//! actually reach.
+//!
+//! Before this, edge FQDNs resolved only over an SBI shim
+//! (`GET /neasdf-dnscontext/v1/dns-queries?fqdn=...`), which no UE, resolver or
+//! forwarder speaks. The resolution engine, the per-session handling rules and the
+//! baseline patterns all existed and were reachable by nothing that would ask.
+//!
+//! # Behind the `dns-udp` cargo feature, off by default
+//!
+//! #276 asks for a cargo feature and gives the reason: unlike the rest of #114's
+//! sub-items this one **binds a privileged port and changes the process's network
+//! posture**, so leaving it uncompiled by default is the conservative trade. That
+//! overrides this project's usual preference for a runtime switch — a preference
+//! whose stated reason is that a gated path rots because CI builds default
+//! features. Two things answer that here: the wire codec is NOT gated (see
+//! [`crate::dns_wire`]), so all the parsing logic is compiled and tested on every
+//! run; and CI gained an explicit `--features dns-udp` build+test step for this
+//! crate, so the gated half cannot rot silently either.
+//!
+//! # Port 53 needs a capability
+//!
+//! Binding 53 requires `CAP_NET_BIND_SERVICE` (or root). The port is configurable
+//! (`--dns-udp-port` / `easdf.dns.udp_port`) precisely so a deployment without
+//! that capability can run the plane on a high port behind a redirect, and so the
+//! tests can bind an ephemeral one.
+//!
+//! # Source-address scoping
+//!
+//! A DNS datagram carries no DNS-context id, so the **source address** is the only
+//! correlator between a query and a PDU session. That is why the DNS context
+//! carries the UE's address ([`crate::context::EasdfDnsContext::ue_addresses`]) and
+//! why the SMF now sends it. A query from an unknown source is answered from the
+//! static EAS map, baseline patterns and miss behaviour — never from some other
+//! session's rules.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use tokio::net::UdpSocket;
+
+use crate::context::{easdf_self, ResolveOutcome};
+use crate::dns_wire::{
+    self, build_error, build_response, parse_message, qtype, rcode, Question, Record, Response,
+    CLASS_IN, MAX_EDNS_PAYLOAD,
+};
+
+/// TTL on an EASDF-authored answer, in seconds.
+///
+/// Deliberately short. An EAS address is a *steering* decision that the SMF may
+/// re-take on the next DNS message report (UL-CL / PSA re-selection), so a UE
+/// caching it for hours would keep using an EAS the network has moved away from.
+/// 30s is the same order as the 5s NRF heartbeat this stack already runs on.
+pub const ANSWER_TTL: u32 = 30;
+
+/// How long to wait for an upstream forwarder before giving up.
+const FORWARD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Largest datagram accepted. A UDP DNS query above this is not a query we can
+/// serve; the EDNS ceiling is the practical bound and this leaves headroom.
+const RECV_BUF: usize = 4096;
+
+/// What the plane needs from configuration.
+#[derive(Debug, Clone)]
+pub struct DnsUdpConfig {
+    pub bind: SocketAddr,
+    /// Where to forward a query the EASDF does not serve. `None` means a miss is
+    /// answered `NXDOMAIN` locally.
+    ///
+    /// Kept separate from the resolution engine's `DnsMissBehavior::Forward`
+    /// rather than derived from it: the engine's value is what it *reports* to an
+    /// SBI caller (a "you should ask this server" answer), while this is the
+    /// address this process dials itself. They come from the same YAML key today,
+    /// and conflating the two would make a forward-on-the-wire silently impossible
+    /// to configure independently later.
+    pub upstream: Option<SocketAddr>,
+}
+
+/// Parse an upstream from config: a bare address gets the default DNS port.
+pub fn parse_upstream(raw: &str) -> Option<SocketAddr> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Ok(addr) = raw.parse::<SocketAddr>() {
+        return Some(addr);
+    }
+    match raw.parse::<IpAddr>() {
+        Ok(ip) => Some(SocketAddr::new(ip, 53)),
+        Err(_) => {
+            log::warn!(
+                "dns.upstream '{raw}' is not an IP address or address:port; \
+                 UDP forwarding is disabled and a miss will answer NXDOMAIN"
+            );
+            None
+        }
+    }
+}
+
+/// Bind the socket and serve until the task is dropped.
+///
+/// Returns the bound address so a caller (and a test) can learn the port when 0
+/// was requested.
+pub async fn spawn(
+    config: DnsUdpConfig,
+) -> std::io::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
+    let socket = Arc::new(UdpSocket::bind(config.bind).await?);
+    let local = socket.local_addr()?;
+    log::info!(
+        "EASDF DNS/UDP listener bound on {local} (upstream: {})",
+        config
+            .upstream
+            .map(|u| u.to_string())
+            .unwrap_or_else(|| "none, a miss answers NXDOMAIN".to_string())
+    );
+    let handle = tokio::spawn(async move { serve(socket, config).await });
+    Ok((local, handle))
+}
+
+async fn serve(socket: Arc<UdpSocket>, config: DnsUdpConfig) {
+    let mut buf = vec![0u8; RECV_BUF];
+    loop {
+        let (len, from) = match socket.recv_from(&mut buf).await {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("EASDF DNS/UDP recv failed: {e}");
+                continue;
+            }
+        };
+        let datagram = buf[..len].to_vec();
+        let socket = socket.clone();
+        let config = config.clone();
+        // One task per datagram: a forward waits up to FORWARD_TIMEOUT on an
+        // upstream, and doing that inline would stall every other UE's query
+        // behind one slow forward.
+        tokio::spawn(async move {
+            if let Some(reply) = handle_datagram(&datagram, from, &config).await {
+                if let Err(e) = socket.send_to(&reply, from).await {
+                    log::warn!("EASDF DNS/UDP reply to {from} failed: {e}");
+                }
+            }
+        });
+    }
+}
+
+/// Turn one received datagram into the bytes to send back, or `None` when there
+/// is nothing answerable.
+///
+/// Separated from the socket loop so every decision below is testable without a
+/// network, and so the UDP test asserts the socket wiring rather than re-testing
+/// the logic.
+pub async fn handle_datagram(
+    datagram: &[u8],
+    from: SocketAddr,
+    config: &DnsUdpConfig,
+) -> Option<Vec<u8>> {
+    let message = match parse_message(datagram) {
+        Ok(m) => m,
+        Err(e) => {
+            if !e.is_answerable() {
+                // No readable ID, so any "response" would be unmatchable noise.
+                log::debug!("unanswerable DNS datagram from {from}: {e:?}");
+                return None;
+            }
+            // The ID is at a fixed offset and was readable; echo it with FORMERR
+            // so the client fails fast instead of retrying until it times out.
+            let id = u16::from_be_bytes([datagram[0], datagram[1]]);
+            log::debug!("malformed DNS query from {from}: {e:?}");
+            return Some(build_error(id, None, rcode::FORM_ERR, false, false, None));
+        }
+    };
+
+    // A response arriving on our listening socket is not ours to answer.
+    if message.flags.response {
+        log::debug!("ignoring a DNS RESPONSE received on the listener from {from}");
+        return None;
+    }
+
+    let edns = message.edns;
+    let recursion_available = config.upstream.is_some();
+
+    // Only standard QUERY, exactly one question, class IN.
+    if message.flags.opcode != 0 || message.question_count != 1 {
+        return Some(build_error(
+            message.id,
+            message.question.as_ref(),
+            if message.flags.opcode == 0 {
+                rcode::FORM_ERR
+            } else {
+                rcode::NOT_IMP
+            },
+            message.flags.recursion_desired,
+            recursion_available,
+            edns,
+        ));
+    }
+    let question = message.question.clone()?;
+    if question.qclass != CLASS_IN {
+        return Some(build_error(
+            message.id,
+            Some(&question),
+            rcode::NOT_IMP,
+            message.flags.recursion_desired,
+            recursion_available,
+            edns,
+        ));
+    }
+
+    let ctx = easdf_self();
+    let (outcome, report, ctx_id) = {
+        match ctx.read() {
+            Ok(c) => c.resolve_for_source(from.ip(), &question.name),
+            Err(_) => {
+                log::error!("EASDF context lock poisoned; answering SERVFAIL");
+                return Some(build_error(
+                    message.id,
+                    Some(&question),
+                    rcode::SERV_FAIL,
+                    message.flags.recursion_desired,
+                    recursion_available,
+                    edns,
+                ));
+            }
+        }
+    };
+
+    // TS 23.548 §6.2.3.2.2 DNS message reporting, on the UDP plane too: the SMF
+    // needs to learn the resolved EAS to drive UL-CL insertion, and it needs to
+    // learn it for a query that arrived over DNS just as much as for one that
+    // arrived over the shim. Awaited before answering for the same reason the
+    // shim awaits it: the SMF should not learn the address after the UE has it.
+    if report {
+        if let Some(id) = &ctx_id {
+            let uri = easdf_self()
+                .read()
+                .ok()
+                .and_then(|c| c.dns_context_notify_uri(id));
+            match uri {
+                Some(uri) => {
+                    crate::send_dns_message_report(&uri, id, &question.name, &outcome).await
+                }
+                None => log::warn!(
+                    "DNS context {id} has a rule requesting a report but no notification URI: \
+                     the report for {} cannot be delivered",
+                    question.name
+                ),
+            }
+        }
+    }
+
+    match outcome {
+        ResolveOutcome::Resolved(addresses) => Some(answer_records(
+            &message,
+            &question,
+            &addresses,
+            recursion_available,
+        )),
+        ResolveOutcome::Forward(reported) => {
+            // The engine names an upstream; this plane dials the one it was
+            // configured with. They are the same value in practice -- both come
+            // from `easdf.dns.upstream` -- and when the plane has none, a
+            // reported forward becomes a local NXDOMAIN rather than a lie.
+            match config.upstream {
+                Some(upstream) => match forward(datagram, upstream).await {
+                    Some(reply) => Some(reply),
+                    None => Some(build_error(
+                        message.id,
+                        Some(&question),
+                        rcode::SERV_FAIL,
+                        message.flags.recursion_desired,
+                        recursion_available,
+                        edns,
+                    )),
+                },
+                None => {
+                    log::debug!(
+                        "resolution reported a forward to {reported} but no UDP upstream is \
+                         configured; answering NXDOMAIN for {}",
+                        question.name
+                    );
+                    Some(build_error(
+                        message.id,
+                        Some(&question),
+                        rcode::NX_DOMAIN,
+                        message.flags.recursion_desired,
+                        false,
+                        edns,
+                    ))
+                }
+            }
+        }
+        ResolveOutcome::Miss => Some(build_error(
+            message.id,
+            Some(&question),
+            rcode::NX_DOMAIN,
+            message.flags.recursion_desired,
+            recursion_available,
+            edns,
+        )),
+    }
+}
+
+/// Build the answer for a name the EASDF serves.
+///
+/// A name that resolves but has no address of the QUERIED family answers
+/// `NOERROR` with zero records (NODATA), not `NXDOMAIN`: the name demonstrably
+/// exists, and telling a dual-stack resolver the name does not exist because we
+/// hold no AAAA for it would make it stop asking for the A as well. Same answer
+/// for a type we do not serve at all (`MX`, `SVCB`, …) — the name exists, we
+/// simply hold no record of that type.
+fn answer_records(
+    message: &dns_wire::Message,
+    question: &Question,
+    addresses: &[String],
+    recursion_available: bool,
+) -> Vec<u8> {
+    let records: Vec<Record> = if question.qtype == qtype::A || question.qtype == qtype::AAAA {
+        addresses
+            .iter()
+            .filter_map(|raw| match raw.trim().parse::<IpAddr>() {
+                Ok(IpAddr::V4(v4)) => Some(Record::A(v4)),
+                Ok(IpAddr::V6(v6)) => Some(Record::Aaaa(v6)),
+                Err(_) => {
+                    log::warn!(
+                        "EAS address '{raw}' for {} is not an IP address; omitted from the answer",
+                        question.name
+                    );
+                    None
+                }
+            })
+            .filter(|r| r.answers(question.qtype))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    build_response(&Response {
+        id: message.id,
+        question: Some(question),
+        recursion_desired: message.flags.recursion_desired,
+        // The EASDF *is* the configured authority for a name its EAS map or a
+        // handling rule answers.
+        authoritative: true,
+        recursion_available,
+        rcode: rcode::NO_ERROR,
+        records: &records,
+        ttl: ANSWER_TTL,
+        edns: message.edns,
+    })
+}
+
+/// Relay a query to the upstream verbatim and return its reply verbatim.
+///
+/// Verbatim in both directions on purpose: the transaction ID, the question, the
+/// EDNS OPT and any option we do not model all survive, which a parse-and-rebuild
+/// would quietly drop. This is a forwarder, not a resolver — it does no caching
+/// and no validation, and the answer the UE gets is the upstream's own.
+async fn forward(query: &[u8], upstream: SocketAddr) -> Option<Vec<u8>> {
+    let bind: SocketAddr = if upstream.is_ipv4() {
+        ([0, 0, 0, 0], 0).into()
+    } else {
+        (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
+    };
+    let socket = match UdpSocket::bind(bind).await {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("EASDF DNS forward: cannot bind an ephemeral socket: {e}");
+            return None;
+        }
+    };
+    if let Err(e) = socket.send_to(query, upstream).await {
+        log::warn!("EASDF DNS forward to {upstream} failed: {e}");
+        return None;
+    }
+    let mut buf = vec![0u8; MAX_EDNS_PAYLOAD as usize];
+    match tokio::time::timeout(FORWARD_TIMEOUT, socket.recv_from(&mut buf)).await {
+        Ok(Ok((len, from))) => {
+            // Only the address we asked answers for us; anything else is either a
+            // stray datagram or an off-path spoof attempt.
+            if from.ip() != upstream.ip() {
+                log::warn!("EASDF DNS forward: reply from {from}, expected {upstream}; dropped");
+                return None;
+            }
+            buf.truncate(len);
+            Some(buf)
+        }
+        Ok(Err(e)) => {
+            log::warn!("EASDF DNS forward recv from {upstream} failed: {e}");
+            None
+        }
+        Err(_) => {
+            log::warn!("EASDF DNS forward to {upstream} timed out after {FORWARD_TIMEOUT:?}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::{
+        easdf_context_final, easdf_context_init, DnsHandlingRule, DnsMissBehavior, EasMapEntry,
+        EasdfDnsContext,
+    };
+    use crate::dns_wire::{Flags, HEADER_LEN};
+
+    // The lock is `context::GLOBAL_TEST_LOCK`, shared with `main.rs`'s tests.
+    // This module first declared its own `tokio::Mutex` and the result was a HANG,
+    // not a failed assertion: a `easdf_context_final()` here wiped a sibling
+    // handler test's EAS map mid-flight, its miss became a hit, and the fake
+    // upstream it was blocked on never received a forward. See the doc comment on
+    // `GLOBAL_TEST_LOCK`.
+    use crate::context::lock_globals;
+
+    /// Install a known EASDF configuration: one static EAS entry and the given
+    /// miss behaviour.
+    fn install_context(miss: DnsMissBehavior) {
+        easdf_context_final();
+        easdf_context_init(64);
+        let ctx = easdf_self();
+        let installed = ctx.write().map(|mut c| {
+            c.set_dns_config(
+                vec![EasMapEntry {
+                    fqdn: "*.edge.example.com".to_string(),
+                    addresses: vec!["10.60.0.1".to_string(), "2001:db8::60".to_string()],
+                }],
+                miss,
+            );
+        });
+        assert!(
+            installed.is_ok(),
+            "the EASDF context lock must not be poisoned"
+        );
+    }
+
+    /// A DNS context for `ue_ip` whose rule answers `fqdn` with `eas`.
+    fn install_ue_context(ue_ip: &str, fqdn: &str, eas: &str) -> String {
+        let ctx = easdf_self();
+        let mut dns_ctx = EasdfDnsContext::new("imsi-001010000000001", 5, "{}");
+        dns_ctx.handling_rules = vec![DnsHandlingRule {
+            domain_patterns: vec![fqdn.to_string()],
+            eas_addresses: vec![eas.to_string()],
+            report: false,
+            forward_to: None,
+        }];
+        dns_ctx.ue_addresses = vec![ue_ip.parse().expect("test address")];
+        let id = dns_ctx.id.clone();
+        ctx.read()
+            .expect("context")
+            .dns_context_insert(dns_ctx)
+            .expect("insert");
+        id
+    }
+
+    fn query(id: u16, name: &str, qt: u16) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&id.to_be_bytes());
+        out.extend_from_slice(&0x0100u16.to_be_bytes()); // RD
+        out.extend_from_slice(&1u16.to_be_bytes());
+        out.extend_from_slice(&[0u8; 6]);
+        for label in name.split('.') {
+            out.push(label.len() as u8);
+            out.extend_from_slice(label.as_bytes());
+        }
+        out.push(0);
+        out.extend_from_slice(&qt.to_be_bytes());
+        out.extend_from_slice(&CLASS_IN.to_be_bytes());
+        out
+    }
+
+    fn no_upstream(bind: SocketAddr) -> DnsUdpConfig {
+        DnsUdpConfig {
+            bind,
+            upstream: None,
+        }
+    }
+
+    /// #276 criterion 2: a real UDP DNS query gets an A-record answer for an edge
+    /// FQDN.
+    ///
+    /// Over a real socket in both directions — bind the listener, send from an
+    /// ordinary client socket, read the datagram back and decode it with the
+    /// production parser. A test that called `handle_datagram` directly would
+    /// prove the logic and say nothing about whether anything is listening, which
+    /// is the entire defect #276 exists to fix.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_real_udp_query_is_answered_with_an_a_record() {
+        let _g = lock_globals();
+        install_context(DnsMissBehavior::NxDomain);
+
+        let (bound, listener) = spawn(no_upstream(([127, 0, 0, 1], 0).into()))
+            .await
+            .expect("bind an ephemeral DNS port");
+
+        let client = UdpSocket::bind::<SocketAddr>(([127, 0, 0, 1], 0).into())
+            .await
+            .expect("client socket");
+        client
+            .send_to(&query(0xa1a1, "app.edge.example.com", qtype::A), bound)
+            .await
+            .expect("send query");
+
+        let mut buf = vec![0u8; 1500];
+        let (len, from) = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.recv_from(&mut buf),
+        )
+        .await
+        .expect("the listener must answer within 5s")
+        .expect("recv");
+        assert_eq!(from, bound, "the answer must come from the listener");
+
+        let answer = parse_message(&buf[..len]).expect("the answer is a DNS message");
+        assert_eq!(answer.id, 0xa1a1, "the transaction ID must be echoed");
+        assert!(answer.flags.response);
+        assert!(
+            answer.flags.authoritative,
+            "the EASDF is the authority here"
+        );
+        assert!(answer.flags.recursion_desired, "RD is echoed");
+        assert!(
+            !answer.flags.recursion_available,
+            "no upstream is configured, so RA must be clear"
+        );
+        assert_eq!(answer.flags.rcode, rcode::NO_ERROR);
+        assert_eq!(
+            answer.answers,
+            vec![Record::A(std::net::Ipv4Addr::new(10, 60, 0, 1))],
+            "the A record from the EAS map, and NOT the AAAA also configured"
+        );
+
+        listener.abort();
+        easdf_context_final();
+    }
+
+    /// The AAAA half of the same map entry, and the NODATA rule.
+    ///
+    /// An `AAAA` query gets the v6 address; a `MX` query for the same
+    /// edge-served name gets `NOERROR` with no records, **not** `NXDOMAIN` — the
+    /// name demonstrably exists, and telling a resolver otherwise would make it
+    /// stop asking for the A record too.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn family_and_type_selection_answers_nodata_rather_than_nxdomain() {
+        let _g = lock_globals();
+        install_context(DnsMissBehavior::NxDomain);
+        let config = no_upstream(([127, 0, 0, 1], 0).into());
+        let from: SocketAddr = ([127, 0, 0, 1], 40000).into();
+
+        let aaaa = handle_datagram(
+            &query(1, "app.edge.example.com", qtype::AAAA),
+            from,
+            &config,
+        )
+        .await
+        .expect("an answer");
+        let aaaa = parse_message(&aaaa).expect("parses");
+        assert_eq!(
+            aaaa.answers,
+            vec![Record::Aaaa("2001:db8::60".parse().expect("v6"))]
+        );
+
+        const MX: u16 = 15;
+        let mx = handle_datagram(&query(2, "app.edge.example.com", MX), from, &config)
+            .await
+            .expect("an answer");
+        let mx = parse_message(&mx).expect("parses");
+        assert_eq!(
+            mx.flags.rcode,
+            rcode::NO_ERROR,
+            "an edge-served name with no record of the queried type is NODATA, not NXDOMAIN"
+        );
+        assert!(mx.answers.is_empty());
+        assert_eq!(
+            mx.question.as_ref().map(|q| q.qtype),
+            Some(MX),
+            "the question is echoed with its original QTYPE"
+        );
+
+        easdf_context_final();
+    }
+
+    /// #276 criterion 3, both halves: a miss forwards to the configured upstream
+    /// on the wire, and answers NXDOMAIN when there is none.
+    ///
+    /// The upstream is a real UDP socket that replies with a recognisable address,
+    /// so the assertion is that the UE received the UPSTREAM's answer — not that
+    /// the EASDF invented one. Asserting only "an answer arrived" would pass
+    /// against a local NXDOMAIN.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_miss_forwards_to_the_upstream_and_nxdomains_without_one() {
+        let _g = lock_globals();
+        install_context(DnsMissBehavior::Forward("127.0.0.1".to_string()));
+
+        // A fake upstream resolver: answers every query with 203.0.113.9.
+        let upstream = UdpSocket::bind::<SocketAddr>(([127, 0, 0, 1], 0).into())
+            .await
+            .expect("upstream socket");
+        let upstream_addr = upstream.local_addr().expect("addr");
+        let upstream_task = tokio::spawn(async move {
+            let mut buf = vec![0u8; 1500];
+            let (len, from) = upstream.recv_from(&mut buf).await.expect("recv");
+            let request = parse_message(&buf[..len]).expect("the forward is a valid DNS query");
+            let question = request.question.clone().expect("question forwarded intact");
+            let reply = build_response(&Response {
+                id: request.id,
+                question: Some(&question),
+                recursion_desired: request.flags.recursion_desired,
+                authoritative: false,
+                recursion_available: true,
+                rcode: rcode::NO_ERROR,
+                records: &[Record::A(std::net::Ipv4Addr::new(203, 0, 113, 9))],
+                ttl: 60,
+                edns: request.edns,
+            });
+            upstream.send_to(&reply, from).await.expect("reply");
+            (request.id, question.name)
+        });
+
+        let forwarding = DnsUdpConfig {
+            bind: ([127, 0, 0, 1], 0).into(),
+            upstream: Some(upstream_addr),
+        };
+        let answer = handle_datagram(
+            &query(0xbbbb, "www.elsewhere.example.net", qtype::A),
+            ([127, 0, 0, 1], 40001).into(),
+            &forwarding,
+        )
+        .await
+        .expect("a forwarded answer");
+        // Bounded: if a regression stops the forward from happening, the fake
+        // upstream never receives and this await would block forever. A hang is a
+        // strictly worse test failure than a failed assertion -- it takes the whole
+        // suite with it -- and that is exactly what the lock split produced here.
+        let (seen_id, seen_name) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), upstream_task)
+                .await
+                .expect("the upstream must receive the forwarded query within 5s")
+                .expect("upstream task");
+        assert_eq!(
+            seen_id, 0xbbbb,
+            "the query is forwarded VERBATIM, ID and all"
+        );
+        assert_eq!(seen_name, "www.elsewhere.example.net");
+
+        let answer = parse_message(&answer).expect("parses");
+        assert_eq!(answer.id, 0xbbbb);
+        assert_eq!(
+            answer.answers,
+            vec![Record::A(std::net::Ipv4Addr::new(203, 0, 113, 9))],
+            "the UE must receive the UPSTREAM's answer, not one the EASDF invented"
+        );
+        assert!(
+            !answer.flags.authoritative,
+            "a forwarded answer is not ours to claim authority for"
+        );
+
+        // Same query, no upstream configured: NXDOMAIN, and RA clear because this
+        // EASDF cannot recurse for anyone.
+        install_context(DnsMissBehavior::NxDomain);
+        let answer = handle_datagram(
+            &query(0xcccc, "www.elsewhere.example.net", qtype::A),
+            ([127, 0, 0, 1], 40002).into(),
+            &no_upstream(([127, 0, 0, 1], 0).into()),
+        )
+        .await
+        .expect("an answer");
+        let answer = parse_message(&answer).expect("parses");
+        assert_eq!(answer.flags.rcode, rcode::NX_DOMAIN);
+        assert!(answer.answers.is_empty());
+        assert!(!answer.flags.recursion_available);
+
+        easdf_context_final();
+    }
+
+    /// A configured forward with an unreachable upstream must SERVFAIL, not hang
+    /// and not silently NXDOMAIN: NXDOMAIN would tell the UE the name does not
+    /// exist, which is a different and stickier lie than "I could not find out".
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn an_unreachable_upstream_servfails() {
+        let _g = lock_globals();
+        install_context(DnsMissBehavior::Forward("127.0.0.1".to_string()));
+
+        // A bound-then-dropped socket's port: nothing is listening there.
+        let dead = {
+            let s = UdpSocket::bind::<SocketAddr>(([127, 0, 0, 1], 0).into())
+                .await
+                .expect("socket");
+            s.local_addr().expect("addr")
+        };
+
+        let answer = handle_datagram(
+            &query(0xdddd, "www.elsewhere.example.net", qtype::A),
+            ([127, 0, 0, 1], 40003).into(),
+            &DnsUdpConfig {
+                bind: ([127, 0, 0, 1], 0).into(),
+                upstream: Some(dead),
+            },
+        )
+        .await
+        .expect("an answer");
+        let answer = parse_message(&answer).expect("parses");
+        assert_eq!(
+            answer.flags.rcode,
+            rcode::SERV_FAIL,
+            "an upstream we could not reach is SERVFAIL, never NXDOMAIN"
+        );
+
+        easdf_context_final();
+    }
+
+    /// #276 criterion 4: two UEs with different DNS contexts get DIFFERENT
+    /// answers for the SAME FQDN, scoped by the query's source address.
+    ///
+    /// This is the criterion the whole `ue_addresses` field exists for. Both
+    /// queries are byte-identical apart from the transaction ID; the only thing
+    /// that differs is where they came from. A third query, from an address no
+    /// context claims, must fall through to the static EAS map — not to either
+    /// UE's rules, which would leak one subscriber's edge steering into another's
+    /// answer.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn two_ues_get_different_answers_for_the_same_fqdn() {
+        let _g = lock_globals();
+        install_context(DnsMissBehavior::NxDomain);
+        install_ue_context("10.45.0.2", "app.edge.example.com", "10.60.0.201");
+        install_ue_context("10.45.0.3", "app.edge.example.com", "10.60.0.202");
+
+        let config = no_upstream(([127, 0, 0, 1], 0).into());
+        let ask = |source: &str| {
+            let config = config.clone();
+            let source: SocketAddr = format!("{source}:40000").parse().expect("source");
+            async move {
+                let bytes =
+                    handle_datagram(&query(7, "app.edge.example.com", qtype::A), source, &config)
+                        .await
+                        .expect("an answer");
+                parse_message(&bytes).expect("parses").answers
+            }
+        };
+
+        assert_eq!(
+            ask("10.45.0.2").await,
+            vec![Record::A(std::net::Ipv4Addr::new(10, 60, 0, 201))],
+            "the first UE must get its OWN context's EAS address"
+        );
+        assert_eq!(
+            ask("10.45.0.3").await,
+            vec![Record::A(std::net::Ipv4Addr::new(10, 60, 0, 202))],
+            "the second UE must get its own, not the first UE's"
+        );
+        assert_eq!(
+            ask("10.45.0.99").await,
+            vec![Record::A(std::net::Ipv4Addr::new(10, 60, 0, 1))],
+            "an unknown source falls through to the static EAS map, never to \
+             another session's rules"
+        );
+
+        easdf_context_final();
+    }
+
+    /// Malformed input, in the three shapes that differ in what can be answered.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn malformed_datagrams_are_answered_or_dropped_deliberately() {
+        let _g = lock_globals();
+        install_context(DnsMissBehavior::NxDomain);
+        let config = no_upstream(([127, 0, 0, 1], 0).into());
+        let from: SocketAddr = ([127, 0, 0, 1], 40004).into();
+
+        // Too short to hold an ID: nothing to answer, so nothing is sent.
+        assert!(
+            handle_datagram(&[0u8; 4], from, &config).await.is_none(),
+            "a datagram with no readable ID gets no reply"
+        );
+
+        // Header present, question missing: FORMERR with the ID echoed.
+        let mut stub = Vec::new();
+        stub.extend_from_slice(&0xeeeeu16.to_be_bytes());
+        stub.extend_from_slice(&0u16.to_be_bytes());
+        stub.extend_from_slice(&1u16.to_be_bytes()); // QDCOUNT lies
+        stub.extend_from_slice(&[0u8; 6]);
+        assert_eq!(stub.len(), HEADER_LEN);
+        let reply = handle_datagram(&stub, from, &config)
+            .await
+            .expect("FORMERR is sendable");
+        let reply = parse_message(&reply).expect("parses");
+        assert_eq!(reply.id, 0xeeee);
+        assert_eq!(reply.flags.rcode, rcode::FORM_ERR);
+
+        // A RESPONSE arriving on the listener is not ours to answer; replying
+        // would make two EASDFs pointed at each other into a packet loop.
+        let mut response = query(0xffff, "app.edge.example.com", qtype::A);
+        response[2] |= 0x80; // set QR
+        assert!(
+            handle_datagram(&response, from, &config).await.is_none(),
+            "a DNS response received on the listener is dropped"
+        );
+
+        // A non-QUERY opcode (here: STATUS = 2) is NOTIMP, not FORMERR.
+        let mut status = query(0x1111, "app.edge.example.com", qtype::A);
+        status[2] |= 2 << 3; // OPCODE occupies bits 11..14 of the flags word
+        let reply = handle_datagram(&status, from, &config)
+            .await
+            .expect("an answer");
+        let reply = parse_message(&reply).expect("parses");
+        assert_eq!(reply.flags.rcode, rcode::NOT_IMP);
+
+        easdf_context_final();
+    }
+
+    /// A class other than IN is NOTIMP: this EASDF serves internet-class names
+    /// and has no opinion about CHAOS or HESIOD.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_non_internet_class_query_is_notimp() {
+        let _g = lock_globals();
+        install_context(DnsMissBehavior::NxDomain);
+
+        let mut wire = query(0x2222, "app.edge.example.com", qtype::A);
+        let len = wire.len();
+        wire[len - 2..].copy_from_slice(&3u16.to_be_bytes()); // CLASS CH
+
+        let reply = handle_datagram(
+            &wire,
+            ([127, 0, 0, 1], 40005).into(),
+            &no_upstream(([127, 0, 0, 1], 0).into()),
+        )
+        .await
+        .expect("an answer");
+        assert_eq!(
+            parse_message(&reply).expect("parses").flags.rcode,
+            rcode::NOT_IMP
+        );
+
+        easdf_context_final();
+    }
+
+    #[test]
+    fn an_upstream_gets_the_default_dns_port_and_a_bad_one_is_refused() {
+        assert_eq!(
+            parse_upstream("8.8.8.8"),
+            Some(([8, 8, 8, 8], 53).into()),
+            "a bare address gets port 53"
+        );
+        assert_eq!(
+            parse_upstream("127.0.0.1:5353"),
+            Some(([127, 0, 0, 1], 5353).into()),
+            "an explicit port is honoured"
+        );
+        assert_eq!(parse_upstream(""), None);
+        assert_eq!(
+            parse_upstream("dns.example.com"),
+            None,
+            "a hostname is refused rather than resolved: the EASDF would have to \
+             ask a resolver to find its own resolver"
+        );
+    }
+
+    /// Flags are read from the right bits. Cheap, and the kind of thing that is
+    /// wrong by one shift for a long time before anyone notices.
+    #[test]
+    fn header_flags_decode_from_their_documented_bits() {
+        let mut wire = query(1, "a.example.com", qtype::A);
+        // QR=1, OPCODE=0, AA=1, TC=1, RD=1, RA=1, RCODE=3
+        wire[2] = 0b1000_0111;
+        wire[3] = 0b1000_0011;
+        let flags = parse_message(&wire).expect("parses").flags;
+        assert_eq!(
+            flags,
+            Flags {
+                response: true,
+                opcode: 0,
+                authoritative: true,
+                truncated: true,
+                recursion_desired: true,
+                recursion_available: true,
+                rcode: rcode::NX_DOMAIN,
+            }
+        );
+    }
+}

--- a/src/bins/nextgcore-easdfd/src/dns_wire.rs
+++ b/src/bins/nextgcore-easdfd/src/dns_wire.rs
@@ -1,0 +1,916 @@
+//! Minimal DNS wire codec for the EASDF's UDP/53 plane (issue #276).
+//!
+//! RFC 1035 message format, RFC 6891 EDNS(0). Hand-rolled rather than vendored,
+//! matching how this tree already carries NAS, NGAP, PFCP and Diameter codecs —
+//! and because the subset an EASDF needs is genuinely small: it answers `A` and
+//! `AAAA` queries for edge FQDNs and forwards everything else verbatim.
+//!
+//! # Why this module is NOT behind the `dns-udp` feature
+//!
+//! The socket is; this is not. Two reasons, and the second is the one that
+//! matters. First, a pure codec changes no network posture, which is the reason
+//! #276 gives for gating at all. Second, the recorded house rule in this project
+//! is to prefer a runtime switch over a cargo feature precisely because CI builds
+//! default features and a gated path therefore rots uncompiled. #276 asks for a
+//! cargo feature with a specific justification (binding a privileged port), so
+//! the feature stands — but keeping the codec out of it means the part with all
+//! the parsing logic is compiled and tested on every CI run regardless.
+//!
+//! # What is deliberately not implemented
+//!
+//! Compression is *read* (a query may arrive with a compressed QNAME) but only
+//! ever *written* as the one pointer to the question name at offset 12, which is
+//! the only compression opportunity a single-question answer has. No AXFR, no
+//! DNSSEC validation, no TCP fallback: a `TC`-flagged truncated answer is the
+//! documented behaviour, and a resolver that wants the rest retries over TCP
+//! against an upstream, not against the EASDF.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Fixed DNS header size (RFC 1035 §4.1.1).
+pub const HEADER_LEN: usize = 12;
+
+/// Bare-UDP payload ceiling before EDNS(0) (RFC 1035 §4.2.1).
+pub const MAX_UDP_PAYLOAD: usize = 512;
+
+/// Largest EDNS(0) payload we will honour, so a peer advertising 65535 cannot
+/// make us allocate a datagram no path will carry.
+pub const MAX_EDNS_PAYLOAD: u16 = 4096;
+
+/// A name longer than this is malformed (RFC 1035 §2.3.4).
+const MAX_NAME_LEN: usize = 255;
+
+/// One label may not exceed this (RFC 1035 §2.3.4).
+const MAX_LABEL_LEN: usize = 63;
+
+/// Pointer-chase ceiling. A compressed name cannot legitimately need more hops
+/// than the message has bytes, so this bounds the "compression loop" case
+/// without needing to track visited offsets.
+const MAX_POINTER_HOPS: usize = 64;
+
+/// RCODEs used by this codec (RFC 1035 §4.1.1, RFC 6895).
+pub mod rcode {
+    pub const NO_ERROR: u8 = 0;
+    pub const FORM_ERR: u8 = 1;
+    pub const SERV_FAIL: u8 = 2;
+    pub const NX_DOMAIN: u8 = 3;
+    pub const NOT_IMP: u8 = 4;
+}
+
+/// RR/query types this codec names.
+pub mod qtype {
+    pub const A: u16 = 1;
+    pub const AAAA: u16 = 28;
+    /// EDNS(0) pseudo-RR (RFC 6891 §6.1).
+    pub const OPT: u16 = 41;
+}
+
+/// The only class an EASDF answers in.
+pub const CLASS_IN: u16 = 1;
+
+/// Why a datagram could not be read as a DNS message.
+///
+/// Distinguished rather than collapsed into one error because the *answer* to a
+/// client differs: a message we cannot parse far enough to find an ID gets no
+/// answer at all (there is no ID to put in one), while a message we can identify
+/// but not serve gets a `FORMERR` or `NOTIMP` with its ID echoed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    /// Fewer bytes than the fixed header, so there is no ID to answer with.
+    ShorterThanHeader,
+    /// Ran off the end of the buffer mid-record.
+    Truncated,
+    /// A label length byte was neither a length ≤63 nor a compression pointer.
+    BadLabelLength,
+    /// Compression pointer chain exceeded [`MAX_POINTER_HOPS`].
+    CompressionLoop,
+    /// Assembled name exceeded 255 octets.
+    NameTooLong,
+    /// A name label was not valid UTF-8. Legal DNS, unusable as an FQDN string.
+    NonUtf8Label,
+}
+
+impl ParseError {
+    /// Whether the ID was readable, i.e. whether an error response can be sent.
+    pub fn is_answerable(&self) -> bool {
+        !matches!(self, Self::ShorterThanHeader)
+    }
+}
+
+/// Parsed DNS header flags, in the shape this codec cares about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Flags {
+    /// `QR`: false = query, true = response.
+    pub response: bool,
+    /// `OPCODE`. Only 0 (QUERY) is served.
+    pub opcode: u8,
+    /// `AA`: authoritative answer.
+    pub authoritative: bool,
+    /// `TC`: truncated.
+    pub truncated: bool,
+    /// `RD`: recursion desired (echoed back per RFC 1035 §4.1.1).
+    pub recursion_desired: bool,
+    /// `RA`: recursion available.
+    pub recursion_available: bool,
+    /// `RCODE`.
+    pub rcode: u8,
+}
+
+/// One question (RFC 1035 §4.1.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Question {
+    /// The QNAME as a dotted string, lowercased, no trailing dot. Matches what
+    /// the EASDF's resolution engine compares against.
+    pub name: String,
+    pub qtype: u16,
+    pub qclass: u16,
+}
+
+/// The EDNS(0) OPT pseudo-RR a modern resolver sets (RFC 6891).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Edns {
+    /// The requestor's advertised UDP payload size, clamped to
+    /// [`MAX_EDNS_PAYLOAD`] and floored at [`MAX_UDP_PAYLOAD`].
+    pub udp_payload_size: u16,
+    /// `DO` bit. Echoed, never acted on: this codec does not sign anything.
+    pub dnssec_ok: bool,
+}
+
+/// One answer record this codec can write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Record {
+    A(Ipv4Addr),
+    Aaaa(Ipv6Addr),
+}
+
+impl Record {
+    fn rr_type(&self) -> u16 {
+        match self {
+            Self::A(_) => qtype::A,
+            Self::Aaaa(_) => qtype::AAAA,
+        }
+    }
+
+    fn rdata_len(&self) -> usize {
+        match self {
+            Self::A(_) => 4,
+            Self::Aaaa(_) => 16,
+        }
+    }
+
+    /// Encoded size when written with a 2-byte compression pointer as its NAME.
+    fn encoded_len(&self) -> usize {
+        // NAME(2, pointer) + TYPE(2) + CLASS(2) + TTL(4) + RDLENGTH(2) + RDATA
+        12 + self.rdata_len()
+    }
+
+    /// Does this record answer a query of `qt`? Used so an `A` query is not
+    /// answered with the `AAAA` an operator also configured, which a stub
+    /// resolver would treat as a bogus response.
+    pub fn answers(&self, qt: u16) -> bool {
+        self.rr_type() == qt
+    }
+}
+
+/// A decoded DNS message: enough of one for the EASDF's purposes.
+///
+/// Both directions use this type. The alternative — a `Query` and a `Response` —
+/// would need the same header, name and RR parsing twice, and the test that
+/// decodes what [`build_response`] produced would then be exercising a *second*
+/// parser rather than the one production uses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Message {
+    pub id: u16,
+    pub flags: Flags,
+    /// The first question, when the message carries exactly one. `None` when
+    /// QDCOUNT is 0; a QDCOUNT above 1 is reported in `question_count` and the
+    /// caller decides (this codec's server refuses it with `FORMERR`).
+    pub question: Option<Question>,
+    pub question_count: u16,
+    pub answers: Vec<Record>,
+    /// Answer records whose type this codec does not model, counted so a test
+    /// can tell "no answers" from "answers we did not decode".
+    pub unmodelled_answers: u16,
+    pub edns: Option<Edns>,
+}
+
+/// Read `n` bytes at `pos`, or fail.
+fn take<'a>(buf: &'a [u8], pos: &mut usize, n: usize) -> Result<&'a [u8], ParseError> {
+    let end = pos.checked_add(n).ok_or(ParseError::Truncated)?;
+    let slice = buf.get(*pos..end).ok_or(ParseError::Truncated)?;
+    *pos = end;
+    Ok(slice)
+}
+
+fn take_u16(buf: &[u8], pos: &mut usize) -> Result<u16, ParseError> {
+    let b = take(buf, pos, 2)?;
+    Ok(u16::from_be_bytes([b[0], b[1]]))
+}
+
+fn take_u32(buf: &[u8], pos: &mut usize) -> Result<u32, ParseError> {
+    let b = take(buf, pos, 4)?;
+    Ok(u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+/// Decode a possibly-compressed domain name starting at `*pos`.
+///
+/// `*pos` is advanced past the name **as it appears at that position**, which for
+/// a compressed name is past the pointer rather than past the pointed-to labels —
+/// the distinction that makes a compressed QNAME parse correctly instead of
+/// resuming inside the target.
+///
+/// The returned name is lowercased with no trailing dot, so it can be compared
+/// against the EAS map without a second normalisation step. The root name
+/// decodes to the empty string.
+fn read_name(buf: &[u8], pos: &mut usize) -> Result<String, ParseError> {
+    let mut name = String::new();
+    let mut cursor = *pos;
+    let mut hops = 0usize;
+    // Where to leave `*pos`: set on the first pointer we follow, because
+    // everything after it belongs to the pointed-to name, not to this one.
+    let mut resume: Option<usize> = None;
+
+    loop {
+        let len = *buf.get(cursor).ok_or(ParseError::Truncated)?;
+        match len & 0xc0 {
+            0x00 => {
+                cursor += 1;
+                if len == 0 {
+                    break;
+                }
+                let len = len as usize;
+                if len > MAX_LABEL_LEN {
+                    return Err(ParseError::BadLabelLength);
+                }
+                let label = buf.get(cursor..cursor + len).ok_or(ParseError::Truncated)?;
+                cursor += len;
+                if !name.is_empty() {
+                    name.push('.');
+                }
+                let label = std::str::from_utf8(label).map_err(|_| ParseError::NonUtf8Label)?;
+                name.push_str(&label.to_ascii_lowercase());
+                if name.len() > MAX_NAME_LEN {
+                    return Err(ParseError::NameTooLong);
+                }
+            }
+            0xc0 => {
+                let hi = (len & 0x3f) as usize;
+                let lo = *buf.get(cursor + 1).ok_or(ParseError::Truncated)? as usize;
+                let target = (hi << 8) | lo;
+                if resume.is_none() {
+                    resume = Some(cursor + 2);
+                }
+                hops += 1;
+                if hops > MAX_POINTER_HOPS {
+                    return Err(ParseError::CompressionLoop);
+                }
+                // A pointer must point backwards; forwards or self-referential is
+                // the loop case the hop counter would otherwise take 64 tries to
+                // notice.
+                if target >= cursor {
+                    return Err(ParseError::CompressionLoop);
+                }
+                cursor = target;
+            }
+            // 0x40 and 0x80 are reserved label types (RFC 6891 §6.1 retired the
+            // one experimental use); neither is a length nor a pointer.
+            _ => return Err(ParseError::BadLabelLength),
+        }
+    }
+
+    *pos = resume.unwrap_or(cursor);
+    Ok(name)
+}
+
+/// Skip an RR's RDATA and return `(rr_type, class, ttl, rdata)`.
+fn read_rr<'a>(
+    buf: &'a [u8],
+    pos: &mut usize,
+) -> Result<(String, u16, u16, u32, &'a [u8]), ParseError> {
+    let name = read_name(buf, pos)?;
+    let rr_type = take_u16(buf, pos)?;
+    let class = take_u16(buf, pos)?;
+    let ttl = take_u32(buf, pos)?;
+    let rdlen = take_u16(buf, pos)? as usize;
+    let rdata = take(buf, pos, rdlen)?;
+    Ok((name, rr_type, class, ttl, rdata))
+}
+
+/// Decode a DNS message.
+///
+/// Records whose type this codec does not model are skipped (their RDLENGTH is
+/// honoured), not rejected: a resolver is entitled to send additional records we
+/// have no opinion about, and refusing the whole datagram over one of them would
+/// make the EASDF unusable behind a forwarder.
+pub fn parse_message(buf: &[u8]) -> Result<Message, ParseError> {
+    if buf.len() < HEADER_LEN {
+        return Err(ParseError::ShorterThanHeader);
+    }
+    let mut pos = 0usize;
+    let id = take_u16(buf, &mut pos)?;
+    let raw_flags = take_u16(buf, &mut pos)?;
+    let qdcount = take_u16(buf, &mut pos)?;
+    let ancount = take_u16(buf, &mut pos)?;
+    let nscount = take_u16(buf, &mut pos)?;
+    let arcount = take_u16(buf, &mut pos)?;
+
+    let flags = Flags {
+        response: raw_flags & 0x8000 != 0,
+        opcode: ((raw_flags >> 11) & 0x0f) as u8,
+        authoritative: raw_flags & 0x0400 != 0,
+        truncated: raw_flags & 0x0200 != 0,
+        recursion_desired: raw_flags & 0x0100 != 0,
+        recursion_available: raw_flags & 0x0080 != 0,
+        rcode: (raw_flags & 0x000f) as u8,
+    };
+
+    let mut question = None;
+    for i in 0..qdcount {
+        let name = read_name(buf, &mut pos)?;
+        let qt = take_u16(buf, &mut pos)?;
+        let qc = take_u16(buf, &mut pos)?;
+        if i == 0 {
+            question = Some(Question {
+                name,
+                qtype: qt,
+                qclass: qc,
+            });
+        }
+    }
+
+    let mut answers = Vec::new();
+    let mut unmodelled_answers = 0u16;
+    for _ in 0..ancount {
+        let (_, rr_type, _, _, rdata) = read_rr(buf, &mut pos)?;
+        match (rr_type, rdata.len()) {
+            (qtype::A, 4) => answers.push(Record::A(Ipv4Addr::new(
+                rdata[0], rdata[1], rdata[2], rdata[3],
+            ))),
+            (qtype::AAAA, 16) => {
+                let mut octets = [0u8; 16];
+                octets.copy_from_slice(rdata);
+                answers.push(Record::Aaaa(Ipv6Addr::from(octets)));
+            }
+            _ => unmodelled_answers += 1,
+        }
+    }
+
+    // Authority section is walked only to reach the additional section, where the
+    // OPT record lives.
+    for _ in 0..nscount {
+        read_rr(buf, &mut pos)?;
+    }
+
+    let mut edns = None;
+    for _ in 0..arcount {
+        let (_, rr_type, class, ttl, _) = read_rr(buf, &mut pos)?;
+        if rr_type == qtype::OPT && edns.is_none() {
+            // RFC 6891 §6.1.2: CLASS carries the requestor's payload size and the
+            // top of TTL carries the extended flags, of which `DO` is bit 15.
+            edns = Some(Edns {
+                udp_payload_size: class.clamp(MAX_UDP_PAYLOAD as u16, MAX_EDNS_PAYLOAD),
+                dnssec_ok: ttl & 0x0000_8000 != 0,
+            });
+        }
+    }
+
+    Ok(Message {
+        id,
+        flags,
+        question,
+        question_count: qdcount,
+        answers,
+        unmodelled_answers,
+        edns,
+    })
+}
+
+fn push_u16(out: &mut Vec<u8>, v: u16) {
+    out.extend_from_slice(&v.to_be_bytes());
+}
+
+/// Encode a name as uncompressed labels. An empty name is the root (a single 0).
+fn write_name(out: &mut Vec<u8>, name: &str) {
+    for label in name.split('.').filter(|l| !l.is_empty()) {
+        let bytes = label.as_bytes();
+        let len = bytes.len().min(MAX_LABEL_LEN);
+        out.push(len as u8);
+        out.extend_from_slice(&bytes[..len]);
+    }
+    out.push(0);
+}
+
+/// What [`build_response`] should say.
+#[derive(Debug, Clone)]
+pub struct Response<'a> {
+    /// Echoed from the query.
+    pub id: u16,
+    /// Echoed from the query, so the client can match it.
+    pub question: Option<&'a Question>,
+    /// Echoed, per RFC 1035 §4.1.1.
+    pub recursion_desired: bool,
+    /// Set when the EASDF is the configured authority for the name — true for an
+    /// EAS-map or handling-rule answer, false for anything derived elsewhere.
+    pub authoritative: bool,
+    /// The EASDF can forward, so `RA` is set whenever an upstream is configured.
+    pub recursion_available: bool,
+    pub rcode: u8,
+    pub records: &'a [Record],
+    pub ttl: u32,
+    /// The query's EDNS(0), when it had one. Its presence changes both the
+    /// payload ceiling and whether the response carries an OPT of its own.
+    pub edns: Option<Edns>,
+}
+
+/// Encode a response, truncating with `TC` when it will not fit.
+///
+/// The payload ceiling is the requestor's EDNS(0) size when it sent one, else
+/// 512. Records are dropped from the end until the message fits; `TC` is set if
+/// any were dropped, which is what tells a resolver to retry over TCP rather
+/// than treat a short answer set as the whole truth.
+///
+/// The OPT record is emitted **only** when the query carried one (RFC 6891
+/// §6.1.1: a response must not contain an OPT unless the request did). This is
+/// the case the issue calls out — a resolver that sets EDNS and gets a response
+/// without it may retry or fail.
+pub fn build_response(resp: &Response<'_>) -> Vec<u8> {
+    let ceiling = resp
+        .edns
+        .map(|e| e.udp_payload_size as usize)
+        .unwrap_or(MAX_UDP_PAYLOAD);
+
+    // Fixed cost: header + question + (OPT, when echoing one).
+    let mut fixed = HEADER_LEN;
+    if let Some(q) = resp.question {
+        // labels + terminator + QTYPE + QCLASS
+        fixed += q
+            .name
+            .split('.')
+            .filter(|l| !l.is_empty())
+            .map(|l| l.len() + 1)
+            .sum::<usize>()
+            + 1
+            + 4;
+    }
+    let opt_len = if resp.edns.is_some() { 11 } else { 0 };
+    fixed += opt_len;
+
+    let mut budget = ceiling.saturating_sub(fixed);
+    let mut included = 0usize;
+    for record in resp.records {
+        let len = record.encoded_len();
+        if len > budget {
+            break;
+        }
+        budget -= len;
+        included += 1;
+    }
+    let truncated = included < resp.records.len();
+
+    let mut flags: u16 = 0x8000; // QR
+    if resp.authoritative {
+        flags |= 0x0400;
+    }
+    if truncated {
+        flags |= 0x0200;
+    }
+    if resp.recursion_desired {
+        flags |= 0x0100;
+    }
+    if resp.recursion_available {
+        flags |= 0x0080;
+    }
+    flags |= (resp.rcode & 0x0f) as u16;
+
+    let mut out = Vec::with_capacity(fixed + 64);
+    push_u16(&mut out, resp.id);
+    push_u16(&mut out, flags);
+    push_u16(&mut out, if resp.question.is_some() { 1 } else { 0 });
+    push_u16(&mut out, included as u16);
+    push_u16(&mut out, 0); // NSCOUNT
+    push_u16(&mut out, if resp.edns.is_some() { 1 } else { 0 });
+
+    if let Some(q) = resp.question {
+        write_name(&mut out, &q.name);
+        push_u16(&mut out, q.qtype);
+        push_u16(&mut out, q.qclass);
+    }
+
+    for record in resp.records.iter().take(included) {
+        // NAME as a pointer to the question name, which always begins at offset
+        // 12. Only valid because the question is written first and there is at
+        // most one; asserted by the round-trip tests rather than assumed.
+        if resp.question.is_some() {
+            push_u16(&mut out, 0xc000 | HEADER_LEN as u16);
+        } else {
+            out.push(0);
+        }
+        push_u16(&mut out, record.rr_type());
+        push_u16(&mut out, CLASS_IN);
+        out.extend_from_slice(&resp.ttl.to_be_bytes());
+        push_u16(&mut out, record.rdata_len() as u16);
+        match record {
+            Record::A(ip) => out.extend_from_slice(&ip.octets()),
+            Record::Aaaa(ip) => out.extend_from_slice(&ip.octets()),
+        }
+    }
+
+    if let Some(edns) = resp.edns {
+        out.push(0); // NAME: root
+        push_u16(&mut out, qtype::OPT);
+        push_u16(&mut out, edns.udp_payload_size); // CLASS: our payload size
+        let ttl: u32 = if edns.dnssec_ok { 0x0000_8000 } else { 0 };
+        out.extend_from_slice(&ttl.to_be_bytes());
+        push_u16(&mut out, 0); // RDLENGTH
+    }
+
+    out
+}
+
+/// A response carrying only an RCODE — used for `FORMERR`, `NOTIMP`, `SERVFAIL`
+/// and `NXDOMAIN`, all of which echo the question when one was readable.
+pub fn build_error(
+    id: u16,
+    question: Option<&Question>,
+    rcode: u8,
+    recursion_desired: bool,
+    recursion_available: bool,
+    edns: Option<Edns>,
+) -> Vec<u8> {
+    build_response(&Response {
+        id,
+        question,
+        recursion_desired,
+        authoritative: false,
+        recursion_available,
+        rcode,
+        records: &[],
+        ttl: 0,
+        edns,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a query the way a stub resolver would, for the parse tests.
+    fn query_bytes(id: u16, name: &str, qt: u16, edns: Option<u16>) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_u16(&mut out, id);
+        push_u16(&mut out, 0x0100); // RD
+        push_u16(&mut out, 1); // QDCOUNT
+        push_u16(&mut out, 0);
+        push_u16(&mut out, 0);
+        push_u16(&mut out, if edns.is_some() { 1 } else { 0 });
+        write_name(&mut out, name);
+        push_u16(&mut out, qt);
+        push_u16(&mut out, CLASS_IN);
+        if let Some(size) = edns {
+            out.push(0);
+            push_u16(&mut out, qtype::OPT);
+            push_u16(&mut out, size);
+            out.extend_from_slice(&0x0000_8000u32.to_be_bytes()); // DO set
+            push_u16(&mut out, 0);
+        }
+        out
+    }
+
+    #[test]
+    fn a_plain_query_round_trips_through_an_answer() {
+        let wire = query_bytes(0xbeef, "app.edge.example.com", qtype::A, None);
+        let query = parse_message(&wire).expect("query parses");
+
+        assert_eq!(query.id, 0xbeef);
+        assert!(!query.flags.response);
+        assert!(query.flags.recursion_desired);
+        assert_eq!(query.question_count, 1);
+        let question = query.question.clone().expect("one question");
+        assert_eq!(question.name, "app.edge.example.com");
+        assert_eq!(question.qtype, qtype::A);
+        assert_eq!(question.qclass, CLASS_IN);
+        assert!(query.edns.is_none());
+
+        let records = [Record::A(Ipv4Addr::new(10, 45, 0, 7))];
+        let answer = build_response(&Response {
+            id: query.id,
+            question: Some(&question),
+            recursion_desired: true,
+            authoritative: true,
+            recursion_available: false,
+            rcode: rcode::NO_ERROR,
+            records: &records,
+            ttl: 30,
+            edns: None,
+        });
+
+        let decoded = parse_message(&answer).expect("answer parses");
+        assert_eq!(decoded.id, 0xbeef);
+        assert!(decoded.flags.response);
+        assert!(decoded.flags.authoritative);
+        assert!(!decoded.flags.truncated);
+        assert!(decoded.flags.recursion_desired, "RD must be echoed");
+        assert_eq!(decoded.flags.rcode, rcode::NO_ERROR);
+        assert_eq!(
+            decoded.question.as_ref().map(|q| q.name.as_str()),
+            Some("app.edge.example.com"),
+            "the question must be echoed so a stub resolver can match it"
+        );
+        assert_eq!(
+            decoded.answers,
+            vec![Record::A(Ipv4Addr::new(10, 45, 0, 7))]
+        );
+        assert_eq!(decoded.unmodelled_answers, 0);
+        assert!(
+            decoded.edns.is_none(),
+            "RFC 6891 §6.1.1: no OPT in the response when the query had none"
+        );
+    }
+
+    /// The compressed-name case #276 names, asserted at `read_name` directly.
+    ///
+    /// Note where compression can and cannot appear, because the obvious version
+    /// of this test is impossible: a *question's* QNAME is the first name in the
+    /// message, so there is nothing before it to point at. Compression is
+    /// therefore something we meet in the ANSWER section (or from a forwarder's
+    /// response), and the property that matters is that the cursor resumes after
+    /// the two-byte POINTER rather than after the pointed-to labels — get that
+    /// wrong and every field following a compressed name is read from the wrong
+    /// offset. The sentinel byte is what makes that observable.
+    #[test]
+    fn a_compressed_name_is_followed_and_resumes_after_the_pointer() {
+        let mut buf = vec![0u8; HEADER_LEN];
+        let suffix_at = buf.len();
+        write_name(&mut buf, "edge.example.com");
+        let name_at = buf.len();
+        buf.push(3);
+        buf.extend_from_slice(b"app");
+        push_u16(&mut buf, 0xc000 | suffix_at as u16);
+        buf.push(0xff); // must survive: not part of the name
+
+        let mut pos = name_at;
+        assert_eq!(
+            read_name(&buf, &mut pos).expect("compressed name reads"),
+            "app.edge.example.com"
+        );
+        assert_eq!(
+            pos,
+            buf.len() - 1,
+            "the cursor must resume after the pointer, not after the target labels"
+        );
+        assert_eq!(buf[pos], 0xff);
+    }
+
+    /// The production compression path: `build_response` writes every answer RR's
+    /// NAME as a pointer to the question, so a second record only decodes if the
+    /// first record's compressed name advanced the cursor by exactly two bytes.
+    #[test]
+    fn multiple_answer_records_decode_after_their_compressed_names() {
+        let wire = query_bytes(0x7777, "app.edge.example.com", qtype::A, None);
+        let question = parse_message(&wire)
+            .expect("parses")
+            .question
+            .expect("question");
+        let records = [
+            Record::A(Ipv4Addr::new(10, 45, 0, 1)),
+            Record::A(Ipv4Addr::new(10, 45, 0, 2)),
+            Record::A(Ipv4Addr::new(10, 45, 0, 3)),
+        ];
+        let answer = build_response(&Response {
+            id: 0x7777,
+            question: Some(&question),
+            recursion_desired: true,
+            authoritative: true,
+            recursion_available: false,
+            rcode: rcode::NO_ERROR,
+            records: &records,
+            ttl: 30,
+            edns: None,
+        });
+        // The pointer is what keeps three answers this small.
+        assert_eq!(answer.len(), HEADER_LEN + 26 + 3 * 16);
+        assert_eq!(
+            parse_message(&answer).expect("parses").answers,
+            records.to_vec(),
+            "all three records must decode, in order"
+        );
+    }
+
+    #[test]
+    fn a_compression_pointer_that_does_not_point_backwards_is_refused() {
+        // Self-referential pointer in the question name.
+        let mut wire = Vec::new();
+        push_u16(&mut wire, 0x0002);
+        push_u16(&mut wire, 0x0000);
+        push_u16(&mut wire, 1);
+        push_u16(&mut wire, 0);
+        push_u16(&mut wire, 0);
+        push_u16(&mut wire, 0);
+        push_u16(&mut wire, 0xc000 | 12u16); // points at itself
+        push_u16(&mut wire, qtype::A);
+        push_u16(&mut wire, CLASS_IN);
+
+        assert_eq!(parse_message(&wire), Err(ParseError::CompressionLoop));
+    }
+
+    #[test]
+    fn an_unknown_qtype_parses_and_is_answered_by_no_record() {
+        // MX is well-formed and something the EASDF has no answer for. It must
+        // parse (so the server can reply NOTIMP with the question echoed) rather
+        // than fail to decode.
+        const MX: u16 = 15;
+        let wire = query_bytes(0x1234, "mail.example.com", MX, None);
+        let msg = parse_message(&wire).expect("an MX query is still a valid query");
+        let question = msg.question.expect("one question");
+        assert_eq!(question.qtype, MX);
+
+        let a = Record::A(Ipv4Addr::LOCALHOST);
+        assert!(!a.answers(MX), "an A record must not answer an MX query");
+        assert!(a.answers(qtype::A));
+
+        let err = build_error(0x1234, Some(&question), rcode::NOT_IMP, true, false, None);
+        let decoded = parse_message(&err).expect("the error parses");
+        assert_eq!(decoded.flags.rcode, rcode::NOT_IMP);
+        assert!(decoded.answers.is_empty());
+        assert_eq!(decoded.question, Some(question));
+    }
+
+    #[test]
+    fn malformed_and_truncated_messages_are_rejected_distinguishably() {
+        // Shorter than the header: no ID, so no answer is possible.
+        let e = parse_message(&[0u8; 5]).expect_err("5 bytes is not a message");
+        assert_eq!(e, ParseError::ShorterThanHeader);
+        assert!(
+            !e.is_answerable(),
+            "with no readable ID there is nothing to answer with"
+        );
+
+        // Header claims a question that is not there.
+        let mut wire = Vec::new();
+        push_u16(&mut wire, 0x0003);
+        push_u16(&mut wire, 0x0000);
+        push_u16(&mut wire, 1);
+        push_u16(&mut wire, 0);
+        push_u16(&mut wire, 0);
+        push_u16(&mut wire, 0);
+        let e = parse_message(&wire).expect_err("QDCOUNT=1 with no question");
+        assert_eq!(e, ParseError::Truncated);
+        assert!(
+            e.is_answerable(),
+            "the ID was readable, so FORMERR is sendable"
+        );
+
+        // A query cut off mid-QNAME.
+        let full = query_bytes(0x0004, "app.edge.example.com", qtype::A, None);
+        assert_eq!(
+            parse_message(&full[..full.len() - 6]),
+            Err(ParseError::Truncated)
+        );
+
+        // A reserved label type (0x80) is neither a length nor a pointer.
+        let mut wire = Vec::new();
+        push_u16(&mut wire, 0x0005);
+        push_u16(&mut wire, 0x0000);
+        push_u16(&mut wire, 1);
+        push_u16(&mut wire, 0);
+        push_u16(&mut wire, 0);
+        push_u16(&mut wire, 0);
+        wire.push(0x80);
+        wire.extend_from_slice(&[0u8; 8]);
+        assert_eq!(parse_message(&wire), Err(ParseError::BadLabelLength));
+    }
+
+    #[test]
+    fn an_edns0_query_gets_an_opt_in_its_response_and_a_larger_ceiling() {
+        let wire = query_bytes(0x4321, "app.edge.example.com", qtype::A, Some(1232));
+        let msg = parse_message(&wire).expect("EDNS query parses");
+        let edns = msg
+            .edns
+            .expect("OPT record found in the additional section");
+        assert_eq!(edns.udp_payload_size, 1232);
+        assert!(edns.dnssec_ok, "the DO bit must be read");
+
+        let question = msg.question.clone().expect("one question");
+        let records = [Record::A(Ipv4Addr::new(10, 45, 0, 8))];
+        let answer = build_response(&Response {
+            id: msg.id,
+            question: Some(&question),
+            recursion_desired: true,
+            authoritative: true,
+            recursion_available: true,
+            rcode: rcode::NO_ERROR,
+            records: &records,
+            ttl: 30,
+            edns: msg.edns,
+        });
+        let decoded = parse_message(&answer).expect("answer parses");
+        let echoed = decoded
+            .edns
+            .expect("a response to an EDNS query must carry an OPT");
+        assert_eq!(echoed.udp_payload_size, 1232);
+        assert!(echoed.dnssec_ok);
+        assert_eq!(decoded.answers.len(), 1);
+    }
+
+    /// A payload size below the bare-UDP floor is raised to it, and one above
+    /// our ceiling is lowered: a peer advertising 65535 must not make us build a
+    /// datagram no path will carry, and one advertising 12 must not make us
+    /// truncate an answer that fits in a plain 512-byte reply.
+    #[test]
+    fn an_absurd_edns_payload_size_is_clamped_both_ways() {
+        for (advertised, expected) in [(1u16, MAX_UDP_PAYLOAD as u16), (65535, MAX_EDNS_PAYLOAD)] {
+            let wire = query_bytes(1, "app.edge.example.com", qtype::A, Some(advertised));
+            let msg = parse_message(&wire).expect("parses");
+            assert_eq!(msg.edns.expect("OPT").udp_payload_size, expected);
+        }
+    }
+
+    /// An EAS list can exceed the UDP limit, which is the case #276 names. The
+    /// answer must be a `TC`-flagged prefix, not a silently short one: a resolver
+    /// reading a short answer set with `TC` clear treats it as complete.
+    #[test]
+    fn an_oversized_answer_set_is_truncated_with_the_tc_bit_set() {
+        let wire = query_bytes(0x5555, "app.edge.example.com", qtype::AAAA, None);
+        let msg = parse_message(&wire).expect("parses");
+        let question = msg.question.clone().expect("one question");
+
+        // 16-byte RDATA + 12 bytes of RR overhead = 28 each; 40 of them is
+        // 1120 bytes, comfortably past the 512 floor.
+        let records: Vec<Record> = (0..40)
+            .map(|i| Record::Aaaa(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, i)))
+            .collect();
+
+        let answer = build_response(&Response {
+            id: msg.id,
+            question: Some(&question),
+            recursion_desired: true,
+            authoritative: true,
+            recursion_available: false,
+            rcode: rcode::NO_ERROR,
+            records: &records,
+            ttl: 30,
+            edns: None,
+        });
+
+        assert!(
+            answer.len() <= MAX_UDP_PAYLOAD,
+            "a bare-UDP answer must fit in 512 bytes, got {}",
+            answer.len()
+        );
+        let decoded = parse_message(&answer).expect("truncated answer still parses");
+        assert!(
+            decoded.flags.truncated,
+            "TC must be set when records were dropped"
+        );
+        assert!(
+            decoded.answers.len() < records.len(),
+            "the point of the test is that some were dropped"
+        );
+        assert!(
+            !decoded.answers.is_empty(),
+            "truncation must keep what fits, not drop everything"
+        );
+
+        // With EDNS advertising 4096 the same set fits, so TC must be clear --
+        // otherwise the ceiling is being ignored.
+        let big = build_response(&Response {
+            id: msg.id,
+            question: Some(&question),
+            recursion_desired: true,
+            authoritative: true,
+            recursion_available: false,
+            rcode: rcode::NO_ERROR,
+            records: &records,
+            ttl: 30,
+            edns: Some(Edns {
+                udp_payload_size: MAX_EDNS_PAYLOAD,
+                dnssec_ok: false,
+            }),
+        });
+        let decoded = parse_message(&big).expect("parses");
+        assert!(!decoded.flags.truncated);
+        assert_eq!(decoded.answers.len(), records.len());
+    }
+
+    #[test]
+    fn a_name_longer_than_255_octets_is_refused() {
+        let long = (0..40)
+            .map(|_| "abcdefghij".to_string())
+            .collect::<Vec<_>>()
+            .join(".");
+        assert!(long.len() > MAX_NAME_LEN);
+        let wire = query_bytes(9, &long, qtype::A, None);
+        assert_eq!(parse_message(&wire), Err(ParseError::NameTooLong));
+    }
+
+    #[test]
+    fn names_are_lowercased_and_the_trailing_root_is_not_part_of_the_name() {
+        let wire = query_bytes(10, "APP.Edge.Example.COM", qtype::A, None);
+        let msg = parse_message(&wire).expect("parses");
+        assert_eq!(
+            msg.question.expect("question").name,
+            "app.edge.example.com",
+            "0x20-randomised or mixed-case queries must compare equal to the EAS map"
+        );
+    }
+}

--- a/src/bins/nextgcore-easdfd/src/main.rs
+++ b/src/bins/nextgcore-easdfd/src/main.rs
@@ -14,8 +14,14 @@
 //!   `GET /neasdf-dnscontext/v1/dns-queries?fqdn=<name>` answers from a
 //!   static FQDN → EAS-address map loaded from the YAML config; a miss
 //!   either reports the configured upstream DNS server (`FORWARD`) or a
-//!   404 (`FQDN_NOT_FOUND`). Phase 1 has NO UDP/53 DNS listener — DNS
-//!   arrives over the SBI binding only.
+//!   404 (`FQDN_NOT_FOUND`).
+//! - **Edge DNS resolution over UDP/53** (#276, `dns-udp` cargo feature, off
+//!   by default): the transport a UE or stub resolver actually speaks. The
+//!   query is decoded by [`dns_wire`] (RFC 1035 + EDNS(0)), scoped to a PDU
+//!   session by the query's **source address**, answered with `A`/`AAAA`
+//!   records, forwarded verbatim to the configured upstream on a miss, or
+//!   answered `NXDOMAIN` when no upstream is configured. See [`dns_udp`] for
+//!   why this half is a cargo feature while the codec is not.
 //!
 //! Off by default: the NF exits immediately unless enabled via `--enabled`
 //! or `easdf.enabled: true` in the YAML config (and, like every NF binary,
@@ -25,8 +31,9 @@
 //! Edge Enabler Server of TS 23.558, not this 5GC NF.
 //!
 //! Deferred per issue #21 (follow-ups): SMF UL-CL / branching-point
-//! insertion, PCF traffic-influence rules, latency-aware UPF/PSA
-//! selection, and DNS message-handling-rule enforcement.
+//! insertion, PCF traffic-influence rules, and latency-aware UPF/PSA
+//! selection. (DNS message-handling-rule enforcement landed in #114; the
+//! UDP/53 listener in #276.)
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -44,6 +51,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 mod context;
+#[cfg(feature = "dns-udp")]
+mod dns_udp;
+mod dns_wire;
 
 pub use context::*;
 
@@ -96,6 +106,17 @@ struct Args {
     /// Maximum stored Neasdf_DNSContext resources.
     #[arg(long, default_value = "4096")]
     max_dns_contexts: usize,
+
+    /// Bind address for the DNS/UDP listener (#276, `dns-udp` feature).
+    #[cfg(feature = "dns-udp")]
+    #[arg(long, default_value = "0.0.0.0")]
+    dns_udp_addr: String,
+
+    /// Bind port for the DNS/UDP listener. 53 needs `CAP_NET_BIND_SERVICE`;
+    /// override it to run the plane on an unprivileged port behind a redirect.
+    #[cfg(feature = "dns-udp")]
+    #[arg(long, default_value = "53")]
+    dns_udp_port: u16,
 }
 
 // ─── YAML config (local serde structs, nssfd pattern) ───────────────────────
@@ -133,6 +154,13 @@ struct DnsYaml {
     /// "forward" (report `upstream` on a miss) or "nxdomain" (default).
     miss_action: Option<String>,
     upstream: Option<String>,
+    /// DNS/UDP listener overrides (#276). Present only with the `dns-udp`
+    /// feature; on a default build these keys are simply ignored, since the
+    /// config structs do not deny unknown fields.
+    #[cfg(feature = "dns-udp")]
+    udp_address: Option<String>,
+    #[cfg(feature = "dns-udp")]
+    udp_port: Option<u16>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -332,6 +360,42 @@ async fn main() -> Result<()> {
             },
         );
     }
+
+    // ---- #276: the DNS/UDP plane ----
+    //
+    // Started AFTER the SBI server and the NRF registration, so a DNS query can
+    // never arrive before the resolution engine's configuration is installed --
+    // answering from a half-configured EAS map would send a UE to the wrong EAS.
+    // A bind failure is FATAL, unlike the non-fatal NRF registration: the
+    // operator compiled the feature in and asked for the port, so silently
+    // running without the listener would be an EASDF that looks up and answers
+    // nothing. Port 53 needs CAP_NET_BIND_SERVICE and the failure is almost
+    // always that.
+    #[cfg(feature = "dns-udp")]
+    let _dns_udp = {
+        let dns = section.and_then(|s| s.dns.as_ref());
+        let addr = dns
+            .and_then(|d| d.udp_address.clone())
+            .unwrap_or_else(|| args.dns_udp_addr.clone());
+        let port = dns.and_then(|d| d.udp_port).unwrap_or(args.dns_udp_port);
+        let bind: SocketAddr = format!("{addr}:{port}")
+            .parse()
+            .context("Invalid DNS/UDP bind address")?;
+        let upstream = dns
+            .and_then(|d| d.upstream.as_deref())
+            .and_then(dns_udp::parse_upstream);
+        let (bound, handle) = dns_udp::spawn(dns_udp::DnsUdpConfig { bind, upstream })
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to bind the DNS/UDP listener on {bind} \
+                     (port 53 needs CAP_NET_BIND_SERVICE; set easdf.dns.udp_port \
+                     or --dns-udp-port to use an unprivileged port)"
+                )
+            })?;
+        log::info!("EASDF DNS/UDP plane serving on {bound}");
+        handle
+    };
 
     log::info!("NextGCore EASDF ready (instance: {nf_instance_id})");
 
@@ -929,13 +993,13 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    /// Serializes tests that touch the process-global EASDF context (the
-    /// context is process-global; parallel mutation flakes — CI learning).
-    static GLOBAL_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-    fn lock_globals() -> std::sync::MutexGuard<'static, ()> {
-        GLOBAL_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    /// Serializes tests that touch the process-global EASDF context.
+    ///
+    /// The lock itself now lives in `context.rs`, beside the global it protects,
+    /// because `dns_udp`'s tests need the SAME one (#276) and a sibling module
+    /// cannot reach a static declared inside this test submodule. Re-exported
+    /// under the local name so the call sites below are unchanged.
+    use crate::context::lock_globals;
 
     /// Reset the process-global context to a fresh, initialized state with
     /// a small EAS map. Callers must hold [`lock_globals`].
@@ -1068,12 +1132,20 @@ easdf:
         assert_eq!(miss_behavior_from(None), DnsMissBehavior::NxDomain);
         // forward without upstream falls back to nxdomain.
         let dns = DnsYaml {
+            #[cfg(feature = "dns-udp")]
+            udp_address: None,
+            #[cfg(feature = "dns-udp")]
+            udp_port: None,
             miss_action: Some("forward".to_string()),
             upstream: None,
         };
         assert_eq!(miss_behavior_from(Some(&dns)), DnsMissBehavior::NxDomain);
         // unknown action is nxdomain.
         let dns = DnsYaml {
+            #[cfg(feature = "dns-udp")]
+            udp_address: None,
+            #[cfg(feature = "dns-udp")]
+            udp_port: None,
             miss_action: Some("drop".to_string()),
             upstream: Some("10.0.0.53:53".to_string()),
         };

--- a/src/bins/nextgcore-smfd/src/easdf.rs
+++ b/src/bins/nextgcore-smfd/src/easdf.rs
@@ -137,7 +137,12 @@ fn should_create(cfg: Option<&EasdfConfig>) -> bool {
 /// The created context carries a DNS message-handling rule per edge FQDN pattern
 /// this DNN is configured for, each asking for a report so this SMF learns the
 /// resolved EAS address and can drive UL-CL / PSA re-selection.
-pub async fn create_dns_context(supi: &str, pdu_session_id: u8, dnn: &str) -> Option<String> {
+pub async fn create_dns_context(
+    supi: &str,
+    pdu_session_id: u8,
+    dnn: &str,
+    ue_ipv4: std::net::Ipv4Addr,
+) -> Option<String> {
     let cfg = config()?;
     if !should_create(Some(&cfg)) {
         // Not an edge-enabled deployment: TS 23.501 §5.6.7 applies to sessions
@@ -153,6 +158,11 @@ pub async fn create_dns_context(supi: &str, pdu_session_id: u8, dnn: &str) -> Op
         "supi": supi,
         "pduSessionId": pdu_session_id,
         "dnn": dnn,
+        // #276: the UE's own address. Without it the EASDF can serve this
+        // session's rules over the SBI shim only -- a DNS query arriving on
+        // UDP/53 carries no context id, so the source address is the sole
+        // correlator between a datagram and a session.
+        "ueIpv4Address": ue_ipv4.to_string(),
         "notificationUri": cfg.report_uri,
         // One rule per configured edge pattern. `reportInd` is what makes the
         // EASDF tell this SMF what it resolved -- without it the context would be
@@ -405,22 +415,37 @@ pub(crate) mod tests {
         let _g = SWITCH_LOCK.lock().await;
         set_for_test(None);
         assert!(!enabled());
-        assert_eq!(create_dns_context("imsi-1", 5, "internet").await, None);
+        assert_eq!(
+            create_dns_context(
+                "imsi-1",
+                5,
+                "internet",
+                std::net::Ipv4Addr::new(10, 45, 0, 2)
+            )
+            .await,
+            None
+        );
     }
 
     /// A loopback NRF answering EASDF discovery, plus a loopback EASDF recording
     /// the requests it receives.
+    /// The recorded requests: `(method, path, body)`.
+    ///
+    /// #276 widened this from `(method, path)`. The create body is the only place
+    /// the UE address appears, and a test that records just the path cannot tell a
+    /// create carrying it from one that does not.
+    pub(crate) type SeenRequests = std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>>;
+
     pub(crate) async fn spawn_nrf_and_easdf() -> (
         nextgcore_sbi::server::SbiServer,
         nextgcore_sbi::server::SbiServer,
-        std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>>,
+        SeenRequests,
     ) {
         use nextgcore_sbi::message::SbiResponse;
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
         use std::net::SocketAddr;
 
-        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>> =
-            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen: SeenRequests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
 
         // EASDF: 201 + Location + dnsContextId on create, 204 on delete.
         let sink = seen.clone();
@@ -433,9 +458,11 @@ pub(crate) mod tests {
             .start(move |req: SbiRequest| {
                 let sink = sink.clone();
                 async move {
-                    sink.lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .push((req.header.method.clone(), req.header.uri.clone()));
+                    sink.lock().unwrap_or_else(|e| e.into_inner()).push((
+                        req.header.method.clone(),
+                        req.header.uri.clone(),
+                        req.http.content.clone().unwrap_or_default(),
+                    ));
                     if req.header.method == "POST" {
                         return SbiResponse::with_status(201)
                             .with_header("Location", "/neasdf-dnscontext/v1/dns-contexts/ctx-abc")
@@ -499,9 +526,14 @@ pub(crate) mod tests {
         let _g = SWITCH_LOCK.lock().await;
         let (nrf, easdf, seen) = spawn_nrf_and_easdf().await;
 
-        let ctx_id = create_dns_context("imsi-001010000000001", 5, "internet")
-            .await
-            .expect("a context id");
+        let ctx_id = create_dns_context(
+            "imsi-001010000000001",
+            5,
+            "internet",
+            std::net::Ipv4Addr::new(10, 45, 0, 2),
+        )
+        .await
+        .expect("a context id");
         assert_eq!(ctx_id, "ctx-abc", "the EASDF-assigned id must be returned");
 
         delete_dns_context("imsi-001010000000001", &ctx_id).await;
@@ -510,7 +542,7 @@ pub(crate) mod tests {
         assert_eq!(
             requests
                 .iter()
-                .filter(|(m, p)| m == "POST" && p == "/neasdf-dnscontext/v1/dns-contexts")
+                .filter(|(m, p, _)| m == "POST" && p == "/neasdf-dnscontext/v1/dns-contexts")
                 .count(),
             1,
             "exactly one DNS context create, got {requests:?}"
@@ -518,11 +550,32 @@ pub(crate) mod tests {
         assert_eq!(
             requests
                 .iter()
-                .filter(|(m, p)| m == "DELETE" && p == "/neasdf-dnscontext/v1/dns-contexts/ctx-abc")
+                .filter(
+                    |(m, p, _)| m == "DELETE" && p == "/neasdf-dnscontext/v1/dns-contexts/ctx-abc"
+                )
                 .count(),
             1,
             "the matching delete must be issued, got {requests:?}"
         );
+
+        // #276: the create body must carry the UE's own address. Without it the
+        // EASDF can serve this session's handling rules over the SBI shim only --
+        // a DNS datagram carries no context id, so the source address is the sole
+        // correlator between a query and a session. Asserted on the BODY rather
+        // than on the path, which is why the recorder was widened to capture it.
+        let create = requests
+            .iter()
+            .find(|(m, p, _)| m == "POST" && p == "/neasdf-dnscontext/v1/dns-contexts")
+            .expect("the create request");
+        let body: serde_json::Value =
+            serde_json::from_str(&create.2).expect("the create body is JSON");
+        assert_eq!(
+            body["ueIpv4Address"],
+            serde_json::json!("10.45.0.2"),
+            "the UE address must reach the EASDF, got {body}"
+        );
+        assert_eq!(body["supi"], serde_json::json!("imsi-001010000000001"));
+        assert_eq!(body["pduSessionId"], serde_json::json!(5));
 
         set_for_test(None);
         easdf.stop().await.expect("stop");

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -2958,7 +2958,24 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
     // EASDF, because the release path would have nothing to delete. Every failure
     // inside is non-fatal: a session without edge DNS steering is still a working
     // session, and refusing it would turn an EASDF outage into a service outage.
-    let easdf_dns_context_id: Option<String> = None;
+    //
+    // #276: this line used to read `let easdf_dns_context_id = None;` under this
+    // same comment. The comment described an await that was not there, so
+    // `create_dns_context` had NO production caller -- and because the id was
+    // always None, the release path's `delete_dns_context` could never fire
+    // either. The whole SMF->EASDF leg was reachable from its own unit tests and
+    // from nothing else.
+    //
+    // The UE's IP address is passed because the EASDF cannot associate a UDP
+    // query with a session without it: a DNS datagram carries no context id, so
+    // the source address is the only correlator (#276).
+    let easdf_dns_context_id: Option<String> = easdf::create_dns_context(
+        &supi,
+        pdu_session_id,
+        &dnn,
+        std::net::Ipv4Addr::from(ue_ip_octets),
+    )
+    .await;
 
     // ---- #78: fill in the registered session, so Retrieve answers with the real
     // session rather than with whatever `sess_add_by_psi` defaulted to ----
@@ -6046,7 +6063,7 @@ mod tests {
         assert!(
             requests
                 .iter()
-                .any(|(m, p)| m == "DELETE" && p == "/neasdf-dnscontext/v1/dns-contexts/ctx-abc"),
+                .any(|(m, p, _)| m == "DELETE" && p == "/neasdf-dnscontext/v1/dns-contexts/ctx-abc"),
             "the release handler must delete the session's DNS context, got {requests:?}"
         );
 


### PR DESCRIPTION
Closes #276. Spec: `specs/fix-easdfd-dns-udp-listener.md`.

## What was found first, and why it had to be fixed here

**`easdf::create_dns_context` had no production caller.** `smfd/main.rs:2961` read:

```rust
// ---- #114: EASDF selection + DNS context (TS 23.501 §5.6.7) ----
// Off by default. Awaited BEFORE the binding is stored so the context id is
// recorded with it -- ...
let easdf_dns_context_id: Option<String> = None;
```

The comment describes an `await` that is not in the code. It came in with `e9c823f` (PR #277,
closing #114), whose commit message says it "gives the DNS plane a driver". The driver is 130
lines and is tested over real HTTP — and nothing in production called it. Because the id was
permanently `None`, the release path's `delete_dns_context` (correctly wired) could never fire
either, so **both** legs were dead.

#114's spec names the ceiling and lands on the wrong side of it: it says the create call site is
"verified **by inspection**". The inspection did not notice the call was absent.

This is a prerequisite, not scope creep: #276's criterion 4 ("a query from a UE whose session has
a DNS context") describes a state the running system could never enter until it was fixed.

## The deliverable

**`dns_wire.rs` — RFC 1035 + RFC 6891 codec, NOT behind the feature.** Header flags, QNAME with
compression *reading*, QTYPE/QCLASS, `A`/`AAAA`, RCODEs, EDNS(0) `OPT`, `TC` truncation against
the negotiated ceiling. Hand-rolled, as this tree already does for NAS, NGAP, PFCP and Diameter.
Left out of the feature deliberately: it changes no network posture, so all the parsing logic stays
compiled and tested in the default CI build — which answers this project's recorded reason for
preferring runtime switches to cargo features.

**`dns_udp.rs`, behind `dns-udp` (off by default) — the socket.** #276 asks for a cargo feature and
justifies it: this sub-item binds a **privileged port**. So the feature stands against the house
rule, and `ci.yml` gained an explicit `--features dns-udp` test step *and* clippy step, so the
gated half cannot rot uncompiled either.

**Source-address scoping.** A DNS datagram carries no context id, so the source address is the only
correlator between a query and a session. `EasdfDnsContext` gains `ue_addresses`, `EasdfContext`
gains a UE-IP index maintained by every mutation, and the SMF now sends `ueIpv4Address` on create.

| decision | why |
|---|---|
| a colliding UE address goes to the **newer** context | an SMF assigns an address to one live session at a time, so the older context's DELETE was lost; steering the live session with a dead session's rules is the worse error |
| …but the stale context itself is kept | removing a resource the SMF did not delete would make its eventual DELETE answer 404 |
| deleting the stale context must **not** un-map the live session | the subtle half; an unconditional `index.remove` passes every other test and breaks the live session later |
| an unknown source falls through to the static map | never to another session's rules — the leak `resolve_in_context` already refuses |
| `ueIpv6Prefix` refused, loudly | prefix matching is a different operation; taking the network address would answer for one address out of 2^64 |
| **NODATA**, not NXDOMAIN, for a served name with an unserved type | NXDOMAIN would make a dual-stack resolver stop asking for the other family too |
| unreachable upstream → **SERVFAIL** | "I could not find out" is far less sticky than "it does not exist" |
| a forward is relayed **verbatim** both ways | the ID, question and any EDNS option we do not model all survive; a parse-and-rebuild would drop the last silently |

## Verification

Workspace **6224 passed / 0 failed** (baseline 6209, +15 default-build tests). With the feature:
**51 passed / 0 failed** (+9 that exist only there). clippy and fmt clean in **both**
configurations.

| revert | expected to break | result |
|---|---|---|
| `resolve_for_source` ignores the source address | the two scoping tests | **2 failed** |
| index removal made unconditional | the stale-delete collision test | **1 failed** |
| the listener binds but never serves | the real-UDP test | **1 failed** |
| `ueIpv4Address` omitted from the create body | the over-the-wire create test | **1 failed** |
| `OPT` emitted even when the query had none | 3 codec tests | **3 failed** |
| `TC` never set | the truncation test | **1 failed** |
| **the smfd create call removed (#114's state)** | — | **425 passed, 0 failed** |

### A lock split that hung rather than flaked

The UDP tests first declared their own `tokio::Mutex` while `main.rs`'s tests already had a
`std::Mutex` over the same process-global context — two disjoint agreements about one variable. The
symptom was not a failed assertion: a `easdf_context_final()` wiped a sibling handler test's EAS map
mid-flight, that sibling's *miss* became a *hit*, so no forward was sent, so the fake upstream it
was blocked on never received anything, and the run **hung** until the harness killed it. One lock
now lives in `context.rs` beside the global it protects, the forward test's `await` is bounded by a
timeout, and eight consecutive feature-suite runs are green — one green run proves nothing about a
process-global race.

## Ceilings

- **The smfd create call site is still untested, and the last revert row proves it.** Reaching it
  needs an associated PFCP peer answering a Session Establishment Request; the smfd harness has no
  UPF stand-in, and two existing tests say so, both adding "if this ever becomes a 2xx the harness
  gained a UPF". Building one is a cross-module test-infrastructure change (`PFCP_CLIENT` is a
  `OnceLock`; `release_association` clears the global map `pfcp_path`'s own lock guards). Filed as
  its own issue. What *is* verified: the create body's contents over real HTTP, and that a failed
  establishment creates no context.
- No TCP fallback (a truncated answer is `TC`-flagged), no DNSSEC (the `DO` bit is echoed, nothing
  is signed), `ueIpv6Prefix` unsupported.
- The EASDF is still not in `docker-compose.yml` and ships no `easdf.yaml`, so none of this is
  exercised by the docker E2E gate. Unchanged here, and now stated in the docs.
- TS 29.556 remains un-vendored, so `ueIpv4Address` rests on #114's accepted-spellings stance, not
  on a schema. The wire format, by contrast, is checked against RFC 1035/6891.

## Also

New `docs-book/src/configuration/easdf.md` (in `SUMMARY.md`) — there was no EASDF page at all.
Covers the `CAP_NET_BIND_SERVICE` requirement and port override, the per-transport resolution
precedence, the full answer table, and the collision/prefix caveats.