### PR TITLE
fix(smfd,amfd): return an EPS bearer identity when its session ends (#291)

### DIFF
--- a/specs/fix-smfd-amfd-ebi-release.md
+++ b/specs/fix-smfd-amfd-ebi-release.md
@@ -1,0 +1,129 @@
+# nextgcore #291 (smfd/amfd): return an EPS bearer identity when its session ends
+
+Verified against `main` @ `eb3490e`.
+
+#291 was split out of #117, which implemented both halves of EBI *assignment* and neither half of the
+release. TS 29.518 §6.1.6.2.5, TS 24.301 §9.3.2.
+
+## Verified against current main
+
+| claim in the issue | site on `eb3490e` | still true? |
+|---|---|---|
+| `releasedEbiList` is implemented on the AMF side, release-before-assign | `namf_server.rs:1994`, order comment at `:1969` | yes |
+| `assign_ebi_releases_before_it_assigns_so_a_freed_ebi_is_reusable` verifies it | `namf_server.rs` tests | yes |
+| the SMF never sends one (`rg releasedEbiList src/bins/nextgcore-smfd/`) | nothing | yes |
+| the assignable space is 5..=15, eleven per UE | `context.rs:2129` `EBI_ASSIGNABLE` | yes |
+| `next_free_ebi` is lowest-free, so the space does not *look* exhausted early | `namf_server.rs:1953` | yes |
+| `request_ebi` treats every failure as non-fatal, so the leak is silent | `eps_iwk.rs:103` | yes |
+| `handle_sm_context_release` is where the sender belongs | `main.rs:4563` | yes |
+| **"a dereg that drops the context already frees them"** | **NO — nothing drops the context** | **false** |
+
+That last row is the finding that changed the shape of this fix, and the issue asked for exactly this
+check ("worth *verifying* rather than assuming, because if the context is reused rather than dropped
+the EBIs survive").
+
+## The verification that mattered: the backstop did not exist
+
+`amf_ue_remove` has **no production caller**. `grep` finds its definition, `amf_ue_remove_all` (context
+teardown), and three test call sites — nothing else. `handle_deregistration_request_nas` releases the
+PDU sessions, purges the UDM registration, answers the UE and calls `finish_deregistration`, which
+drops the NAS state (`ue_auth_state`) and releases the NG UE context. The stored `AmfUe` — and every
+`AssignedEbi` recorded on it — survives all of it.
+
+So before this change the ONLY thing that could ever free an EBI was an SMF-side release that did not
+exist. The leak was not bounded by the UE's registration lifetime as the issue hoped; it was bounded
+by the AMF process lifetime.
+
+## Decision 1: the AMF frees a UE's EBIs on deregistration — implemented, not just considered
+
+The issue lists this as "consider whether". Given the finding above it is implemented, because
+without it the SMF-side release is a single point of failure for an eleven-wide space: one lost
+request leaks one identity forever. `release_all_ebis_on_deregistration` lives in `namf_server.rs`
+beside `handle_assign_ebi`, so the rules about who owns the identity space stay in one module.
+
+It is not an invention: TS 23.502 §4.2.2.3.2 has deregistration release every PDU session the UE has,
+and an EPS bearer identity exists only to map one of those sessions into EPS. A UE with no sessions
+holds no EBIs.
+
+## Decision 2: the wiring point is `finish_deregistration`, not `gmm_handler`
+
+`gmm_handler::handle_deregistration_request(&mut AmfUe, ..)` looks like the natural home — it already
+takes the UE mutably. It has **no production caller**: `grep` finds its definition and its own test.
+The NGAP path handles deregistration itself. Putting the backstop there would have produced a tested
+change that never runs, which is the defect this repo keeps finding (#276's `create_dns_context`
+shipped that way for a month).
+
+`finish_deregistration` is the common tail of both deregistration directions (UE-initiated, and the
+network-initiated one after the Accept), and it still holds `ue_auth_state` — which is where the SUPI
+keying the stored `AmfUe` comes from. The call goes before `ue_auth_state.remove`, for that reason.
+
+## Decision 3: a failed release is logged with the identity named, and NOT retried
+
+The issue offers a bounded retry queue (like #111's in nefd) as the alternative. Logging wins, and
+Decision 1 is what makes that sufficient rather than merely cheap:
+
+- The session is going away either way, so the SMF cannot keep the teardown open waiting.
+- A retry queue that survives what it needs to survive means durable state: a queue held in memory is
+  lost by exactly the restart most likely to have dropped the request in the first place, and #191's
+  snapshot does not model one. That is a bigger change than this issue, for a case the backstop covers.
+- With the AMF freeing on deregistration, a lost release leaks one identity until the UE deregisters
+  instead of forever. Eleven lost releases inside one registration would still exhaust the space, and
+  the log names the identity and the consequence so the operator can see it happening.
+
+## Decision 4: the disabled leg returns early, so `false` means "lost", not "not attempted"
+
+Found by revert 2, not by reading. `release_ebi` returns `bool`, and with the leg off the shared
+`post_assign_ebi` returned `None` — so the caller's log path named a LEAKED identity for a deployment
+that cannot have one. `release_ebi` now checks `enabled()` first and returns quietly. The call site
+ignores the bool either way; the value of the fix is that the log is a true statement.
+
+## Acceptance criteria
+
+- [x] Releasing a session whose binding carries an EBI sends an `assign-ebi` request with that EBI in
+      `releasedEbiList`; asserted **over the wire from the release handler** —
+      `releasing_a_session_returns_its_ebi_to_the_amf`.
+- [x] Twelve sequential establish/release cycles for one UE keep succeeding; a test asserts the
+      twelfth gets an EBI rather than a `403` —
+      `twelve_establish_release_cycles_keep_getting_an_ebi_and_twelve_without_release_do_not`, which
+      also pins the other direction (eleven unreleased sessions exhaust the space).
+- [x] A failed release request does not fail the session release, and the leaked identity is named in
+      the log — `a_failed_ebi_release_does_not_fail_the_session_release`.
+- [x] Whether AMF deregistration frees `assigned_ebis` is verified and stated either way — it did
+      **not**, and now does (Decisions 1 and 2).
+- [x] With interworking disabled, the release path sends nothing —
+      `a_disabled_interworking_leg_releases_no_ebi`.
+
+## Verification
+
+Workspace **6278 passed / 0 failed** over three consecutive runs (baseline 6272 on `eb3490e`; +6 —
+smfd 456 → 459, amfd 433 → 436). `cargo clippy -p nextgcore-smfd -p nextgcore-amfd --all-targets`
+clean; `cargo fmt --all -- --check` clean.
+
+| revert | expected to break | result |
+|---|---|---|
+| the `release_ebi` call made unreachable in `handle_sm_context_release` | `releasing_a_session_returns_its_ebi_to_the_amf` | **1 failed** |
+| a failed release made fatal to the session release | `a_failed_ebi_release_does_not_fail_the_session_release` | **2 failed** (and exposed Decision 4) |
+| the dereg backstop call made unreachable in `finish_deregistration` | `deregistration_frees_the_ues_ebis_through_the_ngap_tail` | **1 failed** |
+| the dereg clear not persisted (`amf_ue_update` dropped) | both dereg tests | **2 failed** |
+| `handle_assign_ebi`'s `releasedEbiList` no longer frees (i.e. #117's release undone) | the twelve-cycle test + 2 existing | **3 failed** |
+
+The last row is worth noting: the twelve-cycle test now guards #117's release path as well as this
+change, so an AMF-side regression that silently stopped freeing would fail here rather than in a
+deployment eleven session-lifetimes later.
+
+## Ceilings
+
+- **The release is asserted from the release handler; the ASSIGNMENT's call site still is not.** Every
+  create test runs with the interworking leg off, so `request_ebi`'s call site in
+  `handle_sm_context_create` is exercised only on its `None` arm. #289 gave the crate the UPF stand-in
+  that makes closing this a test away rather than a harness away; it is not in this issue's criteria.
+- **The twelve cycles are AMF-side.** They drive `assign-ebi` through the real router twelve times with
+  a release between, which is what the SMF now sends — but no test drives both daemons in one process,
+  so "the SMF's release makes the AMF's twelfth assignment succeed" is proven in two halves that meet
+  at the wire format, not end to end. The docker E2E is where an end-to-end version would live.
+- **`releasedEbiList` carries exactly one identity**, because this SMF authorises one default QoS flow
+  per session (`request_ebi` asks for one ARP). A session with several flows would need the list to
+  carry several, and nothing in the tree creates one.
+- **Nothing frees an EBI when the AMF loses the UE without a deregistration** — an implicit
+  detach/timeout path that drops `ue_auth_state` without running `finish_deregistration` would leave
+  the identities held. The mobile-reachable and implicit-dereg timers are #72's scope.

--- a/src/bins/nextgcore-amfd/src/namf_server.rs
+++ b/src/bins/nextgcore-amfd/src/namf_server.rs
@@ -1956,6 +1956,42 @@ fn next_free_ebi(assigned: &[AssignedEbi]) -> Option<u8> {
         .find(|c| !assigned.iter().any(|a| a.ebi == *c))
 }
 
+/// Free every EPS bearer identity a UE holds, because the UE has deregistered
+/// (issue #291). Returns how many were freed.
+///
+/// This is the backstop that makes an SMF-side miss recoverable, and it turned out
+/// to be **necessary rather than merely nice**: #291 asked whether deregistration
+/// already frees `assigned_ebis` because the context is dropped, and it does not.
+/// Nothing in production calls `amf_ue_remove` — `grep` finds only tests and
+/// `amf_ue_remove_all` (context teardown) — so an `AmfUe` outlives every
+/// deregistration it experiences, and with it every EBI recorded on it. Without this
+/// the eleven-wide space (TS 24.301 §9.3.2 reserves 0..=4) is only ever reclaimed by
+/// the SMF's `releasedEbiList`, and any release that fails to reach the AMF leaks an
+/// identity for the lifetime of the process.
+///
+/// Freeing them here is what TS 23.502 §4.2.2.3.2 implies rather than an invention:
+/// deregistration releases every PDU session the UE has, and an EPS bearer identity
+/// exists only to map one of those sessions into EPS. A UE with no sessions holding
+/// EBIs is the state this restores.
+pub(crate) fn release_all_ebis_on_deregistration(supi: &str) -> usize {
+    let Some(mut ue) = find_ue_by_context_id(supi) else {
+        return 0;
+    };
+    if ue.assigned_ebis.is_empty() {
+        return 0;
+    }
+    let freed: Vec<u8> = ue.assigned_ebis.iter().map(|a| a.ebi).collect();
+    ue.assigned_ebis.clear();
+    if let Ok(guard) = amf_self().read() {
+        guard.amf_ue_update(&ue);
+    }
+    log::info!(
+        "[{supi}] deregistration freed EPS bearer identities {freed:?}: the UE holds no \
+         PDU sessions, so it holds no EPS bearers"
+    );
+    freed.len()
+}
+
 /// POST /namf-comm/v1/ue-contexts/{ueContextId}/assign-ebi —
 /// Namf_Communication_EBIAssignment (TS 29.518 §6.1.6.2.5), issue #117.
 ///
@@ -4404,6 +4440,136 @@ mod tests {
                 .len(),
             1,
             "a partial failure is a 200 carrying both lists, not a 403"
+        );
+    }
+
+    /// #291 criterion 2: twelve sequential establish/release cycles for one UE keep
+    /// succeeding — and the same twelve WITHOUT the release do not.
+    ///
+    /// Both halves are the point. The first proves the SMF's `releasedEbiList`
+    /// (#291) makes the space reusable; the second pins what the leak actually did,
+    /// so a future change that stops honouring the release fails here rather than in
+    /// a deployment eleven session-lifetimes later. Eleven cycles is nothing: a UE
+    /// that re-attaches on the way to work reaches it inside a week.
+    #[test]
+    fn twelve_establish_release_cycles_keep_getting_an_ebi_and_twelve_without_release_do_not() {
+        let supi = "imsi-001010000000291";
+        setup_ue(supi, true, true);
+
+        let mut assigned = Vec::new();
+        for cycle in 1..=12u8 {
+            let resp = assign_ebi_request(supi, json!({ "pduSessionId": 5, "arpList": [arp(8)] }));
+            assert_eq!(
+                resp.status, 200,
+                "cycle {cycle}: a session whose predecessor released its EBI must \
+                 get one, not a 403 for a UE with no live bearers"
+            );
+            let body = body_json(&resp);
+            let ebi = body["assignedEbiList"][0]["epsBearerId"]
+                .as_u64()
+                .unwrap_or_else(|| panic!("cycle {cycle}: no EBI assigned: {body}"));
+            assigned.push(ebi);
+
+            // What the SMF now does when the session is released.
+            let released =
+                assign_ebi_request(supi, json!({ "pduSessionId": 5, "releasedEbiList": [ebi] }));
+            assert_eq!(
+                released.status, 200,
+                "cycle {cycle}: the release must succeed"
+            );
+        }
+        assert_eq!(
+            assigned,
+            vec![5u64; 12],
+            "lowest-free reuse means every cycle gets the same identity back; \
+             a climbing allocator would exhaust the space instead"
+        );
+
+        // The other half: eleven sessions that never release exhaust the space, and
+        // the twelfth is refused. This is the state #291 found in the tree.
+        let leaky = "imsi-001010000000292";
+        setup_ue(leaky, true, true);
+        for cycle in 1..=11u8 {
+            let resp = assign_ebi_request(leaky, json!({ "pduSessionId": 5, "arpList": [arp(8)] }));
+            assert_eq!(resp.status, 200, "cycle {cycle} of eleven must fit");
+        }
+        let twelfth = assign_ebi_request(leaky, json!({ "pduSessionId": 5, "arpList": [arp(8)] }));
+        assert_eq!(
+            twelfth.status, 403,
+            "the twelfth unreleased session must be refused: eleven is the whole \
+             assignable space (TS 24.301 §9.3.2 reserves 0..=4)"
+        );
+        // AssignEbiError nests its cause under `error` rather than carrying a
+        // top-level ProblemDetails one (TS 29.518 §6.1.6.2.5).
+        assert_eq!(
+            body_json(&twelfth)["error"]["cause"],
+            json!("INSUFFICIENT_RESOURCES")
+        );
+        assert_eq!(
+            body_json(&twelfth)["failureDetails"]["failedArpList"]
+                .as_array()
+                .map(Vec::len),
+            Some(1),
+            "the SMF must learn WHICH flow got no EBI"
+        );
+    }
+
+    /// #291 criterion 4: deregistration frees the UE's EBIs.
+    ///
+    /// The issue asked whether this already happened because the context is dropped.
+    /// It did not, and the reason is worth pinning: nothing in production removes an
+    /// `AmfUe` (`amf_ue_remove` has only test callers), so the context — and every
+    /// identity recorded on it — outlives every deregistration. Without this
+    /// backstop the only path that frees an EBI is the SMF's release, and an SMF
+    /// whose release never arrives leaks one for the life of the process.
+    #[test]
+    fn deregistration_frees_the_ues_eps_bearer_identities() {
+        let supi = "imsi-001010000000293";
+        setup_ue(supi, true, true);
+
+        // Two sessions of one UE, both holding an identity.
+        for psi in [5u8, 6u8] {
+            let resp =
+                assign_ebi_request(supi, json!({ "pduSessionId": psi, "arpList": [arp(8)] }));
+            assert_eq!(resp.status, 200);
+        }
+        assert_eq!(
+            find_ue_by_context_id(supi)
+                .map(|ue| ue.assigned_ebis.len())
+                .unwrap_or(0),
+            2,
+            "both identities are held before the deregistration"
+        );
+
+        assert_eq!(
+            release_all_ebis_on_deregistration(supi),
+            2,
+            "deregistration frees every identity the UE holds"
+        );
+        assert!(
+            find_ue_by_context_id(supi)
+                .map(|ue| ue.assigned_ebis.is_empty())
+                .unwrap_or(false),
+            "the freed identities must be gone from the STORED context, not just \
+             from a local copy — an unpersisted clear frees nothing"
+        );
+
+        // And the space is genuinely reusable afterwards.
+        let after = assign_ebi_request(supi, json!({ "pduSessionId": 7, "arpList": [arp(8)] }));
+        assert_eq!(after.status, 200);
+        assert_eq!(
+            body_json(&after)["assignedEbiList"][0]["epsBearerId"],
+            json!(5),
+            "the lowest identity is free again"
+        );
+
+        // A UE holding none, and an unknown UE, are both no-ops rather than errors.
+        let empty = "imsi-001010000000294";
+        setup_ue(empty, true, true);
+        assert_eq!(release_all_ebis_on_deregistration(empty), 0);
+        assert_eq!(
+            release_all_ebis_on_deregistration("imsi-999999999999999"),
+            0
         );
     }
 

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -3192,6 +3192,23 @@ impl NgapServer {
             });
         }
 
