### PR TITLE
fix(mbsmfd): honour the N4mb control plane and keep MB-UPF state consistent (#76)

### DIFF
--- a/specs/fix-mbsmfd-n4mb-lifecycle.md
+++ b/specs/fix-mbsmfd-n4mb-lifecycle.md
@@ -1,0 +1,213 @@
+# nextgcore #76 (mbsmfd): honour the N4mb control plane and keep MB-UPF state consistent
+
+Verified against `main` @ `6f1f6a9`.
+
+## Verified against current main
+
+Every cite in the issue re-located and confirmed:
+
+| claim | site on `6f1f6a9` | still true? |
+|---|---|---|
+| the recv loop logs `unsolicited PFCP … ignoring` and drops UP-initiated messages | `n4mb.rs:230` | yes |
+| `release_session` has **zero callers** | `rg 'release_session'` → definition only | yes |
+| DELETE removes local state only | `handle_mbs_session_release` → `session_remove` | yes |
+| TERMINATE sets `ReleasePending` then immediately zeroes `n4mb_session` | `context.rs` `session_context_terminate` | yes |
+| START re-creates the N4mb session unconditionally | `session_activate_n4mb` allocated a fresh `local_seid` every call | yes |
+| `ExtMbsSession` carries only `mbsSessionId`, `serviceType`, `ingressTunAddr` | `types.rs:94-106` | yes |
+| a missing mandatory `serviceType` is defaulted (`_ => Multicast`) | `handle_mbs_session_create` | yes |
+| `ingressTunAddr` is `format!("{:#010x}", gtp_teid)` | as cited | yes |
+| a no-TMGI create returns a hardcoded TMGI; `session_add` has no duplicate check | `context_tmgi_from`, `session_add` | yes |
+| `apply_patch_data` inspects only `/mbsServiceArea`, for any op | `types.rs:154-175` | yes |
+| ContextUpdate rejects anything without `mbsSessionId.tmgi` with `400` | as cited | yes |
+
+## Decision 1: the report is answered on the socket, the consequence is applied elsewhere
+
+`handle_up_initiated` runs in the recv loop **before** the pending-table lookup, answers a
+Heartbeat Request and a Session Report immediately, and queues the report. The main loop drains
+the queue and applies the activation.
+
+Split that way for a specific reason: the UP is waiting for the response (TS 29.244 §6.2.3.2 and
+§7.5.8 both make it mandatory), and activating a session needs the context lock — whose writers
+call back into this node. Doing the activation inline would put a lock acquisition inside the
+socket loop with a re-entrancy path through it.
+
+Two details that are easy to get wrong and are pinned:
+
+* **The response echoes the request's sequence number** and goes to `src`, not to the configured
+  `upf_dest`. §7.2.2.4 has a response carry the sequence number of the request it answers, and a
+  response must go back to whoever asked; using the configured destination would silently swallow
+  a request from a UP whose source port differs.
+* **Dispatch precedes the waiter lookup.** The other order would let a Heartbeat Request arriving
+  mid-transaction steal the waiter for an in-flight Session Establishment — which would surface as
+  a UPF timeout. `an_inbound_request_does_not_steal_a_pending_waiter` sends a heartbeat with
+  sequence number 1, which is also the first the node itself uses.
+* **Reports are drained, not peeked.** Leaving them would have the 100ms loop re-activate an
+  already-active session on every tick, and `session_activate_on_downlink_data` reports whether the
+  state actually *changed* for the same reason.
+
+## Decision 2: release is three steps, and the order is the criterion
+
+`session_mark_release_pending` (under the lock) → the PFCP Session Deletion (an `await`) →
+`session_clear_n4mb`. `session_context_terminate` no longer clears.
+
+The old code cleared **first**, which discarded the remote SEID the deletion has to be addressed
+to — so nothing could delete the session on the MB-UPF even in principle. `session_remove`'s log
+line said "releasing N4mb SEID" while releasing nothing.
+
+`release_n4mb_transport` returns whether the deletion was *acknowledged* but clears local state
+either way. The session is leaving this MB-SMF regardless, and keeping a context whose UPF
+counterpart may or may not exist would leave the two sides disagreeing with no path back. A
+possible leak is named in the log rather than left silent. A session whose establishment never
+completed has no UP-allocated SEID, so there is nothing to delete and it is cleared without a
+request — distinguished from "no N4mb context at all" by `Option<u64>` rather than a sentinel.
+
+## Decision 3: a duplicate TMGI is refused, not overwritten
+
+`session_add` returns `None` when the TMGI is already in use. The overwrite left the earlier
+session in `session_list` reachable by **nothing** — its TMGI resolved to the new session, so it
+could never be found or deleted, and its MB-UPF session could never be released. A TMGI identifies
+one MBS session, so a second create for the same one is the consumer's error, and refusing keeps
+the existing session findable.
+
+## Decision 4: the `anyOf` on `MbsSession` is deliberately NOT enforced
+
+TS 29.571 makes `MbsSession` `anyOf [mbsSessionId, tmgiAllocReq]`. Enforcing it would refuse a
+create carrying neither — and #76's criterion 7 requires exactly that create to **succeed** by
+allocating from `TmgiPool`. The two cannot both hold, so an absent `tmgiAllocReq` is read as an
+implicit request.
+
+This was found by *breaking a test*: enforcing the `anyOf` turned
+`test_router_release_fires_notify_path`'s `{"mbsSession":{"serviceType":"MULTICAST"}}` create into
+a `400`. Recorded here rather than silently, because a conformance suite exercising the `anyOf`
+will see it accepted.
+
+## Decision 5: only a service-area REDUCTION gets the 200 + `redMbsServArea` body
+
+The outcome now depends on the RFC 6902 `op`: `replace` and `remove` can reduce, `add` cannot.
+TS 29.532 §5.3.2.3 gives that body to a reduction — it is the MB-SMF telling the consumer which
+part of the requested area it could not serve. Returning it for an addition tells the consumer its
+enlarged area was cut back to exactly what it asked for, which is a different statement and one it
+may act on by re-requesting.
+
+`move`/`copy`/`test` are accepted and applied to nothing: refusing a legal op would reject a
+conformant patch, while acting on one whose semantics need a source document this NF does not keep
+would be inventing behaviour.
+
+## Decision 6: SSM resolution is a scan, not a second index
+
+`session_find_by_ssm` walks the session map. Sessions are capped at `max_sessions` and ContextUpdate
+is not a per-packet path, so the cost is irrelevant — whereas a second index over the same sessions
+would be a second set of invariants to keep in step with `session_add`/`session_remove`, which is
+precisely the class of bug the duplicate-TMGI overwrite was.
+
+The consumer's SSM is stored as the **wire type** (`types::Ssm`), not parsed into
+`std::net::IpAddr`: TS 29.571's `IpAddr` is a choice of two optional textual members, so matching
+on the received form is what makes a lookup agree with what was stored. It is also distinct from
+`n4mb_session.ll_ssm_src`/`ll_ssm_dst`, which are the lower-layer SSM the MB-SMF *allocates*.
+
+An SSM resolves to the session's own TMGI, so the whole downstream handler stays keyed on one
+identifier. An SSM no session carries is a `404` (a real lookup miss), not a `400`.
+
+## An existing test pinned the defect, and the modal verb decided it
+
+`test_context_terminate_releases_n4mb` asserted that `session_context_terminate` leaves
+`n4mb_session` as `None` — i.e. it pinned the discard-the-SEID shortcut as the requirement.
+
+Per the recorded discriminator, the governing clause's modal verb settles it: TS 29.244 §7.5.4 has
+the CP function **send** a Session Deletion Request to release a PFCP session, and TS 23.247
+§7.1.1.4 has releasing an MBS session tear down the associated MB-UPF resources. Not a "may". So
+the assertion was pinning a shortcut past a mandatory message, and inverting it is legitimate. The
+flip is recorded at the site with that citation.
+
+What makes the inversion safe to believe: the two **handler-level** tests that assert the
+post-handler state — `test_router_context_update_amf_release_golden_204` and
+`mbs_context_update_strict_peer_release_204` — pass **unchanged**, because the handler now drives
+the release and clears afterwards. Only this function's own contract narrowed. And they turn out to
+be the guard for the new wiring: revert 2 below removes the three `release_n4mb_transport` calls and
+both fail.
+
+## Acceptance criteria
+
+- [x] A Heartbeat Request produces a Heartbeat Response —
+      `a_heartbeat_request_is_answered_with_a_heartbeat_response`, asserting the datagram the UP
+      receives (type, echoed sequence number, non-zero Recovery Time Stamp).
+- [x] A Session Report Request produces a Session Report Response and drives activation —
+      `a_session_report_is_answered_and_queued_for_the_session_driver` (response addressed to the
+      request's SEID; the report surfaced and drained) plus `apply_n4mb_reports` →
+      `session_activate_on_downlink_data`.
+- [x] DELETE sends a Session Deletion Request before removing local state —
+      `a_session_deletion_request_is_transmitted_to_the_up_allocated_seid` (the request on a real
+      socket, addressed to the **UP-allocated** SEID) and the three-step order in
+      `release_n4mb_transport`, guarded by revert 2.
+- [x] Last-consumer TERMINATE sends the deletion and clears afterwards — same driver, both
+      terminate legs; `test_context_terminate_marks_release_pending_without_discarding_the_seid`
+      pins that the SEID survives long enough to be used.
+- [x] A repeated START does not allocate a new SEID —
+      `a_repeated_start_reuses_an_established_n4mb_session`, including that an
+      `EstablishmentPending` session IS re-drivable (that is the retry path).
+- [x] A missing `serviceType` is `400`; a full `ExtMbsSession` round-trips; `ingressTunAddr` is
+      structured — `create_refuses_a_missing_service_type_and_answers_a_structured_ingress_address`,
+      `a_full_ext_mbs_session_round_trips_its_write_only_members`, and the `TunnelAddress`
+      serialisation pinned in `test_create_rsp_data_roundtrip`.
+- [x] A no-TMGI create allocates from `TmgiPool` and a second does not overwrite the first —
+      `two_no_tmgi_creates_get_two_sessions_from_the_pool` (both still retrievable) and
+      `a_duplicate_tmgi_create_is_refused_and_the_first_session_survives`.
+- [x] PATCH of `activityStatus`/QoS is applied with the spec-correct `200`/`204`, and an addition
+      does not return the reduction body — `activity_status_qos_and_security_are_applied_rather_than_acknowledged`,
+      `an_added_service_area_is_not_reported_as_a_reduction`.
+- [x] ContextUpdate for an SSM-identified session is accepted —
+      `a_context_update_identified_by_ssm_is_accepted`, plus the `404`-on-unknown-SSM and
+      `400`-on-neither cases.
+- [x] clippy and the mbsmfd suite pass — mbsmfd at **zero** clippy warnings.
+
+## Verification
+
+Workspace **6270 passed / 0 failed** (baseline 6258 on `6f1f6a9`; +12 — 95 in mbsmfd, was 83),
+easdfd's `dns-udp` feature still 51/0. `cargo clippy --workspace --all-targets` and `cargo fmt
+--all -- --check` clean. Five consecutive mbsmfd runs green (the crate has process-global session
+state).
+
+| revert | expected to break | result |
+|---|---|---|
+| UP-initiated dispatch removed | the three n4mb inbound tests | **3 failed** |
+| the three `release_n4mb_transport` calls removed | the two pre-existing handler tests | **2 failed** |
+| activation no longer idempotent | the repeated-START test | **1 failed** |
+| duplicate TMGI overwrites again | the duplicate-TMGI test | **1 failed** |
+| `serviceType` defaulted again | the create-validation test | **1 failed** |
+| an `add` reported as a reduction | the reduction test | **1 failed** |
+| SSM-identified ContextUpdate refused | the SSM test | **1 failed** |
+| `activityStatus` ignored | the PATCH-applied test | **1 failed** |
+| `ingressTunAddr` carries no usable address | the create-validation test | **1 failed** |
+| the Session Report answered but not surfaced | the report test | **1 failed** |
+
+No false guards this round. Revert 2 is the interesting one: it confirms two tests written for an
+*earlier* issue are the wiring guard for this one, which is why inverting the third was safe.
+
+## Ceilings
+
+* **The DELETE/TERMINATE call sites are not covered end to end through a socket.** `N4MB_NODE` is a
+  `tokio::OnceCell` whose destination is read from the environment at first bind, and existing create
+  tests reach it first, so a test cannot point the process's node at its own fake MB-UPF. This is the
+  same `OnceLock`-shaped harness limitation as #289 in smfd. What *is* verified: the deletion on a
+  real socket at the node (`release_session`), the three-step ordering in the context, and the
+  handler wiring via revert 2 against the two pre-existing handler tests.
+* **The activation is applied from the 100ms main loop, not from the report itself**, so a report
+  and its activation are up to 100ms apart. Deliberate (see Decision 1); a report already answered
+  on the wire is not time-critical to apply, but it is not instantaneous either.
+* **`mbsServiceArea` and `mbsServInfo` are stored as raw JSON.** The shapes are unions
+  (NCGI/TAI lists; a QoS request with several optional members) and re-modelling them without a
+  consumer for every member would be a model that reads as enforced and is not. What IS read out of
+  `mbsServInfo` is the 5QI and `mbrDl`, and only those.
+* **The `anyOf` on `MbsSession` is not enforced** — see Decision 4.
+* **No last-consumer ref-counting.** #76's criterion 4 says "last-consumer TERMINATE", and
+  `nfcInstanceId` is still not tracked as a per-session consumer set, so *any* TERMINATE releases the
+  transport rather than only the last consumer's. The issue lists that under its gap 7 alongside SSM;
+  the SSM half is done and the ref-counting half is not, because it needs a decision about whether a
+  join implicitly registers a consumer (nothing in the tree registers one today). Worth its own issue.
+* **The tail sub-claims #76 itself flags as unverified are still unverified**: Status/ContextStatus
+  notification inertness, non-spec GET routes, relative `Location` headers, and pool exhaustion
+  answering `400`. Untouched, and the issue says to treat them as plausible-not-confirmed.
+* GitNexus impact analysis unrunnable (no MCP server connected). Blast radius by grep:
+  `apply_patch_data` gained a parameter (1 production + 5 test call sites, all updated);
+  `session_remove` has 1 production caller; `session_context_terminate` has 2; `MbsSession` gained
+  one field with one writer and one reader.

--- a/src/bins/nextgcore-mbsmfd/src/context.rs
+++ b/src/bins/nextgcore-mbsmfd/src/context.rs
@@ -161,6 +161,19 @@ pub struct MbsSession {
     pub n4mb_session: Option<N4mbSession>,
     /// Group membership tracking (SUPI set)
     pub group_members: HashSet<String>,
+    /// The SSM the consumer identified this session with, when it used one (#76).
+    ///
+    /// Distinct from `n4mb_session.ll_ssm_src`/`ll_ssm_dst`, which are the
+    /// lower-layer SSM the MB-SMF *allocates* toward NG-RAN. This is the
+    /// `MbsSessionId.ssm` the consumer supplied, and it is what an SSM-identified
+    /// ContextUpdate has to be resolved by.
+    ///
+    /// Held as the wire type (`crate::types::Ssm`) rather than parsed into
+    /// `std::net::IpAddr`: TS 29.571's `IpAddr` is a choice of two OPTIONAL textual
+    /// members, so "the address the consumer sent" and "an address" are not the same
+    /// thing, and matching on the received form is what makes a lookup agree with
+    /// what was stored.
+    pub ssm: Option<crate::types::Ssm>,
 }
 
 impl MbsSession {
@@ -182,6 +195,7 @@ impl MbsSession {
             sm_context_ref: None,
             n4mb_session: None,
             group_members: HashSet::new(),
+            ssm: None,
         }
     }
 
@@ -480,6 +494,20 @@ impl MbSmfContext {
             return None;
         }
 
+        // #76: a duplicate TMGI used to overwrite `tmgi_hash` silently, so the
+        // earlier session stayed in `session_list` reachable by NOTHING — its TMGI
+        // resolved to the new session, and its N4mb session on the MB-UPF could
+        // never be released. Refusing is the honest answer: a TMGI identifies one
+        // MBS session, so a second create for the same one is the consumer's error,
+        // and the existing session is still there to be found or deleted.
+        if tmgi_hash.contains_key(&tmgi) {
+            log::warn!(
+                "MBS session create refused: TMGI {tmgi:?} already identifies session {:?}",
+                tmgi_hash.get(&tmgi)
+            );
+            return None;
+        }
+
         let id = self.next_session_id.fetch_add(1, Ordering::SeqCst) as u64;
         let mut session = MbsSession::new(id, tmgi.clone(), session_type);
         // Allocate a multicast TEID for this session
@@ -495,23 +523,44 @@ impl MbSmfContext {
         Some(session)
     }
 
+    /// Remove a session's LOCAL state.
+    ///
+    /// #76: this used to be the whole of DELETE, and its log line said "releasing
+    /// N4mb SEID" while releasing nothing — no PFCP Session Deletion Request was
+    /// ever sent, so every released MBS session leaked an N4mb session on the
+    /// MB-UPF. The wire release is the caller's job (it needs an `await`), which is
+    /// why the removed session — carrying its `n4mb_session` — is returned. Callers
+    /// must use [`Self::session_mark_release_pending`] first and remove only after
+    /// the Session Deletion Response.
     pub fn session_remove(&self, id: u64) -> Option<MbsSession> {
         let mut session_list = self.session_list.write().ok()?;
         let mut tmgi_hash = self.tmgi_hash.write().ok()?;
 
         if let Some(session) = session_list.remove(&id) {
             tmgi_hash.remove(&session.tmgi);
-            if let Some(ref n4mb) = session.n4mb_session {
-                log::info!(
-                    "MBS session removed (id={id}) - releasing N4mb SEID {}",
-                    n4mb.local_seid
-                );
-            } else {
-                log::info!("MBS session removed (id={id})");
-            }
+            log::info!("MBS session local state removed (id={id})");
             return Some(session);
         }
         None
+    }
+
+    /// Mark a session's N4mb context `ReleasePending` and return the remote SEID to
+    /// address the Session Deletion Request to (#76).
+    ///
+    /// Two steps rather than one because the deletion is an `await` and the context
+    /// is behind a `std` lock: the state transition happens under the lock, the wire
+    /// exchange outside it, and the local removal only after the response. The
+    /// remote SEID is what the request must be addressed to (TS 29.244 §7.5.4) —
+    /// the LOCAL seid would address a session the UP does not know.
+    pub fn session_mark_release_pending(&self, id: u64) -> Option<u64> {
+        let mut session_list = self.session_list.write().ok()?;
+        let session = session_list.get_mut(&id)?;
+        let n4mb = session.n4mb_session.as_mut()?;
+        n4mb.state = N4mbSessionState::ReleasePending;
+        // A session whose establishment never completed has no UP-allocated SEID,
+        // so there is nothing on the UP to delete. `None` says so, distinctly from
+        // "no N4mb context at all".
+        (n4mb.remote_seid != 0).then_some(n4mb.remote_seid)
     }
 
     pub fn session_remove_all(&self) {
@@ -553,10 +602,33 @@ impl MbSmfContext {
         self.session_list.read().map(|l| l.len()).unwrap_or(0)
     }
 
-    /// Activate a session with N4mb PFCP establishment to UPF
+    /// Activate a session with N4mb PFCP establishment to UPF.
+    ///
+    /// **Idempotent (#76).** An N4mb session that is already `Established` is
+    /// returned unchanged rather than replaced. It used to allocate a fresh
+    /// `local_seid` and overwrite `n4mb_session` on every call, so N repeated
+    /// joins/STARTs created N PFCP sessions on the MB-UPF and orphaned every
+    /// previous one — contrary to the shared-distribution-session model of TS 23.247
+    /// §7.2.1.3/§7.2.1.4, where one MB-UPF session is established once and reused
+    /// across joins. Under multicast churn that leaked a UPF session per join.
+    ///
+    /// An `EstablishmentPending` session is NOT short-circuited: its establishment
+    /// may have failed, and re-driving it is how a retry works. Only a session the
+    /// UP has confirmed is reused.
     pub fn session_activate_n4mb(&self, session_id: u64, upf_addr: Ipv4Addr) -> Option<MbsSession> {
         let mut session_list = self.session_list.write().ok()?;
         let session = session_list.get_mut(&session_id)?;
+
+        if let Some(existing) = session.n4mb_session.as_ref() {
+            if existing.state == N4mbSessionState::Established {
+                log::debug!(
+                    "MBS session {session_id} already has an established N4mb session \
+                     (seid={}); reusing it rather than allocating a second",
+                    existing.local_seid
+                );
+                return Some(session.clone());
+            }
+        }
 
         let local_seid = self.alloc_n4mb_seid();
         let n4mb = build_n4mb_session_establishment(session, local_seid, upf_addr);
@@ -569,6 +641,57 @@ impl MbSmfContext {
             "MBS session {session_id} activated with N4mb to UPF {upf_addr} (seid={local_seid})"
         );
         Some(session.clone())
+    }
+
+    /// Find a session by the SSM the consumer identified it with (#76).
+    ///
+    /// A linear scan rather than a second index. Sessions are capped at
+    /// `max_sessions` and ContextUpdate is not a per-packet path, so the cost is
+    /// irrelevant — while a second index over the same sessions would be a second
+    /// set of invariants to keep in step with `session_add`/`session_remove`, which
+    /// is exactly the class of bug the duplicate-TMGI overwrite was.
+    pub fn session_find_by_ssm(&self, ssm: &crate::types::Ssm) -> Option<MbsSession> {
+        let session_list = self.session_list.read().ok()?;
+        session_list
+            .values()
+            .find(|s| s.ssm.as_ref() == Some(ssm))
+            .cloned()
+    }
+
+    /// Find a session by the LOCAL N4mb SEID (#76).
+    ///
+    /// The MB-UPF addresses a Session Report to the CP F-SEID it was given at
+    /// establishment, i.e. to our `local_seid` — not to the SEID it allocated
+    /// itself. Looking up by `remote_seid` would find nothing for every report.
+    pub fn session_find_by_local_seid(&self, seid: u64) -> Option<MbsSession> {
+        let session_list = self.session_list.read().ok()?;
+        session_list
+            .values()
+            .find(|s| {
+                s.n4mb_session
+                    .as_ref()
+                    .is_some_and(|n| n.local_seid == seid)
+            })
+            .cloned()
+    }
+
+    /// Activate a session on downlink data arrival (TS 23.247 §7.2.5.2), #76.
+    ///
+    /// Returns whether the state actually CHANGED. A session already `Active` is
+    /// left alone and reports `false`, so the caller can distinguish "traffic
+    /// reactivated a deactivated session" — the event that matters — from a report
+    /// about a session that was never deactivated. Answering `true` unconditionally
+    /// would make the log say a session was reactivated every time a packet arrived.
+    pub fn session_activate_on_downlink_data(&self, session_id: u64) -> bool {
+        if let Ok(mut list) = self.session_list.write() {
+            if let Some(session) = list.get_mut(&session_id) {
+                if session.state != MbsSessionState::Active {
+                    session.state = MbsSessionState::Active;
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// Join a UE to an MBS session group
@@ -778,12 +901,32 @@ impl MbSmfContext {
         };
         if let Ok(mut list) = self.session_list.write() {
             if let Some(session) = list.get_mut(&id) {
+                // #76: this used to set ReleasePending and then IMMEDIATELY zero
+                // `n4mb_session`, so the SEID needed to delete the session on the
+                // MB-UPF was discarded before anything could send the deletion. The
+                // context is now left in place for the caller to release on the
+                // wire and clear afterwards (`session_clear_n4mb`).
                 if let Some(n4mb) = session.n4mb_session.as_mut() {
                     n4mb.state = N4mbSessionState::ReleasePending;
                 }
-                session.n4mb_session = None;
                 session.state = MbsSessionState::Suspended;
                 return true;
+            }
+        }
+        false
+    }
+
+    /// Clear a session's N4mb context after its Session Deletion completed (#76).
+    ///
+    /// Separate from [`Self::session_context_terminate`] so the SEID survives long
+    /// enough to be used. Returns whether a context was cleared, so a caller can
+    /// tell "released and cleared" from "there was nothing to release".
+    pub fn session_clear_n4mb(&self, id: u64) -> bool {
+        if let Ok(mut list) = self.session_list.write() {
+            if let Some(session) = list.get_mut(&id) {
+                let had = session.n4mb_session.is_some();
+                session.n4mb_session = None;
+                return had;
             }
         }
         false
@@ -1127,8 +1270,27 @@ mod tests {
             .is_none());
     }
 
+    /// **Assertion inverted by #76, and why.** This used to assert that
+    /// `session_context_terminate` leaves `n4mb_session` as `None`. That was pinning
+    /// the defect as the requirement: zeroing the context discards the remote SEID a
+    /// PFCP Session Deletion Request has to be addressed to, so nothing could delete
+    /// the session on the MB-UPF even in principle, and every terminate leaked one.
+    ///
+    /// The governing clause is not a "may": TS 29.244 §7.5.4 has the CP function
+    /// **send** a Session Deletion Request to release a PFCP session, and TS 23.247
+    /// §7.1.1.4 has releasing an MBS session tear down the associated MB-UPF
+    /// resources. So the old assertion was asserting a shortcut past a mandatory
+    /// message, and inverting it is legitimate.
+    ///
+    /// Terminate now marks the context `ReleasePending` and LEAVES it; the wire
+    /// release plus the clear is `release_n4mb_transport` in `main.rs`, and the two
+    /// handler-level tests that assert the post-handler state
+    /// (`test_router_context_update_amf_release_golden_204`,
+    /// `mbs_context_update_strict_peer_release_204`) still pass unchanged — which is
+    /// what shows the observable behaviour of the SERVICE is preserved and only this
+    /// function's own contract narrowed.
     #[test]
-    fn test_context_terminate_releases_n4mb() {
+    fn test_context_terminate_marks_release_pending_without_discarding_the_seid() {
         let mut ctx = MbSmfContext::new();
         ctx.init(256);
         let tmgi = make_tmgi(0x43);
@@ -1137,14 +1299,112 @@ mod tests {
             .unwrap();
         ctx.session_context_start(&tmgi, Ipv4Addr::new(10, 0, 0, 7))
             .unwrap();
+        // Pretend the UP answered, so there is a remote SEID to delete.
+        assert!(ctx.apply_n4mb_response(
+            created.id,
+            0xdead_beef,
+            0x1234,
+            Ipv4Addr::new(10, 0, 0, 7)
+        ));
 
         assert!(ctx.session_context_terminate(&tmgi));
         let after = ctx.session_find_by_id(created.id).unwrap();
-        assert!(after.n4mb_session.is_none());
+        let n4mb = after.n4mb_session.as_ref().expect(
+            "the N4mb context must SURVIVE terminate: its remote SEID is what the \
+                     Session Deletion Request is addressed to",
+        );
+        assert_eq!(n4mb.state, N4mbSessionState::ReleasePending);
+        assert_eq!(n4mb.remote_seid, 0xdead_beef);
         assert_eq!(after.state, MbsSessionState::Suspended);
+
+        // The two-step is what the release driver uses: mark, then delete, then clear.
+        assert_eq!(
+            ctx.session_mark_release_pending(created.id),
+            Some(0xdead_beef),
+            "the remote SEID must be recoverable for the deletion request"
+        );
+        assert!(ctx.session_clear_n4mb(created.id));
+        assert!(ctx
+            .session_find_by_id(created.id)
+            .unwrap()
+            .n4mb_session
+            .is_none());
+        assert!(
+            !ctx.session_clear_n4mb(created.id),
+            "clearing twice must report that there was nothing left to clear"
+        );
 
         // Terminating an unknown TMGI is a no-op.
         assert!(!ctx.session_context_terminate(&make_tmgi(0x77)));
+    }
+
+    /// #76 criterion 5: a repeated START must not allocate a second N4mb session.
+    ///
+    /// N repeated joins used to create N PFCP sessions on the MB-UPF and orphan
+    /// every previous one, contrary to the shared-distribution-session model of TS
+    /// 23.247 §7.2.1.3/§7.2.1.4. An `EstablishmentPending` session is deliberately
+    /// NOT short-circuited: its establishment may have failed, and re-driving it is
+    /// how a retry works.
+    #[test]
+    fn a_repeated_start_reuses_an_established_n4mb_session() {
+        let mut ctx = MbSmfContext::new();
+        ctx.init(256);
+        let tmgi = make_tmgi(0x51);
+        let created = ctx
+            .session_add(tmgi.clone(), MbsSessionType::Multicast)
+            .unwrap();
+        let upf = Ipv4Addr::new(10, 0, 0, 7);
+
+        let first = ctx.session_context_start(&tmgi, upf).unwrap();
+        let first_seid = first.n4mb_session.as_ref().unwrap().local_seid;
+        // Not yet established: a second START re-drives it, which is the retry path.
+        let retry = ctx.session_context_start(&tmgi, upf).unwrap();
+        assert_ne!(
+            retry.n4mb_session.as_ref().unwrap().local_seid,
+            first_seid,
+            "an establishment that never completed must be re-drivable"
+        );
+        let retry_seid = retry.n4mb_session.as_ref().unwrap().local_seid;
+
+        // Now the UP confirms it. Every later START must reuse this one.
+        assert!(ctx.apply_n4mb_response(created.id, 0x99, 0x1234, upf));
+        for _ in 0..3 {
+            let again = ctx.session_context_start(&tmgi, upf).unwrap();
+            let n4mb = again.n4mb_session.as_ref().unwrap();
+            assert_eq!(
+                n4mb.local_seid, retry_seid,
+                "a repeated START must not allocate a new SEID for an established session"
+            );
+            assert_eq!(n4mb.remote_seid, 0x99, "nor discard the UP-allocated one");
+            assert_eq!(n4mb.state, N4mbSessionState::Established);
+        }
+    }
+
+    /// #76 criterion 7: a second create for a TMGI already in use is refused rather
+    /// than silently orphaning the first session.
+    ///
+    /// The overwrite used to leave the earlier session in `session_list` reachable
+    /// by NOTHING — its TMGI resolved to the new session, so it could never be found
+    /// or deleted, and its MB-UPF session could never be released.
+    #[test]
+    fn a_duplicate_tmgi_create_is_refused_and_the_first_session_survives() {
+        let mut ctx = MbSmfContext::new();
+        ctx.init(256);
+        let tmgi = make_tmgi(0x61);
+        let first = ctx
+            .session_add(tmgi.clone(), MbsSessionType::Multicast)
+            .expect("the first create succeeds");
+        assert!(
+            ctx.session_add(tmgi.clone(), MbsSessionType::Multicast)
+                .is_none(),
+            "a TMGI identifies one MBS session; a second create for it must be refused"
+        );
+        assert_eq!(
+            ctx.session_find_by_tmgi(&tmgi).map(|s| s.id),
+            Some(first.id),
+            "the TMGI must still resolve to the FIRST session"
+        );
+        assert_eq!(ctx.session_count(), 1, "and no orphan is left behind");
     }
 
     #[test]

--- a/src/bins/nextgcore-mbsmfd/src/main.rs
+++ b/src/bins/nextgcore-mbsmfd/src/main.rs
@@ -268,9 +268,17 @@ async fn main() -> Result<()> {
 
     log::info!("NextGCore MB-SMF ready (instance: {nf_instance_id})");
 
-    // Main event loop
+    // Main event loop.
+    //
+    // #76: also drains the N4mb Session Report queue. The recv loop answers each
+    // report on the wire immediately; this applies the consequence (activating a
+    // deactivated multicast session on downlink data arrival, TS 23.247 §7.2.5.2)
+    // where the session state lives, so the socket loop never takes the context
+    // lock. 100ms is the loop's existing tick, and a report already answered is not
+    // time-critical to apply.
     while !shutdown.load(Ordering::SeqCst) {
         tokio::time::sleep(Duration::from_millis(100)).await;
+        apply_n4mb_reports().await;
     }
 
     // Graceful shutdown
@@ -458,21 +466,66 @@ async fn handle_mbs_session_create(request: &SbiRequest) -> SbiResponse {
         }
     };
 
-    // Read mbsSession.serviceType (the spec field name).
+    // #76: `serviceType` is REQUIRED in TS 29.571's `MbsSession`. It used to be
+    // defaulted (`_ => Multicast`), so a request omitting a mandatory IE was
+    // accepted and silently became a multicast session — the create then succeeded
+    // and the consumer never learned its request was incomplete.
     let session_type = match req.mbs_session.service_type {
         Some(types::MbsServiceType::Broadcast) => MbsSessionType::Broadcast,
-        _ => MbsSessionType::Multicast,
+        Some(types::MbsServiceType::Multicast) => MbsSessionType::Multicast,
+        None => {
+            return send_bad_request(
+                "mbsSession.serviceType is mandatory (TS 29.571 MbsSession)",
+                Some("MANDATORY_IE_MISSING"),
+            )
+        }
     };
 
-    // mbsmfd-07: resolve the TMGI from mbsSession.mbsSessionId (else default).
+    let ctx = mbsmf_self();
+
+    // #76: resolve the TMGI. TS 29.571 makes `MbsSession` `anyOf [mbsSessionId,
+    // tmgiAllocReq]`, so a create either NAMES its session or ASKS for a TMGI.
+    //
+    // The no-TMGI path used to return a HARDCODED TMGI (`mbsServiceId
+    // [0x01,0x02,0x03]`, PLMN 001/01) from `context_tmgi_from`, so every such create
+    // collided with every other one — and `session_add` overwrote `tmgi_hash`
+    // silently, orphaning the earlier session. It now allocates from the same
+    // `TmgiPool` the Nmbsmf TMGI service uses, so two such creates get two sessions.
     let spec_tmgi = req
         .mbs_session
         .mbs_session_id
         .as_ref()
         .and_then(|id| id.tmgi.as_ref());
-    let tmgi = context_tmgi_from(spec_tmgi);
+    let tmgi = match spec_tmgi {
+        Some(t) => context_tmgi_from(Some(t)),
+        None => {
+            // No TMGI: allocate one. TS 29.571's `MbsSession` is
+            // `anyOf [mbsSessionId, tmgiAllocReq]`, and that `anyOf` is deliberately
+            // NOT enforced here -- #76's criterion 7 requires a create carrying no
+            // TMGI to SUCCEED by allocating from the pool, so refusing an absent
+            // `tmgiAllocReq` would contradict it. An absent flag is therefore read as
+            // an implicit request, which is the reading that makes both the criterion
+            // and the schema's intent satisfiable. Stated rather than silent: a
+            // conformance suite exercising the `anyOf` will see it accepted.
+            let allocated = ctx.read().ok().and_then(|c| {
+                let (tmgis, _expiry) =
+                    c.tmgi_allocate(&default_plmn(), 1, context::TMGI_DEFAULT_TTL_SECS);
+                tmgis.into_iter().next()
+            });
+            match allocated {
+                Some(t) => t,
+                None => {
+                    return nextgcore_sbi::server::send_error(
+                        507,
+                        "Insufficient Storage",
+                        "No TMGI could be allocated for this MBS session",
+                        Some("TMGI_POOL_EXHAUSTED"),
+                    )
+                }
+            }
+        }
+    };
 
-    let ctx = mbsmf_self();
     let session = if let Ok(context) = ctx.read() {
         context.session_add(tmgi, session_type)
     } else {
@@ -480,22 +533,66 @@ async fn handle_mbs_session_create(request: &SbiRequest) -> SbiResponse {
     };
 
     match session {
-        Some(session) => {
+        Some(mut session) => {
             let session_id = format!("mbs-sess-{}", session.id);
             log::info!("MBS Session created: {session_id} (type={session_type:?})");
+
+            // #76: remember the SSM the consumer identified this session with, so an
+            // SSM-identified ContextUpdate can resolve it. `MbsSessionId` is
+            // `anyOf(tmgi, ssm)`, and the SSM form used to be unresolvable at all.
+            if let Some(ssm) = req
+                .mbs_session
+                .mbs_session_id
+                .as_ref()
+                .and_then(|id| id.ssm.as_ref())
+                .or(req.mbs_session.ssm.as_ref())
+            {
+                session.ssm = Some(ssm.clone());
+                if let Ok(context) = ctx.read() {
+                    context.session_update(&session);
+                }
+            }
 
             // mbsmfd-06: respond with CreateRspData{ mbsSession }.
             let rsp = types::CreateRspData {
                 mbs_session: types::ExtMbsSession {
                     mbs_session_id: Some(types::MbsSessionId {
                         tmgi: Some(spec_tmgi_from(&session.tmgi)),
-                        ssm: None,
+                        // #76: an SSM-identified create gets its SSM back, so the
+                        // consumer can address the session the way it named it.
+                        ssm: req
+                            .mbs_session
+                            .mbs_session_id
+                            .as_ref()
+                            .and_then(|id| id.ssm.clone()),
                     }),
                     service_type: Some(match session_type {
                         MbsSessionType::Broadcast => types::MbsServiceType::Broadcast,
                         MbsSessionType::Multicast => types::MbsServiceType::Multicast,
                     }),
-                    ingress_tun_addr: Some(format!("{:#010x}", session.gtp_teid)),
+                    // #76: a structured TS 29.571 `TunnelAddress` ARRAY, not the hex
+                    // TEID string this used to emit. `ingressTunAddr` is readOnly and
+                    // `minItems: 1`, and it is the one member a consumer needs in
+                    // order to send traffic anywhere.
+                    ingress_tun_addr: Some(vec![types::TunnelAddress {
+                        // The MB-SMF's own transport address and the GTP-U port
+                        // (TS 29.281): where the content provider sends ingress
+                        // traffic for this session.
+                        ipv4_addr: Some(std::net::Ipv4Addr::from(configured_cp_addr()).to_string()),
+                        ipv6_addr: None,
+                        port_number: 2152,
+                    }]),
+                    // The write-only members are echoed so a consumer can confirm
+                    // what the MB-SMF stored rather than assume it.
+                    ssm: req.mbs_session.ssm.clone(),
+                    mbs_service_area: req.mbs_session.mbs_service_area.clone(),
+                    mbs_serv_info: req.mbs_session.mbs_serv_info.clone(),
+                    mbs_security_context: req.mbs_session.mbs_security_context.clone(),
+                    contact_pcf_ind: req.mbs_session.contact_pcf_ind,
+                    area_session_policy_id: req.mbs_session.area_session_policy_id,
+                    activity_status: None,
+                    tmgi_alloc_req: None,
+                    ingress_tun_addr_req: None,
                 },
             };
 
@@ -622,7 +719,46 @@ async fn handle_mbs_session_update(session_id: &str, request: &SbiRequest) -> Sb
 
     match session {
         Some(mut session) => {
-            let outcome = types::apply_patch_data(&patch, &mut session.service_area_tacs);
+            // #76: `activityStatus`, `mbsServInfo` (QoS) and `mbsSecurityContext`
+            // used to be silently ignored, so a PATCH activating a session answered
+            // 204 and changed nothing. They are collected here and persisted below.
+            let mut changes = types::PatchChanges::default();
+            let outcome =
+                types::apply_patch_data(&patch, &mut session.service_area_tacs, &mut changes);
+
+            // TS 23.247 §7.2.5: `activityStatus` drives whether distribution is
+            // active. Applied to the session state so a subsequent GET and the N4mb
+            // driver both see it, rather than being acknowledged and dropped.
+            if let Some(ref status) = changes.activity_status {
+                session.state = match status.as_str() {
+                    "ACTIVE" => MbsSessionState::Active,
+                    "INACTIVE" => MbsSessionState::Suspended,
+                    other => {
+                        log::warn!(
+                            "MBS session {session_id} PATCH: unrecognised activityStatus \
+                             '{other}'; state left unchanged"
+                        );
+                        session.state
+                    }
+                };
+            }
+            // The QoS request: 5QI and maximum bit rate, when the patch names them.
+            if let Some(ref info) = changes.mbs_serv_info {
+                if let Some(five_qi) = info
+                    .pointer("/mbsQoSReq/5qi")
+                    .or_else(|| info.get("5qi"))
+                    .and_then(serde_json::Value::as_u64)
+                {
+                    session.fiveqi = five_qi as u8;
+                }
+                if let Some(mbr) = info
+                    .pointer("/mbsQoSReq/mbrDl")
+                    .or_else(|| info.get("mbrDl"))
+                    .and_then(serde_json::Value::as_u64)
+                {
+                    session.max_bitrate = mbr;
+                }
+            }
 
             if let Ok(context) = ctx.read() {
                 context.session_update(&session);
@@ -649,6 +785,15 @@ async fn handle_mbs_session_release(session_id: &str) -> SbiResponse {
     log::info!("MBS Session Release: {session_id}");
 
     let pool_id = parse_session_id(session_id);
+
+    // #76: release the N4mb session on the MB-UPF BEFORE dropping local state. The
+    // old code called `session_remove` alone, whose log line said "releasing N4mb
+    // SEID" while releasing nothing, so every released MBS session leaked a session
+    // on the MB-UPF. Awaited, so the local removal below happens after the Session
+    // Deletion Response (or after it demonstrably failed).
+    if let Some(id) = pool_id {
+        release_n4mb_transport(id).await;
+    }
 
     let ctx = mbsmf_self();
     let removed = pool_id.and_then(|id| {
@@ -854,6 +999,132 @@ async fn drive_n4mb_establishment(pool_id: u64, session: MbsSession) {
     }
 }
 
+/// Apply queued N4mb Session Reports to the session state (#76).
+///
+/// TS 23.247 §7.2.5.2: downlink data arriving at the MB-UPF **activates** a
+/// (de)activated multicast session. The report is answered on the wire by the recv
+/// loop (the UP is waiting); this is the consequence, driven where the session state
+/// lives so the socket loop never takes the context lock.
+///
+/// Returns the ids of the sessions whose state actually changed, so a caller — and a
+/// test — can tell a reactivation from a report about an already-active session.
+async fn apply_n4mb_reports() -> Vec<u64> {
+    let Some(node) = n4mb_node().await else {
+        return Vec::new();
+    };
+    let reports = node.take_reports();
+    if reports.is_empty() {
+        return Vec::new();
+    }
+    let ctx = mbsmf_self();
+    let mut activated = Vec::new();
+    for report in reports {
+        if !report.downlink_data {
+            // A report with no Downlink Data Report is answered and otherwise has no
+            // consequence here: usage reporting is not part of this NF's remit, and
+            // acting on a report type we do not model would be inventing behaviour.
+            log::debug!(
+                "[N4mb] Session Report on seid=0x{:016x} carried no Downlink Data Report; \
+                 answered, no activation",
+                report.seid
+            );
+            continue;
+        }
+        let Ok(c) = ctx.read() else { continue };
+        // Addressed to our LOCAL seid: the UP answers to the CP F-SEID it was given.
+        let Some(session) = c.session_find_by_local_seid(report.seid) else {
+            log::warn!(
+                "[N4mb] Downlink Data Report on seid=0x{:016x} matches no session; the \
+                 MB-UPF may hold a session this MB-SMF has released",
+                report.seid
+            );
+            continue;
+        };
+        if c.session_activate_on_downlink_data(session.id) {
+            log::info!(
+                "[N4mb] downlink data reactivated MBS session {} (TS 23.247 §7.2.5.2)",
+                session.id
+            );
+            activated.push(session.id);
+        }
+    }
+    activated
+}
+
+/// Release a session's N4mb transport ON THE WIRE, then clear it locally (#76).
+///
+/// TS 29.244 §7.5.4 / TS 23.247 §7.1.1.4: releasing an MBS session tears down the
+/// associated MB-UPF resources, and that requires a PFCP Session Deletion Request.
+/// `release_session` existed and had **no callers at all** — `grep` found only its
+/// definition — so both the DELETE and the TERMINATE paths mutated local state and
+/// left the UPF session behind. Every released MBS session leaked one.
+///
+/// Order matters and is the criterion: mark `ReleasePending`, send and await the
+/// deletion, and only then clear. Clearing first (which
+/// `session_context_terminate` used to do) discards the remote SEID the request has
+/// to be addressed to, so nothing could be deleted even in principle.
+///
+/// Returns whether the deletion was **acknowledged**. A timeout or a refusal still
+/// clears the local context: the session is going away from this MB-SMF either way,
+/// and keeping a context whose UPF counterpart may or may not exist would leave the
+/// two sides disagreeing with no path back. The leak is named in the log so it is
+/// diagnosable rather than silent.
+async fn release_n4mb_transport(session_id: u64) -> bool {
+    let ctx = mbsmf_self();
+    let remote_seid = match ctx.read() {
+        Ok(c) => c.session_mark_release_pending(session_id),
+        Err(_) => None,
+    };
+    let Some(remote_seid) = remote_seid else {
+        // No N4mb context, or one whose establishment never completed: there is
+        // nothing on the MB-UPF to delete. Clearing is still right.
+        let cleared = ctx
+            .read()
+            .map(|c| c.session_clear_n4mb(session_id))
+            .unwrap_or(false);
+        if cleared {
+            log::debug!(
+                "[N4mb] session {session_id} had no UP-allocated SEID; cleared without a \
+                 Session Deletion (its establishment never completed)"
+            );
+        }
+        return false;
+    };
+
+    let acknowledged = match n4mb_node().await {
+        Some(node) => match node.release_session(remote_seid).await {
+            Ok(()) => {
+                log::info!(
+                    "[N4mb] session {session_id} released on the MB-UPF \
+                     (remote_seid=0x{remote_seid:016x})"
+                );
+                true
+            }
+            Err(e) => {
+                log::warn!(
+                    "[N4mb] Session Deletion for session {session_id} \
+                     (remote_seid=0x{remote_seid:016x}) failed: {e}. The MB-UPF may retain \
+                     the session; local state is cleared regardless."
+                );
+                false
+            }
+        },
+        None => {
+            log::warn!(
+                "[N4mb] no PFCP node: session {session_id} \
+                 (remote_seid=0x{remote_seid:016x}) is released locally only and LEAKS on the \
+                 MB-UPF"
+            );
+            false
+        }
+    };
+
+    if let Ok(c) = ctx.read() {
+        c.session_clear_n4mb(session_id);
+    }
+    acknowledged
+}
+
 /// Handle ContextUpdate (TS 29.532 §5.3.2.5) - start/terminate MBS data
 /// reception. [mbsmfd-03] On an SMF multicast Start the MB-SMF allocates and
 /// returns a `cTeid` + `llSsm` and drives N4mb establishment; on Terminate /
@@ -875,15 +1146,40 @@ async fn handle_mbs_session_context_update(request: &SbiRequest) -> SbiResponse 
         }
     };
 
-    // mbsSessionId is mandatory; resolve the session by TMGI.
+    // #76: resolve the session by TMGI **or by SSM**. `MbsSessionId` is
+    // `anyOf(tmgi, ssm)`, and this used to hard-reject anything without a TMGI with
+    // `400 MANDATORY_IE_MISSING` — so an SSM-identified multicast session could not
+    // be updated at all, by any consumer, ever.
+    //
+    // An SSM resolves to the session's own TMGI, which every session has (allocated
+    // at create when the consumer supplied none). That keeps the whole downstream
+    // handler keyed on one identifier instead of carrying two.
     let tmgi = match req.mbs_session_id.tmgi.as_ref() {
         Some(t) => context_tmgi_from(Some(t)),
-        None => {
-            return send_bad_request(
-                "ContextUpdate requires mbsSessionId.tmgi",
-                Some("MANDATORY_IE_MISSING"),
-            )
-        }
+        None => match req.mbs_session_id.ssm.as_ref() {
+            Some(ssm) => {
+                match mbsmf_self()
+                    .read()
+                    .ok()
+                    .and_then(|c| c.session_find_by_ssm(ssm))
+                {
+                    Some(session) => session.tmgi,
+                    None => {
+                        return send_not_found(
+                            "No MBS session matches the supplied mbsSessionId.ssm",
+                            Some("CONTEXT_NOT_FOUND"),
+                        )
+                    }
+                }
+            }
+            None => {
+                return send_bad_request(
+                    "ContextUpdate requires mbsSessionId.tmgi or mbsSessionId.ssm \
+                     (TS 29.571 MbsSessionId anyOf)",
+                    Some("MANDATORY_IE_MISSING"),
+                )
+            }
+        },
     };
 
     let action = req
@@ -907,6 +1203,17 @@ async fn handle_mbs_session_context_update(request: &SbiRequest) -> SbiResponse 
                 "MBS session not found for ContextUpdate",
                 Some("CONTEXT_NOT_FOUND"),
             );
+        }
+        // #76: `session_context_terminate` now only marks the N4mb context
+        // ReleasePending -- it used to zero it, discarding the remote SEID before
+        // anything could send a Session Deletion. The wire release happens here and
+        // clears the context afterwards.
+        if let Some(id) = ctx
+            .read()
+            .ok()
+            .and_then(|c| c.session_find_by_tmgi(&tmgi).map(|s| s.id))
+        {
+            release_n4mb_transport(id).await;
         }
         log::info!(
             "ContextUpdate Terminate (TMGI {:02x?})",
@@ -1260,6 +1567,15 @@ async fn handle_context_update_amf(
                     "MBS session not found for ContextUpdate",
                     Some("CONTEXT_NOT_FOUND"),
                 );
+            }
+            // #76: same as the SMF terminate leg above -- the wire release, then the
+            // local clear.
+            if let Some(id) = ctx
+                .read()
+                .ok()
+                .and_then(|c| c.session_find_by_tmgi(tmgi).map(|s| s.id))
+            {
+                release_n4mb_transport(id).await;
             }
             log::info!(
                 "ContextUpdate AMF release (TMGI {:02x?})",
@@ -2807,6 +3123,219 @@ mod tests {
     // loopback notifyUri will fail silently, which is expected in unit tests —
     // we verify the router returns 204 and the subscription count is unchanged
     // because the notify is to a different endpoint than the session).
+    // ---- #76: create validation, TMGI allocation, SSM ContextUpdate ---------
+
+    async fn post_create(body: serde_json::Value) -> SbiResponse {
+        mbsmf_sbi_request_handler(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions")
+                .with_body(body.to_string(), "application/json"),
+        )
+        .await
+    }
+
+    fn rsp_json(resp: &SbiResponse) -> serde_json::Value {
+        serde_json::from_str(resp.http.content.as_deref().unwrap_or("{}"))
+            .expect("response body is not JSON")
+    }
+
+    /// #76 criterion 6: a missing mandatory `serviceType` is REFUSED, and the create
+    /// response carries a structured `ingressTunAddr`.
+    ///
+    /// `serviceType` used to be defaulted (`_ => Multicast`), so a request omitting a
+    /// mandatory IE succeeded and silently became a multicast session.
+    /// `ingressTunAddr` used to be `format!("{:#010x}", gtp_teid)` — a hex TEID
+    /// string where TS 29.571 declares an ARRAY of `TunnelAddress`, i.e. the one
+    /// member a consumer needs in order to send traffic anywhere was unparseable.
+    #[tokio::test]
+    async fn create_refuses_a_missing_service_type_and_answers_a_structured_ingress_address() {
+        mbsmf_context_init(256);
+
+        let resp = post_create(serde_json::json!({ "mbsSession": {} })).await;
+        assert_eq!(resp.status, 400, "body: {:?}", resp.http.content);
+        assert_eq!(
+            rsp_json(&resp)["cause"],
+            serde_json::json!("MANDATORY_IE_MISSING")
+        );
+
+        let resp = post_create(serde_json::json!({
+            "mbsSession": { "serviceType": "MULTICAST" }
+        }))
+        .await;
+        assert_eq!(resp.status, 201);
+        let body = rsp_json(&resp);
+        let addrs = body["mbsSession"]["ingressTunAddr"]
+            .as_array()
+            .expect("ingressTunAddr is an ARRAY of TunnelAddress, minItems 1");
+        assert_eq!(addrs.len(), 1);
+        assert!(
+            addrs[0]["ipv4Addr"].as_str().is_some(),
+            "TunnelAddress is anyOf[ipv4Addr, ipv6Addr], got {}",
+            addrs[0]
+        );
+        assert!(
+            addrs[0]["portNumber"].as_u64().is_some(),
+            "portNumber is REQUIRED in TunnelAddress, got {}",
+            addrs[0]
+        );
+        assert!(
+            !addrs[0].is_string(),
+            "the hex-TEID-string form is what this replaces"
+        );
+    }
+
+    /// #76 criterion 6, the round-trip half: a full `ExtMbsSession` keeps its
+    /// `serviceArea`, `ssm`, QoS and security rather than dropping them.
+    #[tokio::test]
+    async fn a_full_ext_mbs_session_round_trips_its_write_only_members() {
+        mbsmf_context_init(256);
+
+        let resp = post_create(serde_json::json!({
+            "mbsSession": {
+                "serviceType": "MULTICAST",
+                "ssm": { "sourceIpAddr": {"ipv4Addr": "10.1.1.1"},
+                         "destIpAddr": {"ipv4Addr": "232.0.0.1"} },
+                "mbsServiceArea": { "ncgiList": [{ "plmnId": {"mcc":"001","mnc":"01"},
+                                                    "nrCellId": "000000001" }] },
+                "mbsServInfo": { "mbsQoSReq": { "5qi": 7 } },
+                "mbsSecurityContext": { "keyList": ["k1"] },
+                "contactPcfInd": true,
+                "areaSessionPolicyId": 42,
+            }
+        }))
+        .await;
+        assert_eq!(resp.status, 201, "body: {:?}", resp.http.content);
+        let s = &rsp_json(&resp)["mbsSession"];
+        assert_eq!(
+            s["ssm"]["destIpAddr"]["ipv4Addr"],
+            serde_json::json!("232.0.0.1")
+        );
+        assert!(
+            s["mbsServiceArea"]["ncgiList"].is_array(),
+            "serviceArea dropped"
+        );
+        assert_eq!(s["mbsServInfo"]["mbsQoSReq"]["5qi"], serde_json::json!(7));
+        assert!(
+            s["mbsSecurityContext"]["keyList"].is_array(),
+            "security dropped"
+        );
+        assert_eq!(s["contactPcfInd"], serde_json::json!(true));
+        assert_eq!(s["areaSessionPolicyId"], serde_json::json!(42));
+    }
+
+    /// #76 criterion 7: two no-TMGI creates yield two DISTINCT sessions.
+    ///
+    /// `context_tmgi_from` returned a hardcoded TMGI for the no-TMGI path, so every
+    /// such create collided — and `session_add` overwrote `tmgi_hash` silently, so
+    /// the earlier session stayed in the list reachable by nothing and its MB-UPF
+    /// session could never be released.
+    #[tokio::test]
+    async fn two_no_tmgi_creates_get_two_sessions_from_the_pool() {
+        mbsmf_context_init(256);
+
+        let first = post_create(serde_json::json!({
+            "mbsSession": { "serviceType": "MULTICAST", "tmgiAllocReq": true }
+        }))
+        .await;
+        let second = post_create(serde_json::json!({
+            "mbsSession": { "serviceType": "MULTICAST", "tmgiAllocReq": true }
+        }))
+        .await;
+        assert_eq!(first.status, 201, "body: {:?}", first.http.content);
+        assert_eq!(
+            second.status, 201,
+            "a second no-TMGI create must succeed, got {:?}",
+            second.http.content
+        );
+
+        let first_tmgi = rsp_json(&first)["mbsSession"]["mbsSessionId"]["tmgi"].clone();
+        let second_tmgi = rsp_json(&second)["mbsSession"]["mbsSessionId"]["tmgi"].clone();
+        assert_ne!(
+            first_tmgi, second_tmgi,
+            "each allocated TMGI must be distinct, got {first_tmgi} twice"
+        );
+        // Both sessions must still be REACHABLE, which is what "the second did not
+        // orphan the first" means in practice. Asserted per-session rather than on a
+        // global count: the session store is process-global and sibling tests create
+        // their own, so an absolute count is a race rather than an assertion.
+        for (label, resp) in [("first", &first), ("second", &second)] {
+            let path = resp.http.get_header("location").expect("Location").clone();
+            let got = mbsmf_sbi_request_handler(SbiRequest::get(path)).await;
+            assert!(
+                got.status == 200 || got.status == 204,
+                "the {label} session must still be retrievable, got {}",
+                got.status
+            );
+        }
+    }
+
+    /// #76 criterion 9: a ContextUpdate identified by SSM is ACCEPTED.
+    ///
+    /// It used to be rejected `400 MANDATORY_IE_MISSING` for having no TMGI, so an
+    /// SSM-identified multicast session could not be updated at all — by any
+    /// consumer, ever — even though `MbsSessionId` is `anyOf(tmgi, ssm)`.
+    #[tokio::test]
+    async fn a_context_update_identified_by_ssm_is_accepted() {
+        mbsmf_context_init(256);
+
+        let ssm = serde_json::json!({
+            "sourceIpAddr": { "ipv4Addr": "10.2.2.2" },
+            "destIpAddr": { "ipv4Addr": "232.0.0.9" }
+        });
+        let created = post_create(serde_json::json!({
+            "mbsSession": {
+                "serviceType": "MULTICAST",
+                "mbsSessionId": { "ssm": ssm },
+            }
+        }))
+        .await;
+        assert_eq!(created.status, 201, "body: {:?}", created.http.content);
+
+        let resp = mbsmf_sbi_request_handler(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                serde_json::json!({
+                    "nfcInstanceId": "smf-ssm",
+                    "mbsSessionId": { "ssm": ssm },
+                    "requestedAction": "TERMINATE",
+                })
+                .to_string(),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(
+            resp.status, 204,
+            "an SSM-identified ContextUpdate must be served, got {} {:?}",
+            resp.status, resp.http.content
+        );
+
+        // An SSM no session carries is a 404 (a real lookup miss), not a 400.
+        let resp = mbsmf_sbi_request_handler(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                serde_json::json!({
+                    "nfcInstanceId": "smf-ssm",
+                    "mbsSessionId": { "ssm": {
+                        "sourceIpAddr": { "ipv4Addr": "10.9.9.9" },
+                        "destIpAddr": { "ipv4Addr": "232.9.9.9" } } },
+                    "requestedAction": "TERMINATE",
+                })
+                .to_string(),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(resp.status, 404);
+
+        // Neither identifier is still a 400: the anyOf is unsatisfied.
+        let resp = mbsmf_sbi_request_handler(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                serde_json::json!({ "nfcInstanceId": "smf-ssm", "mbsSessionId": {} }).to_string(),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(resp.status, 400);
+    }
+
     #[tokio::test]
     async fn test_router_release_fires_notify_path() {
         mbsmf_context_init(256);

--- a/src/bins/nextgcore-mbsmfd/src/n4mb.rs
+++ b/src/bins/nextgcore-mbsmfd/src/n4mb.rs
@@ -25,8 +25,8 @@ use std::time::Duration;
 use bytes::Bytes;
 use nextgcore_pfcp::header::PfcpHeader;
 use nextgcore_pfcp::message::{
-    build_message, parse_message, AssociationSetupRequest, PfcpMessage, SessionDeletionRequest,
-    SessionEstablishmentRequest,
+    build_message, parse_message, AssociationSetupRequest, HeartbeatResponse, PfcpMessage,
+    SessionDeletionRequest, SessionEstablishmentRequest, SessionReportResponse,
 };
 use nextgcore_pfcp::types::{
     ApplyAction, CreateFar, CreatePdr, DestinationInterface, FSeid, FTeid, ForwardingParameters,
@@ -152,6 +152,21 @@ impl From<std::io::Error> for N4mbError {
 
 type PendingTable = Mutex<HashMap<u32, oneshot::Sender<(PfcpHeader, PfcpMessage)>>>;
 
+/// A Session Report the MB-UPF sent us, surfaced to the session driver (#76).
+///
+/// Carries the SEID it arrived on rather than a resolved session, because the
+/// recv loop must not take the context lock: it would hold it across the reply
+/// send, and the context's own writers call back into this node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct N4mbSessionReport {
+    /// The SEID the report arrived on — the MB-SMF's own local SEID, since the UP
+    /// addresses a report to the CP F-SEID it was given at establishment.
+    pub seid: u64,
+    /// Whether the report carried a Downlink Data Report, i.e. traffic arrived for
+    /// a deactivated session (TS 23.247 §7.2.5.2).
+    pub downlink_data: bool,
+}
+
 /// A long-lived N4mb PFCP node toward one MB-UPF (TS 29.244). [mbsmfd-02]
 pub struct N4mbPfcpNode {
     socket: Arc<UdpSocket>,
@@ -163,6 +178,16 @@ pub struct N4mbPfcpNode {
     pending: Arc<PendingTable>,
     t1: Duration,
     n1: u32,
+    /// Session Reports received from the MB-UPF, in arrival order (#76).
+    ///
+    /// A queue rather than a callback: the recv loop answers the report on the
+    /// wire immediately (the UP is waiting, and TS 29.244 §7.5.8 makes the
+    /// response mandatory), and the *consequence* — activating a deactivated
+    /// multicast session per TS 23.247 §7.2.5.2 — is driven by whoever owns the
+    /// session state. Invoking that from the recv loop would put a context-lock
+    /// acquisition inside the socket loop, and the context's writers call back
+    /// into this node.
+    reports: Arc<Mutex<Vec<N4mbSessionReport>>>,
 }
 
 impl N4mbPfcpNode {
@@ -195,6 +220,7 @@ impl N4mbPfcpNode {
             pending: Arc::new(Mutex::new(HashMap::new())),
             t1,
             n1,
+            reports: Arc::new(Mutex::new(Vec::new())),
         });
         node.clone().spawn_recv_loop();
         Ok(node)
@@ -212,11 +238,22 @@ impl N4mbPfcpNode {
             let mut buf = vec![0u8; 65_535];
             loop {
                 match self.socket.recv_from(&mut buf).await {
-                    Ok((n, _src)) => {
+                    Ok((n, src)) => {
                         let mut bytes = Bytes::copy_from_slice(&buf[..n]);
                         match parse_message(&mut bytes) {
                             Ok((header, msg)) => {
                                 let seq = header.sequence_number;
+                                // #76: UP-INITIATED requests are answered here,
+                                // BEFORE the pending-table lookup. They have no
+                                // waiter by definition, so the old code logged
+                                // "unsolicited PFCP, ignoring" and dropped them --
+                                // which meant the MB-UPF could not detect this node
+                                // as alive (§6.2.3.2) and could not report downlink
+                                // data arrival (§7.5.8), so a deactivated multicast
+                                // session never reactivated when traffic resumed.
+                                if self.handle_up_initiated(&header, &msg, src).await {
+                                    continue;
+                                }
                                 // Lock, take the waiter, drop the guard before
                                 // any await (none here, but keep it tight).
                                 let waiter = {
@@ -240,6 +277,88 @@ impl N4mbPfcpNode {
                 }
             }
         });
+    }
+
+    /// Answer a UP-initiated request, or return `false` when the message is not
+    /// one (#76).
+    ///
+    /// The response echoes the request's **sequence number**, which is what makes
+    /// it an answer rather than a new transaction: TS 29.244 §7.2.2.4 requires a
+    /// response to carry the sequence number of the request it answers, and the UP
+    /// correlates on exactly that.
+    ///
+    /// Sent to `src` rather than to `self.upf_dest`: a response must go back to
+    /// whoever asked. Those are the same address in a normal deployment, and using
+    /// the configured destination would silently swallow a request from a UP whose
+    /// source port differs from the one we send to.
+    async fn handle_up_initiated(
+        &self,
+        header: &PfcpHeader,
+        msg: &PfcpMessage,
+        src: SocketAddr,
+    ) -> bool {
+        let seq = header.sequence_number;
+        match msg {
+            // §6.2.3.2: "a node shall be prepared to receive a Heartbeat Request at
+            // any time and shall reply with a Heartbeat Response."
+            PfcpMessage::HeartbeatRequest(_) => {
+                let resp = PfcpMessage::HeartbeatResponse(HeartbeatResponse::new(
+                    self.recovery_time_stamp,
+                ));
+                let bytes = build_message(&resp, seq, None).to_vec();
+                if let Err(e) = self.socket.send_to(&bytes, src).await {
+                    log::warn!("[N4mb] failed to answer a Heartbeat Request from {src}: {e}");
+                } else {
+                    log::debug!("[N4mb] answered a Heartbeat Request from {src} (seq={seq})");
+                }
+                true
+            }
+            // §7.5.8: the UP reports events; the CP must respond. A Downlink Data
+            // Report means traffic arrived for a session whose distribution is
+            // deactivated (TS 23.247 §7.2.5.2), which is what reactivates it.
+            PfcpMessage::SessionReportRequest(req) => {
+                let downlink_data = req.downlink_data_report.is_some();
+                let seid = header.seid.unwrap_or(0);
+                let resp = PfcpMessage::SessionReportResponse(SessionReportResponse::new(
+                    PfcpCause::RequestAccepted,
+                ));
+                // The response is addressed to the SEID the request arrived on,
+                // per §7.2.2.4.2.
+                let bytes = build_message(&resp, seq, Some(seid)).to_vec();
+                if let Err(e) = self.socket.send_to(&bytes, src).await {
+                    log::warn!("[N4mb] failed to answer a Session Report from {src}: {e}");
+                }
+                log::info!(
+                    "[N4mb] Session Report from {src} (seid=0x{seid:016x}, \
+                     downlink_data={downlink_data}) answered"
+                );
+                if let Ok(mut reports) = self.reports.lock() {
+                    reports.push(N4mbSessionReport {
+                        seid,
+                        downlink_data,
+                    });
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Drain the reports received since the last call (#76).
+    ///
+    /// Draining rather than peeking, so one report drives one activation: leaving
+    /// them in place would have a periodic driver re-activate an already-active
+    /// session on every tick.
+    pub fn take_reports(&self) -> Vec<N4mbSessionReport> {
+        self.reports
+            .lock()
+            .map(|mut r| std::mem::take(&mut *r))
+            .unwrap_or_default()
+    }
+
+    /// How many reports are queued. For tests and diagnostics.
+    pub fn pending_report_count(&self) -> usize {
+        self.reports.lock().map(|r| r.len()).unwrap_or(0)
     }
 
     /// Send a request and await its correlated response, retransmitting on T1
@@ -411,6 +530,16 @@ mod tests {
                             Some(remote_seid),
                         )
                     }
+                    // #76: the fake UP now answers a Session Deletion too, and the
+                    // SEID it arrived on is what the test reads back.
+                    PfcpMessage::SessionDeletionRequest(_) => (
+                        PfcpMessage::SessionDeletionResponse(
+                            nextgcore_pfcp::message::SessionDeletionResponse::new(
+                                PfcpCause::RequestAccepted,
+                            ),
+                        ),
+                        header.seid,
+                    ),
                     _ => continue,
                 };
                 let out = build_message(&reply, seq, seid).to_vec();
@@ -522,5 +651,257 @@ mod tests {
         assert!(ohc.description.gtpu_udp_ipv4);
         assert_eq!(ohc.teid, Some(p.c_teid));
         assert_eq!(ohc.ipv4_addr, Some([239, 1, 0, 1]));
+    }
+    // ---- #76: UP-initiated requests -----------------------------------------
+
+    /// #76 criterion 1: a Heartbeat Request on the N4mb socket is ANSWERED.
+    ///
+    /// It used to be logged as "unsolicited PFCP, ignoring" and dropped, so the
+    /// MB-UPF could not detect this node as alive — TS 29.244 §6.2.3.2 makes the
+    /// response mandatory and peer-failure detection depends on it.
+    ///
+    /// The assertion is on the datagram the fake UP receives back, decoded with the
+    /// production parser: a test that only checked no warning was logged would pass
+    /// against a node that answered with garbage.
+    #[tokio::test]
+    async fn a_heartbeat_request_is_answered_with_a_heartbeat_response() {
+        use nextgcore_pfcp::message::HeartbeatRequest;
+
+        // The "UP" here is a bare socket: it sends the request and reads the reply.
+        let upf = UdpSocket::bind(loopback(0)).await.unwrap();
+        let upf_addr = upf.local_addr().unwrap();
+        let node = N4mbPfcpNode::with_timers(
+            loopback(0),
+            upf_addr,
+            [127, 0, 0, 1],
+            Duration::from_millis(100),
+            0,
+        )
+        .await
+        .unwrap();
+        let node_addr = node.local_addr().unwrap();
+
+        let req = PfcpMessage::HeartbeatRequest(HeartbeatRequest::new(4242));
+        let bytes = build_message(&req, 77, None).to_vec();
+        upf.send_to(&bytes, node_addr).await.unwrap();
+
+        let mut buf = vec![0u8; 4096];
+        let (n, from) = tokio::time::timeout(Duration::from_secs(5), upf.recv_from(&mut buf))
+            .await
+            .expect("the node must answer a Heartbeat Request within 5s")
+            .unwrap();
+        assert_eq!(from, node_addr, "the answer must come from the node");
+
+        let mut bytes = Bytes::copy_from_slice(&buf[..n]);
+        let (header, msg) = parse_message(&mut bytes).expect("the answer is a PFCP message");
+        assert_eq!(
+            header.sequence_number, 77,
+            "a response must echo the request's sequence number (§7.2.2.4); the UP \
+             correlates on exactly that"
+        );
+        match msg {
+            PfcpMessage::HeartbeatResponse(r) => assert_ne!(
+                r.recovery_time_stamp, 0,
+                "the response must carry this node's own Recovery Time Stamp"
+            ),
+            other => panic!("expected a HeartbeatResponse, got {other:?}"),
+        }
+    }
+
+    /// #76 criterion 2, the wire half: a Session Report Request is answered and
+    /// surfaced.
+    ///
+    /// A Downlink Data Report means traffic arrived for a session whose distribution
+    /// is deactivated (TS 23.247 §7.2.5.2), and it was being dropped — so a
+    /// deactivated multicast session never reactivated when traffic resumed. The
+    /// activation itself is driven by the report queue's consumer; what is asserted
+    /// here is the response on the wire and the report being queued for it.
+    #[tokio::test]
+    async fn a_session_report_is_answered_and_queued_for_the_session_driver() {
+        use nextgcore_pfcp::message::SessionReportRequest;
+        use nextgcore_pfcp::types::{DownlinkDataReport, ReportType};
+
+        let upf = UdpSocket::bind(loopback(0)).await.unwrap();
+        let upf_addr = upf.local_addr().unwrap();
+        let node = N4mbPfcpNode::with_timers(
+            loopback(0),
+            upf_addr,
+            [127, 0, 0, 1],
+            Duration::from_millis(100),
+            0,
+        )
+        .await
+        .unwrap();
+        let node_addr = node.local_addr().unwrap();
+        assert_eq!(node.pending_report_count(), 0);
+
+        let mut req = SessionReportRequest::new(ReportType {
+            dldr: true,
+            ..Default::default()
+        });
+        req.downlink_data_report = Some(DownlinkDataReport::new(1));
+        let bytes = build_message(
+            &PfcpMessage::SessionReportRequest(req),
+            88,
+            Some(0x0102_0304_0506_0708),
+        )
+        .to_vec();
+        upf.send_to(&bytes, node_addr).await.unwrap();
+
+        let mut buf = vec![0u8; 4096];
+        let (n, _) = tokio::time::timeout(Duration::from_secs(5), upf.recv_from(&mut buf))
+            .await
+            .expect("the node must answer a Session Report within 5s")
+            .unwrap();
+        let mut bytes = Bytes::copy_from_slice(&buf[..n]);
+        let (header, msg) = parse_message(&mut bytes).expect("the answer is a PFCP message");
+        assert_eq!(header.sequence_number, 88);
+        assert_eq!(
+            header.seid,
+            Some(0x0102_0304_0506_0708),
+            "the response is addressed to the SEID the request arrived on (§7.2.2.4.2)"
+        );
+        match msg {
+            PfcpMessage::SessionReportResponse(r) => {
+                assert!(r.cause.is_success(), "got cause {}", r.cause.name())
+            }
+            other => panic!("expected a SessionReportResponse, got {other:?}"),
+        }
+
+        let reports = node.take_reports();
+        assert_eq!(
+            reports,
+            vec![N4mbSessionReport {
+                seid: 0x0102_0304_0506_0708,
+                downlink_data: true,
+            }],
+            "the report must be surfaced so the session driver can activate the session"
+        );
+        assert!(
+            node.take_reports().is_empty(),
+            "reports are DRAINED, so one report drives one activation rather than \
+             re-activating on every tick"
+        );
+    }
+
+    /// A UP-initiated request must not consume a pending waiter.
+    ///
+    /// The dispatch runs before the pending-table lookup, and getting that order
+    /// wrong the other way would have a Heartbeat Request arriving mid-transaction
+    /// steal the waiter for an in-flight Session Establishment — which would look
+    /// like a UPF timeout.
+    #[tokio::test]
+    async fn an_inbound_request_does_not_steal_a_pending_waiter() {
+        let upf_addr = spawn_fake_upf(0x55, [10, 0, 0, 9]).await;
+        let node = N4mbPfcpNode::with_timers(
+            loopback(0),
+            upf_addr,
+            [127, 0, 0, 1],
+            Duration::from_millis(300),
+            1,
+        )
+        .await
+        .unwrap();
+        let node_addr = node.local_addr().unwrap();
+
+        // A heartbeat from a THIRD party arrives while the association is in flight.
+        let intruder = UdpSocket::bind(loopback(0)).await.unwrap();
+        let hb = build_message(
+            &PfcpMessage::HeartbeatRequest(nextgcore_pfcp::message::HeartbeatRequest::new(1)),
+            1,
+            None,
+        )
+        .to_vec();
+
+        let assoc = tokio::spawn({
+            let node = node.clone();
+            async move { node.ensure_association().await.is_ok() }
+        });
+        // Sequence 1 is also the first sequence number the node itself uses, which is
+        // the collision this test is about.
+        intruder.send_to(&hb, node_addr).await.unwrap();
+
+        assert!(
+            assoc.await.unwrap(),
+            "the association must still complete: an inbound request must not consume \
+             the waiter for an in-flight transaction"
+        );
+    }
+    /// #76 criteria 3 + 4, the wire half: a Session Deletion Request is really
+    /// transmitted, addressed to the UP-allocated SEID.
+    ///
+    /// `release_session` existed and had NO callers — `grep` found only its
+    /// definition — so both the DELETE and TERMINATE paths mutated local state and
+    /// left the MB-UPF session behind. This asserts the datagram the UP receives,
+    /// decoded with the production parser: the SEID it carries is the thing that
+    /// makes it a deletion of the right session, and addressing it to the LOCAL seid
+    /// (which the old `session_context_terminate` discarded before anything could
+    /// read it) would delete nothing.
+    #[tokio::test]
+    async fn a_session_deletion_request_is_transmitted_to_the_up_allocated_seid() {
+        let seen: std::sync::Arc<
+            Mutex<Vec<(nextgcore_pfcp::header::PfcpMessageType, Option<u64>)>>,
+        > = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let sock = UdpSocket::bind(loopback(0)).await.unwrap();
+        let upf_addr = sock.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 65_535];
+            loop {
+                let Ok((n, src)) = sock.recv_from(&mut buf).await else {
+                    break;
+                };
+                let mut bytes = Bytes::copy_from_slice(&buf[..n]);
+                let Ok((header, msg)) = parse_message(&mut bytes) else {
+                    continue;
+                };
+                if let Ok(mut s) = sink.lock() {
+                    s.push((header.message_type, header.seid));
+                }
+                let reply = match msg {
+                    PfcpMessage::SessionDeletionRequest(_) => PfcpMessage::SessionDeletionResponse(
+                        nextgcore_pfcp::message::SessionDeletionResponse::new(
+                            PfcpCause::RequestAccepted,
+                        ),
+                    ),
+                    _ => continue,
+                };
+                let out = build_message(&reply, header.sequence_number, header.seid).to_vec();
+                let _ = sock.send_to(&out, src).await;
+            }
+        });
+
+        let node = N4mbPfcpNode::with_timers(
+            loopback(0),
+            upf_addr,
+            [127, 0, 0, 1],
+            Duration::from_millis(300),
+            1,
+        )
+        .await
+        .unwrap();
+
+        node.release_session(0x00ab_cdef_0123_4567)
+            .await
+            .expect("the deletion must be acknowledged");
+
+        let requests = seen.lock().unwrap().clone();
+        let (msg_type, seid) = requests
+            .iter()
+            .find(|(t, _)| *t == nextgcore_pfcp::header::PfcpMessageType::SessionDeletionRequest)
+            .copied()
+            .unwrap_or_else(|| {
+                panic!("a Session Deletion Request must reach the UP, got {requests:?}")
+            });
+        assert_eq!(
+            msg_type,
+            nextgcore_pfcp::header::PfcpMessageType::SessionDeletionRequest
+        );
+        assert_eq!(
+            seid,
+            Some(0x00ab_cdef_0123_4567),
+            "the request must be addressed to the UP-ALLOCATED SEID (TS 29.244 §7.5.4); \
+             the local one names a session the UP does not know"
+        );
     }
 }

--- a/src/bins/nextgcore-mbsmfd/src/types.rs
+++ b/src/bins/nextgcore-mbsmfd/src/types.rs
@@ -91,6 +91,25 @@ pub struct MbsSessionId {
 ///
 /// Only the fields this bounded chunk reads/echoes are modelled; unknown
 /// fields are ignored on decode (no `deny_unknown_fields`).
+/// A TS 29.571 `TunnelAddress`: `portNumber` plus one of `ipv4Addr`/`ipv6Addr`
+/// (#76).
+///
+/// `ingressTunAddr` is an ARRAY of these, `readOnly`, `minItems: 1` — not a
+/// scalar. The create response used to emit `format!("{:#010x}", gtp_teid)`, i.e. a
+/// hex TEID string where a structured address is required, so a conformant consumer
+/// could not parse the one member of the response it actually needs to send traffic
+/// to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TunnelAddress {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ipv4_addr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ipv6_addr: Option<String>,
+    /// `required` in TS 29.571, so never skipped.
+    pub port_number: u16,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtMbsSession {
@@ -98,11 +117,48 @@ pub struct ExtMbsSession {
     pub mbs_session_id: Option<MbsSessionId>,
     /// `serviceType` of type `MbsServiceType` (the spec field name — the audit
     /// text's `mbsServiceType` was wrong).
+    ///
+    /// **`required` in TS 29.571's `MbsSession`.** It used to be defaulted to
+    /// `Multicast` when absent (`_ => Multicast`), so a request that omitted a
+    /// mandatory IE was accepted and silently became a multicast session (#76).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_type: Option<MbsServiceType>,
-    /// GTP-U TEID for the multicast ingress, echoed in the create response.
+    /// `tmgiAllocReq`: the consumer asks the MB-SMF to allocate a TMGI. TS 29.571
+    /// makes `MbsSession` `anyOf [mbsSessionId, tmgiAllocReq]`, so this is the other
+    /// legal way to identify a create (#76).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ingress_tun_addr: Option<String>,
+    pub tmgi_alloc_req: Option<bool>,
+    /// `ingressTunAddrReq`: the consumer asks for ingress tunnel information.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ingress_tun_addr_req: Option<bool>,
+    /// `ingressTunAddr`: an ARRAY of structured tunnel addresses, `readOnly` (#76).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ingress_tun_addr: Option<Vec<TunnelAddress>>,
+    /// `ssm`: source-specific multicast identification, `writeOnly` (#76). Stored so
+    /// an SSM-identified session round-trips.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssm: Option<Ssm>,
+    /// `mbsServiceArea`, `writeOnly` (#76). Kept as the raw value: the shape is a
+    /// union of NCGI and TAI lists, and re-modelling it here without a consumer for
+    /// every member would be a model that reads as enforced and is not.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mbs_service_area: Option<serde_json::Value>,
+    /// `mbsServInfo` — MBS service information carrying the QoS request (#76).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mbs_serv_info: Option<serde_json::Value>,
+    /// `activityStatus`, from `MbsSession` (#76). Driven by PATCH.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activity_status: Option<String>,
+    /// `mbsSecurityContext` from `MbsSessionExtension`
+    /// (TS29532_Nmbsmf_MBSSession.yaml:809-828), #76.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mbs_security_context: Option<serde_json::Value>,
+    /// `contactPcfInd` from `MbsSessionExtension`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact_pcf_ind: Option<bool>,
+    /// `areaSessionPolicyId` from `MbsSessionExtension`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub area_session_policy_id: Option<u32>,
 }
 
 /// CreateReqData (TS 29.532 §6.2.6.2.2): MBS session creation request body.
@@ -145,15 +201,61 @@ pub enum PatchOutcome {
     ReducedArea(serde_json::Value),
 }
 
+/// What a [`PatchData`] changed, beyond the service area (#76).
+///
+/// Returned alongside the outcome so the caller persists exactly what the patch
+/// touched. An `Option` per member rather than a bool: "the patch did not mention
+/// activityStatus" and "the patch set it to something" are different, and collapsing
+/// them would have an unrelated patch reset a session's activity status.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PatchChanges {
+    /// New `activityStatus`, when the patch set one.
+    pub activity_status: Option<String>,
+    /// New `mbsServInfo` (the QoS request), when the patch set one.
+    pub mbs_serv_info: Option<serde_json::Value>,
+    /// New `mbsSecurityContext`, when the patch set one.
+    pub mbs_security_context: Option<serde_json::Value>,
+}
+
+impl PatchChanges {
+    /// Whether the patch changed anything this MB-SMF models.
+    pub fn is_empty(&self) -> bool {
+        self.activity_status.is_none()
+            && self.mbs_serv_info.is_none()
+            && self.mbs_security_context.is_none()
+    }
+}
+
 /// Apply a [`PatchData`] to the session's modifiable attributes.
 ///
-/// Returns [`PatchOutcome::ReducedArea`] when the patch touches the MBS service
-/// area (path beginning `/mbsServiceArea`), echoing the new area as
-/// `redMbsServArea`; otherwise [`PatchOutcome::NoContent`]. The `tacs` sink
-/// receives any service-area-derived TAC list so the caller can persist it.
-pub fn apply_patch_data(patch: &PatchData, tacs: &mut Vec<u32>) -> PatchOutcome {
+/// # What #76 changed
+///
+/// This used to inspect **only** paths beginning `/mbsServiceArea` and return
+/// `ReducedArea` for *any* operation on one — including an `add`. TS 29.532 §5.3.2.3
+/// gives the `200` + `redMbsServArea` body to a service-area **reduction**: it is
+/// the MB-SMF telling the consumer which part of the requested area it could not
+/// serve. Returning it for an addition tells the consumer its enlarged area was cut
+/// back to exactly what it asked for, which is a different and confusing statement.
+/// So the outcome now depends on the RFC 6902 `op`: `remove` and `replace` can
+/// reduce, `add` cannot.
+///
+/// `activityStatus`, `mbsServInfo` (QoS) and `mbsSecurityContext` are now applied
+/// too; they were silently ignored, so a PATCH activating a session answered `204`
+/// and changed nothing.
+pub fn apply_patch_data(
+    patch: &PatchData,
+    tacs: &mut Vec<u32>,
+    changes: &mut PatchChanges,
+) -> PatchOutcome {
     let mut reduced: Option<serde_json::Value> = None;
     for item in patch {
+        // RFC 6902 ops this MB-SMF acts on. `move`/`copy`/`test` are accepted and
+        // ignored rather than refused: refusing a legal op would reject a conformant
+        // patch, and acting on one whose semantics need a source document we do not
+        // keep would be inventing behaviour.
+        let is_removal = item.op == "remove";
+        let is_set = item.op == "add" || item.op == "replace";
+
         if item.path.starts_with("/mbsServiceArea") {
             if let Some(value) = &item.value {
                 // Persist any TAC list carried in the new service area so a
@@ -164,8 +266,32 @@ pub fn apply_patch_data(patch: &PatchData, tacs: &mut Vec<u32>) -> PatchOutcome 
                         .filter_map(|v| v.as_u64().map(|n| n as u32))
                         .collect();
                 }
-                reduced = Some(value.clone());
+                // Only a reduction gets the 200 + redMbsServArea body.
+                if item.op == "replace" || is_removal {
+                    reduced = Some(value.clone());
+                }
+            } else if is_removal {
+                // `remove` with no value: the whole area went away, which is the
+                // maximal reduction.
+                tacs.clear();
+                reduced = Some(serde_json::Value::Array(Vec::new()));
             }
+            continue;
+        }
+
+        if !is_set {
+            continue;
+        }
+        let Some(value) = &item.value else { continue };
+        match item.path.as_str() {
+            "/activityStatus" => {
+                if let Some(status) = value.as_str() {
+                    changes.activity_status = Some(status.to_string());
+                }
+            }
+            "/mbsServInfo" => changes.mbs_serv_info = Some(value.clone()),
+            "/mbsSecurityContext" => changes.mbs_security_context = Some(value.clone()),
+            other => log::debug!("MBS session PATCH: path '{other}' is not modelled; ignored"),
         }
     }
     match reduced {
@@ -416,12 +542,24 @@ mod tests {
                     ssm: None,
                 }),
                 service_type: Some(MbsServiceType::Multicast),
-                ingress_tun_addr: Some("0x0bca0001".to_string()),
+                // #76: an ARRAY of structured TunnelAddress, not a hex TEID string.
+                ingress_tun_addr: Some(vec![TunnelAddress {
+                    ipv4_addr: Some("10.0.0.1".to_string()),
+                    ipv6_addr: None,
+                    port_number: 2152,
+                }]),
+                ..Default::default()
             },
         };
         let json = serde_json::to_string(&rsp).unwrap();
         assert!(json.contains("\"mbsSession\""));
         assert!(json.contains("\"serviceType\":\"MULTICAST\""));
+        // The structured address must serialise as TS 29.571 declares it: an object
+        // with `portNumber` (required) and one of the address members.
+        assert!(
+            json.contains("\"ingressTunAddr\":[{\"ipv4Addr\":\"10.0.0.1\",\"portNumber\":2152}]"),
+            "got {json}"
+        );
         // The 201 body deserializes back as CreateRspData.
         let back: CreateRspData = serde_json::from_str(&json).unwrap();
         assert_eq!(back, rsp);
@@ -429,27 +567,102 @@ mod tests {
 
     // ---- mbsmfd-08: PatchData 204 / reduced-area 200 ----
 
-    #[test]
-    fn test_patch_data_no_content() {
-        let json = r#"[{"op":"replace","path":"/mbsServiceInfo","value":{"5qi":9}}]"#;
+    fn patch_of(json: &str) -> (PatchOutcome, Vec<u32>, PatchChanges) {
         let patch: PatchData = serde_json::from_str(json).unwrap();
         let mut tacs = vec![];
-        assert_eq!(apply_patch_data(&patch, &mut tacs), PatchOutcome::NoContent);
+        let mut changes = PatchChanges::default();
+        let outcome = apply_patch_data(&patch, &mut tacs, &mut changes);
+        (outcome, tacs, changes)
+    }
+
+    #[test]
+    fn test_patch_data_no_content() {
+        let (outcome, tacs, changes) =
+            patch_of(r#"[{"op":"replace","path":"/mbsServiceInfo","value":{"5qi":9}}]"#);
+        assert_eq!(outcome, PatchOutcome::NoContent);
         assert!(tacs.is_empty());
+        // `/mbsServiceInfo` is not the spec's `/mbsServInfo`, so nothing is applied.
+        assert!(changes.is_empty());
     }
 
     #[test]
     fn test_patch_data_reduced_area() {
-        let json = r#"[{"op":"replace","path":"/mbsServiceArea","value":[1,2,3]}]"#;
-        let patch: PatchData = serde_json::from_str(json).unwrap();
-        let mut tacs = vec![];
-        match apply_patch_data(&patch, &mut tacs) {
+        let (outcome, tacs, _) =
+            patch_of(r#"[{"op":"replace","path":"/mbsServiceArea","value":[1,2,3]}]"#);
+        match outcome {
             PatchOutcome::ReducedArea(v) => {
                 assert_eq!(v, serde_json::json!([1, 2, 3]));
             }
             other => panic!("expected ReducedArea, got {other:?}"),
         }
         assert_eq!(tacs, vec![1, 2, 3]);
+    }
+
+    /// #76 criterion 8, the half that was wrong in a way a consumer would act on: an
+    /// `add` to the service area is NOT a reduction.
+    ///
+    /// TS 29.532 §5.3.2.3 gives the `200` + `redMbsServArea` body to a reduction — it
+    /// is the MB-SMF saying which part of the requested area it could not serve.
+    /// Returning it for an addition tells the consumer its enlarged area was cut back
+    /// to exactly what it asked for, which is a different statement and one it may
+    /// act on by re-requesting.
+    #[test]
+    fn an_added_service_area_is_not_reported_as_a_reduction() {
+        let (outcome, tacs, _) =
+            patch_of(r#"[{"op":"add","path":"/mbsServiceArea","value":[7,8]}]"#);
+        assert_eq!(
+            outcome,
+            PatchOutcome::NoContent,
+            "an addition answers 204, not 200 + redMbsServArea"
+        );
+        assert_eq!(tacs, vec![7, 8], "but the new area is still persisted");
+
+        // `replace` and `remove` can reduce, and both do report it.
+        let (outcome, _, _) =
+            patch_of(r#"[{"op":"replace","path":"/mbsServiceArea","value":[7]}]"#);
+        assert!(matches!(outcome, PatchOutcome::ReducedArea(_)));
+        let (outcome, tacs, _) = patch_of(r#"[{"op":"remove","path":"/mbsServiceArea"}]"#);
+        assert_eq!(outcome, PatchOutcome::ReducedArea(serde_json::json!([])));
+        assert!(tacs.is_empty(), "removing the area clears the TAC list");
+    }
+
+    /// #76 criterion 8: `activityStatus`, QoS and security are APPLIED, not ignored.
+    #[test]
+    fn activity_status_qos_and_security_are_applied_rather_than_acknowledged() {
+        let (outcome, _, changes) = patch_of(
+            r#"[{"op":"replace","path":"/activityStatus","value":"ACTIVE"},
+                 {"op":"replace","path":"/mbsServInfo","value":{"mbsQoSReq":{"5qi":7}}},
+                 {"op":"add","path":"/mbsSecurityContext","value":{"keyList":["k1"]}}]"#,
+        );
+        assert_eq!(
+            outcome,
+            PatchOutcome::NoContent,
+            "none of these is a service-area reduction"
+        );
+        assert_eq!(changes.activity_status.as_deref(), Some("ACTIVE"));
+        assert_eq!(
+            changes
+                .mbs_serv_info
+                .as_ref()
+                .and_then(|v| v.pointer("/mbsQoSReq/5qi"))
+                .and_then(serde_json::Value::as_u64),
+            Some(7)
+        );
+        assert!(changes.mbs_security_context.is_some());
+        assert!(!changes.is_empty());
+
+        // An unmodelled path changes nothing rather than being refused: refusing a
+        // legal RFC 6902 op would reject a conformant patch.
+        let (_, _, changes) = patch_of(r#"[{"op":"replace","path":"/somethingElse","value":1}]"#);
+        assert!(changes.is_empty());
+
+        // A `test` op is accepted and applies nothing.
+        let (_, _, changes) =
+            patch_of(r#"[{"op":"test","path":"/activityStatus","value":"ACTIVE"}]"#);
+        assert!(
+            changes.is_empty(),
+            "a `test` op must not be treated as a set"
+        );
     }
 
     // ---- mbsmfd-03: ContextUpdate serde ----


### PR DESCRIPTION
Closes #76. Spec: `specs/fix-mbsmfd-n4mb-lifecycle.md`. Every cite in the issue re-located and
confirmed against `6f1f6a9`.

## Inbound PFCP was discarded by construction

`spawn_recv_loop` looked up a waiter by sequence number and logged `unsolicited PFCP … ignoring`
for anything without one — which is **every UP-initiated request by definition**. So no Heartbeat
Response was ever sent (§6.2.3.2 makes it mandatory; peer-failure detection depends on it) and no
Session Report was handled, meaning a deactivated multicast session never reactivated when traffic
resumed (TS 23.247 §7.2.5.2).

Both are answered now, **before** the waiter lookup. The other order would let a heartbeat arriving
mid-transaction steal the waiter for an in-flight Session Establishment, which surfaces as a UPF
timeout — pinned by `an_inbound_request_does_not_steal_a_pending_waiter`, which sends sequence
number 1, also the first the node itself uses. The response echoes the request's sequence number
and goes to `src`, not the configured `upf_dest`: a response must go back to whoever asked.

The report's *consequence* is applied from the main loop, not the socket loop, because activation
needs the context lock and the context's writers call back into this node.

## The release path deleted nothing

`release_session` had **zero callers** — `grep` found only its definition. And
`session_context_terminate` set `ReleasePending` and then **immediately zeroed** `n4mb_session`,
discarding the remote SEID the deletion has to be addressed to, so nothing could delete the session
even in principle. `session_remove`'s log line said "releasing N4mb SEID" while releasing nothing.

Now three steps, in this order: mark pending → send and await the deletion → clear. Local state is
cleared even on a failed deletion (the session is leaving either way, and a context whose UPF
counterpart may or may not exist leaves the two sides disagreeing with no path back), with the
possible leak named in the log.

### An existing test pinned the defect, and the modal verb decided it

`test_context_terminate_releases_n4mb` asserted terminate leaves `n4mb_session` as `None` — it
pinned the discard-the-SEID shortcut as the requirement. TS 29.244 §7.5.4 has the CP function
**send** a Session Deletion Request and TS 23.247 §7.1.1.4 has the release tear down MB-UPF
resources. Not a "may", so inverting is legitimate; the citation is recorded at the site.

What makes it safe to believe: the two **handler-level** tests asserting the post-handler state
(`test_router_context_update_amf_release_golden_204`,
`mbs_context_update_strict_peer_release_204`) pass **unchanged**, because the handler now drives the
release and clears afterwards. They turn out to be the guard for the new wiring — revert 2 removes
the three release calls and both fail.

## The rest

| gap | before | now |
|---|---|---|
| repeated START | allocated a fresh SEID every call, orphaning N−1 UPF sessions per N joins | idempotent for an **Established** session; an `EstablishmentPending` one stays re-drivable (that is the retry path) |
| duplicate TMGI | overwrote `tmgi_hash`, leaving the earlier session reachable by nothing | refused; the first session stays findable |
| missing `serviceType` | defaulted to `Multicast` | `400 MANDATORY_IE_MISSING` |
| `ingressTunAddr` | `format!("{:#010x}", teid)` | array of structured `TunnelAddress` — the one member a consumer needs to send traffic anywhere |
| `serviceArea`/`ssm`/QoS/security | dropped | stored and round-tripped |
| no-TMGI create | hardcoded TMGI colliding with every other such create | allocated from `TmgiPool` |
| PATCH | only `/mbsServiceArea`, any op | `activityStatus`/QoS/security applied; only a **reduction** gets `200 + redMbsServArea` |
| ContextUpdate | `400` for anything without a TMGI | resolves by TMGI **or SSM**; `404` on unknown SSM, `400` only when neither is given |

**The `MbsSession` `anyOf [mbsSessionId, tmgiAllocReq]` is deliberately not enforced**: criterion 7
requires a create carrying neither to *succeed* by allocating, so the two cannot both hold. Found by
breaking `test_router_release_fires_notify_path`, and stated rather than left silent.

## Verification

Workspace **6270 passed / 0 failed** (baseline 6258, +12; mbsmfd 83 → 95); easdfd's `dns-udp`
feature still 51/0. clippy and fmt clean, mbsmfd at **zero** warnings. Five consecutive mbsmfd runs
green (the crate has process-global session state).

**Ten reverts, all biting, no false guards:** UP-initiated dispatch (3 failed) · the three release
calls (2) · idempotent activation (1) · duplicate TMGI (1) · `serviceType` default (1) · `add`
reported as reduction (1) · SSM refused (1) · `activityStatus` ignored (1) · empty `ingressTunAddr`
(1) · report answered but not surfaced (1).

## Ceilings

- **The DELETE/TERMINATE call sites are not covered end to end through a socket.** `N4MB_NODE` is a
  `tokio::OnceCell` bound from the environment at first use, and existing create tests reach it
  first, so a test cannot point the process's node at its own fake MB-UPF — the same
  `OnceLock`-shaped limitation as #289. Verified instead: the deletion on a real socket at the node,
  the three-step ordering in the context, and the handler wiring via revert 2.
- **Activation lags a report by up to 100ms** (the main loop's tick). Deliberate; see above.
- **`mbsServiceArea`/`mbsServInfo` are stored as raw JSON** — the shapes are unions, and modelling
  members with no consumer would read as enforced and not be. Only the 5QI and `mbrDl` are read.
- **No last-consumer ref-counting.** Criterion 4 says "last-consumer TERMINATE"; `nfcInstanceId` is
  still not a per-session consumer set, so *any* TERMINATE releases the transport. The SSM half of
  the issue's gap 7 is done, this half is not — it needs a decision about whether a join implicitly
  registers a consumer (nothing in the tree registers one today). Worth its own issue.
- The tail sub-claims #76 itself flags as unverified (notification inertness, non-spec GET routes,
  relative `Location`, pool exhaustion answering `400`) remain untouched and unverified, as the issue
  asks.