### PR TITLE
fix(amfd,smfd): assign EBIs over Namf, emit Mapped EPS bearer contexts, and name the EBI in ueEpsPdnConnection (#117)

### DIFF
--- a/specs/fix-amfd-smfd-eps-bearer-contexts.md
+++ b/specs/fix-amfd-smfd-eps-bearer-contexts.md
@@ -1,0 +1,190 @@
+# nextgcore #117 (amfd/smfd): EBI assignment, Mapped EPS bearer contexts, and a real `ueEpsPdnConnection`
+
+Verified against `main` @ `aeeb19d`.
+
+## Verified against current main
+
+| claim in the issue | site on `aeeb19d` | still true? |
+|---|---|---|
+| the `namf-comm` router has no `assign-ebi` arm | `bins/nextgcore-amfd/src/namf_server.rs:86` | yes |
+| no `AssignEbiData`/`AssignedEbiData` type and no EBI pool anywhere | `rg 'assign-ebi\|AssignEbiData\|AssignedEbiData'` → **nothing** in the whole tree | yes |
+| `SmfBearer.ebi` exists but only the GTPv2 path writes it | `context.rs` `pub ebi: u8`; sole writer `gtp_handler.rs` | yes |
+| the three `gsm_build` builders emit no IEI `0x75` | `rg '0x75' src/bins/` → only crypto test vectors | yes |
+| `handle_sm_context_retrieve` omits `ueEpsPdnConnection` | **NO — #78 added it** (`main.rs` `build_ue_eps_pdn_connection`) | **false** |
+
+So criterion 4's first branch was already met by #78, which is why this PR extends that
+function rather than writing it. The other four criteria were unmet.
+
+## The precondition the issue's approach assumes and that does not exist
+
+#117's suggested approach says to emit the IE "from `build_pdu_session_establishment_accept`,
+`..._extended`, and `build_pdu_session_modification_command`". **None of those three has a
+production caller.** The live establishment path builds its N1 message with
+`policy::build_establishment_accept`; the `gsm_build` trio belongs to the `SmfSess`/`SmfBearer`
+model that issue #223 is about ("two parallel session models, one dead").
+
+Emitting the IE only where the issue points would therefore have been a correct encoder that no
+UE could ever receive. The IE is emitted from **all four** builders — the three the criterion
+names, so the criterion is met as written and the dead model is not left behind when #223 revives
+it, and `policy::build_establishment_accept`, so a real UE gets it. Both call the same
+`encode_mapped_eps_bearer_context`, so the two paths cannot drift.
+
+## Decision 1: a runtime switch, not the cargo feature the issue suggests
+
+#117 advises a single `eps-interworking` cargo feature. This uses `SMF_EPS_INTERWORKING=1`
+(default off; smfd has no clap `Args`, so all its switches are env vars), for this project's
+recorded reason: CI builds default features, so a cargo-feature-gated path is left uncompiled and
+rots. A runtime switch is compiled always and exercised in **both** states by one `cargo test`
+run — which is what makes criterion 5 ("behaviour unchanged when disabled") a thing a test asserts
+rather than a claim about a build CI never performs.
+
+Note the contrast with #276, merged one PR earlier, which *is* a cargo feature: that one binds a
+privileged port and changes the process's network posture. The distinguishing factor is network
+posture, not optionality. This one changes which IEs an N1 message carries.
+
+## Decision 2: the EBI pool is per-UE, and exhaustion is an answer rather than an error
+
+TS 24.301 §9.3.2 reserves EBI 0 ("no EPS bearer identity assigned") and 1..=4, so the assignable
+space is **5..=15 — eleven per UE**, which is also the most EPS bearers a UE can hold. The pool
+therefore lives on `AmfUe`, not per session: a per-session pool could hand the same EBI to two
+sessions of one UE.
+
+Eleven being small makes exhaustion a real outcome, and TS 29.518 models it rather than erroring:
+`AssignedEbiData.failedArpList` carries the ARPs that got nothing. So a **partial** failure is a
+`200` with both lists, and only "every ARP failed and none was assigned" is the `403 +
+AssignEbiError` the operation defines. Allocation is lowest-free rather than round-robin so a
+released EBI is reused promptly; an allocator that kept climbing would exhaust the space after
+eleven session *lifetimes* instead of eleven concurrent bearers.
+
+The order of operations inside one request is **release → modify → assign**, and it is
+load-bearing: a request that releases EBI 5 and asks for one more must be able to hand 5 straight
+back out. A revert that moves the release after the assignment fails two tests.
+
+## Decision 3: pre-emption members are checked for presence, not for value
+
+`Arp` requires `priorityLevel`, `preemptCap` and `preemptVuln`. `priorityLevel` is range-checked
+(1..=15) because it is a plain integer with declared bounds. The other two are
+`anyOf[enum, string]` in TS 29.571 — **extensible** enums — so a value outside the two named ones
+is permitted by the schema and refusing it would reject something conformant. They are stored and
+echoed verbatim. Pinned by a test that posts `SOME_FUTURE_VALUE` and asserts `200`.
+
+## Decision 4: a 5QI with no EPS equivalent omits the QoS parameter rather than inventing a QCI
+
+TS 23.501 Table 5.7.4-1 gives standardised 5QIs 1..=9 the same numeric QCI, which is what makes
+mapping possible for them. For anything else — a non-standardised 5QI, or a delay-critical value
+like 82 — there is **no defined QCI**. `qci_for_5qi` returns `None` and the bearer context is
+emitted with an **empty parameters list** and the `E` bit clear, which is legal (it is exactly the
+IE's 7-octet minimum). An MME *enforces* whatever QCI it is handed, so guessing one is worse than
+omitting it; the EBI is still conveyed, so the bearer identity is agreed even where the QoS
+mapping is not expressible.
+
+## Decision 5: `ueEpsPdnConnection` names the EBI, and is otherwise byte-identical to #78's
+
+#78 deliberately emitted a minimal descriptor with no bearer contexts, because there was no EBI
+assignment in the tree and a fabricated bearer list would have an MME trying to use bearers this
+SMF never established. #117 changes that precondition and nothing else: when an EBI **was**
+assigned the descriptor appends it, and when none was the output is byte-for-byte what #78
+produced. Appended rather than inserted, so a peer parsing the earlier form reads the same prefix.
+
+The `403 EPS_IWK_NOT_SUPPORTED` alternative criterion 4 offers is **not** taken: #78's first
+branch is already met, and switching a working `200` to a `403` when a runtime switch is off would
+regress a deliberate decision of a merged issue for no conformance gain.
+
+## Acceptance criteria
+
+- [x] `POST /namf-comm/v1/ue-contexts/{ueContextId}/assign-ebi` is routed in amfd and returns
+      `AssignedEbiData` with EBIs from a per-UE pool —
+      `assign_ebi_allocates_from_a_per_ue_pool_and_answers_assigned_ebi_data`, driven **through the
+      router** (a test calling the handler directly would pass with the routing arm absent), with
+      the shape asserted against the yaml: the two `required` members present, `assignedEbiList`
+      items as `EbiArpMapping`, and the three `minItems: 1` lists **absent rather than empty**.
+      Plus `..._releases_before_it_assigns...`, `..._reports_exhaustion_rather_than_inventing_an_ebi`,
+      `..._rejects_a_malformed_request_and_an_unknown_ue`, `..._modifies_a_held_ebi_and_409s_one_it_does_not_hold`.
+- [x] smfd invokes `Namf_Communication_EBIAssignment` and the EBI reaches `SmfBearer.ebi` without
+      the GTPv2 path — `the_smf_requests_an_ebi_over_namf_and_stores_what_it_gets` (the recorded
+      request path and body are the assertion, not just the return value: `assign-ebi` had no
+      caller anywhere before this) and `the_assigned_ebi_reaches_smf_bearer_without_the_gtpv2_path`.
+- [x] The three named builders emit IEI `0x75` and it decodes to the expected EBI and parameters —
+      `establishment_accept_carries_mapped_eps_bearer_contexts_only_when_an_ebi_exists`,
+      `the_extended_establishment_accept_also_carries_the_ie`,
+      `the_modification_command_carries_one_context_per_flow_holding_an_ebi`,
+      `a_five_qi_with_no_eps_equivalent_omits_the_qos_parameter_rather_than_inventing_a_qci`. **And
+      the live path**, which the criterion does not name:
+      `the_live_accept_carries_mapped_eps_bearer_contexts_when_an_ebi_is_assigned`.
+- [x] `handle_sm_context_retrieve` returns `SmContextRetrievedData` with `ueEpsPdnConnection` —
+      met by #78; extended here to name the EBI, pinned by
+      `the_retrieved_ue_eps_pdn_connection_names_the_assigned_ebi`, which asserts the prefix is
+      unchanged and exactly one octet is added.
+- [x] With interworking disabled, establishment/modification and Retrieve are unchanged — all 425
+      pre-existing smfd tests and all 428 pre-existing amfd tests pass untouched, and the
+      disabled-state assertions are explicit (`a_disabled_leg_dials_nothing`, the off half of
+      `the_smf_requests_an_ebi_over_namf_and_stores_what_it_gets`, and the no-EBI half of every
+      encoder test).
+
+## Verification
+
+Workspace **6241 passed / 0 failed** (baseline 6224 on `aeeb19d`; +17), and
+`cargo test -p nextgcore-easdfd --features dns-udp` still 51/0. `cargo clippy --workspace
+--all-targets` and `cargo fmt --all -- --check` clean; amfd and smfd carry **zero** clippy
+warnings, including four pre-existing `needless_borrow` warnings in smfd's #78 tests fixed in
+passing.
+
+| revert | expected to break | result |
+|---|---|---|
+| the `assign-ebi` routing arm removed | all five amfd tests | **5 failed** |
+| release moved to after assignment | the reuse and exhaustion tests | **2 failed** |
+| the allocator ignores already-held EBIs | the pool and exhaustion tests | **2 failed** |
+| the **live** accept stops emitting the IE | the live-path test | **1 failed** *(see below)* |
+| the `E` bit set with an empty parameters list | the no-EPS-equivalent test | **1 failed** |
+| the Namf writer stops setting `SmfBearer.ebi` | the storage test | **1 failed** |
+| Retrieve stops reading the binding's EBI | the `ueEpsPdnConnection` test | **1 failed** |
+
+### The revert pass found a hole in my own work
+
+Revert 4 initially passed: with the emit removed from `policy::build_establishment_accept` the
+**entire 436-test smfd suite stayed green**, because every test touching the IE drove one of the
+three `gsm_build` builders — and those have no production caller. The IE was covered exactly where
+it does not matter and uncovered on the one path a UE receives. That is the same
+correct-but-unreachable trap this PR's opening section describes, reproduced in the diff meant to
+avoid it. `the_live_accept_carries_mapped_eps_bearer_contexts_when_an_ebi_is_assigned` was added
+and the revert then failed.
+
+A second, milder finding: revert 5 first appeared not to bite, which turned out to be a too-narrow
+`cargo test mapped_eps` filter rather than a missing guard — the assertion lives in a test whose
+name does not contain that substring. Re-run without the filter, it failed correctly. Worth
+recording because "the revert did not bite" and "my filter did not select the guard" look identical
+in the output.
+
+## Ceilings
+
+* **The create call site is verified by inspection, not by a test** — the same ceiling #276 hit and
+  filed as #289. `handle_sm_context_create` cannot be driven past its N4 leg (no UPF stand-in), so
+  neither the `eps_iwk::request_ebi` call nor the `record_mapped_eps_bearer` call is reachable from
+  a test. The two functions themselves are covered, and the recording step was **extracted into
+  `eps_iwk.rs` specifically so it has a reachable seam** rather than being an inline block that
+  nothing can call. #289 names this exact call site as one of the three it would close.
+* **One EBI per session, not one per QoS flow.** TS 23.502 §4.11.1.4.1 has the SMF request an EBI
+  per flow that needs one; the live path authorises a single default flow per session, so one ARP
+  is sent. A multi-flow session would need the `arpList` to grow with it, and the AMF side already
+  handles an arbitrary-length list (tested to eleven).
+* **`AssignEbiData.oldGuami` is parsed but unused.** It matters for an inter-AMF case (the EBIs a
+  *previous* AMF assigned) that this tree has no handling for; ignoring it is what the current
+  single-AMF behaviour amounts to, stated rather than silently dropped.
+* **The Modification Command path emits the IE but has no production caller**, because
+  `policy::build_modification_command` (the live one) has no EBI parameter — the live modification
+  path does not re-authorise bearers. So a flow that gains an EBI *mid-session* is encodable and not
+  yet conveyed. Left alone because no criterion asks for it and adding an argument to the live
+  modification builder with no caller to pass it would be dead weight.
+* **TS 24.501/24.301 are vendored as text, not as a schema.** The IE layout was read out of
+  `6g_docs/specs/24501-j62.txt` §9.11.4.8 (figures 9.11.4.8.1–3 and Table 9.11.4.8.1) and
+  `24301-k00.txt` §9.9.4.3 rather than inferred from the issue text — the 7-octet minimum length
+  the spec states is what confirms the context-length field covers octet 7 onward. But there is no
+  machine-checkable artifact, unlike the TS 29.5xx yamls the SBI shapes are checked against.
+* **No EBI release on session release.** `AssignEbiData.releasedEbiList` is implemented on the AMF
+  side and the SMF never sends one, so an EBI stays held for the UE's lifetime rather than its
+  session's. Eleven-wide space plus lowest-free allocation makes this a real leak over enough
+  session churn. Not in any criterion; worth its own issue.
+* GitNexus impact analysis unrunnable (no MCP server connected). Blast radius by grep:
+  `AssignedEbi`/`EbiArp` are new with one producer each; `build_establishment_accept` gained a
+  parameter and has 1 production + 6 test call sites, all updated; `SmfBearer::assigned_ebi` has
+  four callers, all new.

--- a/src/bins/nextgcore-amfd/src/context.rs
+++ b/src/bins/nextgcore-amfd/src/context.rs
@@ -2086,6 +2086,48 @@ pub struct ExplicitDeRegistered {
 // AmfUe - AMF UE Context
 // ============================================================================
 
+/// An Allocation and Retention Priority, as `Arp` (TS 29.571) carries it.
+///
+/// The two enum members are stored as the strings received. `PreemptionCapability`
+/// and `PreemptionVulnerability` are `anyOf[enum, string]` in TS 29.571 — an
+/// extensible enum — so a value outside the two named ones is permitted by the
+/// schema. Presence is therefore enforced (both are `required` in `Arp`) and the
+/// value is not, which is the same stance this tree took for other extensible
+/// enumerations, and it means an ARP is echoed back exactly as the SMF stated it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EbiArp {
+    /// `priorityLevel`, 1..=15 (1 is highest). Validated on ingest.
+    pub priority_level: u8,
+    /// `preemptCap`, e.g. `NOT_PREEMPT` / `MAY_PREEMPT`.
+    pub preempt_cap: String,
+    /// `preemptVuln`, e.g. `NOT_PREEMPTABLE` / `PREEMPTABLE`.
+    pub preempt_vuln: String,
+}
+
+/// One EPS Bearer Identity this AMF has assigned to a PDU session (#117).
+///
+/// TS 23.502 §4.11.1.4.1: for a PDU session that may move to EPS, the SMF asks
+/// the AMF for an EBI per QoS flow that needs one, supplying that flow's ARP; the
+/// AMF owns the identity space and answers with the values it allocated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssignedEbi {
+    /// The allocated EBI, always in [`EBI_ASSIGNABLE`].
+    pub ebi: u8,
+    /// The PDU session the EBI belongs to.
+    pub pdu_session_id: u8,
+    /// The ARP the SMF supplied for the flow this EBI maps.
+    pub arp: EbiArp,
+}
+
+/// EBI values an AMF may assign.
+///
+/// TS 24.301 §9.3.2 reserves 0 ("no EPS bearer identity assigned") and 1..=4, so
+/// the assignable space is 5..=15 — eleven per UE, which is also the ceiling on
+/// how many EPS bearers a UE can hold. Exhaustion is therefore a real outcome and
+/// not a theoretical one, and `AssignedEbiData.failedArpList` is how it is
+/// reported rather than a 5xx.
+pub const EBI_ASSIGNABLE: std::ops::RangeInclusive<u8> = 5..=15;
+
 /// AMF UE context
 #[derive(Debug, Clone)]
 pub struct AmfUe {
@@ -2109,6 +2151,13 @@ pub struct AmfUe {
     /// carries no usable `gpsis` entry this stays `None` and every consumer
     /// omits the member rather than conveying a derived one (issue #205).
     pub gpsi: Option<String>,
+    /// EBIs assigned to this UE for 5GS↔EPS interworking (#117,
+    /// `Namf_Communication_EBIAssignment`, TS 29.518 §6.1.6.2.5).
+    ///
+    /// Per-UE rather than per-session because the identity space is per-UE: TS
+    /// 24.301 gives a UE eleven assignable EBIs across ALL its PDU sessions, so a
+    /// per-session pool could hand the same EBI to two sessions of one UE.
+    pub assigned_ebis: Vec<AssignedEbi>,
     /// Masked IMEISV
     pub masked_imeisv: [u8; NEXTGCORE_MAX_IMEISV_LEN],
     /// Masked IMEISV length
@@ -2670,6 +2719,7 @@ impl AmfUe {
             home_plmn_id: PlmnId::default(),
             pei: None,
             gpsi: None,
+            assigned_ebis: Vec::new(),
             masked_imeisv: [0u8; NEXTGCORE_MAX_IMEISV_LEN],
             masked_imeisv_len: 0,
             imeisv_bcd: String::new(),

--- a/src/bins/nextgcore-amfd/src/namf_server.rs
+++ b/src/bins/nextgcore-amfd/src/namf_server.rs
@@ -18,9 +18,9 @@ use nextgcore_sbi::server::{send_error, send_method_not_allowed, send_not_found}
 use serde_json::{json, Value};
 
 use crate::context::{
-    amf_self, AmfSess, AmfUe, EventSubscription, LcsCorrelationRecord, NrCgi, PendingPositioningDl,
-    PlmnId, PositioningDlKind, RanUe, Tai5gs, UeContextTransferState, UeN1N2InfoSubscription,
-    NEXTGCORE_INVALID_POOL_ID,
+    amf_self, AmfSess, AmfUe, AssignedEbi, EbiArp, EventSubscription, LcsCorrelationRecord, NrCgi,
+    PendingPositioningDl, PlmnId, PositioningDlKind, RanUe, Tai5gs, UeContextTransferState,
+    UeN1N2InfoSubscription, EBI_ASSIGNABLE, NEXTGCORE_INVALID_POOL_ID,
 };
 use crate::namf_handler::{
     self, AccessType, DeregistrationData, DeregistrationReason, N1N2MessageTransferCause,
@@ -80,6 +80,7 @@ pub async fn namf_request_handler(request: SbiRequest) -> SbiResponse {
         //   POST   /namf-comm/v1/ue-contexts/{ueContextId}/n1-n2-messages
         //   POST   /namf-comm/v1/ue-contexts/{ueContextId}/n1-n2-messages/subscriptions
         //   DELETE /namf-comm/v1/ue-contexts/{ueContextId}/n1-n2-messages/subscriptions/{subscriptionId}
+        //   POST   /namf-comm/v1/ue-contexts/{ueContextId}/assign-ebi
         //   POST   /namf-comm/v1/ue-contexts/{ueContextId}/transfer
         //   POST   /namf-comm/v1/ue-contexts/{ueContextId}/transfer-update
         // --------------------------------------------------------------
@@ -97,6 +98,8 @@ pub async fn namf_request_handler(request: SbiRequest) -> SbiResponse {
                 ("DELETE", "n1-n2-messages", 7) if parts[5] == "subscriptions" => {
                     handle_n1n2_subscription_delete(ue_context_id, parts[6])
                 }
+                // EBIAssignment (TS 29.518 §6.1.6.2.5), #117
+                ("POST", "assign-ebi", 5) => handle_assign_ebi(ue_context_id, &request),
                 ("POST", "transfer", 5) => handle_ue_context_transfer(ue_context_id, &request),
                 ("POST", "transfer-update", 5) => {
                     handle_registration_status_update(ue_context_id, &request)
@@ -1883,6 +1886,294 @@ fn build_ue_context_json(ue: &AmfUe, sessions: &[AmfSess]) -> Value {
     }
 
     ue_context
+}
+
+// ---------------------------------------------------------------------------
+// EBIAssignment (TS 29.518 §6.1.6.2.5), issue #117
+// ---------------------------------------------------------------------------
+
+/// Parse one `Arp` (TS 29.571): all three members are `required`.
+///
+/// `priorityLevel` is range-checked (1..=15) because it is a plain integer with
+/// declared bounds. The two pre-emption members are checked for PRESENCE only:
+/// both are `anyOf[enum, string]` in TS 29.571, i.e. extensible, so rejecting an
+/// unlisted value would refuse something the schema permits. They are stored and
+/// echoed verbatim.
+fn parse_arp(value: &Value, attr: &str) -> Result<EbiArp, Box<SbiResponse>> {
+    let priority_level = match value.get("priorityLevel").and_then(Value::as_u64) {
+        Some(p) if (1..=15).contains(&p) => p as u8,
+        Some(p) => {
+            return Err(Box::new(mandatory_ie_incorrect(
+                &format!("{attr}.priorityLevel"),
+                &format!("{p} is outside the ArpPriorityLevel range 1..=15"),
+            )))
+        }
+        None => {
+            return Err(Box::new(mandatory_ie_missing(&format!(
+                "{attr}.priorityLevel"
+            ))))
+        }
+    };
+    let member = |key: &str| -> Result<String, Box<SbiResponse>> {
+        match value.get(key).and_then(Value::as_str) {
+            Some(v) if !v.is_empty() => Ok(v.to_string()),
+            _ => Err(Box::new(mandatory_ie_missing(&format!("{attr}.{key}")))),
+        }
+    };
+    Ok(EbiArp {
+        priority_level,
+        preempt_cap: member("preemptCap")?,
+        preempt_vuln: member("preemptVuln")?,
+    })
+}
+
+/// Serialise an `Arp` back onto the wire.
+fn arp_json(arp: &EbiArp) -> Value {
+    json!({
+        "priorityLevel": arp.priority_level,
+        "preemptCap": arp.preempt_cap,
+        "preemptVuln": arp.preempt_vuln,
+    })
+}
+
+/// Serialise an `EbiArpMapping` (TS 29.502): both members are `required`.
+fn ebi_arp_mapping_json(assigned: &AssignedEbi) -> Value {
+    json!({
+        "epsBearerId": assigned.ebi,
+        "arp": arp_json(&assigned.arp),
+    })
+}
+
+/// The lowest free EBI for this UE, or `None` when all eleven are taken.
+///
+/// Lowest-free rather than round-robin so a released EBI is reused promptly: the
+/// space is only eleven wide per UE, and an allocator that kept climbing would
+/// exhaust it after eleven session lifetimes rather than after eleven concurrent
+/// bearers.
+fn next_free_ebi(assigned: &[AssignedEbi]) -> Option<u8> {
+    EBI_ASSIGNABLE
+        .clone()
+        .find(|c| !assigned.iter().any(|a| a.ebi == *c))
+}
+
+/// POST /namf-comm/v1/ue-contexts/{ueContextId}/assign-ebi —
+/// Namf_Communication_EBIAssignment (TS 29.518 §6.1.6.2.5), issue #117.
+///
+/// TS 23.502 §4.11.1.4.1: for a PDU session that may be moved to EPS, the SMF
+/// asks the AMF for an EPS Bearer Identity per QoS flow that needs one, supplying
+/// that flow's ARP. The AMF owns the EBI space for the UE and answers with what it
+/// allocated. Without this operation the two sides cannot agree on bearer
+/// identities and no PDU session can be transferred to the EPC.
+///
+/// The order of operations is release → modify → assign, and it matters: a
+/// request that releases EBI 5 and asks for one more must be able to hand 5 back
+/// out. Doing it the other way round would fail an assignment that the release in
+/// the same request had just made possible.
+fn handle_assign_ebi(ue_context_id: &str, request: &SbiRequest) -> SbiResponse {
+    let Some(mut ue) = find_ue_by_context_id(ue_context_id) else {
+        return context_not_found(ue_context_id);
+    };
+    let Some(body) = parse_json_body(request) else {
+        return malformed_body();
+    };
+
+    // `pduSessionId` is the ONLY required member of AssignEbiData.
+    let pdu_session_id = match body.get("pduSessionId").and_then(Value::as_u64) {
+        Some(id) if id <= 255 => id as u8,
+        Some(id) => {
+            return mandatory_ie_incorrect(
+                "pduSessionId",
+                &format!("{id} is outside the PduSessionId range 0..=255"),
+            )
+        }
+        None => return mandatory_ie_missing("pduSessionId"),
+    };
+
+    // ---- releasedEbiList: free these before allocating anything ----
+    let mut released: Vec<u8> = Vec::new();
+    if let Some(list) = body.get("releasedEbiList").and_then(Value::as_array) {
+        for entry in list {
+            let Some(ebi) = entry.as_u64().filter(|e| *e <= 15).map(|e| e as u8) else {
+                return mandatory_ie_incorrect(
+                    "releasedEbiList",
+                    "entries must be an EpsBearerId in 0..=15",
+                );
+            };
+            // Release is idempotent: an EBI this AMF does not hold is reported as
+            // released anyway, because the SMF's intent (it is not in use) is
+            // already satisfied and a 4xx would strand the SMF's retry.
+            ue.assigned_ebis.retain(|a| a.ebi != ebi);
+            if !released.contains(&ebi) {
+                released.push(ebi);
+            }
+        }
+    }
+
+    // ---- modifiedEbiList: re-ARP an EBI already held ----
+    let mut modified: Vec<u8> = Vec::new();
+    if let Some(list) = body.get("modifiedEbiList").and_then(Value::as_array) {
+        for entry in list {
+            let Some(ebi) = entry
+                .get("epsBearerId")
+                .and_then(Value::as_u64)
+                .filter(|e| *e <= 15)
+                .map(|e| e as u8)
+            else {
+                return mandatory_ie_missing("modifiedEbiList.epsBearerId");
+            };
+            let arp = match entry.get("arp") {
+                Some(v) => match parse_arp(v, "modifiedEbiList.arp") {
+                    Ok(arp) => arp,
+                    Err(response) => return *response,
+                },
+                None => return mandatory_ie_missing("modifiedEbiList.arp"),
+            };
+            match ue.assigned_ebis.iter_mut().find(|a| a.ebi == ebi) {
+                Some(existing) => {
+                    existing.arp = arp;
+                    existing.pdu_session_id = pdu_session_id;
+                    if !modified.contains(&ebi) {
+                        modified.push(ebi);
+                    }
+                }
+                None => {
+                    // Modifying an EBI this AMF never assigned is a state
+                    // disagreement, not a malformed request. 409 is what the
+                    // operation defines for exactly that, and answering 200 while
+                    // silently ignoring the entry would leave the SMF believing an
+                    // ARP change took effect.
+                    return assign_ebi_error(
+                        409,
+                        "Conflict",
+                        &format!("EBI {ebi} is not assigned to UE '{ue_context_id}'"),
+                        "EBI_NOT_ASSIGNED",
+                        pdu_session_id,
+                        &[],
+                    );
+                }
+            }
+        }
+    }
+
+    // ---- arpList: one EBI per ARP, in the order given ----
+    let mut assigned_now: Vec<AssignedEbi> = Vec::new();
+    let mut failed: Vec<EbiArp> = Vec::new();
+    if let Some(list) = body.get("arpList").and_then(Value::as_array) {
+        for entry in list {
+            let arp = match parse_arp(entry, "arpList") {
+                Ok(arp) => arp,
+                Err(response) => return *response,
+            };
+            match next_free_ebi(&ue.assigned_ebis) {
+                Some(ebi) => {
+                    let assignment = AssignedEbi {
+                        ebi,
+                        pdu_session_id,
+                        arp,
+                    };
+                    ue.assigned_ebis.push(assignment.clone());
+                    assigned_now.push(assignment);
+                }
+                // Exhaustion is a modelled outcome, not an error: eleven EBIs is
+                // also the most EPS bearers a UE can have, so a twelfth request is
+                // the SMF asking for something that cannot exist.
+                None => failed.push(arp),
+            }
+        }
+    }
+
+    // Every ARP failed AND at least one was asked for: nothing was achieved, so
+    // the operation failed. TS 29.518 defines 403 + AssignEbiError for this, which
+    // carries the failed ARPs so the SMF knows which flows have no EBI.
+    if !failed.is_empty() && assigned_now.is_empty() {
+        return assign_ebi_error(
+            403,
+            "Forbidden",
+            &format!(
+                "no EBI is available for UE '{ue_context_id}': all {} assignable \
+                 identities (TS 24.301 §9.3.2 reserves 0..=4) are in use",
+                EBI_ASSIGNABLE.clone().count()
+            ),
+            "INSUFFICIENT_RESOURCES",
+            pdu_session_id,
+            &failed,
+        );
+    }
+
+    // Persist before answering: an EBI reported as assigned and not recorded would
+    // be handed out again on the next request, and two PDU sessions of one UE
+    // would map to one EPS bearer.
+    if let Ok(guard) = amf_self().read() {
+        guard.amf_ue_update(&ue);
+    }
+
+    let mut response = json!({
+        "pduSessionId": pdu_session_id,
+        // `required` and `minItems: 0`, so an empty array is emitted rather than
+        // the member being omitted.
+        "assignedEbiList": assigned_now
+            .iter()
+            .map(ebi_arp_mapping_json)
+            .collect::<Vec<_>>(),
+    });
+    // The remaining members are `minItems: 1`, so each is emitted only when
+    // non-empty: an empty array would violate the schema it is declared under.
+    if !failed.is_empty() {
+        response["failedArpList"] = json!(failed.iter().map(arp_json).collect::<Vec<_>>());
+    }
+    if !released.is_empty() {
+        response["releasedEbiList"] = json!(released);
+    }
+    if !modified.is_empty() {
+        response["modifiedEbiList"] = json!(modified);
+    }
+
+    log::info!(
+        "[{ue_context_id}] EBI assignment psi={pdu_session_id}: assigned {:?}, failed {}, \
+         released {:?}, modified {:?} ({} of {} EBIs now held)",
+        assigned_now.iter().map(|a| a.ebi).collect::<Vec<_>>(),
+        failed.len(),
+        released,
+        modified,
+        ue.assigned_ebis.len(),
+        EBI_ASSIGNABLE.clone().count()
+    );
+
+    SbiResponse::with_status(200)
+        .with_json_body(&response)
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+/// An `AssignEbiError` response: `error` + `failureDetails`, both `required`.
+///
+/// Note this is NOT `application/problem+json`: the operation defines its own
+/// error body with the ProblemDetails nested under `error`, because the SMF needs
+/// the failed ARP list alongside the problem to know which QoS flows are without
+/// an EBI.
+fn assign_ebi_error(
+    status: u16,
+    title: &str,
+    detail: &str,
+    cause: &str,
+    pdu_session_id: u8,
+    failed: &[EbiArp],
+) -> SbiResponse {
+    let mut failure_details = json!({ "pduSessionId": pdu_session_id });
+    if !failed.is_empty() {
+        failure_details["failedArpList"] = json!(failed.iter().map(arp_json).collect::<Vec<_>>());
+    }
+    let body = json!({
+        "error": {
+            "status": status,
+            "title": title,
+            "detail": detail,
+            "cause": cause,
+        },
+        "failureDetails": failure_details,
+    });
+    SbiResponse::with_status(status)
+        .with_json_body(&body)
+        .unwrap_or_else(|_| SbiResponse::with_status(status))
 }
 
 /// POST /namf-comm/v1/ue-contexts/{ueContextId}/transfer —
@@ -3896,5 +4187,344 @@ mod tests {
             .expect("json");
         assert_eq!(namf_request_handler(req).await.status, 204);
         assert!(drain_network_deregs_for(ue.id).is_empty());
+    }
+    // ---- #117: EBIAssignment (TS 29.518 §6.1.6.2.5) --------------------------
+
+    /// Through the ROUTER, not by calling the handler directly: the routing arm
+    /// is half of criterion 1, and a test that called `handle_assign_ebi` would
+    /// pass with the arm absent (a 405, in production).
+    fn assign_ebi_request(supi: &str, body: Value) -> SbiResponse {
+        let req = SbiRequest::post(format!("/namf-comm/v1/ue-contexts/{supi}/assign-ebi"))
+            .with_body(body.to_string(), "application/json");
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime")
+            .block_on(namf_request_handler(req))
+    }
+
+    fn arp(priority: u8) -> Value {
+        json!({
+            "priorityLevel": priority,
+            "preemptCap": "NOT_PREEMPT",
+            "preemptVuln": "PREEMPTABLE",
+        })
+    }
+
+    /// #117 criterion 1: the operation is routed, allocates from a per-UE pool,
+    /// and answers an `AssignedEbiData` of the shape TS 29.518 declares.
+    ///
+    /// The shape assertions are against the yaml, not against what this
+    /// implementation happens to emit: `pduSessionId` and `assignedEbiList` are
+    /// the two `required` members, `assignedEbiList` items are `EbiArpMapping`
+    /// (`epsBearerId` + `arp`, both required), and the three optional lists are
+    /// `minItems: 1` — so each must be ABSENT rather than empty, which is the part
+    /// a "just serialise the struct" implementation gets wrong.
+    #[test]
+    fn assign_ebi_allocates_from_a_per_ue_pool_and_answers_assigned_ebi_data() {
+        let supi = "imsi-001010000000117";
+        setup_ue(supi, true, true);
+
+        let resp = assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "arpList": [arp(1), arp(8)],
+            }),
+        );
+        assert_eq!(resp.status, 200, "body: {:?}", resp.http.content);
+        let body = body_json(&resp);
+
+        assert_eq!(body["pduSessionId"], json!(5));
+        let assigned = body["assignedEbiList"]
+            .as_array()
+            .expect("assignedEbiList is a required member of AssignedEbiData");
+        assert_eq!(assigned.len(), 2, "one EBI per ARP entry");
+
+        // TS 24.301 §9.3.2: 0..=4 are reserved, so an assignment inside them would
+        // collide with the EPS reserved space.
+        for (i, entry) in assigned.iter().enumerate() {
+            let ebi = entry["epsBearerId"].as_u64().expect("epsBearerId required");
+            assert!(
+                (5..=15).contains(&ebi),
+                "EBI {ebi} is outside the assignable range 5..=15"
+            );
+            assert_eq!(
+                entry["arp"]["priorityLevel"],
+                json!(if i == 0 { 1 } else { 8 }),
+                "each mapping must carry back the ARP it was requested with"
+            );
+            assert_eq!(entry["arp"]["preemptCap"], json!("NOT_PREEMPT"));
+            assert_eq!(entry["arp"]["preemptVuln"], json!("PREEMPTABLE"));
+        }
+        let first = assigned[0]["epsBearerId"].as_u64().expect("ebi");
+        let second = assigned[1]["epsBearerId"].as_u64().expect("ebi");
+        assert_ne!(first, second, "two flows must not share one EBI");
+
+        // minItems: 1 on all three, so an empty array is not a legal value.
+        for optional in ["failedArpList", "releasedEbiList", "modifiedEbiList"] {
+            assert!(
+                body.get(optional).is_none(),
+                "{optional} is minItems:1, so it must be absent rather than empty"
+            );
+        }
+
+        // A SECOND request for the same UE must not hand out the same EBIs: the
+        // pool is per-UE and spans every one of its PDU sessions.
+        let resp = assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 6,
+                "arpList": [arp(2)],
+            }),
+        );
+        assert_eq!(resp.status, 200);
+        let third = body_json(&resp)["assignedEbiList"][0]["epsBearerId"]
+            .as_u64()
+            .expect("ebi");
+        assert!(
+            third != first && third != second,
+            "EBI {third} was already assigned to another session of this UE"
+        );
+    }
+
+    /// Release frees an EBI for reuse, and it happens BEFORE assignment inside one
+    /// request — a request that releases 5 and asks for one more must be able to
+    /// hand 5 straight back out.
+    #[test]
+    fn assign_ebi_releases_before_it_assigns_so_a_freed_ebi_is_reusable() {
+        let supi = "imsi-001010000000118";
+        setup_ue(supi, true, true);
+
+        let first = body_json(&assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "arpList": [arp(1)],
+            }),
+        ))["assignedEbiList"][0]["epsBearerId"]
+            .as_u64()
+            .expect("ebi");
+
+        let body = body_json(&assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "releasedEbiList": [first],
+                "arpList": [arp(3)],
+            }),
+        ));
+        assert_eq!(
+            body["releasedEbiList"],
+            json!([first]),
+            "the release must be reported back"
+        );
+        assert_eq!(
+            body["assignedEbiList"][0]["epsBearerId"],
+            json!(first),
+            "the EBI freed in this same request must be reassignable within it"
+        );
+    }
+
+    /// Pool exhaustion is a modelled outcome. Eleven EBIs is also the most EPS
+    /// bearers a UE can hold, so a twelfth is a request for something that cannot
+    /// exist — and the SMF has to be told WHICH flows went without one, which is
+    /// what `failedArpList` is for.
+    #[test]
+    fn assign_ebi_reports_exhaustion_rather_than_inventing_an_ebi() {
+        let supi = "imsi-001010000000119";
+        setup_ue(supi, true, true);
+
+        // Eleven assignable identities: 5..=15.
+        let eleven: Vec<Value> = (1..=11).map(|i| arp((i % 15) + 1)).collect();
+        let body = body_json(&assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "arpList": eleven,
+            }),
+        ));
+        assert_eq!(
+            body["assignedEbiList"].as_array().expect("list").len(),
+            11,
+            "all eleven assignable EBIs must be usable"
+        );
+        assert!(body.get("failedArpList").is_none());
+
+        // Partial: one more ARP with nothing left. Every ARP failed and none was
+        // assigned, so TS 29.518's 403 + AssignEbiError applies.
+        let resp = assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 6,
+                "arpList": [arp(4)],
+            }),
+        );
+        assert_eq!(resp.status, 403, "body: {:?}", resp.http.content);
+        let body = body_json(&resp);
+        assert_eq!(
+            body["error"]["cause"],
+            json!("INSUFFICIENT_RESOURCES"),
+            "AssignEbiError.error is required and carries the ProblemDetails"
+        );
+        assert_eq!(
+            body["failureDetails"]["pduSessionId"],
+            json!(6),
+            "AssignEbiError.failureDetails is required"
+        );
+        assert_eq!(
+            body["failureDetails"]["failedArpList"][0]["priorityLevel"],
+            json!(4),
+            "the SMF must learn WHICH flow got no EBI"
+        );
+
+        // Partial success: free two, ask for three. Two are assigned and one fails,
+        // which is a 200 carrying both lists -- not a 403.
+        let held: Vec<u64> = body_json(&assign_ebi_request(supi, json!({"pduSessionId": 5})))
+            .get("assignedEbiList")
+            .and_then(Value::as_array)
+            .map(|_| Vec::new())
+            .unwrap_or_default();
+        assert!(held.is_empty(), "a request with no arpList assigns nothing");
+
+        let resp = assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "releasedEbiList": [5, 6],
+                "arpList": [arp(1), arp(2), arp(3)],
+            }),
+        );
+        assert_eq!(resp.status, 200);
+        let body = body_json(&resp);
+        assert_eq!(body["assignedEbiList"].as_array().expect("list").len(), 2);
+        assert_eq!(
+            body["failedArpList"]
+                .as_array()
+                .expect("failedArpList")
+                .len(),
+            1,
+            "a partial failure is a 200 carrying both lists, not a 403"
+        );
+    }
+
+    /// The request-validation surface: the one required member, the ARP members,
+    /// and an unknown UE.
+    #[test]
+    fn assign_ebi_rejects_a_malformed_request_and_an_unknown_ue() {
+        let supi = "imsi-001010000000120";
+        setup_ue(supi, true, true);
+
+        // pduSessionId is the ONLY required member of AssignEbiData.
+        let resp = assign_ebi_request(supi, json!({ "arpList": [arp(1)] }));
+        assert_eq!(resp.status, 400);
+        assert_eq!(problem_cause(&resp), "MANDATORY_IE_MISSING");
+
+        // ...and a request with ONLY it is legal: it assigns nothing and answers
+        // an empty assignedEbiList, which minItems:0 permits.
+        let resp = assign_ebi_request(supi, json!({ "pduSessionId": 5 }));
+        assert_eq!(resp.status, 200);
+        assert_eq!(body_json(&resp)["assignedEbiList"], json!([]));
+
+        // Arp's three members are all required.
+        for missing in ["priorityLevel", "preemptCap", "preemptVuln"] {
+            let mut a = arp(1);
+            a.as_object_mut().expect("obj").remove(missing);
+            let resp = assign_ebi_request(supi, json!({"pduSessionId": 5, "arpList": [a]}));
+            assert_eq!(resp.status, 400, "missing Arp.{missing} must be refused");
+            assert_eq!(problem_cause(&resp), "MANDATORY_IE_MISSING");
+        }
+
+        // ArpPriorityLevel is 1..=15 and is a plain integer, so its value IS
+        // checked -- unlike the two pre-emption members, which are extensible
+        // enums and are checked for presence only.
+        let resp = assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "arpList": [json!({"priorityLevel": 0, "preemptCap": "x", "preemptVuln": "y"})],
+            }),
+        );
+        assert_eq!(resp.status, 400);
+        assert_eq!(problem_cause(&resp), "MANDATORY_IE_INCORRECT");
+
+        let resp = assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "arpList": [json!({
+                    "priorityLevel": 9,
+                    "preemptCap": "SOME_FUTURE_VALUE",
+                    "preemptVuln": "ANOTHER",
+                })],
+            }),
+        );
+        assert_eq!(
+            resp.status, 200,
+            "PreemptionCapability is anyOf[enum, string]; an unlisted value is \
+             permitted by the schema and must not be refused"
+        );
+
+        // A UE this AMF does not hold.
+        let resp = assign_ebi_request("imsi-999990000000000", json!({"pduSessionId": 5}));
+        assert_eq!(resp.status, 404);
+        assert_eq!(problem_cause(&resp), "CONTEXT_NOT_FOUND");
+    }
+
+    /// Modifying an EBI the AMF never assigned is a state disagreement, and 409 is
+    /// what the operation defines for it. Answering 200 while ignoring the entry
+    /// would leave the SMF believing an ARP change took effect.
+    #[test]
+    fn assign_ebi_modifies_a_held_ebi_and_409s_one_it_does_not_hold() {
+        let supi = "imsi-001010000000121";
+        setup_ue(supi, true, true);
+
+        let ebi = body_json(&assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "arpList": [arp(1)],
+            }),
+        ))["assignedEbiList"][0]["epsBearerId"]
+            .as_u64()
+            .expect("ebi");
+
+        let body = body_json(&assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "modifiedEbiList": [{"epsBearerId": ebi, "arp": arp(12)}],
+            }),
+        ));
+        assert_eq!(body["modifiedEbiList"], json!([ebi]));
+
+        // The new ARP is what is held now, not the old one. Read back through a
+        // fresh assignment's echo of the stored state.
+        let stored = amf_self()
+            .read()
+            .expect("ctx")
+            .amf_ue_find_by_supi(supi)
+            .expect("ue");
+        let held = stored
+            .assigned_ebis
+            .iter()
+            .find(|a| a.ebi as u64 == ebi)
+            .expect("the EBI is still held");
+        assert_eq!(
+            held.arp.priority_level, 12,
+            "the modify must replace the stored ARP, not just be reported"
+        );
+
+        let resp = assign_ebi_request(
+            supi,
+            json!({
+                "pduSessionId": 5,
+                "modifiedEbiList": [{"epsBearerId": 15, "arp": arp(3)}],
+            }),
+        );
+        assert_eq!(resp.status, 409, "body: {:?}", resp.http.content);
+        assert_eq!(
+            body_json(&resp)["error"]["cause"],
+            json!("EBI_NOT_ASSIGNED")
+        );
     }
 }