+        // #291: free the UE's EPS bearer identities. Done HERE, in the common tail of
+        // both deregistration directions, and BEFORE `ue_auth_state` is dropped —
+        // that is where the SUPI keying the stored `AmfUe` comes from.
+        //
+        // This is a backstop, not the primary mechanism: the SMF returns each
+        // identity in a `releasedEbiList` when its PDU session is released. It is
+        // needed because the stored `AmfUe` SURVIVES deregistration (nothing in
+        // production removes one), so without it an identity whose release never
+        // reached the AMF is leaked for the life of the process.
+        if let Some(supi) = self
+            .ue_auth_state
+            .get(&amf_ue_ngap_id)
+            .and_then(|s| s.amf_ue.supi.clone())
+        {
+            crate::namf_server::release_all_ebis_on_deregistration(&supi);
+        }
+
         self.ue_auth_state.remove(&amf_ue_ngap_id);
         // Cause: NAS deregister (TS 38.413 Section 9.3.1.2, CauseNas value 2)
         self.release_ue(association_id, amf_ue_ngap_id, ran_ue_ngap_id, 2)
@@ -8622,6 +8639,71 @@ mod tests {
                 tai_slice_support_list: vec![nextgcore_ngap::types::SNssai { sst, sd: None }],
             }],
         }
