### PR TITLE
fix(smfd): interact with the UDM, make Nsmf_EventExposure a real resource, and stop the H-SMF lying (#79)

### DIFF
--- a/specs/fix-smfd-sbi-services.md
+++ b/specs/fix-smfd-sbi-services.md
@@ -1,0 +1,183 @@
+# nextgcore #79 (smfd): UDM interaction, a real `Nsmf_EventExposure`, and an honest H-SMF
+
+Verified against `main` @ `1447dcc`.
+
+## Verified against current main
+
+| claim in the issue | site on `1447dcc` | still true? |
+|---|---|---|
+| `policy.rs` has no UDM client | `rg -i udm bins/nextgcore-smfd/src/policy.rs` → nothing | yes |
+| no `Nudm_UECM_Registration` anywhere | `rg smf-registrations src/` → **nothing** | yes |
+| no `sm-data` retrieval; QoS from `config_default_for_dnn` | `main.rs` config-default arm | yes |
+| **the dead `nudm-sdm` FSM arm** | **removed by #204**, with a comment explaining why | **false** |
+| `handle_event_subscribe` ignores the body, returns `{subscriptionId}`, persists nothing | as described | yes |
+| `handle_event_unsubscribe` returns `204` for any id | as described | yes |
+| no `GET`/`PUT` on `/subscriptions/{subId}` | router had `POST` and `DELETE` only | yes |
+| H-SMF create returns `201` with `{"cause": "REL_DUE_TO_HO"}` | as described | yes |
+
+**Criterion 3 is void, not met.** It asks that "the dead `nudm-sdm` branch in `gsm_sm.rs` is
+reached by a real response". #204 deleted that branch and recorded why: the SMF's real
+`Nudm_SDM_Get` (for the subscribed default DNN) has to complete *before* the session exists,
+because the DNN is an input to creating it, so it returns on a direct `await` rather than as an FSM
+event — and dispatching it in the FSM as well would put one decision in two places. #79's
+criterion was written against the pre-#204 tree. Nothing is added to `gsm_sm.rs`.
+
+#204 also left behind exactly the infrastructure this issue needs: a NRF-based UDM discovery
+routine and a working SDM client pattern. The discovery function is generalised here from
+`nudm-sdm`-only to any named `nudm` service, because a UDM may advertise `nudm-uecm` on a
+different port — which `udm_service_endpoint_from_search_result` already prefers a service's own
+`ipEndPoints` in order to honour.
+
+## Decision 1: the subscription is a baseline; the PCF still outranks it
+
+TS 23.503 §6.1.3.2 has the PCF *authorise* the session-AMBR and default QoS, taking the
+subscribed values as input. So the precedence is **PCF, then subscription, then config default**,
+and `apply_subscribed_baseline` is called on the config-default arm only. Overlaying the
+subscription on top of a PCF answer would override an authorisation with its own input — a
+conformance defect rather than a degradation.
+
+Applied **per member**, not as a struct swap: a subscription stating a session-AMBR and no 5QI
+leaves the configured 5QI in place. A whole-struct replacement would make an absent subscribed
+member silently mean `0`, and a session-AMBR of 0 polices a subscriber to nothing.
+
+For the same reason `parse_bit_rate` returns `None` rather than `0` for an unrecognised unit. A
+subscription meaning gigabits, enforced as bits, is worse than no override at all.
+
+## Decision 2: a runtime switch (`SMF_UDM=1`), off by default
+
+#79 asks for the UDM enforcement to be gated and default-off, and gives the reason: the E2E
+harness has no conformant UDM, and enforcing subscription data nothing supplies would regress the
+matched-sim data-plane path CI does gate on. A **runtime** switch rather than a cargo feature, for
+the reason recorded across this daemon's other switches — CI builds default features, so a gated
+path is left uncompiled and rots, and criterion 5's "unchanged when disabled" becomes a claim
+about a build CI never performs.
+
+The `smfInstanceId` the UDM records is seeded from the value **NRF registration used**. A
+separately minted uuid would have the UDM's serving-SMF record point at an instance nothing else
+in the deployment can resolve, which is the failure this operation exists to prevent.
+
+`plmnId` comes from the serving PLMN the AMF supplied, and a request without one sends **no
+registration at all**: the member is `required`, and inventing a PLMN would record the session as
+served somewhere it is not.
+
+## Decision 3: the H-SMF `/pdu-sessions` service answers 501 — all three operations
+
+#79 offers a choice: implement Create/Update/Release conformantly, or `501` rather than a
+fabricated `201`. `501` is taken.
+
+What it replaces was actively misleading, not merely incomplete. Create answered `201` with
+`{"pduSessionRef": "1", "cause": "REL_DUE_TO_HO"}` — **a release cause on a create success**, at a
+hardcoded reference, with no session created. A partner V-SMF parsing that is told "your session
+was established, and it was released for handover", about a session that does not exist.
+
+Home-routed roaming is not implemented here: nothing establishes an H-SMF session, and
+`PduSessionCreatedData` requires `pduSessionType`, `sscMode` and one of
+`hSmfInstanceId`/`smfInstanceId` (a `oneOf`) — every one of which would be invented. This
+project's recorded rule for that case is that a spec-defined resource whose dependency is absent
+answers `501`, never a `404` and never a fabricated `2xx`.
+
+All three operations answer the same way. A partner that cannot create through this service can
+never legitimately update or release through it, and leaving those at `2xx` would say otherwise.
+The old Release was worse than incomplete: it removed a session by `pduSessionRef` — a reference
+space this SMF does not populate — so it could only ever match state some other path had
+registered, i.e. it let a partner delete state it did not own.
+
+## Decision 4: which events fire, and saying so
+
+`PDU_SES_EST` and `PDU_SES_REL` are emitted. The other twenty `SmfEvent` values name occurrences
+this SMF does not detect (`UP_PATH_CH`, `QOS_MON`, `DISPERSION`, …); subscribing to one is
+**accepted and stored** — refusing a conformant request would be wrong — and it simply never
+fires. That is written in the module header rather than left for a consumer to infer from silence.
+
+A subscription's filters scope it: an absent `supi`/`pduSeId` matches anything (`anyUeInd`
+semantics), a present one must match exactly. The negative direction is the one that matters — a
+SUPI-scoped subscription that matched every UE would leak one subscriber's session events to a
+consumer authorised for another, which is a subscriber-data leak rather than a reporting bug.
+
+## Acceptance criteria
+
+- [x] On SM-context create, smfd issues `Nudm_UECM_Registration` and `Nudm_SDM_Get sm-data` before
+      PFCP establishment — `the_smf_registers_with_the_udm_and_fetches_sm_data` asserts both on the
+      wire against a loopback UDM, including all four `required` members of `SmfRegistration`, the
+      `PUT` method, the per-PDU-session resource path, `nudm-sdm` **v2**, and the `dnn` scoping
+      (read from `http.params`, because the shared SBI server strips the query from `header.uri`).
+- [x] The subscribed default-5QI and session-AMBR are applied, `config_default_for_dnn` only as
+      fallback — `subscribed_values_win_over_the_config_default_per_member`, covering full,
+      partial and empty subscriptions.
+- [ ] ~~The dead `nudm-sdm` branch in `gsm_sm.rs` is reached by a real response~~ — **void**: #204
+      removed that branch deliberately. Nothing added to `gsm_sm.rs`; the reasoning is above.
+- [x] `POST /subscriptions` persists the parsed subscription and returns an `NsmfEventExposure`;
+      `GET` retrieves it; `DELETE` on an unknown id is `404` —
+      `event_subscriptions_are_a_real_resource_with_get_put_and_a_404`, through the **router**
+      (half of what was missing was routing), plus `PUT` (which does not create at a
+      consumer-chosen id) and the three `required`-member rejections.
+- [x] An `Nsmf_EventExposure_Notify` is emitted to the subscribed URI on a subscribed occurrence —
+      `a_released_session_notifies_its_event_subscriber`, captured on a real loopback consumer, and
+      asserting that a subscription scoped to a **different** SUPI is not notified.
+- [x] H-SMF `POST /pdu-sessions` answers `501`, never a release cause on a create —
+      `the_hsmf_pdu_sessions_service_answers_501_and_never_a_release_cause`, over all three
+      operations, asserting the body does not contain `REL_DUE_TO_HO`.
+- [x] clippy and the smfd suite pass — smfd at **zero** clippy warnings.
+
+## Verification
+
+Workspace **6258 passed / 0 failed** (baseline 6241 on `1447dcc`; +17), easdfd's `dns-udp` feature
+still 51/0. `cargo clippy --workspace --all-targets` and `cargo fmt --all -- --check` clean.
+
+| revert | expected to break | result |
+|---|---|---|
+| subscriptions are parsed but not stored | 3 tests | **3 failed** |
+| the `supi` filter is ignored | the filter test + the notify test | **failed** |
+| the UECM registration is never transmitted | the UDM wire test | **1 failed** |
+| the subscribed 5QI is not applied | the per-member test | **failed** |
+| H-SMF create answers `201 REL_DUE_TO_HO` again | the 501 test | **1 failed** |
+| the notify call removed from the release handler | the notify test | **failed** |
+| `DELETE` answers `204` for an unknown id | the resource test | **failed** |
+
+### A third instance of one lock per variable, in one session
+
+`the_smf_registers_with_the_udm_and_fetches_sm_data` flaked: it passed alone and failed in roughly
+one full-suite run in six. Two distinct causes, both process-global state:
+
+1. **A second lock over the same variable.** `main.rs`'s tests already had a `UDM_ENV_TEST_LOCK`
+   over `UDM_SBI_ADDR`/`UDM_SBI_PORT`/`NRF_URI`; the new test set the same variables without it.
+   A sibling re-pointed `UDM_SBI_PORT` at its own loopback UDM between the registration and the
+   `sm-data` fetch, so the fetch reached a server that answers `201` to everything. The lock is
+   now declared at the **crate root**, beside the function that reads the env, so `udm.rs` and
+   `main.rs` take the same one.
+2. **A `find()` that could match someone else's request.** Even with the env locked, the loopback
+   UDM is reachable by any sibling test whose create path fetches a subscribed default DNN. Both
+   lookups now match on the **SUPI** as well as the resource, and the final "no registration was
+   sent" assertion is scoped the same way instead of asserting the server saw no traffic at all.
+
+That is the third time in this run of five issues that a process-global needed one agreement
+rather than two — after the EASDF context in #276 (which manifested as a **hang**) and the
+event-subscription store here (which made `a_released_session_notifies_its_event_subscriber` fail
+in the full suite while passing alone). Eight consecutive clean full-suite runs afterwards.
+
+## Ceilings
+
+* **Both UDM call sites are inspection-only**, like #117's and for the same reason: they sit in
+  `handle_sm_context_create`, which no test can drive past its N4 leg (#289). What *is* verified is
+  both operations end to end against a loopback UDM, and the per-member application of what they
+  return. Same for the `PDU_SES_EST` notification — `PDU_SES_REL` was chosen for the wiring test
+  precisely because the release handler is reachable.
+* **No `Nudm_SDM_Subscribe`.** #79's suggested approach mentions it alongside `Get`; the criterion
+  does not, and a subscription with no notification handler on this side would be a resource the
+  SMF creates on the UDM and then ignores. The UDM would send `Nudm_SDM_Notification` to a callback
+  this SMF does not serve. Worth its own issue, together with the deregistration this PR also does
+  not send.
+* **No UECM deregistration on session release.** The registration is per PDU session and nothing
+  removes it, so a UDM accumulates serving-SMF records for released sessions. Same shape as the EBI
+  leak (#291) and worth the same treatment.
+* **The `503`/retry posture is "log and continue".** Every UDM and notification failure is
+  non-fatal with no retry queue, which is right for the session and means a transient UDM outage
+  silently costs subscription enforcement for the sessions established during it.
+* **Only two of twenty-two `SmfEvent` values fire.** Documented in the module header.
+* **`altNotifIpv4Addrs`/`altNotifFqdns` are stored and never used.** A notification failure does
+  not fall back to the alternates a consumer supplied. Parsed only in the sense that they
+  round-trip in the stored document; no code reads them.
+* GitNexus impact analysis unrunnable (no MCP server connected). Blast radius by grep:
+  `udm_service_endpoint_from_search_result` gained a parameter (1 production + 4 test call sites,
+  all updated); `build_establishment_accept` untouched here; the three H-SMF handlers have one
+  router call site each.

--- a/src/bins/nextgcore-smfd/src/event_exposure.rs
+++ b/src/bins/nextgcore-smfd/src/event_exposure.rs
@@ -1,0 +1,539 @@
+//! `Nsmf_EventExposure` (TS 29.508), issue #79.
+//!
+//! # What this replaces
+//!
+//! A facade. `POST /nsmf-event-exposure/v1/subscriptions` ignored the request body,
+//! returned `{"subscriptionId": <uuid>}` — which is not a schema in TS 29.508 —
+//! persisted nothing, and never notified; `DELETE` answered `204` for any id
+//! including one that never existed; there was no `GET` or `PUT` at all. So a
+//! consumer (NEF/AF, NWDAF, CHF) received an id that referenced nothing and then
+//! waited for notifications that could not arrive.
+//!
+//! # The resource model
+//!
+//! TS 29.508 §4.2.2: an event subscription is a **persisted resource**. `POST
+//! /subscriptions` creates it and answers `201` + `Location` + the created
+//! `NsmfEventExposure` document; `/subscriptions/{subId}` supports `GET` (200),
+//! `PUT` (200) and `DELETE` (204), each `404` for an unknown id.
+//!
+//! # Notification
+//!
+//! §4.2.3.2: on a matching occurrence the SMF sends an
+//! `NsmfEventExposureNotification` to `notifUri`, carrying the subscription's own
+//! `notifId` so the consumer can correlate it with the subscription it made.
+//!
+//! Which events are emitted, and why only these two: `PDU_SES_EST` and
+//! `PDU_SES_REL` are the two occurrences the live establishment and release paths
+//! actually reach. The other twenty values in `SmfEvent` name occurrences this SMF
+//! does not detect (`UP_PATH_CH`, `QOS_MON`, `DISPERSION`, …); subscribing to one
+//! is accepted and stored — refusing it would reject a conformant request — and it
+//! simply never fires. That is stated here rather than left for a consumer to infer
+//! from silence.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use serde_json::Value;
+
+/// The `SmfEvent` values this SMF actually detects and reports (TS 29.508).
+///
+/// Named constants rather than string literals at the call sites: a typo in one
+/// place would produce a subscription that matches and a notification that does
+/// not, and the two are twenty lines apart in different files.
+pub mod event {
+    /// PDU session establishment.
+    pub const PDU_SES_EST: &str = "PDU_SES_EST";
+    /// PDU session release.
+    pub const PDU_SES_REL: &str = "PDU_SES_REL";
+}
+
+/// A stored subscription: the parsed document plus the id this SMF assigned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventSubscription {
+    /// The SMF-assigned resource id (the `{subId}` path segment).
+    pub id: String,
+    /// Consumer-assigned notification correlation id (`notifId`, **required**).
+    pub notif_id: String,
+    /// Where notifications go (`notifUri`, **required**).
+    pub notif_uri: String,
+    /// The subscribed event names, from `eventSubs[].event` (**required**, minItems 1).
+    pub events: Vec<String>,
+    /// SUPI filter, when the subscription is scoped to one UE.
+    pub supi: Option<String>,
+    /// PDU session id filter, when scoped to one session.
+    pub pdu_session_id: Option<u8>,
+    /// The document as received, so `GET` returns what was stored rather than a
+    /// re-serialisation of the subset this SMF models. A consumer that sent
+    /// `sampRatio` or `partitionCriteria` gets them back.
+    pub document: Value,
+}
+
+impl EventSubscription {
+    /// Does an occurrence of `event` for `supi`/`psi` match this subscription?
+    ///
+    /// An absent filter matches anything — `anyUeInd` semantics — while a present
+    /// one must match exactly. Getting this backwards would notify every consumer
+    /// about every UE, which is a subscriber-data leak rather than a bug in
+    /// reporting.
+    pub fn matches(&self, event: &str, supi: &str, psi: u8) -> bool {
+        if !self.events.iter().any(|e| e == event) {
+            return false;
+        }
+        if let Some(ref want) = self.supi {
+            if want != supi {
+                return false;
+            }
+        }
+        if let Some(want) = self.pdu_session_id {
+            if want != psi {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// The subscription store.
+///
+/// Process-global and memory-only, like the other subscription stores in this tree.
+/// A restart loses the subscriptions, which is the honest behaviour for a resource
+/// whose consumer holds a `Location` it will re-create on a `404` — the alternative
+/// (persisting them) would have the SMF notifying against `notifUri`s that may have
+/// moved while it was down.
+static SUBSCRIPTIONS: RwLock<Option<HashMap<String, EventSubscription>>> = RwLock::new(None);
+
+fn with_store<T>(f: impl FnOnce(&mut HashMap<String, EventSubscription>) -> T) -> Option<T> {
+    let mut guard = SUBSCRIPTIONS.write().ok()?;
+    Some(f(guard.get_or_insert_with(HashMap::new)))
+}
+
+/// Why a subscription document was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    /// A `required` member is absent. Carries its name for the ProblemDetails.
+    Missing(&'static str),
+    /// `eventSubs` is present but no entry names an event.
+    NoEvent,
+    /// The body was not a JSON object.
+    NotAnObject,
+}
+
+impl ParseError {
+    pub fn detail(&self) -> String {
+        match self {
+            Self::Missing(m) => format!("Mandatory attribute '{m}' is missing"),
+            Self::NoEvent => {
+                "eventSubs is present but no entry names an 'event' (TS 29.508 EventSubscription \
+                 requires it)"
+                    .to_string()
+            }
+            Self::NotAnObject => "Request body is not an NsmfEventExposure object".to_string(),
+        }
+    }
+
+    pub fn cause(&self) -> &'static str {
+        match self {
+            Self::Missing(_) | Self::NoEvent => "MANDATORY_IE_MISSING",
+            Self::NotAnObject => "INVALID_MSG_FORMAT",
+        }
+    }
+}
+
+/// Parse an `NsmfEventExposure` document.
+///
+/// Enforces the three `required` members TS 29.508 declares — `notifId`, `notifUri`
+/// and `eventSubs` — and nothing else. `eventSubs` items require `event`, so an
+/// `eventSubs` naming none is refused too: it would create a subscription that can
+/// never fire, which is the shape of resource this repo has decided repeatedly not
+/// to accept.
+///
+/// `id` is assigned by the caller, so the same parse serves `POST` and `PUT`.
+pub fn parse_subscription(body: &Value, id: String) -> Result<EventSubscription, ParseError> {
+    let obj = body.as_object().ok_or(ParseError::NotAnObject)?;
+    let notif_id = obj
+        .get("notifId")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or(ParseError::Missing("notifId"))?
+        .to_string();
+    let notif_uri = obj
+        .get("notifUri")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or(ParseError::Missing("notifUri"))?
+        .to_string();
+    let event_subs = obj
+        .get("eventSubs")
+        .and_then(Value::as_array)
+        .filter(|a| !a.is_empty())
+        .ok_or(ParseError::Missing("eventSubs"))?;
+    let events: Vec<String> = event_subs
+        .iter()
+        .filter_map(|e| e.get("event").and_then(Value::as_str).map(str::to_string))
+        .collect();
+    if events.is_empty() {
+        return Err(ParseError::NoEvent);
+    }
+
+    Ok(EventSubscription {
+        id,
+        notif_id,
+        notif_uri,
+        events,
+        supi: obj.get("supi").and_then(Value::as_str).map(str::to_string),
+        pdu_session_id: obj
+            .get("pduSeId")
+            .and_then(Value::as_u64)
+            .and_then(|v| u8::try_from(v).ok()),
+        document: body.clone(),
+    })
+}
+
+/// Store a subscription under its id, returning the document to echo.
+///
+/// The echoed document is the stored one with `subId` and `self` filled in, which
+/// is what makes the `201` body an `NsmfEventExposure` rather than the bare
+/// `{"subscriptionId": ...}` the facade returned.
+pub fn insert(sub: EventSubscription) -> Value {
+    let mut document = sub.document.clone();
+    if let Some(obj) = document.as_object_mut() {
+        obj.insert("subId".to_string(), Value::String(sub.id.clone()));
+        obj.insert("self".to_string(), Value::String(resource_path(&sub.id)));
+    }
+    let id = sub.id.clone();
+    with_store(|store| store.insert(id, sub));
+    document
+}
+
+/// Replace an existing subscription. `false` when the id is unknown — a `PUT` to a
+/// resource that does not exist must not create one at a consumer-chosen id.
+pub fn replace(id: &str, sub: EventSubscription) -> bool {
+    with_store(|store| {
+        if !store.contains_key(id) {
+            return false;
+        }
+        store.insert(id.to_string(), sub);
+        true
+    })
+    .unwrap_or(false)
+}
+
+pub fn find(id: &str) -> Option<EventSubscription> {
+    SUBSCRIPTIONS.read().ok()?.as_ref()?.get(id).cloned()
+}
+
+pub fn remove(id: &str) -> Option<EventSubscription> {
+    with_store(|store| store.remove(id)).flatten()
+}
+
+pub fn count() -> usize {
+    SUBSCRIPTIONS
+        .read()
+        .ok()
+        .and_then(|g| g.as_ref().map(HashMap::len))
+        .unwrap_or(0)
+}
+
+/// The ONE agreement about [`SUBSCRIPTIONS`], for tests.
+///
+/// It lives here, beside the store it protects, so `main.rs`'s router tests and this
+/// module's own tests take the SAME lock. They must: `clear_for_test` empties the
+/// store for the whole process, so a sibling clearing it between another test's
+/// POST and the release that should notify makes the notification simply not
+/// happen — which is how `a_released_session_notifies_its_event_subscriber` failed
+/// on its first full-suite run while passing alone.
+///
+/// A `std::sync::Mutex` even though the async holders keep it across awaits (they
+/// carry `#[allow(clippy::await_holding_lock)]`): every holder is a test in this
+/// crate, none blocks on another, and a second `tokio` lock for the async half
+/// would recreate the split this comment exists to prevent.
+#[cfg(test)]
+pub static STORE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Take [`STORE_LOCK`], recovering a poisoned guard so one failure does not cascade.
+#[cfg(test)]
+pub fn lock_store() -> std::sync::MutexGuard<'static, ()> {
+    STORE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Test-only: empty the store so tests do not inherit each other's subscriptions.
+#[cfg(test)]
+pub fn clear_for_test() {
+    with_store(|store| store.clear());
+}
+
+/// The canonical resource path for a subscription id.
+pub fn resource_path(id: &str) -> String {
+    format!("/nsmf-event-exposure/v1/subscriptions/{id}")
+}
+
+/// Every subscription that matches an occurrence.
+fn matching(event: &str, supi: &str, psi: u8) -> Vec<EventSubscription> {
+    SUBSCRIPTIONS
+        .read()
+        .ok()
+        .and_then(|g| {
+            g.as_ref().map(|store| {
+                store
+                    .values()
+                    .filter(|s| s.matches(event, supi, psi))
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+        })
+        .unwrap_or_default()
+}
+
+/// Build the `NsmfEventExposureNotification` for one occurrence.
+///
+/// Both members TS 29.508 declares `required` are present: `notifId` (the
+/// subscription's, not the SMF's — it is the consumer's correlator) and
+/// `eventNotifs`, which is `minItems: 1` and therefore always carries exactly the
+/// one occurrence being reported.
+pub fn build_notification(sub: &EventSubscription, event: &str, supi: &str, psi: u8) -> Value {
+    serde_json::json!({
+        "notifId": sub.notif_id,
+        "eventNotifs": [{
+            "event": event,
+            "timeStamp": nextgcore_sbi::datetime::epoch_to_rfc3339(
+                nextgcore_sbi::datetime::now_epoch_secs(),
+            ),
+            "supi": supi,
+            "pduSeId": psi,
+        }],
+    })
+}
+
+/// Emit `Nsmf_EventExposure_Notify` to every subscription matching an occurrence
+/// (TS 29.508 §4.2.3.2).
+///
+/// Failures are logged and swallowed: an event is a report about something that
+/// already happened, so a consumer being unreachable must not fail the procedure
+/// that generated it. There is no retry queue, which is stated rather than implied.
+pub async fn notify(event: &str, supi: &str, psi: u8) {
+    let subs = matching(event, supi, psi);
+    if subs.is_empty() {
+        return;
+    }
+    for sub in subs {
+        let body = build_notification(&sub, event, supi, psi);
+        let Some((host, port)) = crate::policy::split_host_port(&sub.notif_uri) else {
+            log::warn!(
+                "subscription {} has an unusable notifUri '{}': the {event} \
+                 notification for {supi} cannot be delivered",
+                sub.id,
+                sub.notif_uri
+            );
+            continue;
+        };
+        let path = notify_path(&sub.notif_uri);
+        let request = nextgcore_sbi::message::SbiRequest::post(path).with_body(
+            body.to_string(),
+            nextgcore_sbi::constants::content_type::APPLICATION_JSON,
+        );
+        let client = nextgcore_sbi::client::SbiClient::new(
+            nextgcore_sbi::security::sbi_peer_client_config(&host, port)
+                .with_connect_timeout(std::time::Duration::from_secs(2))
+                .with_request_timeout(std::time::Duration::from_secs(3)),
+        );
+        match client.send_request(request).await {
+            Ok(resp) => log::info!(
+                "Nsmf_EventExposure_Notify {event} (SUPI {supi}, PSI {psi}) → \
+                 subscription {}: status={}",
+                sub.id,
+                resp.status
+            ),
+            Err(e) => log::warn!(
+                "Nsmf_EventExposure_Notify {event} to subscription {} failed: {e}",
+                sub.id
+            ),
+        }
+    }
+}
+
+/// The path component of a `notifUri`, defaulting to `/` when it names only an
+/// authority.
+///
+/// Split out because the consumer chooses this URI and a bare `http://host:port`
+/// is a legal `Uri` — POSTing to an empty path would produce a malformed request
+/// line rather than a failed delivery, which is much harder to diagnose.
+fn notify_path(uri: &str) -> String {
+    let without_scheme = uri
+        .strip_prefix("https://")
+        .or_else(|| uri.strip_prefix("http://"))
+        .unwrap_or(uri);
+    match without_scheme.find('/') {
+        Some(at) => without_scheme[at..].to_string(),
+        None => "/".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn document() -> Value {
+        serde_json::json!({
+            "notifId": "corr-1",
+            "notifUri": "http://127.0.0.1:9/nsmf-events",
+            "eventSubs": [{ "event": event::PDU_SES_REL }, { "event": event::PDU_SES_EST }],
+            "supi": "imsi-001010000000079",
+            "pduSeId": 5,
+            // A member this SMF does not model, to prove the document round-trips.
+            "sampRatio": 50,
+        })
+    }
+
+    #[test]
+    fn the_three_required_members_are_enforced_and_nothing_else_is() {
+        let sub = parse_subscription(&document(), "sub-1".into()).expect("parses");
+        assert_eq!(sub.notif_id, "corr-1");
+        assert_eq!(sub.events, vec!["PDU_SES_REL", "PDU_SES_EST"]);
+        assert_eq!(sub.supi.as_deref(), Some("imsi-001010000000079"));
+        assert_eq!(sub.pdu_session_id, Some(5));
+
+        for missing in ["notifId", "notifUri", "eventSubs"] {
+            let mut doc = document();
+            doc.as_object_mut().expect("obj").remove(missing);
+            assert_eq!(
+                parse_subscription(&doc, "x".into()),
+                Err(ParseError::Missing(missing)),
+                "{missing} is required by TS 29.508"
+            );
+        }
+
+        // An eventSubs entry with no `event` cannot ever match, so the subscription
+        // is refused rather than stored inert.
+        let mut doc = document();
+        doc["eventSubs"] = serde_json::json!([{ "referenceId": 7 }]);
+        assert_eq!(
+            parse_subscription(&doc, "x".into()),
+            Err(ParseError::NoEvent)
+        );
+
+        // An empty eventSubs violates minItems: 1.
+        let mut doc = document();
+        doc["eventSubs"] = serde_json::json!([]);
+        assert_eq!(
+            parse_subscription(&doc, "x".into()),
+            Err(ParseError::Missing("eventSubs"))
+        );
+
+        assert_eq!(
+            parse_subscription(&serde_json::json!("not an object"), "x".into()),
+            Err(ParseError::NotAnObject)
+        );
+    }
+
+    /// An absent filter matches anything; a present one must match exactly.
+    ///
+    /// The negative direction is the one that matters: a subscription scoped to one
+    /// SUPI that matched every UE would leak one subscriber's session events to a
+    /// consumer authorised for another.
+    #[test]
+    fn filters_scope_a_subscription_and_an_absent_filter_matches_anything() {
+        let scoped = parse_subscription(&document(), "s".into()).expect("parses");
+        assert!(scoped.matches("PDU_SES_REL", "imsi-001010000000079", 5));
+        assert!(
+            !scoped.matches("PDU_SES_REL", "imsi-999990000000000", 5),
+            "a SUPI-scoped subscription must not match another subscriber"
+        );
+        assert!(
+            !scoped.matches("PDU_SES_REL", "imsi-001010000000079", 6),
+            "a session-scoped subscription must not match another session"
+        );
+        assert!(
+            !scoped.matches("UP_PATH_CH", "imsi-001010000000079", 5),
+            "an event this subscription did not name must not match"
+        );
+
+        let mut doc = document();
+        doc.as_object_mut().expect("obj").remove("supi");
+        doc.as_object_mut().expect("obj").remove("pduSeId");
+        let any = parse_subscription(&doc, "s".into()).expect("parses");
+        assert!(any.matches("PDU_SES_REL", "imsi-whoever", 99));
+    }
+
+    #[test]
+    fn the_stored_document_is_echoed_with_sub_id_and_self() {
+        let _g = lock_store();
+        clear_for_test();
+        let sub = parse_subscription(&document(), "sub-echo".into()).expect("parses");
+        let echoed = insert(sub);
+        assert_eq!(echoed["subId"], serde_json::json!("sub-echo"));
+        assert_eq!(
+            echoed["self"],
+            serde_json::json!("/nsmf-event-exposure/v1/subscriptions/sub-echo")
+        );
+        // Required members survive, and so does one this SMF does not model.
+        assert_eq!(echoed["notifId"], serde_json::json!("corr-1"));
+        assert_eq!(
+            echoed["eventSubs"][0]["event"],
+            serde_json::json!("PDU_SES_REL")
+        );
+        assert_eq!(
+            echoed["sampRatio"],
+            serde_json::json!(50),
+            "a member the SMF does not model must round-trip, not be dropped"
+        );
+
+        assert!(find("sub-echo").is_some());
+        assert!(remove("sub-echo").is_some());
+        assert!(find("sub-echo").is_none());
+        assert!(
+            remove("sub-echo").is_none(),
+            "removal is not idempotent-silent"
+        );
+    }
+
+    #[test]
+    fn a_put_to_an_unknown_id_does_not_create_one() {
+        let _g = lock_store();
+        clear_for_test();
+        let sub = parse_subscription(&document(), "never-created".into()).expect("parses");
+        assert!(!replace("never-created", sub));
+        assert!(
+            find("never-created").is_none(),
+            "a PUT must not create a resource at a consumer-chosen id"
+        );
+    }
+
+    #[test]
+    fn the_notification_carries_both_required_members() {
+        let sub = parse_subscription(&document(), "s".into()).expect("parses");
+        let notif = build_notification(&sub, "PDU_SES_REL", "imsi-001010000000079", 5);
+        assert_eq!(
+            notif["notifId"],
+            serde_json::json!("corr-1"),
+            "notifId is the CONSUMER's correlator, not an SMF-side id"
+        );
+        let notifs = notif["eventNotifs"]
+            .as_array()
+            .expect("eventNotifs required");
+        assert_eq!(notifs.len(), 1, "minItems: 1");
+        assert_eq!(notifs[0]["event"], serde_json::json!("PDU_SES_REL"));
+        assert_eq!(notifs[0]["pduSeId"], serde_json::json!(5));
+        assert!(
+            notifs[0]["timeStamp"]
+                .as_str()
+                .is_some_and(|t| t.contains('T')),
+            "the timestamp must be an RFC 3339 DateTime, got {}",
+            notifs[0]["timeStamp"]
+        );
+    }
+
+    #[test]
+    fn a_notif_uri_naming_only_an_authority_still_yields_a_usable_path() {
+        assert_eq!(
+            notify_path("http://127.0.0.1:8080/callbacks/smf"),
+            "/callbacks/smf"
+        );
+        assert_eq!(notify_path("https://nef.example.com/x"), "/x");
+        assert_eq!(
+            notify_path("http://127.0.0.1:8080"),
+            "/",
+            "a bare authority is a legal Uri, and POSTing to an empty path would be \
+             malformed rather than merely undelivered"
+        );
+    }
+}

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -34,6 +34,7 @@ mod context;
 mod easdf; // #114: EASDF selection + DNS-context lifecycle (TS 23.501 §5.6.7)
 mod eps_iwk; // #117: 5GS↔EPS interworking, EBI assignment over Namf_Communication
 mod event;
+mod event_exposure; // #79: Nsmf_EventExposure resource model + notification
 mod gn_build;
 mod gn_handler;
 mod gsm_build;
@@ -54,6 +55,7 @@ mod session_extensions; // #199-#201: IPv6 dual-stack, SSC modes, Ethernet PDU
 pub mod slicing; // Rel-17: per-slice QoS profiles
 mod smf_sm;
 mod timer;
+mod udm; // #79: Nudm_UECM_Registration + Nudm_SDM_Get sm-data
 
 use context::{smf_context_final, smf_context_init, smf_self};
 use smf_sm::SmfFsm;
@@ -469,6 +471,19 @@ async fn main() -> Result<()> {
         eps_iwk::enable();
     }
 
+    // ---- #79: UDM interaction (TS 23.502 §4.3.2.2.1 step 4) ----
+    //
+    // Off by default, as #79 asks: the E2E harness has no conformant UDM, and
+    // enforcing subscription data nothing supplies would regress the matched-sim
+    // data-plane path CI does gate on. A runtime switch rather than a cargo
+    // feature, for the reason recorded across this daemon's other switches.
+    if std::env::var("SMF_UDM")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        udm::enable();
+    }
+
     // Initialize SMF context
     smf_context_init(config.max_ue, config.max_sess, config.max_bearer);
     log::info!(
@@ -554,6 +569,9 @@ async fn main() -> Result<()> {
     // Register with NRF (if configured)
     match smf_nrf_register(&config.sbi_addr, config.sbi_port).await {
         Ok(nf_instance_id) if !nf_instance_id.is_empty() => {
+            // #79: the UDM must record the SAME instance id the NRF knows, or its
+            // serving-SMF record points at an instance nothing else can resolve.
+            udm::set_instance_id(&nf_instance_id);
             // G2-2: PATCH a real NFProfile "/load" gauge to NRF each heartbeat
             // (PDU sessions vs configured capacity; TS 29.510 §5.2.2.3.2).
             nextgcore_sbi::heartbeat::spawn_heartbeat_worker_with_load(nf_instance_id, 5, || {
@@ -1140,6 +1158,20 @@ impl DefaultDnnError {
     }
 }
 
+/// The ONE agreement about the `UDM_SBI_ADDR` / `UDM_SBI_PORT` / `NRF_URI`
+/// environment, for tests.
+///
+/// Declared at the crate root rather than inside `mod tests` because `udm.rs`'s
+/// tests set the same variables (#79) and a sibling module cannot reach a static
+/// inside this file's test submodule. It was in `mod tests` first, and the result
+/// was a flaky `the_smf_registers_with_the_udm_and_fetches_sm_data`: another test
+/// re-pointed `UDM_SBI_PORT` at its own loopback UDM between the registration and
+/// the `sm-data` fetch, so the fetch reached a server that answers 201 to
+/// everything and returned no subscription. Env is per-process; two locks over it
+/// are two disjoint agreements.
+#[cfg(test)]
+pub(crate) static UDM_ENV_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Resolve a UDM `nudm-sdm` endpoint.
 ///
 /// NRF discovery first (TS 29.510 §5.3.2), because that is the mechanism a real
@@ -1151,6 +1183,25 @@ impl DefaultDnnError {
 /// carry a full cache-populating discovery routine, and a third copy is a
 /// maintenance cost this issue does not need. What the SMF wants is one address.
 async fn discover_udm_sdm_endpoint() -> Option<(String, u16)> {
+    discover_udm_service_endpoint("nudm-sdm").await
+}
+
+/// Resolve a UDM `nudm-uecm` endpoint (#79).
+///
+/// Separate from the `nudm-sdm` lookup rather than reusing it, because a UDM may
+/// advertise the two services on different ports — `udm_service_endpoint_from_search_result`
+/// already prefers a service's own `ipEndPoints` for exactly that reason, and
+/// asking for one service name and using the answer for another would defeat it.
+pub(crate) async fn discover_udm_uecm_endpoint() -> Option<(String, u16)> {
+    discover_udm_service_endpoint("nudm-uecm").await
+}
+
+/// The shared body of the two lookups above.
+///
+/// The env fallback is deliberately shared: `UDM_SBI_ADDR`/`UDM_SBI_PORT` names one
+/// UDM, so a deployment with no NRF gets both services at the same address, which
+/// is what a single-container UDM actually does.
+async fn discover_udm_service_endpoint(service: &str) -> Option<(String, u16)> {
     let sbi_ctx = global_context();
     let nrf_uri = match sbi_ctx.get_nrf_uri().await {
         Some(uri) => Some(uri),
@@ -1160,21 +1211,23 @@ async fn discover_udm_sdm_endpoint() -> Option<(String, u16)> {
     if let Some(nrf_uri) = nrf_uri {
         if let Some((nrf_host, nrf_port)) = parse_host_port(&nrf_uri) {
             let client = sbi_ctx.get_client(&nrf_host, nrf_port).await;
-            let path = "/nnrf-disc/v1/nf-instances\
-                        ?target-nf-type=UDM&requester-nf-type=SMF&service-names=nudm-sdm";
-            match client.get(path).await {
+            let path = format!(
+                "/nnrf-disc/v1/nf-instances\
+                 ?target-nf-type=UDM&requester-nf-type=SMF&service-names={service}"
+            );
+            match client.get(&path).await {
                 Ok(resp) if resp.status == 200 => {
                     if let Some(ep) = resp
                         .http
                         .content
                         .as_deref()
                         .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok())
-                        .and_then(|json| udm_sdm_endpoint_from_search_result(&json))
+                        .and_then(|json| udm_service_endpoint_from_search_result(&json, service))
                     {
-                        log::debug!("UDM nudm-sdm discovered via NRF at {}:{}", ep.0, ep.1);
+                        log::debug!("UDM {service} discovered via NRF at {}:{}", ep.0, ep.1);
                         return Some(ep);
                     }
-                    log::debug!("NRF returned no usable UDM nudm-sdm endpoint");
+                    log::debug!("NRF returned no usable UDM {service} endpoint");
                 }
                 Ok(resp) => log::debug!("NRF UDM discovery returned status {}", resp.status),
                 Err(e) => log::debug!("NRF UDM discovery failed: {e}"),
@@ -1190,16 +1243,20 @@ async fn discover_udm_sdm_endpoint() -> Option<(String, u16)> {
     Some((host, port))
 }
 
-/// Pull a `nudm-sdm` address out of a TS 29.510 `SearchResult`.
+/// Pull a named UDM service's address out of a TS 29.510 `SearchResult`.
 ///
 /// Split out so the decode is testable without an NRF. Prefers the service's own
 /// `ipEndPoints` over the instance's `ipv4Addresses`, because a UDM may serve
-/// `nudm-sdm` on a different port from its other services.
-fn udm_sdm_endpoint_from_search_result(json: &serde_json::Value) -> Option<(String, u16)> {
+/// `nudm-sdm` on a different port from `nudm-uecm` — which is why the service name
+/// is a parameter rather than a constant (#79).
+fn udm_service_endpoint_from_search_result(
+    json: &serde_json::Value,
+    service: &str,
+) -> Option<(String, u16)> {
     for instance in json.get("nfInstances")?.as_array()? {
         let services = instance.get("nfServices").and_then(|v| v.as_array());
         for svc in services.into_iter().flatten() {
-            if svc.get("serviceName").and_then(|v| v.as_str()) != Some("nudm-sdm") {
+            if svc.get("serviceName").and_then(|v| v.as_str()) != Some(service) {
                 continue;
             }
             let endpoint = svc.get("ipEndPoints").and_then(|v| v.as_array());
@@ -1472,12 +1529,29 @@ async fn smf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
         // Event Exposure Service (nsmf-event-exposure)
         // =====================================================================
 
-        // Subscribe to events
+        // Nsmf_EventExposure (TS 29.508 §4.2.2), #79: a subscription is a
+        // PERSISTED resource, so the collection takes POST and the individual
+        // resource takes GET / PUT / DELETE. Before #79 only POST and DELETE
+        // existed and neither touched any store.
+        //
         // POST /nsmf-event-exposure/v1/subscriptions
-        ("nsmf-event-exposure", "subscriptions", "POST") => handle_event_subscribe().await,
+        ("nsmf-event-exposure", "subscriptions", "POST") if resource_id.is_none() => {
+            handle_event_subscribe(&request).await
+        }
 
-        // Unsubscribe from events
-        // DELETE /nsmf-event-exposure/v1/subscriptions/{subscriptionId}
+        // GET /nsmf-event-exposure/v1/subscriptions/{subId}
+        ("nsmf-event-exposure", "subscriptions", "GET") => match resource_id {
+            Some(sub_id) => handle_event_subscription_get(sub_id).await,
+            None => send_bad_request("Missing subscription ID", None),
+        },
+
+        // PUT /nsmf-event-exposure/v1/subscriptions/{subId}
+        ("nsmf-event-exposure", "subscriptions", "PUT") => match resource_id {
+            Some(sub_id) => handle_event_subscription_put(sub_id, &request).await,
+            None => send_bad_request("Missing subscription ID", None),
+        },
+
+        // DELETE /nsmf-event-exposure/v1/subscriptions/{subId}
         ("nsmf-event-exposure", "subscriptions", "DELETE") => {
             if let Some(sub_id) = resource_id {
                 handle_event_unsubscribe(sub_id).await
@@ -2729,6 +2803,47 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
         Vec::new(),
     ));
 
+    // ---- #79: UDM interaction (TS 23.502 §4.3.2.2.1 step 4) ----
+    //
+    // Both legs happen BEFORE the PCF call and before PFCP establishment, which is
+    // where the spec puts them and what makes them useful: the subscribed values
+    // are an INPUT to the policy decision, so fetching them afterwards could only
+    // override a PCF decision -- a conformance defect rather than a degradation.
+    //
+    // Off by default (`SMF_UDM=1`). Both are non-fatal: a session that could not
+    // reach the UDM is a working session on config-default QoS, and refusing it
+    // would make a UDM outage a total outage.
+    //
+    // The registration is awaited rather than spawned so its failure is logged
+    // against this session rather than arriving after the response.
+    let serving_plmn = req_body["guami"]["plmnId"]
+        .as_object()
+        .and_then(|p| {
+            Some((
+                p.get("mcc")?.as_str()?.to_string(),
+                p.get("mnc")?.as_str()?.to_string(),
+            ))
+        })
+        .or_else(|| {
+            let p = req_body["servingNetwork"].as_object()?;
+            Some((
+                p.get("mcc")?.as_str()?.to_string(),
+                p.get("mnc")?.as_str()?.to_string(),
+            ))
+        });
+    udm::register_as_serving_smf(
+        &supi,
+        pdu_session_id,
+        &dnn,
+        sst,
+        snssai_sd.as_deref(),
+        serving_plmn
+            .as_ref()
+            .map(|(mcc, mnc)| (mcc.as_str(), mnc.as_str())),
+    )
+    .await;
+    let subscribed = udm::fetch_sm_data(&supi, &dnn, sst, snssai_sd.as_deref()).await;
+
     // ---- Npcf_SMPolicyControl_Create (TS 29.512 §4.2.2) ----
     let notification_uri = format!(
         "{}/nsmf-callback/v1/sm-policy-notify/{}",
@@ -2746,7 +2861,15 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
             // DNN-aware default: an XR DNN (e.g. "xr") yields a delay-critical
             // GBR XR 5QI (82-85) with a populated PCC rule, exercising the
             // XR-aware QoS-flow binding + PFCP QER setup below even without a PCF.
-            policy::PolicyDecision::config_default_for_dnn(&dnn)
+            // #79: the subscribed values, when the UDM supplied any, are the
+            // baseline here -- the config default is what they fall back TO, not
+            // the other way round. With a PCF present its decision wins outright
+            // (TS 23.503 §6.1.3.2), which is why this applies only on this arm.
+            let mut decision = policy::PolicyDecision::config_default_for_dnn(&dnn);
+            if let Some(ref sub) = subscribed {
+                decision.apply_subscribed_baseline(sub);
+            }
+            decision
         }
         Some(pcf) => {
             let create_ctx = policy::SmPolicyCreateContext {
@@ -3098,6 +3221,11 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
         // Issue #191: after the write guard drops (see `SmfContext::persist`).
         context.persist();
     }
+
+    // #79: Nsmf_EventExposure_Notify for PDU_SES_EST (TS 29.508 §4.2.3.2). After
+    // the binding is stored, so the session a consumer is told about exists by the
+    // time the notification lands.
+    event_exposure::notify(event_exposure::event::PDU_SES_EST, &supi, pdu_session_id).await;
 
     // ---- N1: PDU Session Establishment Accept with authorized QoS ----
     // S-NSSAI (smfd-04) is taken from the create request's S-NSSAI; the SD hex
@@ -4497,6 +4625,19 @@ async fn handle_sm_context_release(
         }
     }
 
+    // #79: Nsmf_EventExposure_Notify for PDU_SES_REL (TS 29.508 §4.2.3.2). Emitted
+    // from the binding taken above, so a subscription scoped to this SUPI or this
+    // PDU session id can be matched. A session with no matching subscription costs
+    // one map read.
+    if let Some(binding) = &binding {
+        event_exposure::notify(
+            event_exposure::event::PDU_SES_REL,
+            &binding.supi,
+            binding.psi,
+        )
+        .await;
+    }
+
     // Drive the GSM FSM: Operational → WaitPfcpDeletion
     let mut fsm = binding.as_ref().map(|b| b.fsm.clone());
     if let Some(ref mut f) = fsm {
@@ -4795,50 +4936,66 @@ fn build_ue_eps_pdn_connection(sess: &context::SmfSess, eps_bearer_id: Option<u8
 
 /// Handle PDU Session Create
 async fn handle_pdu_session_create(_request: &SbiRequest) -> SbiResponse {
-    log::info!("PDU Session Create request received");
+    log::info!("H-SMF PDU Session Create request received (home-routed roaming)");
+    hsmf_not_implemented("Create")
+}
 
-    let pdu_session_ref = "1";
-    let response_body = serde_json::json!({
-        "pduSessionRef": pdu_session_ref,
-        "cause": "REL_DUE_TO_HO"
-    });
-
-    let location = format!("/nsmf-pdusession/v1/pdu-sessions/{pdu_session_ref}");
-
-    SbiResponse::with_status(201)
-        .with_header("Location", location)
-        .with_body(response_body.to_string(), "application/json")
+/// The H-SMF `/pdu-sessions` service answers `501`, deliberately.
+///
+/// #79's criterion offers a choice: implement Create/Update/Release with conformant
+/// `PduSessionCreatedData`/`HsmfUpdatedData` bodies, or return `501` rather than a
+/// fabricated `201`. `501` is taken, for two reasons.
+///
+/// **What it replaces was actively misleading.** Create answered `201` with
+/// `{"pduSessionRef": "1", "cause": "REL_DUE_TO_HO"}` — a **release cause on a
+/// create success**, at a hardcoded reference, with no session created. A partner
+/// V-SMF parsing that gets "your session was established, and by the way it was
+/// released for handover", about a session that does not exist. Update and Release
+/// answered empty `200`/`204` bodies where `HsmfUpdatedData` is expected.
+///
+/// **Home-routed roaming is not implemented here.** There is no V-SMF/H-SMF split
+/// in this tree: nothing establishes an H-SMF session, `PduSessionCreatedData`
+/// requires `pduSessionType`, `sscMode` and one of `hSmfInstanceId`/`smfInstanceId`
+/// (a `oneOf`), and every one of those would have to be invented. This project's
+/// recorded rule for exactly this case is that a spec-defined resource whose
+/// dependency is absent answers `501` — never a `404`, never a fabricated `2xx`.
+///
+/// A partner then fails **cleanly and diagnosably** at the point of the create,
+/// instead of proceeding on a session that was never built. All three operations
+/// answer the same way, because a partner that cannot create can never legitimately
+/// update or release either, and leaving those at `2xx` would say otherwise.
+fn hsmf_not_implemented(operation: &str) -> SbiResponse {
+    nextgcore_sbi::server::send_error(
+        501,
+        "Not Implemented",
+        &format!(
+            "H-SMF PDU Session {operation} is not implemented: this SMF does not \
+             support home-routed roaming (TS 29.502 §5.2.2.7). No V-SMF/H-SMF split \
+             exists in this deployment."
+        ),
+        Some("NOT_IMPLEMENTED"),
+    )
 }
 
 /// Handle PDU Session Update
 async fn handle_pdu_session_update(pdu_session_ref: &str) -> SbiResponse {
-    log::info!("PDU Session Update request for ref={pdu_session_ref}");
-
-    let ctx = smf_self();
-    if let Ok(context) = ctx.read() {
-        if context
-            .sess_find_by_pdu_session_ref(pdu_session_ref)
-            .is_some()
-        {
-            return SbiResponse::with_status(200);
-        }
-    }
-
-    SbiResponse::with_status(404)
+    log::info!("H-SMF PDU Session Update request for ref={pdu_session_ref}");
+    // Answered 200 with an EMPTY body where TS 29.502 §5.2.2.8 expects
+    // `HsmfUpdatedData`. See `hsmf_not_implemented`: a partner that cannot create
+    // through this service can never legitimately update through it either, and a
+    // 2xx here would say otherwise.
+    hsmf_not_implemented("Update")
 }
 
 /// Handle PDU Session Release
 async fn handle_pdu_session_release(pdu_session_ref: &str) -> SbiResponse {
-    log::info!("PDU Session Release request for ref={pdu_session_ref}");
-
-    let ctx = smf_self();
-    if let Ok(context) = ctx.read() {
-        if let Some(sess) = context.sess_find_by_pdu_session_ref(pdu_session_ref) {
-            context.sess_remove(sess.id);
-        }
-    }
-
-    SbiResponse::with_status(204)
+    log::info!("H-SMF PDU Session Release request for ref={pdu_session_ref}");
+    // Used to remove a session by `pduSessionRef` and answer 204. That reference
+    // space is the H-SMF's, which this SMF does not populate, so the lookup could
+    // only ever match a session some other path had registered under it -- i.e. it
+    // was a way for a partner to delete state it did not own. 501 both refuses the
+    // unimplemented service and closes that.
+    hsmf_not_implemented("Release")
 }
 
 // =============================================================================
@@ -4846,25 +5003,115 @@ async fn handle_pdu_session_release(pdu_session_ref: &str) -> SbiResponse {
 // =============================================================================
 
 /// Handle Event Subscribe
-async fn handle_event_subscribe() -> SbiResponse {
-    log::info!("Event subscription request received");
-
-    let subscription_id = uuid::Uuid::new_v4().to_string();
-    let response_body = serde_json::json!({
-        "subscriptionId": subscription_id
-    });
-
-    let location = format!("/nsmf-event-exposure/v1/subscriptions/{subscription_id}");
-
+/// `POST /nsmf-event-exposure/v1/subscriptions` — Nsmf_EventExposure_Subscribe
+/// (TS 29.508 §4.2.2.2), #79.
+///
+/// Answers `201` + `Location` + the created `NsmfEventExposure` document. The
+/// previous version ignored the body, returned `{"subscriptionId": ...}` (not a
+/// schema in TS 29.508) and stored nothing, so the id it handed out referenced
+/// nothing and no notification could ever be sent to it.
+async fn handle_event_subscribe(request: &SbiRequest) -> SbiResponse {
+    let Some(body) = request
+        .http
+        .content
+        .as_deref()
+        .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+    else {
+        return send_bad_request(
+            "Request body is missing or not valid JSON",
+            Some("INVALID_MSG_FORMAT"),
+        );
+    };
+    let id = uuid::Uuid::new_v4().to_string();
+    let sub = match event_exposure::parse_subscription(&body, id.clone()) {
+        Ok(sub) => sub,
+        Err(e) => return send_bad_request(&e.detail(), Some(e.cause())),
+    };
+    log::info!(
+        "Event subscription {id} created: events={:?} notifUri={} ({} stored)",
+        sub.events,
+        sub.notif_uri,
+        event_exposure::count() + 1
+    );
+    let document = event_exposure::insert(sub);
     SbiResponse::with_status(201)
-        .with_header("Location", location)
-        .with_body(response_body.to_string(), "application/json")
+        .with_header("Location", event_exposure::resource_path(&id))
+        .with_json_body(&document)
+        .unwrap_or_else(|_| SbiResponse::with_status(201))
 }
 
-/// Handle Event Unsubscribe
+/// `GET /nsmf-event-exposure/v1/subscriptions/{subId}` (TS 29.508 §4.2.2.3), #79.
+async fn handle_event_subscription_get(subscription_id: &str) -> SbiResponse {
+    match event_exposure::find(subscription_id) {
+        Some(sub) => {
+            let mut document = sub.document;
+            if let Some(obj) = document.as_object_mut() {
+                obj.insert("subId".to_string(), serde_json::json!(subscription_id));
+                obj.insert(
+                    "self".to_string(),
+                    serde_json::json!(event_exposure::resource_path(subscription_id)),
+                );
+            }
+            SbiResponse::with_status(200)
+                .with_json_body(&document)
+                .unwrap_or_else(|_| SbiResponse::with_status(200))
+        }
+        None => event_subscription_not_found(subscription_id),
+    }
+}
+
+/// `PUT /nsmf-event-exposure/v1/subscriptions/{subId}` (TS 29.508 §4.2.2.4), #79.
+///
+/// Replaces an existing subscription and answers `200` with the stored document. A
+/// `PUT` to an unknown id is a `404`, not a create: the id space belongs to the
+/// SMF, so honouring a consumer-chosen one would let a consumer mint resources.
+async fn handle_event_subscription_put(subscription_id: &str, request: &SbiRequest) -> SbiResponse {
+    let Some(body) = request
+        .http
+        .content
+        .as_deref()
+        .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+    else {
+        return send_bad_request(
+            "Request body is missing or not valid JSON",
+            Some("INVALID_MSG_FORMAT"),
+        );
+    };
+    let sub = match event_exposure::parse_subscription(&body, subscription_id.to_string()) {
+        Ok(sub) => sub,
+        Err(e) => return send_bad_request(&e.detail(), Some(e.cause())),
+    };
+    if !event_exposure::replace(subscription_id, sub) {
+        return event_subscription_not_found(subscription_id);
+    }
+    log::info!("Event subscription {subscription_id} replaced");
+    handle_event_subscription_get(subscription_id).await
+}
+
+/// `DELETE /nsmf-event-exposure/v1/subscriptions/{subId}` —
+/// Nsmf_EventExposure_Unsubscribe (TS 29.508 §4.2.2.5), #79.
+///
+/// `404` on an unknown id. The previous version answered `204` for anything, so a
+/// consumer could not tell a successful unsubscribe from a subscription that had
+/// never existed — which matters, because the latter means its notifications were
+/// never going to arrive.
 async fn handle_event_unsubscribe(subscription_id: &str) -> SbiResponse {
-    log::info!("Event unsubscription request for id={subscription_id}");
-    SbiResponse::with_status(204)
+    match event_exposure::remove(subscription_id) {
+        Some(_) => {
+            log::info!("Event subscription {subscription_id} removed");
+            SbiResponse::with_status(204)
+        }
+        None => event_subscription_not_found(subscription_id),
+    }
+}
+
+fn event_subscription_not_found(subscription_id: &str) -> SbiResponse {
+    nextgcore_sbi::server::send_error(
+        404,
+        "Not Found",
+        &format!("Event subscription '{subscription_id}' not found"),
+        Some("SUBSCRIPTION_NOT_FOUND"),
+    )
 }
 
 // =============================================================================
@@ -5726,7 +5973,7 @@ mod tests {
             ]
         });
         assert_eq!(
-            udm_sdm_endpoint_from_search_result(&result),
+            udm_service_endpoint_from_search_result(&result, "nudm-sdm"),
             Some(("10.0.0.9".to_string(), 8080)),
             "the nudm-sdm service's own endpoint wins over the instance address"
         );
@@ -5737,7 +5984,7 @@ mod tests {
                               "nfServices": [{ "serviceName": "nudm-sdm" }] }]
         });
         assert_eq!(
-            udm_sdm_endpoint_from_search_result(&no_endpoints),
+            udm_service_endpoint_from_search_result(&no_endpoints, "nudm-sdm"),
             Some(("10.0.0.3".to_string(), 7777))
         );
 
@@ -5750,18 +5997,17 @@ mod tests {
                 "nfServices": [{ "serviceName": "nudm-uecm" }] }] }),
         ] {
             assert_eq!(
-                udm_sdm_endpoint_from_search_result(&empty),
+                udm_service_endpoint_from_search_result(&empty, "nudm-sdm"),
                 None,
                 "body {empty} must not yield an endpoint"
             );
         }
     }
 
-    /// Serialises the tests that set the process-global `UDM_SBI_ADDR` /
-    /// `UDM_SBI_PORT` / `NRF_URI` environment. Env is per-process, so two of these
-    /// running concurrently would each see the other's UDM address — the same
-    /// process-global-state race the workspace has hit before with `UDR_SBI_*`.
-    static UDM_ENV_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    /// The lock over the `UDM_SBI_*` / `NRF_URI` environment now lives at the crate
+    /// root, because `udm.rs`'s tests take the SAME one (#79). Re-exported under the
+    /// local name so the call sites below are unchanged.
+    use super::UDM_ENV_TEST_LOCK;
 
     /// **Issue #204, end to end.** `fetch_subscribed_default_dnn` really reaches a
     /// UDM, sends a conformant `Nudm_SDM_Get smf-select-data` with a
@@ -6942,6 +7188,355 @@ mod tests {
             *carried.last().expect("last octet"),
             6,
             "the descriptor must name the EBI the AMF assigned"
+        );
+    }
+
+    // ---- #79: Nsmf_EventExposure, UDM interaction, H-SMF -------------------
+
+    fn events_request(method: &str, path: &str, body: Option<serde_json::Value>) -> SbiRequest {
+        let mut req = match method {
+            "POST" => SbiRequest::post(path.to_string()),
+            "GET" => SbiRequest::get(path.to_string()),
+            "PUT" => SbiRequest::put(path.to_string()),
+            "DELETE" => SbiRequest::delete(path.to_string()),
+            other => panic!("unsupported method {other}"),
+        };
+        if let Some(body) = body {
+            req = req.with_body(body.to_string(), "application/json");
+        }
+        req
+    }
+
+    fn subscription_body(notif_uri: &str, supi: Option<&str>) -> serde_json::Value {
+        let mut body = serde_json::json!({
+            "notifId": "corr-79",
+            "notifUri": notif_uri,
+            "eventSubs": [{ "event": "PDU_SES_REL" }],
+        });
+        if let Some(supi) = supi {
+            body["supi"] = serde_json::json!(supi);
+        }
+        body
+    }
+
+    /// #79 criterion 4: create → get → delete, and `404` on an unknown id.
+    ///
+    /// Driven through the ROUTER, because half of what was missing was routing: no
+    /// `GET` and no `PUT` arm existed at all, so a test calling the handlers
+    /// directly would pass against a service a consumer cannot reach.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn event_subscriptions_are_a_real_resource_with_get_put_and_a_404() {
+        let _g = event_exposure::lock_store();
+        event_exposure::clear_for_test();
+
+        // Create.
+        let resp = smf_sbi_request_handler(events_request(
+            "POST",
+            "/nsmf-event-exposure/v1/subscriptions",
+            Some(subscription_body("http://127.0.0.1:9/cb", Some("imsi-79"))),
+        ))
+        .await;
+        assert_eq!(resp.status, 201, "body: {:?}", resp.http.content);
+        let location = resp
+            .http
+            .get_header("location")
+            .expect("201 must carry a Location")
+            .to_string();
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        // An NsmfEventExposure document, not the bare {"subscriptionId": ...} the
+        // facade returned.
+        assert!(
+            body.get("subscriptionId").is_none(),
+            "subscriptionId is not a member of NsmfEventExposure, got {body}"
+        );
+        let sub_id = body["subId"].as_str().expect("subId").to_string();
+        assert_eq!(body["notifId"], serde_json::json!("corr-79"));
+        assert_eq!(
+            body["eventSubs"][0]["event"],
+            serde_json::json!("PDU_SES_REL")
+        );
+        assert_eq!(
+            location,
+            format!("/nsmf-event-exposure/v1/subscriptions/{sub_id}")
+        );
+
+        // Get.
+        let resp = smf_sbi_request_handler(events_request("GET", &location, None)).await;
+        assert_eq!(resp.status, 200, "the created resource must be retrievable");
+        let fetched: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(fetched["subId"], serde_json::json!(sub_id));
+        assert_eq!(
+            fetched["notifUri"],
+            serde_json::json!("http://127.0.0.1:9/cb")
+        );
+
+        // Put replaces.
+        let resp = smf_sbi_request_handler(events_request(
+            "PUT",
+            &location,
+            Some(subscription_body(
+                "http://127.0.0.1:9/moved",
+                Some("imsi-79"),
+            )),
+        ))
+        .await;
+        assert_eq!(resp.status, 200);
+        let replaced: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(
+            replaced["notifUri"],
+            serde_json::json!("http://127.0.0.1:9/moved"),
+            "the PUT must be applied, not merely acknowledged"
+        );
+
+        // A PUT to an unknown id must NOT create one.
+        let resp = smf_sbi_request_handler(events_request(
+            "PUT",
+            "/nsmf-event-exposure/v1/subscriptions/never-existed",
+            Some(subscription_body("http://127.0.0.1:9/cb", None)),
+        ))
+        .await;
+        assert_eq!(resp.status, 404);
+
+        // Delete, then delete again: 204 then 404. The facade answered 204 for
+        // both, so a consumer could not tell an unsubscribe from a subscription
+        // that had never existed.
+        assert_eq!(
+            smf_sbi_request_handler(events_request("DELETE", &location, None))
+                .await
+                .status,
+            204
+        );
+        assert_eq!(
+            smf_sbi_request_handler(events_request("DELETE", &location, None))
+                .await
+                .status,
+            404,
+            "a second DELETE must 404: the resource is gone"
+        );
+        assert_eq!(
+            smf_sbi_request_handler(events_request("GET", &location, None))
+                .await
+                .status,
+            404
+        );
+
+        // A body missing a required member is refused rather than stored.
+        for missing in ["notifId", "notifUri", "eventSubs"] {
+            let mut body = subscription_body("http://127.0.0.1:9/cb", None);
+            body.as_object_mut().expect("obj").remove(missing);
+            let resp = smf_sbi_request_handler(events_request(
+                "POST",
+                "/nsmf-event-exposure/v1/subscriptions",
+                Some(body),
+            ))
+            .await;
+            assert_eq!(
+                resp.status, 400,
+                "a subscription without {missing} must be refused"
+            );
+        }
+        event_exposure::clear_for_test();
+    }
+
+    /// #79 criterion 5: a subscribed event occurrence produces a notification at
+    /// the subscribed `notifUri`.
+    ///
+    /// `PDU_SES_REL` is chosen because the release handler is reachable from a test,
+    /// unlike the establishment path (which needs a UPF — see #289). The
+    /// notification is captured on a real loopback consumer, so what is asserted is
+    /// a delivered HTTP request rather than a function having been called.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_released_session_notifies_its_event_subscriber() {
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+
+        let _g = event_exposure::lock_store();
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        event_exposure::clear_for_test();
+
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let port = nextgcore_sbi::test_support::free_port();
+        let consumer = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            port,
+        ))));
+        consumer
+            .start(move |req: SbiRequest| {
+                let sink = sink.clone();
+                async move {
+                    sink.lock().unwrap_or_else(|e| e.into_inner()).push((
+                        req.header.uri.clone(),
+                        req.http.content.clone().unwrap_or_default(),
+                    ));
+                    SbiResponse::with_status(204)
+                }
+            })
+            .await
+            .expect("consumer start");
+
+        let supi = "imsi-001010000000079";
+        let resp = smf_sbi_request_handler(events_request(
+            "POST",
+            "/nsmf-event-exposure/v1/subscriptions",
+            Some(subscription_body(
+                &format!("http://127.0.0.1:{port}/nsmf-events"),
+                Some(supi),
+            )),
+        ))
+        .await;
+        assert_eq!(resp.status, 201);
+
+        // A session for that SUPI, then release it.
+        seed_binding("events-release-ref", 4);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut("events-release-ref") {
+                    b.supi = supi.to_string();
+                    b.psi = 4;
+                }
+            }
+        }
+        let _ = handle_sm_context_release("events-release-ref", None).await;
+
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let notif = requests
+            .iter()
+            .find(|(uri, _)| uri.contains("/nsmf-events"))
+            .unwrap_or_else(|| {
+                panic!("a PDU_SES_REL notification must reach the subscriber, got {requests:?}")
+            });
+        let body: serde_json::Value = serde_json::from_str(&notif.1).expect("json");
+        assert_eq!(
+            body["notifId"],
+            serde_json::json!("corr-79"),
+            "the notification must carry the CONSUMER's correlation id"
+        );
+        assert_eq!(
+            body["eventNotifs"][0]["event"],
+            serde_json::json!("PDU_SES_REL")
+        );
+        assert_eq!(body["eventNotifs"][0]["supi"], serde_json::json!(supi));
+        assert_eq!(body["eventNotifs"][0]["pduSeId"], serde_json::json!(4));
+
+        // A subscription scoped to a DIFFERENT SUPI must not be notified: that
+        // would leak one subscriber's session events to another's consumer.
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        seed_binding("events-release-other", 5);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut("events-release-other") {
+                    b.supi = "imsi-999990000000000".to_string();
+                    b.psi = 5;
+                }
+            }
+        }
+        let _ = handle_sm_context_release("events-release-other", None).await;
+        assert!(
+            seen.lock().unwrap_or_else(|e| e.into_inner()).is_empty(),
+            "a SUPI-scoped subscription must not be notified about another subscriber"
+        );
+
+        event_exposure::clear_for_test();
+        consumer.stop().await.expect("stop");
+    }
+
+    /// #79 criterion 6: the H-SMF `/pdu-sessions` service never answers a release
+    /// cause on a create success.
+    ///
+    /// It used to answer `201` with `{"pduSessionRef": "1", "cause":
+    /// "REL_DUE_TO_HO"}` — a release cause on a create — at a hardcoded reference,
+    /// with no session created. `501` is the recorded answer in this project for a
+    /// spec-defined resource whose dependency is absent.
+    #[tokio::test]
+    async fn the_hsmf_pdu_sessions_service_answers_501_and_never_a_release_cause() {
+        for (method, path) in [
+            ("POST", "/nsmf-pdusession/v1/pdu-sessions"),
+            ("POST", "/nsmf-pdusession/v1/pdu-sessions/1/modify"),
+            ("POST", "/nsmf-pdusession/v1/pdu-sessions/1/release"),
+        ] {
+            let resp = smf_sbi_request_handler(events_request(
+                method,
+                path,
+                Some(serde_json::json!({ "vsmfId": "vsmf-1" })),
+            ))
+            .await;
+            assert_eq!(resp.status, 501, "{method} {path} must answer 501");
+            let body = resp.http.content.clone().unwrap_or_default();
+            assert!(
+                !body.contains("REL_DUE_TO_HO"),
+                "a create must never carry a release cause, got {body}"
+            );
+            let json: serde_json::Value = serde_json::from_str(&body).expect("ProblemDetails");
+            assert_eq!(json["cause"], serde_json::json!("NOT_IMPLEMENTED"));
+            assert_eq!(json["status"], serde_json::json!(501));
+        }
+    }
+
+    /// #79 criteria 1 + 2: the subscribed session-AMBR and default 5QI are applied,
+    /// with the configured default as the fallback and NOT the other way round.
+    ///
+    /// Asserted on `apply_subscribed_baseline` because the config-default arm of the
+    /// create path is downstream of the N4 leg no test can reach (#289). The
+    /// per-member behaviour is the part that matters: a whole-struct replacement
+    /// would make an absent subscribed member silently mean 0.
+    #[test]
+    fn subscribed_values_win_over_the_config_default_per_member() {
+        let subscribed = udm::SubscribedSmData {
+            sess_ambr_ul_bps: Some(100_000_000),
+            sess_ambr_dl_bps: Some(500_000_000),
+            default_5qi: Some(7),
+            arp_priority_level: Some(3),
+        };
+        let mut decision = policy::PolicyDecision::config_default_for_dnn("internet");
+        let configured_5qi = decision.def_five_qi;
+        decision.apply_subscribed_baseline(&subscribed);
+        assert_eq!(decision.sess_ambr_ul_bps, 100_000_000);
+        assert_eq!(decision.sess_ambr_dl_bps, 500_000_000);
+        assert_eq!(decision.def_five_qi, 7);
+        assert_eq!(decision.arp_priority_level, 3);
+        assert_ne!(
+            decision.def_five_qi, configured_5qi,
+            "the subscription must actually displace the configured value"
+        );
+
+        // A subscription stating only the AMBR leaves the configured 5QI alone.
+        let partial = udm::SubscribedSmData {
+            sess_ambr_ul_bps: Some(1_000_000),
+            ..Default::default()
+        };
+        let mut decision = policy::PolicyDecision::config_default_for_dnn("internet");
+        let configured_dl = decision.sess_ambr_dl_bps;
+        decision.apply_subscribed_baseline(&partial);
+        assert_eq!(decision.sess_ambr_ul_bps, 1_000_000);
+        assert_eq!(
+            decision.sess_ambr_dl_bps, configured_dl,
+            "an absent subscribed member must fall back to config, not to 0"
+        );
+        assert_eq!(decision.def_five_qi, 9);
+
+        // An empty subscription changes nothing at all.
+        let mut decision = policy::PolicyDecision::config_default_for_dnn("internet");
+        let before = (
+            decision.sess_ambr_ul_bps,
+            decision.sess_ambr_dl_bps,
+            decision.def_five_qi,
+            decision.arp_priority_level,
+        );
+        decision.apply_subscribed_baseline(&udm::SubscribedSmData::default());
+        assert_eq!(
+            (
+                decision.sess_ambr_ul_bps,
+                decision.sess_ambr_dl_bps,
+                decision.def_five_qi,
+                decision.arp_priority_level
+            ),
+            before
         );
     }
 

--- a/src/bins/nextgcore-smfd/src/policy.rs
+++ b/src/bins/nextgcore-smfd/src/policy.rs
@@ -92,6 +92,34 @@ pub struct PolicyDecision {
 }
 
 impl PolicyDecision {
+    /// Overlay the subscribed SM data onto a config-default decision (#79).
+    ///
+    /// Each member is applied ONLY when the subscription states it, so a
+    /// subscription that carries a session-AMBR and no 5QI leaves the configured
+    /// 5QI in place rather than zeroing it. That per-member granularity is the
+    /// point: the criterion is "subscribed values win over config where present,
+    /// config is the fallback", and a whole-struct replacement would make an absent
+    /// member silently mean 0.
+    ///
+    /// Applied to the config-default arm only. With a PCF configured its decision
+    /// is authoritative (TS 23.503 §6.1.3.2 has the PCF take the subscribed values
+    /// as input and answer with authorised ones), so overlaying the subscription on
+    /// top of a PCF answer would override the authorisation with its own input.
+    pub fn apply_subscribed_baseline(&mut self, sub: &crate::udm::SubscribedSmData) {
+        if let Some(ul) = sub.sess_ambr_ul_bps {
+            self.sess_ambr_ul_bps = ul;
+        }
+        if let Some(dl) = sub.sess_ambr_dl_bps {
+            self.sess_ambr_dl_bps = dl;
+        }
+        if let Some(five_qi) = sub.default_5qi {
+            self.def_five_qi = five_qi;
+        }
+        if let Some(arp) = sub.arp_priority_level {
+            self.arp_priority_level = arp;
+        }
+    }
+
     /// Documented config-default fallback used ONLY when no PCF is configured
     /// (see module docs). 5QI=9 non-GBR default bearer, 100 Mbps AMBR.
     pub fn config_default() -> Self {

--- a/src/bins/nextgcore-smfd/src/udm.rs
+++ b/src/bins/nextgcore-smfd/src/udm.rs
@@ -1,0 +1,656 @@
+//! UDM interaction: `Nudm_UECM_Registration` and `Nudm_SDM_Get sm-data` (#79).
+//!
+//! TS 23.502 §4.3.2.2.1 step 4: during UE-requested PDU Session Establishment the
+//! SMF **registers itself with the UDM** as the serving SMF for the SUPI/PDU
+//! session (`Nudm_UECM_Registration`, TS 29.503 §5.3.2) and **retrieves the SM
+//! subscription data** (`Nudm_SDM_Get sm-data`, §5.2.2.2), then enforces what it
+//! retrieved.
+//!
+//! # What was missing, precisely
+//!
+//! #204 gave this daemon a UDM *discovery* routine and one real SDM call — for
+//! `smf-select-data`, to learn the subscribed default DNN when the AMF supplies
+//! none. That is the whole of the SMF's UDM interaction before #79:
+//!
+//! - **No UECM registration at all.** `rg smf-registrations` across `src/`
+//!   returned nothing, so the UDM held no serving-SMF record and any procedure
+//!   that resolves the serving SMF through the UDM had nothing to resolve.
+//! - **No `sm-data` retrieval**, so the subscribed session-AMBR and default 5QI
+//!   were never consulted. QoS came from the AMF's request body and
+//!   `policy::PolicyDecision::config_default_for_dnn` — a *local config* default.
+//!   Behind a real UDM that means the SMF applies the operator's file instead of
+//!   the subscriber's profile.
+//!
+//! # The subscription is a baseline, and the PCF still outranks it
+//!
+//! TS 23.503 §6.1.3.2: the PCF authorises the session-AMBR and default QoS, using
+//! the subscribed values as input. So the precedence here is
+//! `PCF` then `subscription` then `config default`, and the subscription is
+//! consulted only to build the input the PCF's decision replaces — or, with no PCF
+//! configured, to be the answer.
+//! Getting this order wrong in the other direction would have a subscription
+//! override a policy decision, which is a conformance defect rather than a
+//! degradation.
+//!
+//! # Off by default
+//!
+//! Gated on `SMF_UDM=1`. A runtime switch for the recorded reason (a
+//! cargo-feature-gated path is left uncompiled by CI and rots), and off by default
+//! because #79 says so explicitly: the E2E harness has no conformant UDM, and
+//! enforcing subscription data that no UDM supplies would regress the matched-sim
+//! data-plane path that CI does gate on.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Is the UDM leg enabled for this process?
+static UDM_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// This SMF's NF instance id, as the NRF knows it.
+///
+/// Seeded from the value NRF registration used, so the `smfInstanceId` the UDM
+/// records is the one a peer resolving this SMF through the NRF would dial. A
+/// second, independently minted uuid would make the UDM's serving-SMF record point
+/// at an instance nothing else in the deployment knows.
+static SMF_INSTANCE_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Enable the UDM leg (called once at startup).
+pub fn enable() {
+    UDM_ENABLED.store(true, Ordering::SeqCst);
+    log::info!(
+        "[SMF] UDM interaction ENABLED: sessions will register with the UDM and \
+         enforce subscribed SM data (TS 23.502 §4.3.2.2.1)"
+    );
+}
+
+pub fn enabled() -> bool {
+    UDM_ENABLED.load(Ordering::SeqCst)
+}
+
+/// Record the NF instance id NRF registration used.
+pub fn set_instance_id(id: &str) {
+    if !id.is_empty() {
+        let _ = SMF_INSTANCE_ID.set(id.to_string());
+    }
+}
+
+/// This SMF's instance id. Falls back to a stable per-process uuid when NRF
+/// registration never happened, so a UECM registration still carries the
+/// `smfInstanceId` its schema requires rather than an empty string.
+pub fn smf_instance_id() -> &'static str {
+    SMF_INSTANCE_ID.get_or_init(|| uuid::Uuid::new_v4().to_string())
+}
+
+/// Serialises tests that touch the process-global switch. `pub` within the crate
+/// because `main.rs`'s tests toggle the same variable — one agreement, not two.
+#[cfg(test)]
+pub static SWITCH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[cfg(test)]
+pub fn set_for_test(on: bool) {
+    UDM_ENABLED.store(on, Ordering::SeqCst);
+}
+
+/// The subscribed values this SMF acts on, from `SessionManagementSubscriptionData`.
+///
+/// A narrow struct rather than the whole schema: these are the members #79 names as
+/// enforceable (`sessionAmbr`, `5gQosProfile.5qi`), plus the ARP that comes with the
+/// QoS profile because TS 29.571 makes it `required` there and it is what an EPS
+/// bearer's ARP is derived from (#117). Everything else in `DnnConfiguration` is
+/// deliberately not modelled — a member parsed and never enforced reads as
+/// implemented and is not.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SubscribedSmData {
+    /// Subscribed session-AMBR uplink, in bits per second.
+    pub sess_ambr_ul_bps: Option<u64>,
+    /// Subscribed session-AMBR downlink, in bits per second.
+    pub sess_ambr_dl_bps: Option<u64>,
+    /// Subscribed default 5QI.
+    pub default_5qi: Option<u8>,
+    /// ARP priority level from the subscribed default QoS profile.
+    pub arp_priority_level: Option<u8>,
+}
+
+impl SubscribedSmData {
+    /// Whether anything enforceable was retrieved. A response that parsed but
+    /// carried none of these is not an error — the subscription simply states no
+    /// override — but it is worth distinguishing from a failed fetch at the call
+    /// site, so the log can say which happened.
+    pub fn is_empty(&self) -> bool {
+        self.sess_ambr_ul_bps.is_none()
+            && self.sess_ambr_dl_bps.is_none()
+            && self.default_5qi.is_none()
+            && self.arp_priority_level.is_none()
+    }
+}
+
+/// Parse a bit rate as TS 29.571's `BitRate` states it: a decimal number followed
+/// by a unit, e.g. `"200 Mbps"`.
+///
+/// Returns `None` for anything unparseable rather than defaulting to zero: a
+/// session AMBR of 0 would police the subscriber's traffic to nothing, which is far
+/// worse than falling back to the configured default.
+pub fn parse_bit_rate(raw: &str) -> Option<u64> {
+    let raw = raw.trim();
+    let split = raw
+        .find(|c: char| c.is_ascii_alphabetic())
+        .unwrap_or(raw.len());
+    let (value, unit) = raw.split_at(split);
+    let value: f64 = value.trim().parse().ok()?;
+    if !value.is_finite() || value < 0.0 {
+        return None;
+    }
+    let multiplier: f64 = match unit.trim().to_ascii_lowercase().as_str() {
+        "bps" => 1.0,
+        "kbps" => 1e3,
+        "mbps" => 1e6,
+        "gbps" => 1e9,
+        "tbps" => 1e12,
+        other => {
+            log::warn!("subscribed BitRate '{raw}' has unrecognised unit '{other}'; ignored");
+            return None;
+        }
+    };
+    let bps = value * multiplier;
+    if bps > u64::MAX as f64 {
+        return None;
+    }
+    Some(bps as u64)
+}
+
+/// Extract the enforceable subscription values for `dnn` out of an `sm-data` body.
+///
+/// The response is either one `SessionManagementSubscriptionData` or an array of
+/// them (one per S-NSSAI); both are accepted, and when an S-NSSAI is supplied the
+/// matching entry is preferred over the first. Inside it, `dnnConfigurations` is a
+/// map keyed by DNN, and TS 29.503 allows the **wildcard DNN** as a key, so an
+/// exact match is tried first and the wildcard second.
+///
+/// Split out from the request so every one of those shapes is testable without a
+/// UDM — which matters more than usual here, because `dnnConfigurations` being a
+/// free-form map means a wrong key lookup silently yields "no subscription" rather
+/// than an error.
+pub fn parse_sm_data(
+    json: &serde_json::Value,
+    dnn: &str,
+    sst: u8,
+    sd: Option<&str>,
+) -> SubscribedSmData {
+    let entries: Vec<&serde_json::Value> = match json {
+        serde_json::Value::Array(items) => items.iter().collect(),
+        other => vec![other],
+    };
+    // Prefer the entry whose singleNssai matches; fall back to the first.
+    let entry = entries
+        .iter()
+        .find(|e| {
+            let nssai = &e["singleNssai"];
+            nssai["sst"].as_u64() == Some(sst as u64)
+                && match sd {
+                    Some(sd) => nssai["sd"].as_str() == Some(sd),
+                    None => nssai.get("sd").is_none() || nssai["sd"].is_null(),
+                }
+        })
+        .or(entries.first())
+        .copied();
+    let Some(entry) = entry else {
+        return SubscribedSmData::default();
+    };
+
+    let configs = &entry["dnnConfigurations"];
+    // TS 29.503: the wildcard DNN is a permitted key. Exact match wins.
+    let config = configs
+        .get(dnn)
+        .or_else(|| configs.get("*"))
+        .unwrap_or(&serde_json::Value::Null);
+
+    let ambr = &config["sessionAmbr"];
+    let qos = &config["5gQosProfile"];
+    SubscribedSmData {
+        sess_ambr_ul_bps: ambr["uplink"].as_str().and_then(parse_bit_rate),
+        sess_ambr_dl_bps: ambr["downlink"].as_str().and_then(parse_bit_rate),
+        // 5Qi is 0..=255 in TS 29.571.
+        default_5qi: qos["5qi"].as_u64().and_then(|v| u8::try_from(v).ok()),
+        arp_priority_level: qos["arp"]["priorityLevel"]
+            .as_u64()
+            .filter(|p| (1..=15).contains(p))
+            .map(|p| p as u8),
+    }
+}
+
+/// `Nudm_SDM_Get sm-data` for one DNN (TS 29.503 §5.2.2.2).
+///
+/// Scoped with `?dnn=` only. `single-nssai` is deliberately omitted for the reason
+/// #204 documented at `smf_select_data_path`: its value is JSON, the shared SBI
+/// server stores query values without percent-decoding them (issue #65), so a
+/// conformantly-encoded value cannot round-trip in-tree. The S-NSSAI is instead
+/// matched inside [`parse_sm_data`], which needs no wire support.
+pub async fn fetch_sm_data(
+    supi: &str,
+    dnn: &str,
+    sst: u8,
+    sd: Option<&str>,
+) -> Option<SubscribedSmData> {
+    if !enabled() {
+        return None;
+    }
+    let (host, port) = crate::discover_udm_sdm_endpoint().await?;
+    let client = nextgcore_sbi::context::global_context()
+        .get_client(&host, port)
+        .await;
+    let path = format!("/nudm-sdm/v2/{supi}/sm-data?dnn={dnn}");
+    let response = match client.get(&path).await {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!(
+                "[{supi}] Nudm_SDM_Get sm-data failed: {e}. QoS falls back to the \
+                 configured default for DNN {dnn}."
+            );
+            return None;
+        }
+    };
+    if !response.is_success() {
+        log::warn!(
+            "[{supi}] Nudm_SDM_Get sm-data returned status {}. QoS falls back to the \
+             configured default for DNN {dnn}.",
+            response.status
+        );
+        return None;
+    }
+    let body = response.http.content.as_deref().unwrap_or_default();
+    let json: serde_json::Value = match serde_json::from_str(body) {
+        Ok(j) => j,
+        Err(e) => {
+            log::warn!("[{supi}] sm-data is not valid JSON: {e}");
+            return None;
+        }
+    };
+    let data = parse_sm_data(&json, dnn, sst, sd);
+    if data.is_empty() {
+        log::info!(
+            "[{supi}] sm-data carried no enforceable values for DNN {dnn}: the \
+             subscription states no session-AMBR or default 5QI override"
+        );
+    } else {
+        log::info!("[{supi}] subscribed SM data for DNN {dnn}: {data:?}");
+    }
+    Some(data)
+}
+
+/// `Nudm_UECM_Registration` — register as the serving SMF for this PDU session
+/// (TS 29.503 §5.3.2.2, `PUT .../registrations/smf-registrations/{pduSessionId}`).
+///
+/// The four `required` members of `SmfRegistration` are `smfInstanceId`,
+/// `pduSessionId`, `singleNssai` and `plmnId`. `plmnId` comes from the serving PLMN
+/// the AMF supplied on the create request — **not** from a configured home PLMN:
+/// the registration records where the session is being served, and for a roamer
+/// those differ.
+///
+/// Failure is non-fatal and says what it costs: the UDM holds no serving-SMF record
+/// for this session, so procedures that resolve the serving SMF through the UDM
+/// will not find it. Refusing the session instead would make a UDM outage a total
+/// outage.
+pub async fn register_as_serving_smf(
+    supi: &str,
+    pdu_session_id: u8,
+    dnn: &str,
+    sst: u8,
+    sd: Option<&str>,
+    plmn: Option<(&str, &str)>,
+) -> bool {
+    if !enabled() {
+        return false;
+    }
+    let Some((host, port)) = crate::discover_udm_uecm_endpoint().await else {
+        log::warn!(
+            "[{supi}] no UDM nudm-uecm endpoint: cannot register as serving SMF for \
+             PSI {pdu_session_id}, so the UDM holds no serving-SMF record for it"
+        );
+        return false;
+    };
+    let Some((mcc, mnc)) = plmn else {
+        // plmnId is `required`. Sending the registration without it would be
+        // rejected by a conformant UDM, and inventing a PLMN would record the
+        // session as served somewhere it is not.
+        log::warn!(
+            "[{supi}] the create request carried no serving PLMN: SmfRegistration \
+             requires plmnId, so no UECM registration is sent for PSI {pdu_session_id}"
+        );
+        return false;
+    };
+
+    let mut body = serde_json::json!({
+        "smfInstanceId": smf_instance_id(),
+        "pduSessionId": pdu_session_id,
+        "singleNssai": { "sst": sst },
+        "plmnId": { "mcc": mcc, "mnc": mnc },
+        "dnn": dnn,
+    });
+    if let Some(sd) = sd {
+        body["singleNssai"]["sd"] = serde_json::json!(sd);
+    }
+
+    let path = format!("/nudm-uecm/v1/{supi}/registrations/smf-registrations/{pdu_session_id}");
+    let request = nextgcore_sbi::message::SbiRequest::put(path).with_body(
+        body.to_string(),
+        nextgcore_sbi::constants::content_type::APPLICATION_JSON,
+    );
+    let client = nextgcore_sbi::context::global_context()
+        .get_client(&host, port)
+        .await;
+    match client.send_request(request).await {
+        // 201 (created) and 200/204 (replaced) are all success for a PUT upsert.
+        Ok(resp) if resp.is_success() => {
+            log::info!(
+                "[{supi}] registered as serving SMF for PSI {pdu_session_id} (status {})",
+                resp.status
+            );
+            true
+        }
+        Ok(resp) => {
+            log::warn!(
+                "[{supi}] Nudm_UECM_Registration for PSI {pdu_session_id} returned status {}: \
+                 the UDM holds no serving-SMF record for this session",
+                resp.status
+            );
+            false
+        }
+        Err(e) => {
+            log::warn!(
+                "[{supi}] Nudm_UECM_Registration for PSI {pdu_session_id} failed: {e}: \
+                 the UDM holds no serving-SMF record for this session"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bit_rates_parse_in_every_unit_and_refuse_nonsense() {
+        assert_eq!(parse_bit_rate("200 Mbps"), Some(200_000_000));
+        assert_eq!(parse_bit_rate("1Gbps"), Some(1_000_000_000));
+        assert_eq!(parse_bit_rate("500 Kbps"), Some(500_000));
+        assert_eq!(parse_bit_rate("64 bps"), Some(64));
+        assert_eq!(parse_bit_rate("1.5 Mbps"), Some(1_500_000));
+        // A unit we do not know must yield None, not a silent 1x multiplier: a
+        // subscription meaning gigabits enforced as bits would police a subscriber
+        // to nothing.
+        assert_eq!(parse_bit_rate("200 Zbps"), None);
+        assert_eq!(parse_bit_rate(""), None);
+        assert_eq!(parse_bit_rate("Mbps"), None);
+        assert_eq!(parse_bit_rate("-5 Mbps"), None);
+    }
+
+    fn sm_data_body() -> serde_json::Value {
+        serde_json::json!({
+            "singleNssai": { "sst": 1, "sd": "010203" },
+            "dnnConfigurations": {
+                "internet": {
+                    "pduSessionTypes": { "defaultSessionType": "IPV4" },
+                    "sscModes": { "defaultSscMode": "SSC_MODE_1" },
+                    "sessionAmbr": { "uplink": "100 Mbps", "downlink": "500 Mbps" },
+                    "5gQosProfile": {
+                        "5qi": 7,
+                        "arp": { "priorityLevel": 3, "preemptCap": "NOT_PREEMPT",
+                                 "preemptVuln": "PREEMPTABLE" }
+                    }
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn sm_data_yields_the_subscribed_ambr_and_default_5qi_for_the_right_dnn() {
+        let data = parse_sm_data(&sm_data_body(), "internet", 1, Some("010203"));
+        assert_eq!(data.sess_ambr_ul_bps, Some(100_000_000));
+        assert_eq!(data.sess_ambr_dl_bps, Some(500_000_000));
+        assert_eq!(data.default_5qi, Some(7));
+        assert_eq!(data.arp_priority_level, Some(3));
+        assert!(!data.is_empty());
+
+        // A DNN the subscription does not configure yields nothing enforceable --
+        // NOT another DNN's values, which is what a "take the first entry" lookup
+        // over a map would do.
+        let other = parse_sm_data(&sm_data_body(), "ims", 1, Some("010203"));
+        assert!(
+            other.is_empty(),
+            "an unconfigured DNN must not inherit another DNN's subscription, got {other:?}"
+        );
+    }
+
+    /// TS 29.503 allows the wildcard DNN as a `dnnConfigurations` key, and it is
+    /// the fallback rather than the winner: an exact entry must beat it.
+    #[test]
+    fn the_wildcard_dnn_is_a_fallback_and_never_beats_an_exact_entry() {
+        let body = serde_json::json!({
+            "singleNssai": { "sst": 1 },
+            "dnnConfigurations": {
+                "*": { "sessionAmbr": { "uplink": "1 Mbps", "downlink": "1 Mbps" } },
+                "internet": { "sessionAmbr": { "uplink": "100 Mbps", "downlink": "500 Mbps" } }
+            }
+        });
+        assert_eq!(
+            parse_sm_data(&body, "internet", 1, None).sess_ambr_ul_bps,
+            Some(100_000_000),
+            "the exact DNN entry must win"
+        );
+        assert_eq!(
+            parse_sm_data(&body, "anything-else", 1, None).sess_ambr_ul_bps,
+            Some(1_000_000),
+            "an unlisted DNN falls back to the wildcard"
+        );
+    }
+
+    /// An array response is one entry per S-NSSAI, and the matching one must be
+    /// chosen: taking the first would apply another slice's subscription.
+    #[test]
+    fn an_array_response_selects_the_matching_snssai() {
+        let body = serde_json::json!([
+            {
+                "singleNssai": { "sst": 2 },
+                "dnnConfigurations": { "internet": {
+                    "sessionAmbr": { "uplink": "1 Mbps", "downlink": "1 Mbps" } } }
+            },
+            {
+                "singleNssai": { "sst": 1, "sd": "010203" },
+                "dnnConfigurations": { "internet": {
+                    "sessionAmbr": { "uplink": "100 Mbps", "downlink": "500 Mbps" } } }
+            }
+        ]);
+        assert_eq!(
+            parse_sm_data(&body, "internet", 1, Some("010203")).sess_ambr_ul_bps,
+            Some(100_000_000),
+            "the entry for the session's own S-NSSAI must be chosen, not the first"
+        );
+        assert_eq!(
+            parse_sm_data(&body, "internet", 2, None).sess_ambr_ul_bps,
+            Some(1_000_000)
+        );
+    }
+
+    #[test]
+    fn a_malformed_or_absent_subscription_yields_nothing_rather_than_zero() {
+        for body in [
+            serde_json::json!({}),
+            serde_json::json!({ "singleNssai": { "sst": 1 } }),
+            serde_json::json!({ "singleNssai": { "sst": 1 },
+                                "dnnConfigurations": { "internet": {} } }),
+            // An AMBR whose units are unrecognisable: better no override than a 0.
+            serde_json::json!({ "singleNssai": { "sst": 1 },
+                                "dnnConfigurations": { "internet": {
+                                    "sessionAmbr": { "uplink": "lots", "downlink": "more" } } } }),
+        ] {
+            let data = parse_sm_data(&body, "internet", 1, None);
+            assert!(data.is_empty(), "expected nothing enforceable from {body}");
+            assert_ne!(
+                data.sess_ambr_ul_bps,
+                Some(0),
+                "a zero AMBR would police the subscriber to nothing"
+            );
+        }
+
+        // An out-of-range ARP priority level is dropped rather than clamped: the
+        // value is meaningless, and clamping would invent a priority.
+        let body = serde_json::json!({ "singleNssai": { "sst": 1 },
+            "dnnConfigurations": { "internet": {
+                "5gQosProfile": { "5qi": 9, "arp": { "priorityLevel": 0 } } } } });
+        let data = parse_sm_data(&body, "internet", 1, None);
+        assert_eq!(data.default_5qi, Some(9));
+        assert_eq!(data.arp_priority_level, None);
+    }
+
+    #[tokio::test]
+    async fn a_disabled_leg_neither_fetches_nor_registers() {
+        let _g = SWITCH_LOCK.lock().await;
+        set_for_test(false);
+        assert!(fetch_sm_data("imsi-1", "internet", 1, None).await.is_none());
+        assert!(
+            !register_as_serving_smf("imsi-1", 5, "internet", 1, None, Some(("001", "01"))).await
+        );
+    }
+    /// #79 criterion 1, on the wire: the SMF really performs
+    /// `Nudm_UECM_Registration` and `Nudm_SDM_Get sm-data`.
+    ///
+    /// The recorded `(method, path, body)` is the assertion. Neither operation had
+    /// ANY caller before this — `rg smf-registrations` across `src/` was empty — so
+    /// a test that only checked the returned value would pass against a function
+    /// that answered from nowhere.
+    #[tokio::test]
+    async fn the_smf_registers_with_the_udm_and_fetches_sm_data() {
+        use nextgcore_sbi::message::{SbiRequest, SbiResponse};
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+        use std::net::SocketAddr;
+
+        // Loopback plaintext peer: the default SbiProfile is Production and would
+        // refuse the connection, failing this test for an unrelated reason.
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+
+        // TWO locks, and both are needed: the switch, and the `UDM_SBI_*`
+        // environment this test re-points at its own loopback UDM. The second is
+        // the crate-root one `main.rs`'s #204 tests also take — a lock of this
+        // module's own would be a second disjoint agreement about one variable, and
+        // that is exactly how this test first flaked.
+        let _g = SWITCH_LOCK.lock().await;
+        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        set_for_test(true);
+
+        // `(method, path, body, dnn-query-param)`. The fourth field exists because
+        // the shared SBI server STRIPS the query string from `header.uri` and
+        // delivers pairs in `http.params`, so asserting the scoping against the URI
+        // would assert something the server never puts there.
+        #[allow(clippy::type_complexity)]
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String, String)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let port = nextgcore_sbi::test_support::free_port();
+        let udm = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
+            [127, 0, 0, 1],
+            port,
+        ))));
+        udm.start(move |req: SbiRequest| {
+            let sink = sink.clone();
+            async move {
+                sink.lock().unwrap_or_else(|e| e.into_inner()).push((
+                    req.header.method.clone(),
+                    req.header.uri.clone(),
+                    req.http.content.clone().unwrap_or_default(),
+                    req.http.get_param("dnn").cloned().unwrap_or_default(),
+                ));
+                if req.header.uri.contains("/sm-data") {
+                    return SbiResponse::with_status(200)
+                        .with_json_body(&sm_data_body())
+                        .unwrap_or_else(|_| SbiResponse::with_status(200));
+                }
+                SbiResponse::with_status(201)
+            }
+        })
+        .await
+        .expect("udm start");
+
+        // Both legs discover the UDM through the env fallback, which names one UDM
+        // for every nudm service (see `discover_udm_service_endpoint`).
+        std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
+        std::env::set_var("UDM_SBI_PORT", port.to_string());
+
+        let supi = "imsi-001010000000079";
+        assert!(
+            register_as_serving_smf(supi, 5, "internet", 1, Some("010203"), Some(("001", "01")))
+                .await,
+            "the UECM registration must succeed against a 201"
+        );
+        let data = fetch_sm_data(supi, "internet", 1, Some("010203"))
+            .await
+            .expect("sm-data must be fetched");
+        assert_eq!(data.sess_ambr_ul_bps, Some(100_000_000));
+        assert_eq!(data.default_5qi, Some(7));
+
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+
+        // Matched by SUPI as well as by resource: this loopback server is reachable
+        // by any sibling test that reads `UDM_SBI_*` (the create path fetches the
+        // subscribed default DNN from it), so a bare "find a registration" could
+        // pick up a request this test did not make.
+        let reg = requests
+            .iter()
+            .find(|(_, uri, _, _)| uri.contains("smf-registrations") && uri.contains(supi))
+            .unwrap_or_else(|| panic!("a UECM registration must be sent, got {requests:?}"));
+        assert_eq!(reg.0, "PUT", "TS 29.503 §5.3.2.2 registers with a PUT");
+        assert_eq!(
+            reg.1, "/nudm-uecm/v1/imsi-001010000000079/registrations/smf-registrations/5",
+            "the resource is per PDU session"
+        );
+        let body: serde_json::Value = serde_json::from_str(&reg.2).expect("json");
+        // The four `required` members of SmfRegistration.
+        for required in ["smfInstanceId", "pduSessionId", "singleNssai", "plmnId"] {
+            assert!(
+                body.get(required).is_some(),
+                "SmfRegistration.{required} is required, got {body}"
+            );
+        }
+        assert_eq!(body["pduSessionId"], serde_json::json!(5));
+        assert_eq!(body["singleNssai"]["sst"], serde_json::json!(1));
+        assert_eq!(body["singleNssai"]["sd"], serde_json::json!("010203"));
+        assert_eq!(body["plmnId"]["mcc"], serde_json::json!("001"));
+        assert!(
+            body["smfInstanceId"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "smfInstanceId must be a real value, not an empty string"
+        );
+
+        let sdm = requests
+            .iter()
+            .find(|(_, uri, _, _)| uri.ends_with("/sm-data") && uri.contains(supi))
+            .unwrap_or_else(|| panic!("an sm-data GET must be sent, got {requests:?}"));
+        assert_eq!(sdm.0, "GET");
+        assert_eq!(
+            sdm.1, "/nudm-sdm/v2/imsi-001010000000079/sm-data",
+            "Nudm_SDM is at v2, unlike the other Nudm services"
+        );
+        assert_eq!(
+            sdm.3, "internet",
+            "the request must be scoped to the session's DNN. `single-nssai` is \
+             deliberately omitted -- see `fetch_sm_data`"
+        );
+
+        // A registration with no serving PLMN is NOT sent: plmnId is required, and
+        // inventing one would record the session as served somewhere it is not.
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        assert!(!register_as_serving_smf(supi, 6, "internet", 1, None, None).await);
+        let after = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            !after
+                .iter()
+                .any(|(_, uri, _, _)| uri.contains("smf-registrations") && uri.contains(supi)),
+            "no PLMN means no registration on the wire, got {after:?}"
+        );
+
+        set_for_test(false);
+        std::env::remove_var("UDM_SBI_ADDR");
+        std::env::remove_var("UDM_SBI_PORT");
+        udm.stop().await.expect("stop");
+    }
+}


### PR DESCRIPTION
Closes #79. Spec: `specs/fix-smfd-sbi-services.md`.

## Criterion 3 is void, not met

It asks that the dead `nudm-sdm` FSM branch be "reached by a real response". **#204 deleted that
branch**, and recorded why: the SMF's real `Nudm_SDM_Get` must complete *before* the session
exists, because the DNN is an input to creating it, so it returns on a direct `await` rather than
as an FSM event — and dispatching it in the FSM too would put one decision in two places. The
criterion was written against the pre-#204 tree. Nothing is added to `gsm_sm.rs`.

#204 did leave exactly the infrastructure this needs (UDM discovery + a working SDM client), here
generalised from `nudm-sdm`-only to any named `nudm` service, because a UDM may advertise
`nudm-uecm` on a different port.

## What was missing, and what it cost

| service | before | now |
|---|---|---|
| UDM | `rg smf-registrations src/` → **nothing**; no `sm-data` fetch; QoS from a *local config* default | both operations, before PFCP establishment |
| `Nsmf_EventExposure` | body ignored, `{"subscriptionId": …}` (not a TS 29.508 schema), nothing stored, `DELETE` `204` for any id, **no GET/PUT arm at all** | persisted resource, POST/GET/PUT/DELETE, `404` on unknown, real Notify |
| H-SMF `/pdu-sessions` | `201` + `{"pduSessionRef":"1","cause":"REL_DUE_TO_HO"}` — **a release cause on a create success** | `501` on all three operations |

## Decisions

**Precedence is PCF → subscription → config default.** TS 23.503 §6.1.3.2 has the PCF *authorise*
using the subscribed values as input, so `apply_subscribed_baseline` runs on the config-default arm
only. Overlaying the subscription on a PCF answer would override an authorisation with its own
input.

**Per member, not a struct swap.** A subscription stating an AMBR and no 5QI leaves the configured
5QI alone. A whole-struct replacement makes an absent member silently mean `0`, and a session-AMBR
of 0 polices a subscriber to nothing. `parse_bit_rate` returns `None` (not `0`) for an unrecognised
unit for the same reason — a subscription meaning gigabits enforced as bits is worse than no
override.

**`smfInstanceId` is seeded from the value NRF registration used** — a separately minted uuid would
point the UDM's serving-SMF record at an instance nothing else in the deployment can resolve, which
is the failure this operation exists to prevent. **No serving PLMN → no registration sent**:
`plmnId` is `required`, and inventing one records the session as served somewhere it is not.

**H-SMF `501`, all three operations.** Home-routed roaming is not implemented here and every
`required` member of `PduSessionCreatedData` would be invented, so this is the recorded case for
`501` — never a `404`, never a fabricated `2xx`. All three, because a partner that cannot create
can never legitimately update or release. The old Release was worse than incomplete: it removed a
session by `pduSessionRef`, a reference space this SMF does not populate, so it let a partner delete
state it did not own.

**Filters scope a subscription, and the negative direction is the point.** A SUPI-scoped
subscription matching every UE would leak one subscriber's session events to a consumer authorised
for another. Only `PDU_SES_EST` and `PDU_SES_REL` fire; the other twenty `SmfEvent` values are
accepted, stored, and never fire — stated in the module header rather than left to be inferred from
silence.

## Verification

Workspace **6258 passed / 0 failed** (baseline 6241, +17); easdfd's `dns-udp` feature still 51/0.
clippy and fmt clean, smfd at **zero** warnings.

| revert | expected to break | result |
|---|---|---|
| subscriptions parsed but not stored | 3 tests | **3 failed** |
| the `supi` filter ignored | filter + notify tests | **failed** |
| the UECM registration never transmitted | the UDM wire test | **1 failed** |
| the subscribed 5QI not applied | the per-member test | **failed** |
| H-SMF create answers `201 REL_DUE_TO_HO` again | the 501 test | **1 failed** |
| the notify call removed from the release handler | the notify test | **failed** |
| `DELETE` answers `204` for an unknown id | the resource test | **failed** |

### A third instance of one-lock-per-variable, in one session

The UDM wire test flaked one run in six, from two distinct causes:

1. **A second lock over the same variable.** `main.rs`'s tests already had `UDM_ENV_TEST_LOCK` over
   `UDM_SBI_*`/`NRF_URI`; the new test set the same env without it, so a sibling re-pointed
   `UDM_SBI_PORT` at *its* loopback UDM between the registration and the `sm-data` fetch — which
   then reached a server that `201`s everything. The lock now lives at the crate root, beside the
   function that reads the env.
2. **A `find()` that could match someone else's request.** Even with the env locked, that loopback
   UDM is reachable by any sibling whose create path fetches a subscribed default DNN. Both lookups
   now match on **SUPI** too, and the closing "no registration sent" assertion is scoped the same
   way rather than asserting the server saw no traffic at all.

Separately, the event-subscription store needed the same treatment: `clear_for_test` empties it
process-wide, so a sibling wiped this test's subscription between the POST and the release, making
`a_released_session_notifies_its_event_subscriber` fail in the full suite while passing alone.

After #276's **hang**, that is three in one run of five issues. Eight consecutive clean full-suite
runs after the deflake.

## Ceilings

- **Both UDM call sites are inspection-only** (they sit past the N4 leg no test can drive — #289).
  Verified instead: both operations end to end against a loopback UDM, and the per-member
  application of what they return. Same for `PDU_SES_EST`; `PDU_SES_REL` was chosen for the wiring
  test *because* the release handler is reachable.
- **No `Nudm_SDM_Subscribe`, and no UECM deregistration on release.** The former would create a
  resource on the UDM whose notifications this SMF does not serve; the latter means a UDM
  accumulates serving-SMF records for released sessions — same shape as the EBI leak (#291). Both
  worth their own issue.
- **Failure posture is log-and-continue with no retry queue**, so a transient UDM outage silently
  costs subscription enforcement for sessions established during it.
- **`altNotifIpv4Addrs`/`altNotifFqdns` round-trip but are never used** — a failed notification does
  not fall back to the alternates a consumer supplied.