--- a/src/bins/nextgcore-smfd/src/context.rs
+++ b/src/bins/nextgcore-smfd/src/context.rs
@@ -861,6 +861,18 @@ pub struct SmfBearer {
 }
 
 impl SmfBearer {
+    /// The EBI assigned to this flow, or `None` when it has none (#117).
+    ///
+    /// `ebi` is a bare `u8` whose zero value is not a valid identity: TS 24.301
+    /// §9.3.2 defines 0 as "no EPS bearer identity assigned" and reserves 1..=4,
+    /// so an unset field and a real EBI are distinguishable without an `Option`.
+    /// This accessor exists so no caller has to remember that — emitting a Mapped
+    /// EPS bearer contexts IE with EBI 0 would tell the UE to build a bearer on
+    /// the reserved identity.
+    pub fn assigned_ebi(&self) -> Option<u8> {
+        (self.ebi >= 5 && self.ebi <= 15).then_some(self.ebi)
+    }
+
     pub fn new(id: u64, sess_id: u64) -> Self {
         Self {
             id,
@@ -1530,6 +1542,13 @@ pub struct PolicyBinding {
     /// release: a DNS context whose session is gone is exactly the orphan the
     /// delete exists to prevent.
     pub easdf_dns_context_id: Option<String>,
+    /// The EPS Bearer Identity the AMF assigned this session's default QoS flow
+    /// (#117), or `None` when EPS interworking is off or the assignment failed.
+    ///
+    /// Held on the binding rather than only on the `SmfSess` because the binding is
+    /// what the release, update and retrieve paths already key off; a value only on
+    /// the session would be invisible to them.
+    pub mapped_eps_bearer_id: Option<u8>,
     /// EAS address(es) the EASDF last reported for this session (#114).
     ///
     /// Recorded, not yet acted on: inserting a UL-CL toward the reported EAS is
@@ -1546,7 +1565,7 @@ impl PolicyBinding {
     /// Not a `Default` impl: an empty `supi` with `psi` 0 names no session, and a
     /// binding is only ever created from a real SM context request. Only serde
     /// reaches this, and only for a member the snapshot does not carry.
-    fn snapshot_default() -> Self {
+    pub(crate) fn snapshot_default() -> Self {
         Self {
             sm_policy_id: None,
             supi: String::new(),
@@ -1563,6 +1582,7 @@ impl PolicyBinding {
             sm_context_status_uri: None,
             fsm: crate::gsm_sm::GsmFsm::new(0),
             easdf_dns_context_id: None,
+            mapped_eps_bearer_id: None,
             easdf_reported_eas: Vec::new(),
         }
     }

--- a/src/bins/nextgcore-smfd/src/eps_iwk.rs
+++ b/src/bins/nextgcore-smfd/src/eps_iwk.rs
@@ -1,0 +1,477 @@
+//! 5GS↔EPS interworking: EBI assignment over Namf_Communication (issue #117).
+//!
+//! TS 23.502 §4.11.1.4.1: a PDU session that may be moved to the EPC needs an EPS
+//! Bearer Identity per QoS flow, and the **AMF** owns that identity space. The SMF
+//! asks for one with `Namf_Communication_EBIAssignment`
+//! (`POST /namf-comm/v1/ue-contexts/{ueContextId}/assign-ebi`, TS 29.518
+//! §6.1.6.2.5), supplying the flow's ARP, and stores what comes back so the
+//! Mapped EPS bearer contexts IE can name it to the UE.
+//!
+//! # Why this module exists
+//!
+//! Nothing in the workspace performed this operation: `grep` for `assign-ebi`
+//! across `src/` returned nothing on either side, so `SmfBearer.ebi` was written
+//! **only** by the EPC GTPv2 path (`gtp_handler.rs`) — i.e. only for a session
+//! that had already been established from the EPC side. In the 5GC-first
+//! interworking flow the two sides had no way to agree on bearer identities, so no
+//! PDU session could be transferred to EPS.
+//!
+//! # A runtime switch, not a cargo feature
+//!
+//! #117 suggests `eps-interworking` as a cargo feature. This uses a runtime
+//! switch (`SMF_EPS_INTERWORKING=1`, default **off** — this daemon has no clap
+//! `Args` struct, so every switch is an env var) for the
+//! reason recorded in this project and applied the same way by the EASDF leg
+//! (#114): CI builds default features, so a cargo-feature-gated path is left
+//! **uncompiled** and rots. A runtime switch is compiled always and exercised in
+//! *both* states by one `cargo test` run — which is what makes #117's criterion 5
+//! ("with interworking disabled, behaviour is unchanged") a thing a test can
+//! assert rather than a claim about a build that CI never performs.
+//!
+//! Contrast #276, which *is* a cargo feature: that one binds a privileged port and
+//! changes the process's network posture. This one changes which IEs an N1 message
+//! carries. The distinction is the network posture, not the fact of being optional.
+//!
+//! # Failure posture
+//!
+//! Every failure here is **non-fatal to the session**. A session that could not
+//! get an EBI is a working 5G session that cannot be moved to EPS; refusing it
+//! would turn an interworking hiccup into a total service outage for the DNN.
+//! Failures are logged with that consequence named.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Is the interworking leg enabled for this process?
+static EPS_IWK_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable the leg (called once at startup).
+pub fn enable() {
+    EPS_IWK_ENABLED.store(true, Ordering::SeqCst);
+    log::info!(
+        "[SMF] 5GS↔EPS interworking ENABLED: PDU sessions will request an EBI from \
+         the AMF and carry Mapped EPS bearer contexts (TS 23.502 §4.11.1.4.1)"
+    );
+}
+
+/// Whether the leg is enabled.
+pub fn enabled() -> bool {
+    EPS_IWK_ENABLED.load(Ordering::SeqCst)
+}
+
+/// Serialises every test that touches the process-global switch.
+///
+/// Public within the crate because `main.rs`'s tests toggle the same variable; a
+/// lock private to this module would be a second disjoint agreement about one
+/// variable, which is the collision shape this repo keeps recording (and which
+/// #276 hit as a hang rather than a flake).
+#[cfg(test)]
+pub static SWITCH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Test-only: set the switch without going through startup.
+#[cfg(test)]
+pub fn set_for_test(on: bool) {
+    EPS_IWK_ENABLED.store(on, Ordering::SeqCst);
+}
+
+/// The ARP this SMF supplies for a session's default QoS flow.
+///
+/// `preemptCap` / `preemptVuln` are the conservative pair: a default flow that
+/// cannot pre-empt others and can itself be pre-empted. Chosen rather than derived
+/// because the policy decision this tree makes carries only an ARP **priority
+/// level** (`decision.arp_priority_level`) and no pre-emption members, and the two
+/// are `required` in TS 29.571's `Arp` — so they have to come from somewhere, and a
+/// stated conservative default is better than a value invented per call.
+pub fn default_flow_arp(priority_level: u8) -> serde_json::Value {
+    serde_json::json!({
+        // ArpPriorityLevel is 1..=15; clamp rather than send an out-of-range value
+        // the AMF would (correctly) refuse with a 400.
+        "priorityLevel": priority_level.clamp(1, 15),
+        "preemptCap": "NOT_PREEMPT",
+        "preemptVuln": "PREEMPTABLE",
+    })
+}
+
+/// Request one EBI for a session's default QoS flow.
+///
+/// Returns the assigned EBI, or `None` when the leg is off, the AMF is unknown or
+/// unreachable, it refused, or it had none left. `None` always means "this session
+/// proceeds without EPS interworking", never "fail the session".
+///
+/// `amf_uri` is the AMF's callback root, which is the only address the SMF has for
+/// it — the same source `send_n1_n2_message_transfer` uses. A create request that
+/// carried no `smContextStatusUri` therefore cannot get an EBI, and says so.
+pub async fn request_ebi(
+    amf_uri: Option<&str>,
+    supi: &str,
+    pdu_session_id: u8,
+    arp_priority_level: u8,
+) -> Option<u8> {
+    if !enabled() {
+        return None;
+    }
+    let Some(amf_uri) = amf_uri else {
+        log::warn!(
+            "[{supi}] EPS interworking is on but the AMF supplied no callback URI: \
+             no EBI can be requested for PSI {pdu_session_id}, so this session \
+             cannot be moved to EPS"
+        );
+        return None;
+    };
+    let Some((host, port)) = crate::policy::split_host_port(amf_uri) else {
+        log::warn!("[{supi}] AMF URI '{amf_uri}' is not a valid URI: no EBI requested");
+        return None;
+    };
+
+    let body = serde_json::json!({
+        "pduSessionId": pdu_session_id,
+        // One ARP entry, so one EBI: this SMF authorises a single default QoS flow
+        // per session on the live path, and asking for more than it has flows for
+        // would burn identities out of an eleven-wide per-UE space.
+        "arpList": [default_flow_arp(arp_priority_level)],
+    });
+
+    let path = format!("/namf-comm/v1/ue-contexts/{supi}/assign-ebi");
+    let request = nextgcore_sbi::message::SbiRequest::post(&path).with_body(
+        body.to_string(),
+        nextgcore_sbi::constants::content_type::APPLICATION_JSON,
+    );
+    let client = nextgcore_sbi::client::SbiClient::new(
+        nextgcore_sbi::security::sbi_peer_client_config(&host, port)
+            .with_connect_timeout(std::time::Duration::from_secs(2))
+            .with_request_timeout(std::time::Duration::from_secs(3)),
+    );
+
+    let response = match client.send_request(request).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            log::warn!(
+                "[{supi}] EBI assignment to {host}:{port} failed: {e}. The session \
+                 proceeds without EPS interworking."
+            );
+            return None;
+        }
+    };
+    if response.status != 200 {
+        log::warn!(
+            "[{supi}] AMF refused EBI assignment for PSI {pdu_session_id}: status={}. \
+             The session proceeds without EPS interworking.",
+            response.status
+        );
+        return None;
+    }
+
+    parse_assigned_ebi(response.http.content.as_deref().unwrap_or_default()).or_else(|| {
+        log::warn!(
+            "[{supi}] AMF answered 200 to EBI assignment for PSI {pdu_session_id} but \
+             `assignedEbiList` named no usable EPS bearer identity"
+        );
+        None
+    })
+}
+
+/// Pull the first usable EBI out of an `AssignedEbiData` body.
+///
+/// Separated from the request so the parse is testable against the shapes a
+/// conformant AMF may send, including the empty `assignedEbiList` that
+/// `minItems: 0` permits and that means "none was assigned".
+///
+/// An EBI outside 5..=15 is REFUSED rather than stored: TS 24.301 §9.3.2 reserves
+/// 0..=4, and putting a reserved identity into a Mapped EPS bearer contexts IE
+/// would tell the UE to build a bearer on it.
+pub fn parse_assigned_ebi(body: &str) -> Option<u8> {
+    let parsed: serde_json::Value = serde_json::from_str(body).ok()?;
+    parsed
+        .get("assignedEbiList")?
+        .as_array()?
+        .iter()
+        .filter_map(|entry| entry.get("epsBearerId").and_then(serde_json::Value::as_u64))
+        .find_map(|ebi| {
+            let ebi = u8::try_from(ebi).ok()?;
+            if (5..=15).contains(&ebi) {
+                Some(ebi)
+            } else {
+                log::warn!(
+                    "AMF assigned EPS bearer identity {ebi}, which TS 24.301 §9.3.2 \
+                     reserves; ignoring it"
+                );
+                None
+            }
+        })
+}
+
+/// Record an assigned EBI on a QoS flow for `sess_id` (#117).
+///
+/// `SmfBearer.ebi` is where `gsm_build::encode_mapped_eps_bearer_context` reads the
+/// identity from, and until #117 the ONLY writer of that field was the EPC GTPv2
+/// path (`gtp_handler.rs`) — so an EBI could exist for a session established from
+/// the EPC side and never for a 5GC-first one. This is the Namf writer the issue
+/// asks for.
+///
+/// A QoS flow is created **only** when an EBI was assigned. `qos_flow_add` has no
+/// other production caller (the live 5G path carries its QoS on the session and the
+/// policy binding), so creating one unconditionally would populate a store nothing
+/// reads and change what `max_num_of_bearer` means for every session in the process.
+///
+/// A separate function rather than an inline block because the SM-context create
+/// path cannot be driven past its N4 leg by any test in this crate (no UPF
+/// stand-in — issue #289), so an inline block would be unreachable from a test.
+/// This seam is the reachable half; the call site itself is covered by inspection,
+/// and that limitation is stated rather than implied.
+pub fn record_mapped_eps_bearer(
+    sess_id: u64,
+    ebi: u8,
+    qfi: u8,
+    five_qi: u8,
+    arp_priority_level: u8,
+    supi: &str,
+) -> Option<u64> {
+    let ctx = crate::context::smf_self();
+    let context = ctx.read().ok()?;
+    match context.qos_flow_add(sess_id) {
+        Some(mut flow) => {
+            flow.ebi = ebi;
+            flow.qfi = qfi;
+            flow.qos.index = five_qi;
+            flow.qos.arp_priority_level = arp_priority_level;
+            let id = flow.id;
+            context.bearer_update(&flow);
+            log::info!(
+                "[{supi}] EPS bearer {ebi} mapped onto QoS flow QFI {qfi} (5QI {five_qi}) for session {sess_id}"
+            );
+            Some(id)
+        }
+        None => {
+            log::warn!(
+                "[{supi}] EBI {ebi} was assigned but no QoS flow could be stored (bearer table full): the session cannot be moved to EPS"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_leg_is_off_by_default() {
+        // Not under the lock on purpose: this asserts the STATIC initialiser, and
+        // taking the lock would not protect it from a sibling that has already
+        // enabled the switch. Read as documentation of the default; the
+        // behavioural guard is `request_ebi` returning None when disabled, below.
+        assert!(!EPS_IWK_ENABLED.load(Ordering::SeqCst) || enabled());
+    }
+
+    #[tokio::test]
+    async fn a_disabled_leg_dials_nothing() {
+        let _g = SWITCH_LOCK.lock().await;
+        set_for_test(false);
+        // A URI that would fail loudly if it were dialled at all.
+        assert_eq!(
+            request_ebi(Some("http://127.0.0.1:1"), "imsi-1", 5, 8).await,
+            None
+        );
+    }
+
+    /// The parse accepts what a conformant AMF sends and refuses a reserved EBI.
+    ///
+    /// The reserved case is the one worth having: an AMF answering `epsBearerId: 0`
+    /// is answering "none assigned" in the shape of an assignment, and storing it
+    /// would put EBI 0 into a Mapped EPS bearer contexts IE.
+    #[test]
+    fn parse_assigned_ebi_takes_the_first_usable_identity() {
+        assert_eq!(
+            parse_assigned_ebi(
+                r#"{"pduSessionId":5,"assignedEbiList":[{"epsBearerId":7,"arp":{"priorityLevel":8}}]}"#
+            ),
+            Some(7)
+        );
+        // minItems: 0 -- an empty list is legal and means none was assigned.
+        assert_eq!(
+            parse_assigned_ebi(r#"{"pduSessionId":5,"assignedEbiList":[]}"#),
+            None
+        );
+        // Reserved identities are skipped, and a usable later entry still wins.
+        assert_eq!(
+            parse_assigned_ebi(
+                r#"{"assignedEbiList":[{"epsBearerId":0},{"epsBearerId":4},{"epsBearerId":5}]}"#
+            ),
+            Some(5)
+        );
+        assert_eq!(
+            parse_assigned_ebi(r#"{"assignedEbiList":[{"epsBearerId":16}]}"#),
+            None,
+            "16 is outside the EpsBearerId range and must not be stored"
+        );
+        assert_eq!(parse_assigned_ebi("not json"), None);
+        assert_eq!(parse_assigned_ebi(r#"{"pduSessionId":5}"#), None);
+    }
+
+    /// The ARP this SMF sends carries all three members `Arp` declares required,
+    /// and clamps the priority level into the range the schema allows.
+    #[test]
+    fn the_default_flow_arp_is_schema_complete_and_clamped() {
+        let arp = default_flow_arp(8);
+        for required in ["priorityLevel", "preemptCap", "preemptVuln"] {
+            assert!(
+                arp.get(required).is_some(),
+                "Arp.{required} is required by TS 29.571"
+            );
+        }
+        assert_eq!(arp["priorityLevel"], serde_json::json!(8));
+        assert_eq!(
+            default_flow_arp(0)["priorityLevel"],
+            serde_json::json!(1),
+            "0 is outside ArpPriorityLevel 1..=15 and must be clamped, not sent"
+        );
+        assert_eq!(
+            default_flow_arp(200)["priorityLevel"],
+            serde_json::json!(15)
+        );
+    }
+    /// #117 criterion 2, the wire half: the SMF actually performs
+    /// `Namf_Communication_EBIAssignment`, against a loopback AMF that records the
+    /// request.
+    ///
+    /// The recorded `(path, body)` is the assertion, not just the returned EBI: a
+    /// test that checked only the return value would pass against a function that
+    /// invented one without dialling anything, which is precisely the defect class
+    /// this issue is about (`assign-ebi` had no caller ANYWHERE before this).
+    #[tokio::test]
+    async fn the_smf_requests_an_ebi_over_namf_and_stores_what_it_gets() {
+        use nextgcore_sbi::message::{SbiRequest, SbiResponse};
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+        use std::net::SocketAddr;
+
+        // Drives production peer-call code against a loopback PLAINTEXT peer, i.e.
+        // a dev-profile deployment. Declared rather than inherited: the default
+        // `SbiProfile` is Production, which refuses a plaintext connection and
+        // would make this test fail for a reason unrelated to what it asserts.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+
+        let _g = SWITCH_LOCK.lock().await;
+        set_for_test(true);
+
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let port = nextgcore_sbi::test_support::free_port();
+        let amf = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+            [127, 0, 0, 1],
+            port,
+        ))));
+        amf.start(move |req: SbiRequest| {
+            let sink = sink.clone();
+            async move {
+                sink.lock().unwrap_or_else(|e| e.into_inner()).push((
+                    req.header.uri.clone(),
+                    req.http.content.clone().unwrap_or_default(),
+                ));
+                SbiResponse::with_status(200)
+                    .with_json_body(&serde_json::json!({
+                        "pduSessionId": 5,
+                        "assignedEbiList": [{
+                            "epsBearerId": 6,
+                            "arp": {
+                                "priorityLevel": 8,
+                                "preemptCap": "NOT_PREEMPT",
+                                "preemptVuln": "PREEMPTABLE",
+                            },
+                        }],
+                    }))
+                    .unwrap_or_else(|_| SbiResponse::with_status(200))
+            }
+        })
+        .await
+        .expect("amf start");
+
+        let ebi = request_ebi(
+            Some(&format!("http://127.0.0.1:{port}")),
+            "imsi-001010000000117",
+            5,
+            8,
+        )
+        .await;
+        assert_eq!(ebi, Some(6), "the AMF-assigned EBI must be returned");
+
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(requests.len(), 1, "exactly one request, got {requests:?}");
+        assert_eq!(
+            requests[0].0, "/namf-comm/v1/ue-contexts/imsi-001010000000117/assign-ebi",
+            "TS 29.518 §6.1.6.2.5's resource, addressed to the UE's own ue-context"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(&requests[0].1).expect("the request body is JSON");
+        assert_eq!(
+            body["pduSessionId"],
+            serde_json::json!(5),
+            "pduSessionId is AssignEbiData's only required member"
+        );
+        let arp = &body["arpList"][0];
+        assert_eq!(arp["priorityLevel"], serde_json::json!(8));
+        assert!(
+            arp.get("preemptCap").is_some() && arp.get("preemptVuln").is_some(),
+            "all three Arp members are required by TS 29.571, got {arp}"
+        );
+
+        // With the leg OFF the same call dials nothing -- criterion 5's half of this.
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        set_for_test(false);
+        assert_eq!(
+            request_ebi(Some(&format!("http://127.0.0.1:{port}")), "imsi-1", 5, 8).await,
+            None
+        );
+        assert!(
+            seen.lock().unwrap_or_else(|e| e.into_inner()).is_empty(),
+            "a disabled leg must not dial the AMF at all"
+        );
+
+        amf.stop().await.expect("stop");
+    }
+
+    /// #117 criterion 2, the storage half: the assigned EBI reaches
+    /// `SmfBearer.ebi` **without** traversing the GTPv2 path.
+    ///
+    /// The negative assertion matters as much as the positive one. Before this, the
+    /// only writer of `ebi` was `gtp_handler.rs`, so "the field is populated" could
+    /// be satisfied by an EPC-side establishment. This session is created directly
+    /// in the context and no GTPv2 message is involved anywhere.
+    #[test]
+    fn the_assigned_ebi_reaches_smf_bearer_without_the_gtpv2_path() {
+        use crate::context::{smf_context_init, smf_self};
+
+        smf_context_init(64, 256, 512);
+        let ctx = smf_self();
+        let sess_id = {
+            let guard = ctx.read().expect("context");
+            let ue = guard.ue_add_by_supi("imsi-001010000000122").expect("ue");
+            guard.sess_add_by_psi(ue.id, 5).expect("sess").id
+        };
+
+        let flow_id = record_mapped_eps_bearer(sess_id, 6, 1, 9, 8, "imsi-001010000000122")
+            .expect("a QoS flow must be created for the assigned EBI");
+
+        let guard = ctx.read().expect("context");
+        let flow = guard
+            .bearer_find_by_id(flow_id)
+            .expect("the flow is stored");
+        assert_eq!(
+            flow.ebi, 6,
+            "SmfBearer.ebi must carry the Namf-assigned EBI"
+        );
+        assert_eq!(flow.qfi, 1, "and the QFI it maps");
+        assert_eq!(flow.qos.index, 9, "and the 5QI, which becomes the EPS QCI");
+        assert_eq!(
+            flow.assigned_ebi(),
+            Some(6),
+            "assigned_ebi() must recognise it as a real identity"
+        );
+
+        // The encoder the accept path uses reads it back.
+        let contents = crate::gsm_build::encode_mapped_eps_bearer_context(
+            flow.assigned_ebi().expect("ebi"),
+            flow.qos.index,
+        );
+        assert_eq!(contents[0] >> 4, 6, "the EBI reaches the wire encoding");
+    }
+}

--- a/src/bins/nextgcore-smfd/src/gsm_build.rs
+++ b/src/bins/nextgcore-smfd/src/gsm_build.rs
@@ -730,6 +730,102 @@ fn encode_bitrate(bitrate: u64) -> Vec<u8> {
 // GSM Message Building Functions
 // ============================================================================
 
+// ---------------------------------------------------------------------------
+// Mapped EPS bearer contexts, IEI 0x75 (TS 24.501 §9.11.4.8), issue #117
+// ---------------------------------------------------------------------------
+
+/// IEI of the Mapped EPS bearer contexts IE (TS 24.501 §9.11.4.8).
+pub const IEI_MAPPED_EPS_BEARER_CONTEXTS: u8 = 0x75;
+
+/// Operation code "Create new EPS bearer" (bits 8..7 of octet 7 = `01`).
+const MAPPED_EPS_OP_CREATE: u8 = 0b01 << 6;
+
+/// E bit (bit 5 of octet 7): the parameters list is included.
+const MAPPED_EPS_E_PARAMS_INCLUDED: u8 = 1 << 4;
+
+/// EPS parameter identifier 01H — Mapped EPS QoS parameters, whose contents are
+/// coded per TS 24.301 §9.9.4.3 (QCI first, bit rates optional).
+const EPS_PARAM_MAPPED_EPS_QOS: u8 = 0x01;
+
+/// Map a 5QI onto the EPS QCI that means the same thing, or `None`.
+///
+/// TS 23.501 Table 5.7.4-1 gives the standardised 5QI values 1..=9 the same
+/// numeric QCI, which is what makes 5GS↔EPS QoS mapping possible at all for them.
+/// For any other 5QI — non-standardised, or one of the higher standardised values
+/// with no EPS equivalent — there is **no defined QCI**, and this returns `None`
+/// so the caller omits the QoS parameter rather than inventing one. An EPS bearer
+/// context with an empty parameters list is legal (the IE's 7-octet minimum is
+/// exactly that case); a bearer carrying a QCI the operator never configured is
+/// not, and an MME would enforce it.
+pub fn qci_for_5qi(five_qi: u8) -> Option<u8> {
+    (1..=9).contains(&five_qi).then_some(five_qi)
+}
+
+/// Encode the Mapped EPS bearer contexts IE **contents** for one EPS bearer.
+///
+/// Layout, per figures 9.11.4.8.1–9.11.4.8.3:
+///
+/// ```text
+/// octet 4      EPS bearer identity in bits 8..5, bits 4..1 spare (zero)
+/// octets 5..6  length of the mapped EPS bearer context (octet 7 onward)
+/// octet 7      operation code (8..7) | spare (6) | E bit (5) | #params (4..1)
+/// octets 8..u  EPS parameters list: id, length, contents — repeated
+/// ```
+///
+/// Returns the contents only; the caller writes the IEI and the two-octet outer
+/// length (`write_tlv_e` does both).
+///
+/// `five_qi` is mapped through [`qci_for_5qi`]; when it has no EPS equivalent the
+/// parameters list is empty and the E bit is clear, which the spec permits and
+/// which is honest about what this SMF knows.
+pub fn encode_mapped_eps_bearer_context(ebi: u8, five_qi: u8) -> Vec<u8> {
+    let mut params: Vec<u8> = Vec::new();
+    let mut param_count = 0u8;
+    if let Some(qci) = qci_for_5qi(five_qi) {
+        // TS 24.301 §9.9.4.3: the 3-octet form of the EPS QoS IE is IEI, length
+        // and QCI, so as an EPS *parameter* the contents are the QCI alone. The
+        // optional bit-rate octets are omitted deliberately: octet 4 cannot be
+        // included without octets 5..7, and this SMF has no per-bearer MBR/GBR to
+        // put in them (the session AMBR travels in its own IE).
+        params.push(EPS_PARAM_MAPPED_EPS_QOS);
+        params.push(1);
+        params.push(qci);
+        param_count = 1;
+    }
+
+    let mut octet7 = MAPPED_EPS_OP_CREATE | (param_count & 0x0f);
+    if param_count > 0 {
+        octet7 |= MAPPED_EPS_E_PARAMS_INCLUDED;
+    }
+
+    // The context length covers octet 7 onward, which is why the whole IE has a
+    // 7-octet minimum: IEI + 2 outer length + EBI + 2 context length + octet 7.
+    let context_len = (1 + params.len()) as u16;
+
+    let mut out = Vec::with_capacity(3 + 1 + params.len());
+    out.push((ebi & 0x0f) << 4);
+    out.extend_from_slice(&context_len.to_be_bytes());
+    out.push(octet7);
+    out.extend_from_slice(&params);
+    out
+}
+
+/// Emit the Mapped EPS bearer contexts IE onto `builder` when `ebi` is set.
+///
+/// A single helper so the three N1 builders here and the live accept builder in
+/// `policy.rs` cannot disagree about the encoding — the shape of bug where two
+/// copies of one IE drift and only the unused copy is tested.
+pub fn write_mapped_eps_bearer_contexts(
+    builder: &mut GsmMessageBuilder,
+    ebi: Option<u8>,
+    five_qi: u8,
+) {
+    if let Some(ebi) = ebi {
+        let contents = encode_mapped_eps_bearer_context(ebi, five_qi);
+        builder.write_tlv_e(IEI_MAPPED_EPS_BEARER_CONTEXTS, &contents);
+    }
+}
+
 /// Build PDU Session Establishment Accept message
 pub fn build_pdu_session_establishment_accept(
     sess: &SmfSess,
@@ -780,6 +876,12 @@ pub fn build_pdu_session_establishment_accept(
     let default_desc = encode_default_qos_flow_description(qos_flow);
     let qos_desc_bytes = encode_qos_flow_descriptions(&[default_desc]);
     builder.write_tlv_e(0x79, &qos_desc_bytes);
+
+    // Mapped EPS bearer contexts (optional, IEI = 0x75), #117. Emitted only when
+    // the AMF assigned this flow an EBI: without one there is no EPS bearer to
+    // describe, and an IE naming EBI 0 would tell the UE to build a bearer on the
+    // identity TS 24.301 §9.3.2 reserves for "none".
+    write_mapped_eps_bearer_contexts(&mut builder, qos_flow.assigned_ebi(), qos_flow.qos.index);
 
     // DNN (optional, IEI = 0x25). Labelled-name form, same encoder the live
     // accept path uses — a single label with dots inline is malformed for any
@@ -836,6 +938,23 @@ pub fn build_pdu_session_modification_command(
             .collect();
         let qos_desc_bytes = encode_qos_flow_descriptions(&descs);
         builder.write_tlv_e(0x79, &qos_desc_bytes);
+    }
+
+    // Mapped EPS bearer contexts (optional, IEI = 0x75), #117. TS 24.501
+    // §8.3.2.7 lets the Modification Command carry it, so a flow that GAINED an
+    // EBI mid-session is conveyed here rather than only at establishment. One
+    // context per flow holding an EBI; flows without one contribute nothing, and
+    // when no flow has one the IE is omitted entirely rather than emitted empty.
+    let mapped: Vec<u8> = qos_flows
+        .iter()
+        .filter_map(|f| {
+            f.assigned_ebi()
+                .map(|ebi| encode_mapped_eps_bearer_context(ebi, f.qos.index))
+        })
+        .flatten()
+        .collect();
+    if !mapped.is_empty() {
+        builder.write_tlv_e(IEI_MAPPED_EPS_BEARER_CONTEXTS, &mapped);
     }
 
     Some(builder.build())
@@ -981,6 +1100,12 @@ pub fn build_pdu_session_establishment_accept_extended(
     let default_desc = encode_default_qos_flow_description(qos_flow);
     let qos_desc_bytes = encode_qos_flow_descriptions(&[default_desc]);
     builder.write_tlv_e(0x79, &qos_desc_bytes);
+
+    // Mapped EPS bearer contexts (optional, IEI = 0x75), #117. Emitted only when
+    // the AMF assigned this flow an EBI: without one there is no EPS bearer to
+    // describe, and an IE naming EBI 0 would tell the UE to build a bearer on the
+    // identity TS 24.301 §9.3.2 reserves for "none".
+    write_mapped_eps_bearer_contexts(&mut builder, qos_flow.assigned_ebi(), qos_flow.qos.index);
 
     // Extended protocol configuration options (optional, IEI = 0x7B)
     // Build ePCO with DNS servers and MTU
@@ -1595,5 +1720,246 @@ mod tests {
     fn test_gsm_message_builder_default() {
         let builder = GsmMessageBuilder::default();
         assert!(builder.is_empty());
+    }
+    // ---- #117: Mapped EPS bearer contexts, IEI 0x75 --------------------------
+
+    /// Find and fully decode the Mapped EPS bearer contexts IE in a built N1
+    /// message, returning `(offset, contexts)` where each context is
+    /// `(ebi, octet7, params)`.
+    ///
+    /// A scan-and-VALIDATE rather than a walk: the Establishment Accept begins with
+    /// mandatory V/LV fields that are not TLVs, so a length-driven walk from the
+    /// 5GSM header does not work without a full message parser. And a scan alone
+    /// would be a false guard — 0x75 is an ordinary byte that can appear inside
+    /// another IE's contents. So every candidate offset is parsed as
+    /// TS 24.501 §9.11.4.8 and accepted only if the whole structure is
+    /// self-consistent: the outer length fits the buffer, each context's own length
+    /// fits the outer contents, and the parameters consume their context exactly.
+    #[allow(clippy::type_complexity)]
+    fn decode_mapped_eps_at(msg: &[u8]) -> Option<(usize, Vec<(u8, u8, Vec<(u8, Vec<u8>)>)>)> {
+        for at in 0..msg.len() {
+            if msg[at] != IEI_MAPPED_EPS_BEARER_CONTEXTS || at + 3 > msg.len() {
+                continue;
+            }
+            let len = u16::from_be_bytes([msg[at + 1], msg[at + 2]]) as usize;
+            if len < 4 || at + 3 + len > msg.len() {
+                continue;
+            }
+            let body = &msg[at + 3..at + 3 + len];
+            let mut contexts = Vec::new();
+            let mut b = 0usize;
+            let mut consistent = true;
+            while b < body.len() {
+                if b + 4 > body.len() || body[b] & 0x0f != 0 {
+                    // Bits 4..1 of octet 4 are spare and shall be zero.
+                    consistent = false;
+                    break;
+                }
+                let ebi = body[b] >> 4;
+                let ctx_len = u16::from_be_bytes([body[b + 1], body[b + 2]]) as usize;
+                if ctx_len == 0 || b + 3 + ctx_len > body.len() {
+                    consistent = false;
+                    break;
+                }
+                let octet7 = body[b + 3];
+                let params_bytes = &body[b + 4..b + 3 + ctx_len];
+                let mut params = Vec::new();
+                let mut p = 0usize;
+                while p < params_bytes.len() {
+                    if p + 2 > params_bytes.len() {
+                        consistent = false;
+                        break;
+                    }
+                    let id = params_bytes[p];
+                    let plen = params_bytes[p + 1] as usize;
+                    if p + 2 + plen > params_bytes.len() {
+                        consistent = false;
+                        break;
+                    }
+                    params.push((id, params_bytes[p + 2..p + 2 + plen].to_vec()));
+                    p += 2 + plen;
+                }
+                if !consistent {
+                    break;
+                }
+                if (octet7 & 0x0f) as usize != params.len() {
+                    // The number-of-parameters field must match what is there.
+                    consistent = false;
+                    break;
+                }
+                contexts.push((ebi, octet7, params));
+                b += 3 + ctx_len;
+            }
+            if consistent && b == body.len() && !contexts.is_empty() {
+                return Some((at, contexts));
+            }
+        }
+        None
+    }
+
+    /// The first (and, for the accept builders, only) mapped EPS bearer context.
+    fn decode_mapped_eps(msg: &[u8]) -> Option<(u8, u8, Vec<(u8, Vec<u8>)>)> {
+        decode_mapped_eps_at(msg).map(|(_, mut c)| c.remove(0))
+    }
+
+    fn bearer_with_ebi(ebi: u8, five_qi: u8) -> SmfBearer {
+        let mut b = create_test_bearer();
+        b.ebi = ebi;
+        b.qos.index = five_qi;
+        b
+    }
+
+    /// #117 criterion 3: the IE is emitted and decodes to the expected EBI and
+    /// parameters, and it is ABSENT when no EBI was assigned.
+    ///
+    /// The absent half is criterion 5: a deployment with interworking off must
+    /// produce the same N1 bytes it did before, and an IE emitted with EBI 0 would
+    /// tell the UE to build a bearer on the identity TS 24.301 §9.3.2 reserves for
+    /// "none assigned".
+    #[test]
+    fn establishment_accept_carries_mapped_eps_bearer_contexts_only_when_an_ebi_exists() {
+        let sess = create_test_sess();
+
+        let msg = build_pdu_session_establishment_accept(&sess, &bearer_with_ebi(7, 9))
+            .expect("accept builds");
+        let (ebi, octet7, params) =
+            decode_mapped_eps(&msg).expect("IEI 0x75 must be present when an EBI is held");
+        assert_eq!(ebi, 7, "the EBI occupies bits 8..5 of octet 4");
+        assert_eq!(
+            octet7 >> 6,
+            0b01,
+            "operation code must be 'Create new EPS bearer'"
+        );
+        assert_eq!(
+            octet7 & 0x20,
+            0,
+            "bit 6 of octet 7 is spare and must be zero"
+        );
+        assert_eq!(
+            octet7 & 0x10,
+            0x10,
+            "the E bit must say the parameters list is included"
+        );
+        assert_eq!(octet7 & 0x0f, 1, "one EPS parameter");
+        assert_eq!(
+            params,
+            vec![(0x01u8, vec![9u8])],
+            "01H is Mapped EPS QoS parameters; its contents are the QCI (TS 24.301 §9.9.4.3)"
+        );
+
+        // No EBI: the IE must not appear at all.
+        let msg = build_pdu_session_establishment_accept(&sess, &bearer_with_ebi(0, 9))
+            .expect("accept builds");
+        assert!(
+            decode_mapped_eps(&msg).is_none(),
+            "EBI 0 means 'none assigned' and must not produce an IE"
+        );
+        // ...nor for a RESERVED identity.
+        let msg = build_pdu_session_establishment_accept(&sess, &bearer_with_ebi(4, 9))
+            .expect("accept builds");
+        assert!(
+            decode_mapped_eps(&msg).is_none(),
+            "EBIs 1..=4 are reserved by TS 24.301 §9.3.2"
+        );
+    }
+
+    /// The extended accept builder emits it too — the two accept builders are
+    /// separate functions and a fix applied to one is invisible in the other.
+    #[test]
+    fn the_extended_establishment_accept_also_carries_the_ie() {
+        let sess = create_test_sess();
+        let msg = build_pdu_session_establishment_accept_extended(
+            &sess,
+            &bearer_with_ebi(9, 5),
+            &[std::net::Ipv4Addr::new(8, 8, 8, 8)],
+            Some(1400),
+        )
+        .expect("extended accept builds");
+        let (ebi, _, params) = decode_mapped_eps(&msg).expect("IEI 0x75 present");
+        assert_eq!(ebi, 9);
+        assert_eq!(params, vec![(0x01u8, vec![5u8])]);
+    }
+
+    /// TS 24.501 §8.3.2.7: the Modification Command may carry the IE, so a flow
+    /// that gains an EBI mid-session is conveyed without a new establishment. One
+    /// context per flow holding an EBI, and none for flows without one.
+    #[test]
+    fn the_modification_command_carries_one_context_per_flow_holding_an_ebi() {
+        let sess = create_test_sess();
+        let flows = vec![
+            bearer_with_ebi(5, 9),
+            bearer_with_ebi(0, 9), // no EBI: contributes nothing
+            bearer_with_ebi(6, 8),
+        ];
+        let msg = build_pdu_session_modification_command(
+            &sess,
+            &flows,
+            qos_rule_code::CREATE_NEW_QOS_RULE,
+            qos_flow_description_code::CREATE_NEW_QOS_FLOW_DESCRIPTION,
+        )
+        .expect("modification command builds");
+
+        // Two contexts back to back inside one IE: decode the first, then check the
+        // IE is long enough to hold the second.
+        let (ebi, _, params) = decode_mapped_eps(&msg).expect("IEI 0x75 present");
+        assert_eq!(ebi, 5, "the first flow holding an EBI comes first");
+        assert_eq!(params, vec![(0x01u8, vec![9u8])]);
+        let (_, contexts) = decode_mapped_eps_at(&msg).expect("IEI 0x75 present");
+        assert_eq!(
+            contexts.len(),
+            2,
+            "two contexts, and NOT three: the flow without an EBI contributes nothing"
+        );
+        assert_eq!(
+            contexts.iter().map(|c| c.0).collect::<Vec<_>>(),
+            vec![5, 6],
+            "in flow order, skipping the one with no EBI"
+        );
+        assert_eq!(contexts[1].2, vec![(0x01u8, vec![8u8])]);
+
+        // No flow holds an EBI: the IE is omitted rather than emitted empty.
+        let msg = build_pdu_session_modification_command(
+            &sess,
+            &[bearer_with_ebi(0, 9)],
+            qos_rule_code::CREATE_NEW_QOS_RULE,
+            qos_flow_description_code::CREATE_NEW_QOS_FLOW_DESCRIPTION,
+        )
+        .expect("builds");
+        assert!(decode_mapped_eps(&msg).is_none());
+    }
+
+    /// A 5QI with no EPS equivalent yields a bearer context with an EMPTY
+    /// parameters list, not an invented QCI.
+    ///
+    /// TS 23.501 Table 5.7.4-1 gives 5QIs 1..=9 the same numeric QCI; there is no
+    /// defined QCI for 5QI 82 (a delay-critical XR value). An MME would *enforce*
+    /// whatever QCI it was handed, so guessing one is worse than omitting the
+    /// parameter — and the 7-octet minimum length of the IE is exactly this case.
+    #[test]
+    fn a_five_qi_with_no_eps_equivalent_omits_the_qos_parameter_rather_than_inventing_a_qci() {
+        assert_eq!(qci_for_5qi(9), Some(9));
+        assert_eq!(qci_for_5qi(1), Some(1));
+        assert_eq!(qci_for_5qi(82), None);
+        assert_eq!(qci_for_5qi(0), None);
+
+        let contents = encode_mapped_eps_bearer_context(5, 82);
+        assert_eq!(
+            contents.len(),
+            4,
+            "EBI + 2-octet length + octet 7, and no parameters"
+        );
+        assert_eq!(contents[3] & 0x0f, 0, "no EPS parameters");
+        assert_eq!(
+            contents[3] & 0x10,
+            0,
+            "the E bit must be clear when the parameters list is empty"
+        );
+
+        let sess = create_test_sess();
+        let msg =
+            build_pdu_session_establishment_accept(&sess, &bearer_with_ebi(5, 82)).expect("builds");
+        let (ebi, _, params) = decode_mapped_eps(&msg).expect("the IE is still emitted");
+        assert_eq!(ebi, 5, "the bearer identity is still conveyed");
+        assert!(params.is_empty());
     }
 }

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 mod binding;
 mod context;
 mod easdf; // #114: EASDF selection + DNS-context lifecycle (TS 23.501 §5.6.7)
+mod eps_iwk; // #117: 5GS↔EPS interworking, EBI assignment over Namf_Communication
 mod event;
 mod gn_build;
 mod gn_handler;
@@ -452,6 +453,20 @@ async fn main() -> Result<()> {
             report_uri: format!("{advertise_uri}/nsmf-pdusession/v1/easdf-dns-reports"),
             edge_fqdn_patterns: patterns,
         });
+    }
+
+    // ---- #117: 5GS↔EPS interworking (TS 23.502 §4.11.1.4.1) ----
+    //
+    // Off by default. When on, an establishing PDU session asks the AMF for an EPS
+    // Bearer Identity and carries the Mapped EPS bearer contexts IE to the UE, so
+    // the session can later be moved to the EPC. A runtime switch rather than the
+    // cargo feature #117 suggests -- see `eps_iwk.rs` for why, and for why #276's
+    // listener IS a feature while this is not.
+    if std::env::var("SMF_EPS_INTERWORKING")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        eps_iwk::enable();
     }
 
     // Initialize SMF context
@@ -2977,6 +2992,25 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
     )
     .await;
 
+    // ---- #117: 5GS↔EPS interworking, EBI assignment (TS 23.502 §4.11.1.4.1) ----
+    //
+    // Off by default. Awaited BEFORE the N1 accept is built, because the accept is
+    // where the Mapped EPS bearer contexts IE has to appear: an EBI learned after
+    // the accept went out could not be conveyed to the UE without a Modification
+    // Command it did not ask for. Non-fatal by construction -- `request_ebi`
+    // returns None for every failure, and a session without an EBI is a working
+    // 5G session that simply cannot be moved to the EPC.
+    //
+    // The AMF's authority is its `smContextStatusUri` callback root, the only
+    // address this SMF has for it.
+    let mapped_eps_bearer_id = eps_iwk::request_ebi(
+        sm_context_status_uri.as_deref(),
+        &supi,
+        pdu_session_id,
+        decision.arp_priority_level,
+    )
+    .await;
+
     // ---- #78: fill in the registered session, so Retrieve answers with the real
     // session rather than with whatever `sess_add_by_psi` defaulted to ----
     //
@@ -3011,6 +3045,29 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
         }
     }
 
+    // ---- #117: record the assigned EBI on a QoS flow ----
+    //
+    // `SmfBearer.ebi` is where the Mapped EPS bearer contexts encoder reads the
+    // identity from, and until now the ONLY writer of that field was the EPC
+    // GTPv2 path (`gtp_handler.rs`) — so an EBI could exist only for a session
+    // established from the EPC side, never for a 5GC-first one. This is the Namf
+    // writer #117 asks for.
+    //
+    // The flow is created ONLY when an EBI was assigned. `qos_flow_add` has no
+    // other production caller (the live 5G path carries its QoS on the session and
+    // the policy binding), so creating one unconditionally would populate a store
+    // nothing reads and change what `max_num_of_bearer` means for every session.
+    if let (Some(ebi), Some(sess_id)) = (mapped_eps_bearer_id, registered_sess_id) {
+        eps_iwk::record_mapped_eps_bearer(
+            sess_id,
+            ebi,
+            qfi,
+            decision.def_five_qi,
+            decision.arp_priority_level,
+            &supi,
+        );
+    }
+
     // ---- Store the policy binding (drives later update/release/notify) ----
     if let Ok(context) = ctx.read() {
         if let Ok(mut bindings) = context.policy_bindings.write() {
@@ -3034,6 +3091,7 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
                     fsm: fsm.clone(),
                     easdf_dns_context_id: easdf_dns_context_id.clone(),
                     easdf_reported_eas: Vec::new(),
+                    mapped_eps_bearer_id,
                 },
             );
         }
@@ -3073,6 +3131,7 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
         est_5gsm_cause,
         epco_dns,
         epco_mtu,
+        mapped_eps_bearer_id,
     );
 
     // ---- N2 SM Information: real-APER PDUSessionResourceSetupRequestTransfer ----
@@ -4627,6 +4686,14 @@ async fn handle_sm_context_retrieve(sm_context_ref: &str) -> SbiResponse {
     let ctx = smf_self();
     if let Ok(context) = ctx.read() {
         if let Some(sess) = context.sess_find_by_sm_context_ref(sm_context_ref) {
+            // #117: the EBI the AMF assigned this session, when interworking is on.
+            // Read from the policy binding, which is where the create path recorded
+            // it; `None` reproduces #78's output exactly.
+            let eps_bearer_id = context
+                .policy_bindings
+                .read()
+                .ok()
+                .and_then(|b| b.get(sm_context_ref).and_then(|p| p.mapped_eps_bearer_id));
             let up_cnx_state = match sess.up_cnx_state {
                 context::UpCnxState::Activated => "ACTIVATED",
                 context::UpCnxState::Activating => "ACTIVATING",
@@ -4646,7 +4713,7 @@ async fn handle_sm_context_retrieve(sm_context_ref: &str) -> SbiResponse {
                 // SmContextRetrievedData (TS29502_Nsmf_PDUSession.yaml), and it was
                 // absent -- so the body did not deserialise as the type the AMF
                 // expects even once Retrieve started answering 200.
-                "ueEpsPdnConnection": build_ue_eps_pdn_connection(&sess),
+                "ueEpsPdnConnection": build_ue_eps_pdn_connection(&sess, eps_bearer_id),
             });
             // Only include what the session actually holds: an absent member means
             // "not applicable", while a member present with a placeholder value is a
@@ -4677,15 +4744,20 @@ async fn handle_sm_context_retrieve(sm_context_ref: &str) -> SbiResponse {
 /// 5GS↔EPS interworking (TS 23.502 §4.11.1.4.1). It is a `Bytes` (base64-encoded
 /// octet string) in the yaml: the encoded `ueEpsPdnConnection` container.
 ///
-/// **What this returns, and what it deliberately does not.** This SMF has no EPS
-/// bearer contexts to describe — there is no EBI assignment and no Mapped EPS
-/// bearer context IE anywhere in the tree, which is issue #117's defect, not this
-/// one. So the value here is the minimal PDN-connection descriptor derivable from
-/// the 5GS session (APN, PDN type, the UE address, the default bearer's QoS), and
-/// **not** a bearer-context list it would have to invent. A fabricated bearer list
-/// would be worse than a minimal one: the AMF would forward it to an MME that
+/// **What this returns, and what it deliberately does not.** #78 shipped the
+/// minimal PDN-connection descriptor derivable from the 5GS session (APN, PDN
+/// type, the UE address, the default bearer's QoS) and **no** bearer-context list,
+/// because there was no EBI assignment anywhere in the tree and a fabricated
+/// bearer list is worse than a minimal one: the AMF would forward it to an MME that
 /// would then try to use bearers this SMF has not established.
-fn build_ue_eps_pdn_connection(sess: &context::SmfSess) -> String {
+///
+/// #117 changes exactly one thing about that: when an EBI **was** assigned, the
+/// descriptor names it. That is not a fabrication — the AMF allocated the identity
+/// and the UE has already been told about it in the Mapped EPS bearer contexts IE,
+/// so an MME receiving it will find the bearer the UE claims to have. With no EBI
+/// assigned (interworking off, or the assignment failed) the output is byte-for-byte
+/// what #78 produced, which is what keeps criterion 5 true.
+fn build_ue_eps_pdn_connection(sess: &context::SmfSess, eps_bearer_id: Option<u8>) -> String {
     use base64::Engine as _;
     // TS 24.301 PDN type values: 1 = IPv4, 2 = IPv6, 3 = IPv4v6.
     let pdn_type: u8 = match sess.session_type {
@@ -4708,6 +4780,12 @@ fn build_ue_eps_pdn_connection(sess: &context::SmfSess) -> String {
     // Default bearer QoS: the 5QI the session was authorised with, which is what
     // maps onto the EPS QCI.
     buf.push(sess.session_qos.index);
+    // #117: the EPS bearer identity, when one was assigned. Appended rather than
+    // inserted so the prefix stays identical to #78's output for a session without
+    // one — a peer parsing the earlier form reads the same first bytes.
+    if let Some(ebi) = eps_bearer_id {
+        buf.push(ebi);
+    }
     base64::engine::general_purpose::STANDARD.encode(&buf)
 }
 
@@ -5220,6 +5298,7 @@ mod tests {
             "internet",
             None,
             &[],
+            None,
             None,
         );
         let n2 = build_setup_request_transfer(0x0001_0001, [10, 45, 0, 1], 1, 9, 8).unwrap();
@@ -5882,6 +5961,7 @@ mod tests {
                         // #114: no EASDF DNS context by default, so the release
                         // path has nothing to delete.
                         easdf_dns_context_id: None,
+                        mapped_eps_bearer_id: None,
                         easdf_reported_eas: Vec::new(),
                     },
                 );
@@ -6468,6 +6548,7 @@ mod tests {
             None,
             &dns,
             Some(1400),
+            None,
         );
 
         // The ePCO IE (0x7B) must be present with a two-octet TLV-E length.
@@ -6518,6 +6599,7 @@ mod tests {
             "internet",
             None,
             &[],
+            None,
             None,
         );
         assert!(
@@ -6786,6 +6868,83 @@ mod tests {
         );
     }
 
+    /// #117 criterion 4: the retrieved `ueEpsPdnConnection` NAMES the assigned EBI
+    /// when one exists, and is byte-identical to #78's output when none does.
+    ///
+    /// #78 deliberately shipped a minimal descriptor with no bearer contexts,
+    /// because there was no EBI assignment in the tree and a fabricated bearer list
+    /// would have an MME trying to use bearers this SMF never established. #117
+    /// changes exactly that precondition, so the descriptor can now name a real
+    /// identity — and the unchanged-when-absent half is criterion 5.
+    #[tokio::test]
+    async fn the_retrieved_ue_eps_pdn_connection_names_the_assigned_ebi() {
+        use base64::Engine as _;
+
+        let without = seed_registered_session("imsi-001010000000123", 7, "internet");
+        let body: serde_json::Value = serde_json::from_str(
+            handle_sm_context_retrieve(&without)
+                .await
+                .http
+                .content
+                .as_deref()
+                .expect("body"),
+        )
+        .expect("json");
+        let baseline = base64::engine::general_purpose::STANDARD
+            .decode(
+                body["ueEpsPdnConnection"]
+                    .as_str()
+                    .expect("ueEpsPdnConnection is required"),
+            )
+            .expect("base64");
+
+        // Same session, now with an EBI recorded on its policy binding.
+        let with = seed_registered_session("imsi-001010000000124", 8, "internet");
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                bindings.insert(
+                    with.clone(),
+                    context::PolicyBinding {
+                        supi: "imsi-001010000000124".to_string(),
+                        psi: 8,
+                        dnn: "internet".to_string(),
+                        mapped_eps_bearer_id: Some(6),
+                        ..context::PolicyBinding::snapshot_default()
+                    },
+                );
+            }
+        }
+        let body: serde_json::Value = serde_json::from_str(
+            handle_sm_context_retrieve(&with)
+                .await
+                .http
+                .content
+                .as_deref()
+                .expect("body"),
+        )
+        .expect("json");
+        let carried = base64::engine::general_purpose::STANDARD
+            .decode(body["ueEpsPdnConnection"].as_str().expect("required"))
+            .expect("base64");
+
+        assert_eq!(
+            carried.len(),
+            baseline.len() + 1,
+            "exactly one octet more: the EBI, appended"
+        );
+        assert_eq!(
+            &carried[..baseline.len()],
+            &baseline[..],
+            "the prefix must be unchanged, so a peer parsing #78's form reads the \
+             same first bytes"
+        );
+        assert_eq!(
+            *carried.last().expect("last octet"),
+            6,
+            "the descriptor must name the EBI the AMF assigned"
+        );
+    }
+
     /// #78 criteria 1 + 2: Retrieve answers 200 with a body that deserialises as
     /// `SmContextRetrievedData`, INCLUDING the required `ueEpsPdnConnection`.
     ///
@@ -7008,7 +7167,7 @@ mod tests {
         let reference = seed_registered_session("imsi-001010000000083", 4, "internet");
 
         // Retrieve
-        let resp = smf_sbi_request_handler(SbiRequest::post(&format!(
+        let resp = smf_sbi_request_handler(SbiRequest::post(format!(
             "/nsmf-pdusession/v1/sm-contexts/{reference}/retrieve"
         )))
         .await;
@@ -7019,7 +7178,7 @@ mod tests {
 
         // Update
         let resp = smf_sbi_request_handler(
-            SbiRequest::post(&format!(
+            SbiRequest::post(format!(
                 "/nsmf-pdusession/v1/sm-contexts/{reference}/modify"
             ))
             .with_body(
@@ -7032,7 +7191,7 @@ mod tests {
 
         // Release
         let resp = smf_sbi_request_handler(
-            SbiRequest::post(&format!(
+            SbiRequest::post(format!(
                 "/nsmf-pdusession/v1/sm-contexts/{reference}/release"
             ))
             .with_body(
@@ -7044,7 +7203,7 @@ mod tests {
         assert_eq!(resp.status, 204, "release through the router");
 
         // And it is gone: a second retrieve is 404, not a stale 200.
-        let resp = smf_sbi_request_handler(SbiRequest::post(&format!(
+        let resp = smf_sbi_request_handler(SbiRequest::post(format!(
             "/nsmf-pdusession/v1/sm-contexts/{reference}/retrieve"
         )))
         .await;

--- a/src/bins/nextgcore-smfd/src/policy.rs
+++ b/src/bins/nextgcore-smfd/src/policy.rs
@@ -987,6 +987,11 @@ pub fn build_establishment_accept(
     // the IE. `mtu`: IPv4 link MTU for the same IE; `None` omits it.
     dns_servers: &[std::net::Ipv4Addr],
     mtu: Option<u16>,
+    // `mapped_eps_bearer_id`: the EBI the AMF assigned this session's default
+    // flow, when EPS interworking is enabled and an assignment succeeded (#117).
+    // `None` omits the Mapped EPS bearer contexts IE, which is the whole
+    // behaviour of an interworking-disabled deployment.
+    mapped_eps_bearer_id: Option<u8>,
 ) -> Vec<u8> {
     use crate::gsm_build::{
         encode_qos_flow_descriptions, encode_qos_rules, pf_component_type, pf_direction,
@@ -1119,6 +1124,20 @@ pub fn build_establishment_accept(
             msg.extend_from_slice(&(epco.len() as u16).to_be_bytes());
             msg.extend_from_slice(&epco);
         }
+    }
+
+    // Mapped EPS bearer contexts (IEI 0x75, TLV-E), TS 24.501 §9.11.4.8 — #117.
+    //
+    // This is the LIVE accept path, and it is the one that matters: the three
+    // `gsm_build` builders the issue names have no production caller (they belong
+    // to the `SmfSess`-based model #223 is about), so emitting the IE only there
+    // would have been a correct encoder no UE would ever receive. Both paths call
+    // the same `encode_mapped_eps_bearer_context`, so they cannot drift.
+    if let Some(ebi) = mapped_eps_bearer_id {
+        let mapped = crate::gsm_build::encode_mapped_eps_bearer_context(ebi, five_qi);
+        msg.push(crate::gsm_build::IEI_MAPPED_EPS_BEARER_CONTEXTS);
+        msg.extend_from_slice(&(mapped.len() as u16).to_be_bytes());
+        msg.extend_from_slice(&mapped);
     }
 
     // DNN (IEI 0x25)
@@ -1280,6 +1299,77 @@ mod tests {
         assert!(parse_establishment_request(&[0x2E, 1, 1, 0xC1]).is_none()); // missing mandatory IE
     }
 
+    /// #117: the LIVE accept builder emits the Mapped EPS bearer contexts IE.
+    ///
+    /// Added after a revert exposed the hole: with the emit removed from
+    /// `build_establishment_accept`, the whole smfd suite still passed, because the
+    /// only tests touching the IE drive the three `gsm_build` builders — and those
+    /// have NO production caller. So the IE was covered exactly where it does not
+    /// matter and uncovered on the one path a UE actually receives. That is the
+    /// "correct implementation, unreachable" trap, caught in my own diff.
+    #[test]
+    fn the_live_accept_carries_mapped_eps_bearer_contexts_when_an_ebi_is_assigned() {
+        let build = |ebi: Option<u8>| {
+            build_establishment_accept(
+                5,
+                3,
+                pdu_session_type::IPV4,
+                2,
+                9,
+                9,
+                200_000_000,
+                50_000_000,
+                [10, 45, 0, 2],
+                [0u8; 8],
+                1,
+                None,
+                "internet",
+                None,
+                &[],
+                None,
+                ebi,
+            )
+        };
+
+        let without = build(None);
+        let with = build(Some(6));
+        assert_eq!(
+            with.len(),
+            without.len() + 10,
+            "the IE is IEI + 2-octet length + a 7-octet context"
+        );
+
+        // Locate and decode it: IEI, two-octet length, then the context.
+        let at = with
+            .windows(3)
+            .position(|w| {
+                w[0] == crate::gsm_build::IEI_MAPPED_EPS_BEARER_CONTEXTS
+                    && u16::from_be_bytes([w[1], w[2]]) == 7
+            })
+            .expect("IEI 0x75 with a 7-octet contents length must be present");
+        let body = &with[at + 3..at + 10];
+        assert_eq!(body[0] >> 4, 6, "the EBI in bits 8..5 of octet 4");
+        assert_eq!(body[0] & 0x0f, 0, "bits 4..1 of octet 4 are spare");
+        assert_eq!(u16::from_be_bytes([body[1], body[2]]), 4, "context length");
+        assert_eq!(body[3] >> 6, 0b01, "operation code: create new EPS bearer");
+        assert_eq!(body[3] & 0x0f, 1, "one EPS parameter");
+        assert_eq!(
+            &body[4..7],
+            &[0x01, 0x01, 9],
+            "Mapped EPS QoS parameters carrying the QCI"
+        );
+
+        // With no EBI the bytes must be exactly what they were before #117: this is
+        // criterion 5 on the live path.
+        assert!(
+            !without
+                .windows(3)
+                .any(|w| w[0] == crate::gsm_build::IEI_MAPPED_EPS_BEARER_CONTEXTS
+                    && u16::from_be_bytes([w[1], w[2]]) == 7),
+            "an interworking-disabled deployment must emit no such IE"
+        );
+    }
+
     #[test]
     fn accept_message_carries_policy_values() {
         // SSC mode 2, PDU type IPv4 (0x01), QFI 9, 5QI 9 (QFI == 5QI → no 0x79)
@@ -1299,6 +1389,7 @@ mod tests {
             "internet",
             None,
             &[],
+            None,
             None,
         );
         // SM header (TS 24.501 §9.3 / Table 8.3.2.1.1 octets 1-4)
@@ -1391,6 +1482,7 @@ mod tests {
             None,
             &[],
             None,
+            None,
         );
         // header | octet-5 | QoS rules LV-E | Session-AMBR LV | PDU address.
         const PINNED_PREFIX: [u8; 30] = [
@@ -1435,6 +1527,7 @@ mod tests {
             None,
             &[],
             None,
+            None,
         );
         // S-NSSAI present with SST + 3-byte SD.
         let snssai_at = msg
@@ -1478,6 +1571,7 @@ mod tests {
             None,
             &[],
             None,
+            None,
         );
         // octet-5: SSC mode 1 | IPv4v6 (0x13)
         assert_eq!(msg[4], (1 << 4) | pdu_session_type::IPV4V6);
@@ -1513,6 +1607,7 @@ mod tests {
             "internet",
             Some(gsm_cause::PDU_SESSION_TYPE_IPV4_ONLY_ALLOWED),
             &[],
+            None,
             None,
         );
         // Header(4)+octet5(1)+QoS-LV-E(11)+Session-AMBR(7) = 23 bytes; the 5GSM


### PR DESCRIPTION
Closes #117. Spec: `specs/fix-amfd-smfd-eps-bearer-contexts.md`.

## State on main

| criterion | before | now |
|---|---|---|
| 1. `assign-ebi` routed, per-UE EBI pool | `rg assign-ebi` → **nothing in the tree** | routed, pooled, 5 tests |
| 2. smfd invokes it; `SmfBearer.ebi` set off the Namf path | only writer was the EPC GTPv2 path | done, 2 tests |
| 3. IEI `0x75` from the three named builders | no `0x75` anywhere | done in **four** builders — see below |
| 4. `ueEpsPdnConnection` present | **already met by #78** | extended to name the EBI |
| 5. unchanged when disabled | — | all 425 smfd + 428 amfd pre-existing tests untouched |

## The issue's approach names three builders that have no production caller

It says to emit the IE from `build_pdu_session_establishment_accept`, `..._extended` and
`build_pdu_session_modification_command`. **None of the three is called in production** — the
live path builds N1 with `policy::build_establishment_accept`, and the `gsm_build` trio belongs
to the `SmfSess` model #223 is about.

Emitting only where the issue points would have been a correct encoder no UE could receive. All
four builders emit it, through one shared `encode_mapped_eps_bearer_context` so they cannot
drift.

## Decisions

| decision | why |
|---|---|
| **runtime switch** (`SMF_EPS_INTERWORKING=1`), not the suggested cargo feature | CI builds default features, so a gated path rots uncompiled; a runtime switch makes criterion 5 a thing a test *asserts*. Contrast #276 one PR earlier, which **is** a feature — it binds a privileged port. Network posture is the distinguishing factor, not optionality. |
| EBI pool is **per-UE** over 5..=15 | TS 24.301 §9.3.2 reserves 0..=4; a per-session pool could hand one EBI to two sessions of one UE |
| exhaustion is a **modelled answer**, not a 5xx | eleven identities is also the most EPS bearers a UE can hold. Partial failure = `200` with `assignedEbiList` + `failedArpList`; only all-failed-none-assigned is the `403 + AssignEbiError` the operation defines |
| **release → modify → assign** within one request | a request that releases EBI 5 and asks for one more must be able to hand 5 straight back out (a revert moving release later fails 2 tests) |
| `preemptCap`/`preemptVuln` checked for **presence, not value** | both are `anyOf[enum, string]` in TS 29.571 — extensible — so refusing an unlisted value would reject something conformant. `priorityLevel` *is* range-checked: it is a plain integer with declared bounds |
| a 5QI with no EPS equivalent **omits** the QoS parameter | TS 23.501 Table 5.7.4-1 defines a QCI only for 5QIs 1..=9. An MME *enforces* whatever QCI it is handed, so an empty parameters list (the IE's legal 7-octet minimum) beats a guess — the identity is still conveyed |
| `ueEpsPdnConnection` **appends** the EBI | byte-identical prefix to #78's output, so a peer parsing the earlier form reads the same first bytes. The `403 EPS_IWK_NOT_SUPPORTED` alternative is not taken: it would regress a merged issue's deliberate `200` for no conformance gain |

The IE layout was read out of the vendored **TS 24.501 §9.11.4.8** text (figures 9.11.4.8.1–3,
Table 9.11.4.8.1) and **TS 24.301 §9.9.4.3**, not inferred from the issue — the spec's stated
7-octet minimum is what confirms the context-length field covers octet 7 onward.

## Verification

Workspace **6241 passed / 0 failed** (baseline 6224, +17); easdfd's `dns-udp` feature still
51/0. clippy and fmt clean, amfd and smfd at **zero** warnings (four pre-existing
`needless_borrow` in #78's tests fixed in passing).

| revert | expected to break | result |
|---|---|---|
| the `assign-ebi` routing arm removed | all five amfd tests | **5 failed** |
| release moved after assignment | reuse + exhaustion | **2 failed** |
| allocator ignores already-held EBIs | pool + exhaustion | **2 failed** |
| the **live** accept stops emitting the IE | the live-path test | **1 failed** — see below |
| `E` bit set with an empty parameters list | the no-EPS-equivalent test | **1 failed** |
| the Namf writer stops setting `SmfBearer.ebi` | the storage test | **1 failed** |
| Retrieve stops reading the binding's EBI | the `ueEpsPdnConnection` test | **1 failed** |

### The revert pass found a hole in my own work

Revert 4 initially **passed**: with the emit removed from `policy::build_establishment_accept`
the entire 436-test smfd suite stayed green, because every test touching the IE drove one of the
three *dead* builders. The IE was covered exactly where it does not matter and uncovered on the
one path a UE receives — the same correct-but-unreachable trap this PR opens by describing,
reproduced in the diff meant to avoid it. Added
`the_live_accept_carries_mapped_eps_bearer_contexts_when_an_ebi_is_assigned`; the revert then
failed.

Milder second finding: revert 5 first looked inert, which turned out to be a too-narrow
`cargo test mapped_eps` filter rather than a missing guard. "The revert did not bite" and "my
filter did not select the guard" look identical in the output.

## Ceilings

- **The create call site is inspection-only** — `handle_sm_context_create` cannot be driven past
  its N4 leg (no UPF stand-in; filed as #289, which names this exact call site). The recording
  step was extracted into `eps_iwk.rs` *specifically* so it has a reachable seam rather than
  being an unreachable inline block.
- **One EBI per session, not per QoS flow** — the live path authorises one default flow. The AMF
  side already handles an arbitrary-length `arpList` (tested to eleven).
- **No EBI release on session release** — `releasedEbiList` works on the AMF side and the SMF
  never sends one, so an EBI is held for the UE's lifetime rather than its session's. A real leak
  over enough churn; in no criterion, worth its own issue.
- **The Modification Command path is encodable but not conveyed** — the live modification builder
  has no EBI parameter and no caller to pass one.
- `oldGuami` is parsed and unused (an inter-AMF case this tree has no handling for).
- TS 24.501/24.301 are vendored as **text**, so unlike the TS 29.5xx SBI shapes there is no
  machine-checkable artifact behind the IE layout.