+    }
+
+    /// #291: the deregistration tail actually calls the EBI backstop.
+    ///
+    /// The state change itself is asserted by
+    /// `namf_server::tests::deregistration_frees_the_ues_eps_bearer_identities`; this
+    /// asserts the WIRING, because "the helper is tested and the wiring is not" is
+    /// the defect this repo keeps finding — #276 shipped a fully tested
+    /// `create_dns_context` with no production caller for a month. Driven through
+    /// `finish_deregistration`, the common tail of both deregistration directions.
+    ///
+    /// The NG release at the end of that tail fails (no live SCTP association in this
+    /// test, per `test_ngap_server`), which is fine: the freeing happens before it,
+    /// and asserting on the STORED context is what distinguishes the two.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deregistration_frees_the_ues_ebis_through_the_ngap_tail() {
+        use crate::context::{amf_context_init, amf_self};
+
+        let mut server = test_ngap_server().await;
+        let supi = "imsi-001010000000295";
+        let amf_ue_ngap_id = 9_291u64;
+
+        // A stored UE holding an identity, in the GLOBAL context the EBI space lives
+        // in (`handle_assign_ebi` reads it there; the server's own context is a
+        // separate object in this harness).
+        amf_context_init(64, 1024, 4096);
+        {
+            let ctx = amf_self();
+            let guard = ctx.read().expect("ctx");
+            let ran_ue = guard.ran_ue_add(900_291, 291).expect("ran_ue");
+            let ue = guard.amf_ue_add(ran_ue.id).expect("amf_ue");
+            guard.amf_ue_set_supi(ue.id, supi);
+            let mut ue = guard.amf_ue_find_by_supi(supi).expect("stored ue");
+            ue.assigned_ebis.push(crate::context::AssignedEbi {
+                ebi: 5,
+                pdu_session_id: 5,
+                arp: crate::context::EbiArp {
+                    priority_level: 8,
+                    preempt_cap: "NOT_PREEMPT".to_string(),
+                    preempt_vuln: "PREEMPTABLE".to_string(),
+                },
+            });
+            guard.amf_ue_update(&ue);
+        }
+
+        // The NAS state the tail reads the SUPI out of.
+        let mut state = UeNasContext::new(amf_ue_ngap_id, 291, 9_291, false);
+        state.amf_ue.supi = Some(supi.to_string());
+        server.ue_auth_state.insert(amf_ue_ngap_id, state);
+
+        let _ = server
+            .finish_deregistration(9_291, amf_ue_ngap_id, 291)
+            .await;
+
+        let held = amf_self()
+            .read()
+            .expect("ctx")
+            .amf_ue_find_by_supi(supi)
+            .map(|ue| ue.assigned_ebis.len())
+            .unwrap_or(usize::MAX);
+        assert_eq!(
+            held, 0,
+            "the deregistration tail must free the UE's EPS bearer identities; the \
+             stored AmfUe survives deregistration, so nothing else will"
+        );
     }
 
     // ---- criterion 1: RAN Configuration Update stores what it acknowledges ----

