### PR TITLE
test(smfd): give the N4 path a UPF stand-in so the post-establishment tail is reachable (#289)

### DIFF
--- a/specs/fix-smfd-upf-stand-in.md
+++ b/specs/fix-smfd-upf-stand-in.md
@@ -1,0 +1,146 @@
+# nextgcore #289 (smfd tests): a UPF stand-in, so the post-N4 tail is reachable
+
+Verified against `main` @ `02c39dc`.
+
+#289 is test infrastructure with one production decision inside it, filed by #276's revert pass
+after that pass found a call site which had been absent for a month while looking wired.
+
+## Verified against current main
+
+| claim in the issue | site on `02c39dc` | still true? |
+|---|---|---|
+| `handle_sm_context_create` cannot pass its N4 leg in any test | `main.rs:1709` `select_upf()` → `None`, `main.rs:1714` `is_associated()` | yes |
+| everything after the PFCP block is dead to the suite | `main.rs:3093-3223` (EASDF leg, session fill-in, `PolicyBinding` insert) | yes |
+| `a_failed_establishment_creates_no_easdf_dns_context` says so in its own doc comment | `main.rs:6298` | yes |
+| `a_failed_create_leaves_no_registered_sm_context` predicts this issue | `main.rs:6980` | yes |
+| `PFCP_CLIENT` is a `OnceLock`, so an installed client is permanent | `pfcp_path.rs:270` | yes |
+| `teardown_association` → `clear_pfcp_sessions` clears a process-global map | `pfcp_path.rs:698`, `:821` | yes |
+| `SESSION_MAP_LOCK` guards that map from inside `mod tests` | `pfcp_path.rs:909` | yes |
+| removing the `easdf::create_dns_context` call leaves the suite green | re-checked by reverting it | yes — **425 → 456 tests later, still green before this change** |
+| the `PolicyBinding` insert is at `main.rs:2998` | it is at **`main.rs:3194`** | numbering only; the site is there |
+
+## Decision 1: `PFCP_CLIENT` becomes settable, and install-and-release happens per test
+
+The issue names this decision and recommends the opposite of what landed:
+
+> Decide deliberately: does the harness **install** the global client (permanent, …), or is
+> `PFCP_CLIENT` changed from `OnceLock` to something settable per test? … Installing-and-releasing
+> is the smaller change and probably right; say which and why.
+
+Installing permanently was implemented first and **does not work**, for a reason the issue could
+not have known from reading the code: a `PfcpClient` owns a `tokio::net::UdpSocket`, and a tokio
+socket belongs to the runtime that created it. `#[tokio::test]` gives every test its own runtime, so
+a client installed by whichever test touched the harness first is a client whose socket is dead for
+every test after it. The failure is not subtle once seen:
+
+```
+the stand-in UPF must accept the association:
+  Local("send failed: A Tokio 1.x context was found, but it is being shutdown.")
+```
+
+So `PFCP_CLIENT` and `PFCP_POOL` are now `std::sync::RwLock`s rather than `OnceLock`s, each test
+installs its own stand-in, and the stand-in **un-installs itself on drop** — install-and-release, at
+per-test rather than per-process granularity. `clear_global_upf_for_test` is `#[cfg(test)]`: a
+running SMF has no reason to un-install its own N4 endpoint, and doing so mid-session would strand
+the `SESSION_PEERS` bindings.
+
+What changes for the running daemon: `set_global_client` overwrites instead of being first-wins.
+`main` calls it exactly once, through `set_global_pool` at startup (`main.rs:660`, the only external
+caller), so today's behaviour is identical. `global_pool()` returns an owned `Vec` instead of a
+`&'static [_]` because a lock guard must not be held across the `await`s its callers perform; the
+cost is one `Vec<Arc<_>>` clone per session establishment.
+
+This is a production change made for a test reason, which is exactly why the issue asked for it to
+be stated rather than done quietly. The alternative — leaving production alone and accepting that
+the whole post-N4 tail stays unverifiable — is what the last three issues in this area already paid
+for once each.
+
+## Decision 2: one lock, and it lives beside the globals rather than in `mod tests`
+
+`SESSION_MAP_LOCK` is replaced by `pfcp_path::N4_TEST_LOCK`, declared at module level next to the
+statics it protects and `pub(crate)` so `main.rs`'s tests take the *same* lock rather than declaring
+a second one. Three variables are involved and they cannot be guarded separately: the two globals,
+the context's `pfcp_sessions` map that `clear_pfcp_sessions` empties process-wide, and the
+association state of the one installed client. The stand-in holds the guard as a field, so a test
+gets serialisation and a UPF from one binding and cannot accidentally take one without the other.
+
+A second lock over the same variables is the mistake #276 made with the EASDF context lock, where
+the symptom was a **hang** rather than a flaky assertion. The lock order is written into the doc
+comment — any module switch lock first, `N4_TEST_LOCK` second — because the two tests that hold
+`easdf::SWITCH_LOCK` and this lock together would deadlock against each other if any future call
+site reversed it.
+
+## Decision 3: the stand-in hand-encodes its Session Establishment Response
+
+The Association Setup / Heartbeat / Association Release replies use the `nextgcore-pfcp` library
+codec (as `pfcp_path`'s existing fake UPF already did). The **Session Establishment Response** is
+hand-encoded instead, because the SMF's own establishment parser is what the success path is being
+trusted to run: it reads F-SEID with V4 on bit 2 (TS 29.244 §8.2.37) and F-TEID with V4 on bit 1
+(§8.2.3), an asymmetry the production parser calls out in a comment and a stand-in sharing an
+encoder with it could not catch. The stand-in also answers Session Modification and Session
+Deletion, so the update and release paths become reachable for later work (#291, #293).
+
+## Decision 4: the failure-path tests keep their halves, and now fail for the real reason
+
+Both converted tests previously reached `504 UPF_NOT_RESPONDING` because **no UPF existed at all**.
+They now use a stand-in whose association is deliberately down, so they exercise the real failure
+mode — TS 29.244 §6.2.6.2, no session signalling without an association, which is the first thing
+`pfcp_session_establish` checks. Their assertions are unchanged in substance: a create that answers
+an error creates no EASDF DNS context and leaves no registered SM context behind.
+
+## Acceptance criteria
+
+- [x] A test drives `handle_sm_context_create` to a `201` against a stand-in UPF —
+      `a_successful_create_registers_an_activated_session_and_its_binding` and
+      `an_established_session_creates_its_easdf_dns_context`.
+- [x] Removing the `easdf::create_dns_context` call makes a NAMED test fail (today: nothing fails).
+- [x] Removing the `PolicyBinding` insert makes a named test fail.
+- [x] The success path asserts `upCnxState == ACTIVATED` and the stored session AMBR.
+- [x] Exactly ONE lock guards `PFCP_CLIENT` + `pfcp_sessions` across `pfcp_path` and `main.rs`
+      tests; its doc comment names the variables it is the one agreement about.
+- [x] The two tests quoted in the issue are converted per their own instructions, keeping their
+      failure-path halves.
+- [x] The whole-workspace suite is green over repeated runs (≥5).
+
+## Verification
+
+Workspace **6272 passed / 0 failed** (baseline 6270 on `02c39dc`; +2, the two new create tests —
+`nextgcore-smfd` 454 → 456), and `cargo test -p nextgcore-easdfd --features dns-udp` unchanged at
+**51 passed / 0 failed**. `cargo clippy -p nextgcore-smfd --all-targets` clean, no new warning in
+the workspace lint; `cargo fmt --all` applied.
+
+**Five consecutive whole-workspace runs, all 6272 / 0** — the change touches process-global state,
+so a single green run is not evidence about it. The count is identical across runs, which is the
+part that matters: a per-test install that leaked would show up as a different number, not as a
+failure, in whichever crate ran next.
+
+| revert | expected to break | result |
+|---|---|---|
+| `easdf::create_dns_context` call removed (i.e. #114's state restored) | `an_established_session_creates_its_easdf_dns_context` | **1 failed** |
+| the `PolicyBinding` insert made unreachable | `a_successful_create_registers_an_activated_session_and_its_binding` | **1 failed** |
+| the session fill-in of `up_cnx_state` + `session_ambr` removed | same test | **1 failed** (`left: Deactivated`) |
+
+The first row is the whole point of the issue: **that exact revert left all 425 tests green on
+`main`**, and it is the row #276's spec had to record as a ceiling rather than as a result.
+
+Each revert was run against the whole crate suite rather than a name filter: "the revert did not
+bite" and "my filter did not select the guard" produce identical output, and #117 already lost a
+finding that way.
+
+## Ceilings
+
+- **The third inspection-only call site named in #289 is now guarded, but only for the values this
+  harness sets.** `upCnxState` and the session AMBR are asserted; the rest of the fill-in (`pti`,
+  `ue_ssc_mode`, the S-NSSAI, `establishment_accept_sent`) is written by the same block and is
+  therefore *reachable*, not *asserted*. A future test that needs one of them no longer needs a
+  harness first.
+- **The stand-in answers; it does not enforce.** It returns a fixed F-SEID/F-TEID and accepts every
+  request. It cannot catch a malformed Create PDR, because it never decodes the PDRs it is sent —
+  `n4_build`'s own tests cover the encoding. A stand-in that validated the request would be a second
+  PFCP implementation to keep in step with TS 29.244.
+- **`request_ebi` and the UDM legs stay off in these tests**, so #291's and #293's wire assertions
+  are not covered here — they are those issues' work, and the harness they need now exists.
+- **One consumer of the tail is still unreachable**: `handle_sm_context_update`'s
+  `pfcp_session_modify` path needs a session established *and* an N2 setup response, which this
+  spec does not build. The stand-in answers Session Modification already, so that is a test away
+  rather than a harness away.

--- a/src/bins/nextgcore-smfd/src/eps_iwk.rs
+++ b/src/bins/nextgcore-smfd/src/eps_iwk.rs
@@ -212,11 +212,17 @@ pub fn parse_assigned_ebi(body: &str) -> Option<u8> {
 /// policy binding), so creating one unconditionally would populate a store nothing
 /// reads and change what `max_num_of_bearer` means for every session in the process.
 ///
-/// A separate function rather than an inline block because the SM-context create
-/// path cannot be driven past its N4 leg by any test in this crate (no UPF
-/// stand-in — issue #289), so an inline block would be unreachable from a test.
-/// This seam is the reachable half; the call site itself is covered by inspection,
-/// and that limitation is stated rather than implied.
+/// A separate function rather than an inline block because when this was written the
+/// SM-context create path could not be driven past its N4 leg by any test in this
+/// crate, so an inline block would have been unreachable from a test.
+///
+/// #289 has since given the crate a UPF stand-in
+/// (`pfcp_path::stand_in::associated_upf`), so the create path DOES reach this call
+/// site under test. What is still not driven is this call site with the
+/// interworking switch ON — every create test runs with the leg off, so the
+/// `if let (Some(ebi), Some(sess_id))` guard above it is only ever taken on the
+/// `None` arm. The seam remains the tested half; the difference is that closing the
+/// gap is now a test away rather than a harness away.
 pub fn record_mapped_eps_bearer(
     sess_id: u64,
     ebi: u8,

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -6302,18 +6302,20 @@ mod tests {
     /// that then fails is an orphan on the EASDF that nothing will ever delete,
     /// because the release path never runs for a session that never existed.
     ///
-    /// It is also the honest limit of what this harness can assert about the
-    /// create call site. Reaching the success path needs a PFCP-responding UPF —
-    /// without one, `handle_sm_context_create` returns `504 UPF_NOT_RESPONDING`
-    /// before the EASDF leg — and the smfd test harness has no UPF stand-in (no
-    /// existing test establishes a session either). The create leg itself is
-    /// covered over real HTTP by
-    /// `easdf::tests::the_dns_context_is_created_and_deleted_over_the_wire`, and
-    /// the RELEASE call site by the test below; the create call site is verified by
-    /// inspection plus this no-orphan assertion.
+    /// #289 converted this test: the harness now HAS a UPF stand-in, so the
+    /// failure has to be arranged deliberately rather than being the only thing
+    /// this harness could produce. The N4 leg fails here because the association
+    /// is down, which is the real failure mode (TS 29.244 §6.2.6.2) and the one
+    /// `pfcp_session_establish` checks first. The success half — the create call
+    /// site actually firing — is
+    /// `an_established_session_creates_its_easdf_dns_context` below; until it
+    /// existed, removing the `easdf::create_dns_context` call left the whole suite
+    /// green (#276).
     #[tokio::test]
     async fn a_failed_establishment_creates_no_easdf_dns_context() {
+        // Lock order (see `pfcp_path::N4_TEST_LOCK`): switch lock first, N4 second.
         let _g = easdf::SWITCH_LOCK.lock().await;
+        let _upf = pfcp_path::stand_in::unassociated_upf().await;
         let (nrf, easdf_srv, seen) = easdf::tests::spawn_nrf_and_easdf().await;
         smf_context_init(64, 256, 512);
         seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
@@ -6342,17 +6344,79 @@ mod tests {
             ));
         let resp = handle_sm_context_create(&request).await;
 
-        // No UPF in this harness, so establishment fails at the N4 leg.
+        // The stand-in UPF is present but NOT associated, so establishment fails
+        // at the N4 leg exactly as it does against an unreachable UPF.
         assert_eq!(
             resp.status, 504,
-            "without a UPF the session cannot establish; if this ever becomes a \
-             2xx the harness gained a UPF and this test should assert the CREATE \
-             instead"
+            "an un-associated UPF must fail the N4 leg (TS 29.244 §6.2.6.2)"
         );
         let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
         assert!(
             requests.is_empty(),
             "a session that never established must leave no DNS context behind, got {requests:?}"
+        );
+
+        easdf::set_for_test(None);
+        easdf_srv.stop().await.expect("stop");
+        nrf.stop().await.expect("stop");
+    }
+
+    /// #289 acceptance: a create that REACHES the success path creates the
+    /// session's EASDF DNS context, asserted from `handle_sm_context_create`
+    /// rather than by calling `easdf::create_dns_context` directly.
+    ///
+    /// This is the guard #276 could not write. `create_dns_context` had no
+    /// production caller for a month — PR #277 wrote `let easdf_dns_context_id =
+    /// None;` under a comment describing the awaited call — and the module's own
+    /// over-the-wire test said nothing about it, because a helper's test cannot
+    /// see whether a handler calls it. Removing the call from the handler now
+    /// fails HERE.
+    ///
+    /// The recorded `(method, path, body)` list is the assertion, and the UE
+    /// address in the body is part of it: the EASDF cannot correlate a UDP query
+    /// with a session without it (#276), so a create that omitted it would be a
+    /// context that can never match a query.
+    #[tokio::test]
+    async fn an_established_session_creates_its_easdf_dns_context() {
+        // Lock order (see `pfcp_path::N4_TEST_LOCK`): switch lock first, N4 second.
+        let _g = easdf::SWITCH_LOCK.lock().await;
+        let upf = pfcp_path::stand_in::associated_upf().await;
+        let (nrf, easdf_srv, seen) = easdf::tests::spawn_nrf_and_easdf().await;
+        smf_context_init(64, 256, 512);
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+        let resp = handle_sm_context_create(&create_request(
+            "imsi-001010000000289",
+            6,
+            &n1(
+                6,
+                1,
+                gsm_build::message_type::PDU_SESSION_ESTABLISHMENT_REQUEST,
+                &[0x91, 0x00],
+            ),
+        ))
+        .await;
+        assert_eq!(
+            resp.status, 201,
+            "the stand-in UPF answers Session Establishment, so the create must succeed"
+        );
+        assert!(
+            upf.seen()
+                .contains(&pfcp_path::pfcp_message_type::SESSION_ESTABLISHMENT_REQUEST),
+            "the 201 must have been earned on the N4 wire, not short-circuited"
+        );
+
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let create = requests
+            .iter()
+            .find(|(m, p, _)| m == "POST" && p.contains("/neasdf-dnscontext/v1/dns-contexts"))
+            .unwrap_or_else(|| {
+                panic!("the create handler must POST a DNS context, got {requests:?}")
+            });
+        assert!(
+            create.2.contains("imsi-001010000000289"),
+            "the DNS context must name the subscriber it belongs to, got {}",
+            create.2
         );
 
         easdf::set_for_test(None);
@@ -6413,6 +6477,31 @@ mod tests {
         let mut m = vec![0x2E, psi, pti, message_type];
         m.extend_from_slice(tail);
         m
+    }
+
+    /// A well-formed `SmContextCreateData` request with its N1 container as a
+    /// multipart 5gnas part — the shape the AMF sends (#289).
+    ///
+    /// Shared by every create test so they differ only in the SUPI and PSI they
+    /// drive; three copies of this literal had already drifted apart in wording
+    /// while meaning the same thing.
+    fn create_request(supi: &str, psi: u8, n1_msg: &[u8]) -> SbiRequest {
+        let body = serde_json::json!({
+            "pduSessionId": psi,
+            "supi": supi,
+            "sNssai": { "sst": 1, "sd": "010203" },
+            "dnn": "internet",
+            "anType": "3GPP_ACCESS",
+            "ratType": "NR",
+            "n1SmMsg": { "contentId": "n1SmMsg" },
+        });
+        SbiRequest::post("/nsmf-pdusession/v1/sm-contexts")
+            .with_body(body.to_string(), "application/json")
+            .with_part(nextgcore_sbi::message::SbiPart::with_content(
+                "n1SmMsg",
+                "application/vnd.3gpp.5gnas",
+                bytes::Bytes::copy_from_slice(n1_msg),
+            ))
     }
 
     // ---- criteria 1 + 3: the 5GSM message is classified and dispatched ----
@@ -6969,49 +7058,34 @@ mod tests {
     /// guards Retrieve, not create. This drives the real
     /// `handle_sm_context_create` through the router.
     ///
-    /// The create CANNOT succeed here: it needs a PFCP-responding UPF, and no
-    /// harness in this tree has one (no existing test establishes an N4 session
-    /// either). So what is asserted is the rollback contract instead, which is the
-    /// half a failing create can prove and the half that a naive registration gets
-    /// wrong: a create that answers an error must leave **no** SM context behind.
-    /// An abandoned registration would be a context the AMF never learned about and
-    /// will never release.
+    /// What is asserted here is the rollback contract, the half that a naive
+    /// registration gets wrong: a create that answers an error must leave **no**
+    /// SM context behind. An abandoned registration would be a context the AMF
+    /// never learned about and will never release.
+    ///
+    /// #289 converted this test: the N4 leg now fails because the stand-in UPF's
+    /// association is deliberately down, not because no UPF exists. The
+    /// REGISTRATION half its old comment asked for is
+    /// `a_successful_create_registers_an_activated_session_and_its_binding` below.
     #[tokio::test]
     async fn a_failed_create_leaves_no_registered_sm_context() {
+        let _upf = pfcp_path::stand_in::unassociated_upf().await;
         smf_context_init(64, 256, 512);
         let supi = "imsi-001010000000086";
         let psi = 11u8;
 
         // A create that reaches the N4 leg and fails there, the same shape
         // `a_failed_establishment_creates_no_easdf_dns_context` uses.
-        let body = serde_json::json!({
-            "pduSessionId": psi,
-            "supi": supi,
-            "sNssai": { "sst": 1, "sd": "010203" },
-            "dnn": "internet",
-            "anType": "3GPP_ACCESS",
-            "ratType": "NR",
-            "n1SmMsg": { "contentId": "n1SmMsg" },
-        });
         let n1_msg = n1(
             psi,
             1,
             gsm_build::message_type::PDU_SESSION_ESTABLISHMENT_REQUEST,
             &[0x91, 0x00],
         );
-        let request = SbiRequest::post("/nsmf-pdusession/v1/sm-contexts")
-            .with_body(body.to_string(), "application/json")
-            .with_part(nextgcore_sbi::message::SbiPart::with_content(
-                "n1SmMsg",
-                "application/vnd.3gpp.5gnas",
-                n1_msg.into(),
-            ));
-        let resp = handle_sm_context_create(&request).await;
+        let resp = handle_sm_context_create(&create_request(supi, psi, &n1_msg)).await;
         assert_eq!(
             resp.status, 504,
-            "without a UPF the session cannot establish; if this ever becomes a 2xx \
-             the harness gained a UPF and this test should assert the REGISTRATION \
-             instead of the rollback"
+            "an un-associated UPF must fail the N4 leg (TS 29.244 §6.2.6.2)"
         );
 
         // Asserted per-SUPI, not on a global session count: this context is
@@ -7030,6 +7104,91 @@ mod tests {
              abandoned registration is an SM context the AMF never learned about and \
              will never release"
         );
+    }
+
+    /// #289 acceptance: the whole tail after the PFCP block, which no test could
+    /// reach before the stand-in UPF existed.
+    ///
+    /// Four claims, each of which was "verified by inspection" until now:
+    /// 1. the create answers `201` with a resolvable `smContextRef`;
+    /// 2. the session fill-in ran — `upCnxState` is ACTIVATED and the authorised
+    ///    session AMBR is stored on the session (#78, #191);
+    /// 3. the `PolicyBinding` was inserted — the release, update and notify paths
+    ///    all key off it, so a create that skipped it produces a session none of
+    ///    them can act on;
+    /// 4. the N4 exchange really happened, asserted from the stand-in's own
+    ///    record rather than from the SMF's report of it.
+    ///
+    /// Positive assertions throughout: each reads a value only reachable by
+    /// executing the step it names, so no early return can satisfy them.
+    #[tokio::test]
+    async fn a_successful_create_registers_an_activated_session_and_its_binding() {
+        let upf = pfcp_path::stand_in::associated_upf().await;
+        smf_context_init(64, 256, 512);
+        let supi = "imsi-001010000000290";
+        let psi = 7u8;
+
+        let n1_msg = n1(
+            psi,
+            1,
+            gsm_build::message_type::PDU_SESSION_ESTABLISHMENT_REQUEST,
+            &[0x91, 0x00],
+        );
+        let resp = handle_sm_context_create(&create_request(supi, psi, &n1_msg)).await;
+        assert_eq!(
+            resp.status, 201,
+            "the stand-in UPF answers Session Establishment, so the create must succeed"
+        );
+        assert!(
+            upf.seen()
+                .contains(&pfcp_path::pfcp_message_type::SESSION_ESTABLISHMENT_REQUEST),
+            "the create must have established the session on the N4 wire"
+        );
+
+        let root: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("JSON root"))
+                .expect("SmContextCreatedData is JSON");
+        let sm_context_ref = root["smContextRef"]
+            .as_str()
+            .expect("smContextRef is mandatory")
+            .to_string();
+
+        // (2) The session fill-in ran. Both values are read back off the
+        // registered session, so they can only be there if the create wrote them
+        // after the N4 leg settled.
+        let sess = smf_self()
+            .read()
+            .expect("context")
+            .sess_find_by_sm_context_ref(&sm_context_ref)
+            .expect("the reference the AMF was handed must resolve to a session");
+        assert_eq!(
+            sess.up_cnx_state,
+            context::UpCnxState::Activated,
+            "upCnxState is ACTIVATED once the user plane exists"
+        );
+        assert_eq!(
+            (sess.session_ambr.uplink, sess.session_ambr.downlink),
+            (100_000_000, 100_000_000),
+            "the authorised session AMBR must be stored on the session"
+        );
+
+        // (3) The policy binding exists, keyed by the reference the AMF holds.
+        let binding = lookup_policy_binding(&sm_context_ref)
+            .expect("the create must store the PolicyBinding the release path keys off");
+        assert_eq!(binding.supi, supi);
+        assert_eq!(binding.psi, psi);
+
+        // The stored UPF SEID is the one the stand-in allocated, so the SEID the
+        // release path will address is the peer's and not a local invention.
+        let stored_seid = smf_self()
+            .read()
+            .expect("context")
+            .pfcp_sessions
+            .read()
+            .expect("sessions")
+            .get(&sm_context_ref)
+            .copied();
+        assert_eq!(stored_seid, Some(upf.upf_seid));
     }
 
     /// #78 criterion 1's invariant, at the function the create handler calls: the
@@ -7345,10 +7504,12 @@ mod tests {
     /// #79 criterion 5: a subscribed event occurrence produces a notification at
     /// the subscribed `notifUri`.
     ///
-    /// `PDU_SES_REL` is chosen because the release handler is reachable from a test,
-    /// unlike the establishment path (which needs a UPF — see #289). The
-    /// notification is captured on a real loopback consumer, so what is asserted is
-    /// a delivered HTTP request rather than a function having been called.
+    /// `PDU_SES_REL` is chosen because the release handler needs no N4 establishment
+    /// to reach; since #289 the establishment path is reachable too (against
+    /// `pfcp_path::stand_in`), so the `PDU_SES_EST` notification is now a test away
+    /// rather than blocked. The notification is captured on a real loopback
+    /// consumer, so what is asserted is a delivered HTTP request rather than a
+    /// function having been called.
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn a_released_session_notifies_its_event_subscriber() {
@@ -7481,10 +7642,12 @@ mod tests {
     /// #79 criteria 1 + 2: the subscribed session-AMBR and default 5QI are applied,
     /// with the configured default as the fallback and NOT the other way round.
     ///
-    /// Asserted on `apply_subscribed_baseline` because the config-default arm of the
-    /// create path is downstream of the N4 leg no test can reach (#289). The
-    /// per-member behaviour is the part that matters: a whole-struct replacement
-    /// would make an absent subscribed member silently mean 0.
+    /// Asserted on `apply_subscribed_baseline` rather than through the create path:
+    /// the per-member behaviour is the part that matters, and a whole-struct
+    /// replacement would make an absent subscribed member silently mean 0. (The
+    /// create path itself is no longer unreachable — #289 gave the crate a UPF
+    /// stand-in — but driving it here would assert the merge through two layers
+    /// instead of one.)
     #[test]
     fn subscribed_values_win_over_the_config_default_per_member() {
         let subscribed = udm::SubscribedSmData {

--- a/src/bins/nextgcore-smfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-smfd/src/pfcp_path.rs
@@ -267,37 +267,86 @@ pub struct PfcpClient {
     timers: SmfTimerConfigs,
 }
 
-static PFCP_CLIENT: OnceLock<Arc<PfcpClient>> = OnceLock::new();
+/// The process-wide PFCP client.
+///
+/// A `RwLock<Option<..>>` rather than a `OnceLock` (issue #289), and this is the
+/// production change that issue asked to be decided out loud rather than
+/// silently. The decision was forced by evidence, not preference: a `PfcpClient`
+/// owns a `tokio::net::UdpSocket`, and a tokio socket belongs to the runtime that
+/// created it. Under `#[tokio::test]` — one runtime per test — a client installed
+/// permanently by whichever test ran first is a client whose socket is dead for
+/// every test after it ("A Tokio 1.x context was found, but it is being
+/// shutdown"), so the install-once shape cannot express a UPF stand-in at all.
+///
+/// What changes for the running SMF: `set_global_client` now overwrites instead
+/// of being first-wins. `main` calls it exactly once (through
+/// [`set_global_pool`]) at startup, so today's behaviour is identical, and a
+/// re-installable pool is the more predictable of the two if a future
+/// reconfiguration path ever wants one. What is deliberately NOT added is any
+/// caller that swaps the client while sessions are live: the sessions' peer
+/// bindings (`SESSION_PEERS`) would still point at the old peer.
+static PFCP_CLIENT: std::sync::RwLock<Option<Arc<PfcpClient>>> = std::sync::RwLock::new(None);
 
-/// Install the process-wide PFCP client (once, at startup).
+/// Install the process-wide PFCP client (at startup, or per test).
 pub fn set_global_client(client: Arc<PfcpClient>) {
-    let _ = PFCP_CLIENT.set(client);
+    if let Ok(mut slot) = PFCP_CLIENT.write() {
+        *slot = Some(client);
+    }
 }
 
-/// The process-wide PFCP client, if initialised.
+/// The process-wide PFCP client, if initialised. Cloned out of the lock so no
+/// guard is ever held across an `await`.
 pub fn global_client() -> Option<Arc<PfcpClient>> {
-    PFCP_CLIENT.get().cloned()
+    PFCP_CLIENT.read().ok()?.clone()
 }
 
 // ============================================================================
 // UPF pool + load-aware selection (issue #20)
 // ============================================================================
 
-static PFCP_POOL: OnceLock<Vec<Arc<PfcpClient>>> = OnceLock::new();
+/// The process-wide UPF pool. Settable for the same reason as [`PFCP_CLIENT`],
+/// and always set together with it so the two cannot disagree about which peer
+/// is the default.
+static PFCP_POOL: std::sync::RwLock<Vec<Arc<PfcpClient>>> = std::sync::RwLock::new(Vec::new());
 
-/// Install the process-wide UPF pool (once, at startup). The first entry is
-/// also installed as the process-wide default client, so every legacy
+/// Install the process-wide UPF pool (at startup, or per test). The first entry
+/// is also installed as the process-wide default client, so every legacy
 /// single-client path keeps its pre-pool behavior.
 pub fn set_global_pool(clients: Vec<Arc<PfcpClient>>) {
     if let Some(first) = clients.first() {
         set_global_client(first.clone());
     }
-    let _ = PFCP_POOL.set(clients);
+    if let Ok(mut slot) = PFCP_POOL.write() {
+        *slot = clients;
+    }
 }
 
-/// The process-wide UPF pool (all configured peers), if initialised.
-pub fn global_pool() -> Option<&'static [Arc<PfcpClient>]> {
-    PFCP_POOL.get().map(|v| v.as_slice())
+/// Uninstall the client and pool, returning the process to its pre-startup state.
+///
+/// Test-only, and the "release" half of the per-test install the stand-in does:
+/// a test that asked for a UPF must not leave one behind for a sibling that
+/// expects none, and the sibling would find a client whose runtime has since shut
+/// down. Not offered to production — a running SMF has no reason to un-install
+/// its own N4 endpoint, and doing so mid-session would strand `SESSION_PEERS`.
+#[cfg(test)]
+pub(crate) fn clear_global_upf_for_test() {
+    if let Ok(mut slot) = PFCP_CLIENT.write() {
+        *slot = None;
+    }
+    if let Ok(mut pool) = PFCP_POOL.write() {
+        pool.clear();
+    }
+}
+
+/// The process-wide UPF pool (all configured peers); empty until installed.
+///
+/// Returns an owned snapshot rather than a borrow: the pool is now behind a lock,
+/// and a guard must not be held across the `await`s every caller performs.
+pub fn global_pool() -> Vec<Arc<PfcpClient>> {
+    PFCP_POOL
+        .read()
+        .map(|pool| pool.clone())
+        .unwrap_or_default()
 }
 
 /// Session → UPF binding: the SMF's own N4 SEID → PFCP peer address,
@@ -338,9 +387,9 @@ pub fn client_for_session(smf_n4_seid: u64) -> Option<Arc<PfcpClient>> {
         .read()
         .ok()
         .and_then(|map| map.get(&smf_n4_seid).copied());
-    if let (Some(peer), Some(pool)) = (peer, global_pool()) {
-        if let Some(client) = pool.iter().find(|c| c.peer() == peer) {
-            return Some(client.clone());
+    if let Some(peer) = peer {
+        if let Some(client) = global_pool().into_iter().find(|c| c.peer() == peer) {
+            return Some(client);
         }
     }
     global_client()
@@ -363,11 +412,11 @@ pub async fn select_upf() -> Option<Arc<PfcpClient>> {
     if !cfg!(feature = "compute-aware-upf") {
         return global_client();
     }
-    let pool = match global_pool() {
-        Some(pool) if pool.len() > 1 => pool,
-        _ => return global_client(),
-    };
-    match select_upf_from(pool).await {
+    let pool = global_pool();
+    if pool.len() <= 1 {
+        return global_client();
+    }
+    match select_upf_from(&pool).await {
         Some(client) => Some(client),
         None => {
             log::warn!(
@@ -843,11 +892,306 @@ pub fn clear_pfcp_sessions() -> usize {
 }
 
 // ============================================================================
+// Test harness: the process-wide stand-in UPF (issue #289)
+// ============================================================================
+
+/// One agreement about every N4 process-global in this crate.
+///
+/// Three variables are involved and they cannot be guarded separately:
+/// - `PFCP_CLIENT` / `PFCP_POOL` (this module) — `OnceLock`s, so the first
+///   installer wins for the whole test process;
+/// - `SmfContext::pfcp_sessions` (`context.rs`) — `teardown_association` calls
+///   `clear_pfcp_sessions`, which clears the map for the WHOLE process rather
+///   than for the client that tore down;
+/// - the `AssociationState` of the one installed client, which decides whether
+///   `pfcp_session_establish` proceeds or bails.
+///
+/// Any two tests that touch any of these will flush or contradict each other if
+/// they interleave — which is how the #191 pair first failed, one clearing the
+/// other's session key mid-assertion. A SECOND lock over the same variables
+/// would be two disjoint agreements rather than one, and #276 showed that
+/// mistake HANGS the suite rather than merely flaking it, so this is deliberately
+/// declared here beside the globals and shared by `main.rs`'s tests
+/// (`pub(crate)`) instead of being re-declared there.
+///
+/// Lock order, where a test needs more than one process-global: take
+/// `easdf::SWITCH_LOCK` (or any other module's switch lock) FIRST, then this
+/// one. Every call site in the crate follows that order; reversing it anywhere
+/// reintroduces the deadlock this comment exists to prevent.
+#[cfg(test)]
+pub(crate) static N4_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// A PFCP-answering UPF stand-in for tests (issue #289).
+///
+/// Before this existed, `handle_sm_context_create` could not get past its N4 leg
+/// in ANY test: `select_upf()` returned no client, so every create answered
+/// `504 UPF_NOT_RESPONDING` and the whole tail after the PFCP block — the session
+/// fill-in, the policy binding, the EASDF leg, the N1 accept — was unreachable.
+/// Three call sites in that tail were therefore "verified by inspection", and one
+/// of them (`easdf::create_dns_context`, #276) had simply been absent for a month
+/// while looking wired.
+///
+/// **The design choice #289 asks to be made explicitly: install-and-release, per
+/// test, which required making `PFCP_CLIENT` settable.** The issue proposed
+/// installing ONE stand-in permanently and leaving the `OnceLock` alone, calling
+/// that the smaller change — and it cannot work here, for a reason the issue did
+/// not anticipate: a `PfcpClient` owns a `tokio::net::UdpSocket`, which belongs to
+/// the runtime that created it. `#[tokio::test]` gives each test its own runtime,
+/// so a client installed by the first test to touch it is dead for every test
+/// after ("A Tokio 1.x context was found, but it is being shutdown" — observed,
+/// not predicted). So each test installs its own stand-in and RELEASES it on drop
+/// (see [`clear_global_upf_for_test`]), leaving the process exactly as a test that
+/// never asked for a UPF expects to find it.
+///
+/// Which association state a test gets is still its own choice
+/// ([`associated_upf`] / [`unassociated_upf`]): a failure-path test wants the REAL
+/// failure mode (TS 29.244 §6.2.6.2, no session signalling without an
+/// association) rather than the absence of a client, which is what those tests
+/// were approximating all along.
+#[cfg(test)]
+pub(crate) mod stand_in {
+    use super::*;
+
+    /// The stand-in UPF and the identities it hands out, so a test can assert on
+    /// the values that must survive the round trip.
+    ///
+    /// Holds the [`N4_TEST_LOCK`] guard for as long as the test holds this, and
+    /// un-installs the client on drop — so binding it to `_` (which drops it
+    /// immediately) would silently give the test no UPF and no serialisation.
+    #[must_use = "the stand-in UPF is uninstalled as soon as it is dropped"]
+    pub(crate) struct StandInUpf {
+        /// The client installed as the process-wide PFCP client + pool.
+        pub(crate) client: Arc<PfcpClient>,
+        /// Message types the stand-in answered, in order.
+        pub(crate) seen: Arc<std::sync::Mutex<Vec<u8>>>,
+        /// The UP F-SEID this stand-in allocates for every session.
+        pub(crate) upf_seid: u64,
+        /// The F-TEID it returns in the Created PDR.
+        pub(crate) upf_teid: u32,
+        /// The N3 address it reports alongside the F-TEID.
+        pub(crate) upf_ip: [u8; 4],
+        /// Serialises every N4 test against every other; released with this value.
+        _n4_guard: tokio::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for StandInUpf {
+        fn drop(&mut self) {
+            // Runs BEFORE `_n4_guard` is released (Rust drops the body first, then
+            // the fields), so no sibling can observe the half-torn-down state.
+            clear_global_upf_for_test();
+        }
+    }
+
+    impl StandInUpf {
+        /// Message types answered since the last [`Self::clear_seen`].
+        pub(crate) fn seen(&self) -> Vec<u8> {
+            self.seen.lock().unwrap_or_else(|e| e.into_inner()).clone()
+        }
+
+        /// Forget the recorded traffic, so a test asserts only about its own.
+        pub(crate) fn clear_seen(&self) {
+            self.seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        }
+    }
+
+    /// Flat TLV encoder for the response IEs the SMF's establishment parser reads.
+    fn tlv(ie_type: u16, value: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(4 + value.len());
+        out.extend_from_slice(&ie_type.to_be_bytes());
+        out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+        out.extend_from_slice(value);
+        out
+    }
+
+    /// A Session Establishment Response body: Cause + UP F-SEID + Created PDR
+    /// carrying the allocated F-TEID (TS 29.244 §7.5.3).
+    ///
+    /// Hand-encoded rather than built with the library's message types because
+    /// the SMF's own establishment parser is what is under test here: it reads
+    /// F-SEID with V4 on **bit 2** (§8.2.37) and F-TEID with V4 on **bit 1**
+    /// (§8.2.3), an asymmetry the production parser calls out and a stand-in that
+    /// shared an encoder with it could not catch.
+    fn establishment_response_body(seid: u64, teid: u32, ip: [u8; 4]) -> Vec<u8> {
+        let mut body = tlv(19, &[pfcp_cause::REQUEST_ACCEPTED]);
+
+        let mut f_seid = Vec::with_capacity(13);
+        f_seid.push(0x02); // V4 present (bit 2)
+        f_seid.extend_from_slice(&seid.to_be_bytes());
+        f_seid.extend_from_slice(&ip);
+        body.extend_from_slice(&tlv(57, &f_seid));
+
+        let mut f_teid = Vec::with_capacity(9);
+        f_teid.push(0x01); // V4 present (bit 1)
+        f_teid.extend_from_slice(&teid.to_be_bytes());
+        f_teid.extend_from_slice(&ip);
+        let mut created_pdr = tlv(56, &[0x00, 0x01]); // PDR ID 1
+        created_pdr.extend_from_slice(&tlv(21, &f_teid));
+        body.extend_from_slice(&tlv(8, &created_pdr));
+
+        body
+    }
+
+    /// Bind a client whose peer socket is returned to the caller and never
+    /// answers on its own. Promoted out of this module's `tests` submodule
+    /// (issue #289) so both `pfcp_path`'s own tests and the stand-in build their
+    /// clients the same way.
+    pub(crate) async fn client_with_silent_peer() -> (Arc<PfcpClient>, UdpSocket) {
+        let peer_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer_sock.local_addr().unwrap();
+        let local = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let client = Arc::new(PfcpClient::new(Arc::new(local), peer_addr, [127, 0, 0, 1]));
+
+        // Pump incoming datagrams into the engine
+        let c = client.clone();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 4096];
+            loop {
+                let Ok((len, from)) = c.socket.recv_from(&mut buf).await else {
+                    break;
+                };
+                c.on_datagram(&buf[..len], from).await;
+            }
+        });
+        (client, peer_sock)
+    }
+
+    /// Install a stand-in UPF as `PFCP_CLIENT` + `PFCP_POOL` for this test, and
+    /// serialise against every other N4 test until the returned value drops.
+    ///
+    /// Not associated yet — [`associated_upf`] adds the handshake.
+    pub(crate) async fn install_stand_in_upf() -> StandInUpf {
+        let n4_guard = N4_TEST_LOCK.lock().await;
+        let (client, upf_sock) = client_with_silent_peer().await;
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let upf_seid = 0x0000_0000_dead_beef_u64;
+        let upf_teid = 0x0000_1289_u32;
+        let upf_ip = [127, 0, 0, 4];
+
+        let recorded = seen.clone();
+        tokio::spawn(async move {
+            let rts = 0x5EED_0289_u32;
+            let mut buf = vec![0u8; 8192];
+            loop {
+                let Ok((len, from)) = upf_sock.recv_from(&mut buf).await else {
+                    break;
+                };
+                let Some(h) = parse_wire_header(&buf[..len]) else {
+                    continue;
+                };
+                recorded
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(h.msg_type);
+
+                let reply = match h.msg_type {
+                    pfcp_message_type::ASSOCIATION_SETUP_REQUEST => {
+                        let mut resp = AssociationSetupResponse::new(
+                            NodeId::new_ipv4(upf_ip),
+                            nextgcore_pfcp::types::PfcpCause::RequestAccepted,
+                            rts,
+                        );
+                        resp.up_function_features = Some(UpFunctionFeatures {
+                            ftup: true,
+                            ..Default::default()
+                        });
+                        Some(Vec::from(build_message(
+                            &PfcpMessage::AssociationSetupResponse(resp),
+                            h.sequence_number,
+                            None,
+                        )))
+                    }
+                    pfcp_message_type::HEARTBEAT_REQUEST => Some(Vec::from(build_message(
+                        &PfcpMessage::HeartbeatResponse(HeartbeatResponse::new(rts)),
+                        h.sequence_number,
+                        None,
+                    ))),
+                    pfcp_message_type::ASSOCIATION_RELEASE_REQUEST => {
+                        Some(Vec::from(build_message(
+                            &PfcpMessage::AssociationReleaseResponse(
+                                nextgcore_pfcp::message::AssociationReleaseResponse::new(
+                                    NodeId::new_ipv4(upf_ip),
+                                    nextgcore_pfcp::types::PfcpCause::RequestAccepted,
+                                ),
+                            ),
+                            h.sequence_number,
+                            None,
+                        )))
+                    }
+                    pfcp_message_type::SESSION_ESTABLISHMENT_REQUEST => Some(encode_wire_message(
+                        pfcp_message_type::SESSION_ESTABLISHMENT_RESPONSE,
+                        Some(h.seid),
+                        h.sequence_number,
+                        &establishment_response_body(upf_seid, upf_teid, upf_ip),
+                    )),
+                    pfcp_message_type::SESSION_MODIFICATION_REQUEST => Some(encode_wire_message(
+                        pfcp_message_type::SESSION_MODIFICATION_RESPONSE,
+                        Some(h.seid),
+                        h.sequence_number,
+                        &tlv(19, &[pfcp_cause::REQUEST_ACCEPTED]),
+                    )),
+                    pfcp_message_type::SESSION_DELETION_REQUEST => Some(encode_wire_message(
+                        pfcp_message_type::SESSION_DELETION_RESPONSE,
+                        Some(h.seid),
+                        h.sequence_number,
+                        &tlv(19, &[pfcp_cause::REQUEST_ACCEPTED]),
+                    )),
+                    _ => None,
+                };
+                if let Some(pkt) = reply {
+                    let _ = upf_sock.send_to(&pkt, from).await;
+                }
+            }
+        });
+
+        // Installs BOTH globals: `set_global_pool` also sets the default client,
+        // so the two can never disagree about which peer is ours.
+        set_global_pool(vec![client.clone()]);
+
+        StandInUpf {
+            client,
+            seen,
+            upf_seid,
+            upf_teid,
+            upf_ip,
+            _n4_guard: n4_guard,
+        }
+    }
+
+    /// A stand-in UPF with its association UP. Use for a test that must reach the
+    /// success path.
+    pub(crate) async fn associated_upf() -> StandInUpf {
+        let upf = install_stand_in_upf().await;
+        upf.client
+            .associate()
+            .await
+            .expect("the stand-in UPF must accept the association");
+        upf.clear_seen();
+        upf
+    }
+
+    /// A stand-in UPF with its association DOWN. Use for a test that must see
+    /// establishment fail at the N4 leg — the real failure mode (TS 29.244
+    /// §6.2.6.2), rather than the absence of a client.
+    ///
+    /// A freshly built client is un-associated already; the state is set
+    /// explicitly so the test's intent is visible at the call site. Deliberately
+    /// NOT `teardown_association`, which would clear the process-global
+    /// `pfcp_sessions` map — a sibling's state rather than this test's.
+    pub(crate) async fn unassociated_upf() -> StandInUpf {
+        let upf = install_stand_in_upf().await;
+        upf.client.set_assoc_state_for_test(false, None, None).await;
+        upf.clear_seen();
+        upf
+    }
+}
+
+// ============================================================================
 // Unit Tests
 // ============================================================================
 
 #[cfg(test)]
 mod tests {
+    use super::stand_in::{client_with_silent_peer as make_client_with_peer, unassociated_upf};
     use super::*;
 
     fn body_with_cause(cause: u8) -> Vec<u8> {
@@ -893,39 +1237,6 @@ mod tests {
         ));
         assert!(!is_response_type(pfcp_message_type::HEARTBEAT_REQUEST));
         assert!(!is_response_type(pfcp_message_type::SESSION_REPORT_REQUEST));
-    }
-
-    /// One agreement about the process-global `pfcp_sessions` map.
-    ///
-    /// `teardown_association` calls `clear_pfcp_sessions`, which clears the map
-    /// for the WHOLE process, not for the client that tore down. So any two tests
-    /// that can reach a teardown will flush each other's session entries if they
-    /// interleave — which is exactly how the #191 pair below first failed, one
-    /// clearing the other's key mid-assertion.
-    ///
-    /// Every test that can reach a teardown takes this, so there is one lock
-    /// rather than two disjoint agreements about the same variable. A test that
-    /// only reads client-local association state does not need it.
-    static SESSION_MAP_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-    async fn make_client_with_peer() -> (Arc<PfcpClient>, UdpSocket) {
-        let peer_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        let peer_addr = peer_sock.local_addr().unwrap();
-        let local = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        let client = Arc::new(PfcpClient::new(Arc::new(local), peer_addr, [127, 0, 0, 1]));
-
-        // Pump incoming datagrams into the engine
-        let c = client.clone();
-        tokio::spawn(async move {
-            let mut buf = vec![0u8; 4096];
-            loop {
-                let Ok((len, from)) = c.socket.recv_from(&mut buf).await else {
-                    break;
-                };
-                c.on_datagram(&buf[..len], from).await;
-            }
-        });
-        (client, peer_sock)
     }
 
     /// Association Setup round-trip against a fake UPF answering with the
@@ -1088,8 +1399,8 @@ mod tests {
     #[tokio::test]
     async fn test_heartbeat_detects_peer_restart() {
         // Serialised: this test can reach a teardown, which flushes the
-        // process-global session map (see SESSION_MAP_LOCK).
-        let _map_guard = SESSION_MAP_LOCK.lock().await;
+        // process-global session map (see N4_TEST_LOCK).
+        let _map_guard = N4_TEST_LOCK.lock().await;
         let (client, upf) = make_client_with_peer().await;
         {
             let mut a = client.assoc.write().await;
@@ -1150,8 +1461,8 @@ mod tests {
     #[tokio::test]
     async fn test_inbound_association_release() {
         // Serialised: this test can reach a teardown, which flushes the
-        // process-global session map (see SESSION_MAP_LOCK).
-        let _map_guard = SESSION_MAP_LOCK.lock().await;
+        // process-global session map (see N4_TEST_LOCK).
+        let _map_guard = N4_TEST_LOCK.lock().await;
         let (client, upf) = make_client_with_peer().await;
         client.assoc.write().await.associated = true;
         let local_addr = client.socket.local_addr().unwrap();
@@ -1236,12 +1547,21 @@ mod tests {
 
     /// Acceptance (issue #20): with the feature off — or a pool of one —
     /// session establishment selects the sole/global client, i.e. the
-    /// pre-pool single-client path. This is the ONLY test that installs the
-    /// process-global pool (OnceLock allows a single set per test process).
+    /// pre-pool single-client path.
+    ///
+    /// Takes its client from the shared stand-in (issue #289) rather than
+    /// installing one of its own. `PFCP_CLIENT` and `PFCP_POOL` are `OnceLock`s,
+    /// so two installers race on test order and the loser leaves the winner's
+    /// silent peer installed for every other test in the process — which is
+    /// exactly how a create against the stand-in would have started timing out
+    /// instead of establishing. There is one installer in the test build.
     #[tokio::test]
     async fn test_select_upf_defaults_to_global_client_and_bindings_resolve() {
-        let (client, _upf) = make_client_with_peer().await;
-        set_global_pool(vec![client.clone()]);
+        // Association state is irrelevant to a single-peer pool: `select_upf`
+        // returns the default client without consulting it (the load-aware path
+        // needs the feature AND more than one peer).
+        let upf = unassociated_upf().await;
+        let client = upf.client.clone();
 
         let selected = select_upf().await.expect("pool installed");
         assert_eq!(
@@ -1338,8 +1658,8 @@ mod tests {
     #[tokio::test]
     async fn test_teardown_clears_load_state() {
         // Serialised: this test can reach a teardown, which flushes the
-        // process-global session map (see SESSION_MAP_LOCK).
-        let _map_guard = SESSION_MAP_LOCK.lock().await;
+        // process-global session map (see N4_TEST_LOCK).
+        let _map_guard = N4_TEST_LOCK.lock().await;
         let (client, _upf) = make_client_with_peer().await;
         client
             .set_assoc_state_for_test(true, Some(40), Some(5000))
@@ -1370,8 +1690,8 @@ mod tests {
     #[tokio::test]
     async fn a_seeded_recovery_time_stamp_makes_a_peer_restart_detectable() {
         // Serialised: this test can reach a teardown, which flushes the
-        // process-global session map (see SESSION_MAP_LOCK).
-        let _map_guard = SESSION_MAP_LOCK.lock().await;
+        // process-global session map (see N4_TEST_LOCK).
+        let _map_guard = N4_TEST_LOCK.lock().await;
         let (client, _upf) = make_client_with_peer().await;
         client.seed_peer_recovery_time_stamp(100).await;
         client.set_assoc_state_for_test(true, None, None).await;
@@ -1416,8 +1736,8 @@ mod tests {
     #[tokio::test]
     async fn an_unchanged_recovery_time_stamp_leaves_restored_sessions_alone() {
         // Serialised: this test can reach a teardown, which flushes the
-        // process-global session map (see SESSION_MAP_LOCK).
-        let _map_guard = SESSION_MAP_LOCK.lock().await;
+        // process-global session map (see N4_TEST_LOCK).
+        let _map_guard = N4_TEST_LOCK.lock().await;
         let (client, _upf) = make_client_with_peer().await;
         client.seed_peer_recovery_time_stamp(300).await;
         client.set_assoc_state_for_test(true, None, None).await;


### PR DESCRIPTION
Closes #289.

`handle_sm_context_create` could not get past its N4 leg in **any** test, so everything after the PFCP block — the session fill-in, the policy binding, the EASDF leg, the N1 accept — was dead code as far as the suite was concerned. Three call sites there were "verified by inspection", and #276 showed one of them had been absent for a month. Removing `easdf::create_dns_context` again left all 425 tests green; it now fails a named test.

## The decision #289 asked for, and why it went the other way

The issue proposed installing ONE stand-in permanently and leaving `PFCP_CLIENT` as a `OnceLock`, calling that the smaller change. **It cannot work**, for a reason not visible in the code: a `PfcpClient` owns a `tokio::net::UdpSocket`, and a tokio socket belongs to the runtime that created it. `#[tokio::test]` gives each test its own runtime, so a client installed by whichever test touched the harness first is dead for every test after it:

```
the stand-in UPF must accept the association:
  Local("send failed: A Tokio 1.x context was found, but it is being shutdown.")
```

Observed, not predicted. So `PFCP_CLIENT`/`PFCP_POOL` are now `RwLock`s, each test installs its own stand-in, and the stand-in **uninstalls itself on drop** — install-and-release at per-test rather than per-process granularity. For the running daemon `set_global_client` overwrites instead of being first-wins; `main` calls it exactly once at startup via `set_global_pool` (the only external caller), so behaviour is unchanged. `global_pool()` returns an owned `Vec` because a lock guard must not be held across its callers' `await`s.

## One lock, declared beside the globals

`SESSION_MAP_LOCK` (inside `mod tests`) becomes `pfcp_path::N4_TEST_LOCK` at module level next to the statics, `pub(crate)` so `main.rs`'s tests take the *same* lock. Three variables cannot be guarded separately: the two globals, the `pfcp_sessions` map `clear_pfcp_sessions` empties process-wide, and the installed client's association state. The stand-in holds the guard as a field, so a test cannot get a UPF without the serialisation. A second lock over the same variables is what #276 did with the EASDF context lock — symptom: a **hang**, not a flake — so the lock order (module switch lock first, N4 second) is written into the doc comment.

## Acceptance criteria

- [x] A test drives `handle_sm_context_create` to a `201` against a stand-in UPF
- [x] Removing the `easdf::create_dns_context` call makes a NAMED test fail
- [x] Removing the `PolicyBinding` insert makes a named test fail
- [x] The success path asserts `upCnxState == ACTIVATED` and the stored session AMBR
- [x] Exactly ONE lock guards `PFCP_CLIENT` + `pfcp_sessions` across `pfcp_path` and `main.rs`
- [x] Both quoted tests converted per their own instructions, failure-path halves kept
- [x] Whole-workspace suite green over ≥5 repeated runs

## Verification

Workspace **6272 passed / 0 failed over five consecutive runs** (baseline 6270 on `02c39dc`; +2 — smfd 454 → 456), identical count each time: a per-test install that leaked would show up as a different number rather than as a failure. `cargo test -p nextgcore-easdfd --features dns-udp` unchanged at 51. clippy clean for `nextgcore-smfd`, `cargo fmt --all -- --check` clean.

| revert | expected to break | result |
|---|---|---|
| `easdf::create_dns_context` call removed (#114's state restored) | `an_established_session_creates_its_easdf_dns_context` | **1 failed** |
| `PolicyBinding` insert made unreachable | `a_successful_create_registers_an_activated_session_and_its_binding` | **1 failed** |
| session fill-in of `up_cnx_state` + `session_ambr` removed | same test | **1 failed** (`left: Deactivated`) |

The first row is the point of the issue: that exact revert left all 425 tests green on `main`, and it is the row #276's spec had to record as a ceiling. Each revert was run against the whole crate suite rather than a name filter — #117 already lost a finding that way.

## Ceilings

- The stand-in **answers, it does not enforce**: fixed F-SEID/F-TEID, accepts every request, never decodes the PDRs it is sent (`n4_build`'s own tests cover the encoding). Validating them would be a second PFCP implementation to keep in step with TS 29.244.
- `request_ebi` and the UDM legs stay off in these tests, so #291's and #293's wire assertions are not covered here — that is those issues' work, and the harness they need now exists.
- Three comments elsewhere in the crate that cited this ceiling are corrected rather than left to mislead; `eps_iwk::record_mapped_eps_bearer` now names what is still not driven (its call site with the interworking switch ON), which is a test away rather than a harness away.

Spec: `specs/fix-smfd-upf-stand-in.md`