--- a/src/bins/nextgcore-smfd/src/eps_iwk.rs
+++ b/src/bins/nextgcore-smfd/src/eps_iwk.rs
@@ -106,22 +106,6 @@ pub async fn request_ebi(
     pdu_session_id: u8,
     arp_priority_level: u8,
 ) -> Option<u8> {
-    if !enabled() {
-        return None;
-    }
-    let Some(amf_uri) = amf_uri else {
-        log::warn!(
-            "[{supi}] EPS interworking is on but the AMF supplied no callback URI: \
-             no EBI can be requested for PSI {pdu_session_id}, so this session \
-             cannot be moved to EPS"
-        );
-        return None;
-    };
-    let Some((host, port)) = crate::policy::split_host_port(amf_uri) else {
-        log::warn!("[{supi}] AMF URI '{amf_uri}' is not a valid URI: no EBI requested");
-        return None;
-    };
-
     let body = serde_json::json!({
         "pduSessionId": pdu_session_id,
         // One ARP entry, so one EBI: this SMF authorises a single default QoS flow
@@ -130,27 +114,7 @@ pub async fn request_ebi(
         "arpList": [default_flow_arp(arp_priority_level)],
     });
 
-    let path = format!("/namf-comm/v1/ue-contexts/{supi}/assign-ebi");
-    let request = nextgcore_sbi::message::SbiRequest::post(&path).with_body(
-        body.to_string(),
-        nextgcore_sbi::constants::content_type::APPLICATION_JSON,
-    );
-    let client = nextgcore_sbi::client::SbiClient::new(
-        nextgcore_sbi::security::sbi_peer_client_config(&host, port)
-            .with_connect_timeout(std::time::Duration::from_secs(2))
-            .with_request_timeout(std::time::Duration::from_secs(3)),
-    );
-
-    let response = match client.send_request(request).await {
-        Ok(resp) => resp,
-        Err(e) => {
-            log::warn!(
-                "[{supi}] EBI assignment to {host}:{port} failed: {e}. The session \
-                 proceeds without EPS interworking."
-            );
-            return None;
-        }
-    };
+    let response = post_assign_ebi(amf_uri, supi, pdu_session_id, &body, "assignment").await?;
     if response.status != 200 {
         log::warn!(
             "[{supi}] AMF refused EBI assignment for PSI {pdu_session_id}: status={}. \
@@ -167,6 +131,115 @@ pub async fn request_ebi(
         );
         None
     })
+}
+
+/// Give an assigned EBI back to the AMF when its PDU session is released
+/// (issue #291, TS 29.518 §6.1.6.2.5's `releasedEbiList`).
+///
+/// The identity space is **eleven wide per UE** — TS 24.301 §9.3.2 reserves 0..=4 —
+/// so an SMF that assigns and never releases exhausts it after eleven session
+/// lifetimes rather than after eleven concurrent bearers. `next_free_ebi` on the AMF
+/// side is lowest-free, so the space does not look under pressure until it is gone,
+/// and the twelfth session gets a `403 INSUFFICIENT_RESOURCES` with no live bearers
+/// to account for it. The failure is silent in the direction that matters:
+/// [`request_ebi`] treats every failure as non-fatal, so nothing surfaces except
+/// that interworking has quietly stopped working for that subscriber.
+///
+/// Returns `true` when the AMF confirmed the release. A `false` is **not** a session
+/// failure — see the module's failure posture — but it does mean one identity is
+/// leaked until the UE deregisters, which is why the log names it.
+///
+/// The disabled leg returns early and says nothing: `false` would otherwise conflate
+/// "not attempted" with "attempted and lost", and the leak warning below would name a
+/// consequence that a deployment with interworking off cannot have.
+pub async fn release_ebi(amf_uri: Option<&str>, supi: &str, pdu_session_id: u8, ebi: u8) -> bool {
+    if !enabled() {
+        return false;
+    }
+    let body = serde_json::json!({
+        "pduSessionId": pdu_session_id,
+        // The AMF frees these BEFORE it allocates anything in the same request, and
+        // treats a release of an EBI it does not hold as a success — so this is
+        // safely repeatable and cannot strand a retry (`handle_assign_ebi`).
+        "releasedEbiList": [ebi],
+    });
+
+    let Some(response) = post_assign_ebi(amf_uri, supi, pdu_session_id, &body, "release").await
+    else {
+        // `post_assign_ebi` logs why it could not send; name the consequence here,
+        // where the leaked identity is known.
+        log::warn!(
+            "[{supi}] EPS bearer identity {ebi} (PSI {pdu_session_id}) could not be \
+             returned to the AMF and is LEAKED until this UE deregisters: the UE has \
+             eleven per its whole registration, so repeated releases like this one end \
+             in a 403 for a session with no live bearers"
+        );
+        return false;
+    };
+    if response.status != 200 {
+        log::warn!(
+            "[{supi}] AMF refused to release EPS bearer identity {ebi} (PSI \
+             {pdu_session_id}): status={}. The identity is LEAKED until this UE \
+             deregisters.",
+            response.status
+        );
+        return false;
+    }
+    log::info!("[{supi}] EPS bearer identity {ebi} (PSI {pdu_session_id}) returned to the AMF");
+    true
+}
+
+/// POST an `AssignEbiData` body to the UE's `assign-ebi` resource.
+///
+/// One place where the leg's switch, the AMF authority and the client posture are
+/// decided, because the assignment and the release differ only in the body they
+/// carry: two copies of this would be two chances for the switch check or the
+/// timeouts to drift apart. `None` means nothing was sent, and why is logged here.
+///
+/// `amf_uri` is the AMF's callback root, which is the only address the SMF has for
+/// it — the same source `send_n1_n2_message_transfer` uses. A session whose create
+/// carried no `smContextStatusUri` therefore can neither get an EBI nor give one
+/// back, and says so.
+async fn post_assign_ebi(
+    amf_uri: Option<&str>,
+    supi: &str,
+    pdu_session_id: u8,
+    body: &serde_json::Value,
+    what: &str,
+) -> Option<nextgcore_sbi::message::SbiResponse> {
+    if !enabled() {
+        return None;
+    }
+    let Some(amf_uri) = amf_uri else {
+        log::warn!(
+            "[{supi}] EPS interworking is on but the AMF supplied no callback URI: \
+             no EBI {what} is possible for PSI {pdu_session_id}"
+        );
+        return None;
+    };
+    let Some((host, port)) = crate::policy::split_host_port(amf_uri) else {
+        log::warn!("[{supi}] AMF URI '{amf_uri}' is not a valid URI: no EBI {what} attempted");
+        return None;
+    };
+
+    let path = format!("/namf-comm/v1/ue-contexts/{supi}/assign-ebi");
+    let request = nextgcore_sbi::message::SbiRequest::post(&path).with_body(
+        body.to_string(),
+        nextgcore_sbi::constants::content_type::APPLICATION_JSON,
+    );
+    let client = nextgcore_sbi::client::SbiClient::new(
+        nextgcore_sbi::security::sbi_peer_client_config(&host, port)
+            .with_connect_timeout(std::time::Duration::from_secs(2))
+            .with_request_timeout(std::time::Duration::from_secs(3)),
+    );
+
+    match client.send_request(request).await {
+        Ok(resp) => Some(resp),
+        Err(e) => {
+            log::warn!("[{supi}] EBI {what} to {host}:{port} failed: {e}");
+            None
+        }
+    }
 }
 
 /// Pull the first usable EBI out of an `AssignedEbiData` body.

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -4625,6 +4625,31 @@ async fn handle_sm_context_release(
         }
     }
 
+    // #291: give this session's EPS bearer identity back to the AMF, which owns the
+    // space. Same shape as the EASDF delete above and for the same reason: read off
+    // the binding taken above, so a session that never had an EBI costs nothing, and
+    // best-effort because the session is leaving either way.
+    //
+    // Without this the eleven-wide per-UE space (TS 24.301 §9.3.2 reserves 0..=4)
+    // leaks one identity per session lifetime, and because the AMF allocates
+    // lowest-free it does not look under pressure until the twelfth session gets a
+    // 403 with no live bearers to show for it.
+    //
+    // The AMF's authority is the same `smContextStatusUri` callback root the
+    // assignment used and that this handler notifies below — the only address this
+    // SMF has for it.
+    if let Some(binding) = &binding {
+        if let Some(ebi) = binding.mapped_eps_bearer_id {
+            eps_iwk::release_ebi(
+                binding.sm_context_status_uri.as_deref(),
+                &binding.supi,
+                binding.psi,
+                ebi,
+            )
+            .await;
+        }
+    }
+
     // #79: Nsmf_EventExposure_Notify for PDU_SES_REL (TS 29.508 §4.2.3.2). Emitted
     // from the binding taken above, so a subscription scoped to this SUPI or this
     // PDU session id can be matched. A session with no matching subscription costs
@@ -6471,6 +6496,202 @@ mod tests {
         easdf::set_for_test(None);
         easdf_srv.stop().await.expect("stop");
         nrf.stop().await.expect("stop");
+    }
+
+    /// Seed a binding that carries an assigned EBI and an AMF callback root, i.e.
+    /// the state a session established with EPS interworking on leaves behind (#291).
+    fn seed_binding_with_ebi(sm_context_ref: &str, psi: u8, ebi: u8, amf_uri: &str) {
+        seed_binding(sm_context_ref, psi);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut(sm_context_ref) {
+                    b.mapped_eps_bearer_id = Some(ebi);
+                    b.sm_context_status_uri = Some(amf_uri.to_string());
+                }
+            }
+        }
+    }
+
+    /// A loopback AMF that answers `assign-ebi` with an `AssignedEbiData` echoing
+    /// the released list, and records every request it received (#291).
+    async fn spawn_recording_amf() -> (
+        nextgcore_sbi::server::SbiServer,
+        String,
+        std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>>,
+    ) {
+        use nextgcore_sbi::message::SbiResponse;
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let port = nextgcore_sbi::test_support::free_port();
+        let amf = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            port,
+        ))));
+        amf.start(move |req: SbiRequest| {
+            let sink = sink.clone();
+            async move {
+                let body = req.http.content.clone().unwrap_or_default();
+                sink.lock().unwrap_or_else(|e| e.into_inner()).push((
+                    req.header.method.clone(),
+                    req.header.uri.clone(),
+                    body.clone(),
+                ));
+                if !req.header.uri.ends_with("/assign-ebi") {
+                    // The RELEASED status notification lands here too; 204 is what
+                    // an AMF answers it with.
+                    return SbiResponse::with_status(204);
+                }
+                let released = serde_json::from_str::<serde_json::Value>(&body)
+                    .ok()
+                    .and_then(|b| b.get("releasedEbiList").cloned())
+                    .unwrap_or_else(|| serde_json::json!([]));
+                SbiResponse::with_status(200)
+                    .with_json_body(&serde_json::json!({
+                        "pduSessionId": 5,
+                        "assignedEbiList": [],
+                        "releasedEbiList": released,
+                    }))
+                    .unwrap_or_else(|_| SbiResponse::with_status(200))
+            }
+        })
+        .await
+        .expect("amf start");
+        (amf, format!("http://127.0.0.1:{port}"), seen)
+    }
+
+    /// #291 criterion 1: releasing a session whose binding carries an EBI returns
+    /// that EBI to the AMF in a `releasedEbiList`, asserted **over the wire from the
+    /// release handler**.
+    ///
+    /// Driven through `handle_sm_context_release` rather than by calling
+    /// `eps_iwk::release_ebi`, because the helper-is-tested-and-the-wiring-is-not
+    /// shape has bitten this exact area twice (#276's dead `create_dns_context`, and
+    /// #117's IE emitted only from builders with no production caller). What is
+    /// asserted is a recorded HTTP request with the identity in it.
+    #[tokio::test]
+    async fn releasing_a_session_returns_its_ebi_to_the_amf() {
+        let _g = eps_iwk::SWITCH_LOCK.lock().await;
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        eps_iwk::set_for_test(true);
+        let (amf, amf_uri, seen) = spawn_recording_amf().await;
+
+        seed_binding_with_ebi("ebi-release-ref", 5, 7, &amf_uri);
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+        let resp = handle_sm_context_release("ebi-release-ref", None).await;
+        assert_eq!(resp.status, 204, "the release itself must succeed");
+
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let release = requests
+            .iter()
+            .find(|(m, p, _)| m == "POST" && p.ends_with("/assign-ebi"))
+            .unwrap_or_else(|| {
+                panic!("the release handler must return the EBI to the AMF, got {requests:?}")
+            });
+        assert_eq!(
+            release.1, "/namf-comm/v1/ue-contexts/imsi-001010000000001/assign-ebi",
+            "addressed to the UE's own ue-context (TS 29.518 §6.1.6.2.5)"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(&release.2).expect("the request body is JSON");
+        assert_eq!(
+            body["releasedEbiList"],
+            serde_json::json!([7]),
+            "the identity on the binding is the one handed back, got {body}"
+        );
+        assert_eq!(
+            body["pduSessionId"],
+            serde_json::json!(5),
+            "pduSessionId is AssignEbiData's only required member"
+        );
+        assert!(
+            body.get("arpList").is_none(),
+            "a release must not ask for a new EBI in the same breath, got {body}"
+        );
+
+        // A session with NO EBI must not dial the AMF's assign-ebi at all: an SMF
+        // that did would send one request per released session in every deployment
+        // that does not use interworking.
+        seed_binding("ebi-release-none", 6);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut("ebi-release-none") {
+                    b.sm_context_status_uri = Some(amf_uri.clone());
+                }
+            }
+        }
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        let _ = handle_sm_context_release("ebi-release-none", None).await;
+        assert!(
+            !seen
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .iter()
+                .any(|(_, p, _)| p.ends_with("/assign-ebi")),
+            "a session that never had an EBI must not dial assign-ebi"
+        );
+
+        eps_iwk::set_for_test(false);
+        amf.stop().await.expect("stop");
+    }
+
+    /// #291 criterion 5: with interworking disabled the release path sends nothing,
+    /// even for a binding that carries an EBI from an earlier enabled run.
+    #[tokio::test]
+    async fn a_disabled_interworking_leg_releases_no_ebi() {
+        let _g = eps_iwk::SWITCH_LOCK.lock().await;
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        eps_iwk::set_for_test(false);
+        let (amf, amf_uri, seen) = spawn_recording_amf().await;
+
+        seed_binding_with_ebi("ebi-release-off", 5, 8, &amf_uri);
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+        assert_eq!(
+            handle_sm_context_release("ebi-release-off", None)
+                .await
+                .status,
+            204
+        );
+        assert!(
+            !seen
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .iter()
+                .any(|(_, p, _)| p.ends_with("/assign-ebi")),
+            "a disabled leg must not dial the AMF"
+        );
+
+        amf.stop().await.expect("stop");
+    }
+
+    /// #291 criterion 3: a failed release does not fail the session release.
+    ///
+    /// The session is going away either way, so the SMF cannot make its own
+    /// teardown depend on the AMF answering. Port 1 is closed, so the request
+    /// fails at connect.
+    #[tokio::test]
+    async fn a_failed_ebi_release_does_not_fail_the_session_release() {
+        let _g = eps_iwk::SWITCH_LOCK.lock().await;
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        eps_iwk::set_for_test(true);
+
+        seed_binding_with_ebi("ebi-release-dead", 5, 9, "http://127.0.0.1:1");
+        let resp = handle_sm_context_release("ebi-release-dead", None).await;
+        assert_eq!(
+            resp.status, 204,
+            "an unreachable AMF must not turn a session release into a failure"
+        );
+        // The binding is gone regardless: the release completed locally.
+        assert!(
+            lookup_policy_binding("ebi-release-dead").is_none(),
+            "the release must complete even when the EBI could not be returned"
+        );
+
+        eps_iwk::set_for_test(false);
     }
 
     fn n1(psi: u8, pti: u8, message_type: u8, tail: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Closes #291.

#117 implemented both halves of EBI *assignment* and neither half of the release. The SMF never sent a `releasedEbiList`, so every released session left its identity held. The space is **eleven wide per UE** (TS 24.301 §9.3.2 reserves 0..=4) and `next_free_ebi` is lowest-free, so it does not *look* under pressure until it is gone: the twelfth establish/release cycle gets `403 INSUFFICIENT_RESOURCES` with no live bearers to account for it — and silently, because `request_ebi` treats every failure as non-fatal by design.

## The verification that changed the fix

#291 asked whether deregistration already frees the identities because the UE context is dropped. **It does not**, and the reason is worse than the issue guessed:

`amf_ue_remove` has **no production caller** — grep finds its definition, `amf_ue_remove_all` (context teardown), and three test call sites. `handle_deregistration_request_nas` releases the PDU sessions, purges the UDM registration, answers the UE and calls `finish_deregistration`, which drops the NAS state and releases the NG context. The stored `AmfUe`, and every `AssignedEbi` on it, survives all of that.

So the leak was bounded by the **AMF process lifetime**, not by the UE's registration — and the SMF-side release would have been a single point of failure for the whole space. The backstop is therefore **implemented** rather than merely considered. It is not an invention: TS 23.502 §4.2.2.3.2 has deregistration release every PDU session, and an EBI exists only to map one of those into EPS.

## Where the backstop is wired, and where it deliberately is not

`gmm_handler::handle_deregistration_request` takes the `AmfUe` mutably and looks like the natural home. It has **no production caller either** — only its own test. Putting it there would have shipped a tested change that never runs, which is exactly what #276 found in the EASDF leg. It goes in `finish_deregistration` (the common tail of both deregistration directions), before `ue_auth_state.remove`, because that is where the SUPI keying the stored `AmfUe` comes from. **The wiring has its own test through the NGAP tail**, not just the state change.

## A failed release is logged with the identity named, not retried

The session is leaving either way. A retry queue that survives what it needs to survive means durable state, and an in-memory queue is lost by exactly the restart most likely to have dropped the request (#191's snapshot does not model one). The backstop is what makes logging *sufficient* rather than merely cheap: a lost release now leaks one identity until the UE deregisters instead of forever.

## Acceptance criteria

- [x] Releasing a session whose binding carries an EBI sends `assign-ebi` with that EBI in `releasedEbiList`, asserted over the wire **from the release handler**
- [x] Twelve sequential establish/release cycles keep succeeding; the twelfth gets an EBI rather than a 403 (the test also pins the other direction: eleven unreleased sessions exhaust the space)
- [x] A failed release does not fail the session release, and the leaked identity is named
- [x] Whether AMF deregistration frees `assigned_ebis` is verified and stated — it did **not**, and now does
- [x] With interworking disabled, the release path sends nothing

## Verification

Workspace **6278 passed / 0 failed over three consecutive runs** (baseline 6272 on `eb3490e`; +6 — smfd 456 → 459, amfd 433 → 436). clippy and fmt clean.

| revert | expected to break | result |
|---|---|---|
| `release_ebi` call made unreachable | `releasing_a_session_returns_its_ebi_to_the_amf` | **1 failed** |
| a failed release made fatal to the session release | `a_failed_ebi_release_does_not_fail_the_session_release` | **2 failed** |
| dereg backstop call made unreachable | `deregistration_frees_the_ues_ebis_through_the_ngap_tail` | **1 failed** |
| the dereg clear not persisted | both dereg tests | **2 failed** |
| `handle_assign_ebi`'s `releasedEbiList` no longer frees (#117's release undone) | twelve-cycle test + 2 existing | **3 failed** |

Revert 2 also exposed a wart in this diff: `release_ebi` returned `false` for "leg disabled" as well as "attempted and lost", so the caller's log named a LEAKED identity for a deployment that cannot have one. It now returns early when disabled — the call site ignores the bool either way, but the log is now a true statement.

## Ceilings

- The release is asserted from the release handler; the **assignment's** call site still is not, because every create test runs with the leg off. #289's stand-in makes closing that a test away rather than a harness away; it is not in this issue's criteria.
- The twelve cycles are AMF-side: they drive the real router twelve times with a release between, which is what the SMF now sends, but no test drives both daemons in one process — the two halves meet at the wire format, not end to end.
- `releasedEbiList` carries exactly one identity, because this SMF authorises one default QoS flow per session. Nothing in the tree creates a session with several.
- Nothing frees an EBI if the AMF loses the UE **without** a deregistration (an implicit-detach path that drops `ue_auth_state` without running the tail). Those timers are #72's scope.

Spec: `specs/fix-smfd-amfd-ebi-release.md`