### PR TITLE
fix(smfd): deregister at the UDM, subscribe to SM data, and act on the notification (#293)

### DIFF
--- a/specs/fix-smfd-udm-sdm-subscribe-uecm-dereg.md
+++ b/specs/fix-smfd-udm-sdm-subscribe-uecm-dereg.md
@@ -1,0 +1,155 @@
+# nextgcore #293 (smfd): close the UDM loop — deregister, subscribe, and act on the notification
+
+Verified against `main` @ `3799767`.
+
+#293 was split out of #79, which implemented the two UDM operations its criteria named
+(`Nudm_UECM_Registration`, `Nudm_SDM_Get sm-data`) and neither of the two that close the loop.
+TS 29.503 §5.2.2.3 / §5.2.2.4 / §5.3.2.4, TS 23.502 §4.3.2.2.1.
+
+## Verified against current main
+
+| claim in the issue | site on `3799767` | still true? |
+|---|---|---|
+| the UECM registration is a PUT and nothing deletes it (`rg smf-registrations`) | `udm.rs:332` PUT only | yes |
+| `sm-data` is fetched once, at establishment | `main.rs:2845` | yes |
+| the SMF serves no `Nudm_SDM_Notification` handler | no `sdm` route in `smf_sbi_request_handler` | yes |
+| subscribing without one would notify into a 404 | the router's fallback is `send_not_found` | yes |
+| both hooks belong in `handle_sm_context_release` and read off `PolicyBinding` | `main.rs:4563` | yes |
+| `handle_sm_policy_notify` already re-authorises an existing session's N4 QER | `main.rs:5149` | yes |
+| the same decision about a failed teardown as #291 | #291 landed while this was open; same answer reused | yes |
+
+## Decision 1: the notification is a trigger to RE-READ, not a patch to apply
+
+TS 29.503's `ModificationNotification` carries `notifyItems[].changes[]` as operation / path /
+newValue triples over the `sm-data` document. Honouring that literally means implementing a patch
+interpreter over `dnnConfigurations`, which is a **free-form map keyed by DNN** — so a path this SMF
+fails to understand yields "no change" indistinguishably from "nothing changed", and a partially
+understood patch applies half an edit. Both failure modes are silent.
+
+Instead the handler re-reads the authoritative document with the same `fetch_sm_data` the
+establishment path uses, and applies the result through the same `apply_subscribed_baseline`. One
+behaviour to keep correct instead of two, and the notification's role is to say *when* and *for which
+resource*. A test asserts the re-read actually happens (the recorded `GET /sm-data`), so this is not
+a claim about intent.
+
+## Decision 2: the re-read is scoped to the session's own S-NSSAI, which needed two new binding fields
+
+`sm-data` is one entry per S-NSSAI and `parse_sm_data` falls back to the **first** entry when none
+matches. So a re-read that lost the session's S-NSSAI would apply *another slice's* session-AMBR and
+look like a successful update — the exact class of half-truth this backlog keeps finding.
+
+`PolicyBinding` carried no S-NSSAI (the create path had it in locals only), so `sst: u8` and
+`sd: Option<String>` are now stored on it. The `sd` is kept as the **hex string as received** rather
+than the parsed `u32` the session record holds: `parse_sm_data` compares it to the UDM's document as
+a string, and re-formatting `u32` → hex would risk a case/width mismatch against the value the AMF
+actually sent.
+
+The guard is a decoy: `sm_data_with` returns an ARRAY whose first entry is a different slice with
+different values, so every test asserting the real values also asserts the scoping. Reverting to the
+old hardcoded `(1, None)` fails a named test.
+
+## Decision 3: with a PCF configured, the SMF does NOT apply a subscription-driven change
+
+This is the precedence question #293 asks to be answered either way.
+
+TS 23.503 §6.1.3.2 makes the PCF the authority on session-AMBR and default QoS, and the
+**subscription is one of its inputs**. Re-deriving the session's QoS from the subscription behind the
+PCF's back would have the SMF enforce something the PCF never authorised — a conformance defect
+rather than a degradation, which is the same reasoning #79 recorded for the establishment-time
+precedence (`PCF` then `subscription` then `config default`).
+
+So a notification for a session with an `sm_policy_id` is accepted (`204`), logged, and **not
+applied**. The change reaches such a session when the PCF re-authorises it, which the PCF learns to
+do from its own policy-data subscription to the UDR — not from the SMF.
+
+**Consequence, stated rather than left implicit:** in a deployment whose PCF does not subscribe to
+policy-data changes, an administrative edit will not reach a PCF-authorised live session at all. That
+is a PCF-side gap, not an SMF-side one, and it is filed as its own follow-up. The alternative — the
+SMF forwarding the change to the PCF — was rejected because there is no such operation: an SMF sends
+`SmPolicyUpdateContextData` for triggers the PCF subscribed to, and "the subscribed QoS changed" is
+not one of them.
+
+## Decision 4: a failed teardown is logged with what is left behind, not retried
+
+Same answer and the same reasoning as #291, which landed while this was open: the session is leaving
+either way, and a retry queue that survives what it needs to survive means durable state. What
+differs is the consequence named in each log line, because the two leaks are not the same:
+
+- a stale **serving-SMF record** makes a procedure resolving the serving SMF through the UDM resolve
+  a *released* session to this SMF (it answers `404 CONTEXT_NOT_FOUND` at best), self-heals when the
+  same `pduSessionId` is reused, and is permanent for one that never is;
+- a stale **SDM subscription** keeps the UDM notifying a callback URI whose `smContextRef` no longer
+  resolves. The handler answers `404` to exactly that, deliberately, because that is what tells a
+  conformant UDM to stop.
+
+A `404` from either delete is treated as success: it means the UDM does not hold the resource, which
+is the state the call wanted.
+
+## Decision 5: the handler ships in the same change as the subscribe, and the callback URI is per session
+
+#79 left the subscribe out because subscribing creates a resource on the UDM whose notifications go
+to a callback URI, and an SMF that serves no handler would create a resource that notifies into a
+`404` — strictly worse than not subscribing, because the UDM then retries against us. So the route
+(`POST /nsmf-callback/v1/sdm-notify/{smContextRef}`) is part of this change, and
+`subscribe_sm_data`'s `callback_uri` parameter is the caller's proof that it has one.
+
+The URI is **per SM context** because the SMF chooses its shape and a notification has to name the
+live session it applies to. The subscription id comes from the `Location` header and is stored on the
+binding, so the release can delete the resource it created; a subscribe that succeeds without naming
+an id is reported as an orphan rather than stored as an empty string.
+
+## Acceptance criteria
+
+- [x] Releasing a session sends a UECM DELETE for its `pduSessionId`, asserted over the wire **from
+      the release handler** — `the_create_subscribes_to_sm_data_and_the_release_deregisters_and_unsubscribes`.
+- [x] A failed deregistration does not fail the session release, and names the leaked record —
+      `a_failed_udm_teardown_does_not_fail_the_session_release`.
+- [x] The SMF serves a `Nudm_SDM_Notification` callback that applies a changed session-AMBR /
+      default 5QI to a live session, asserted by driving the callback and reading back the session —
+      `a_sdm_notification_applies_the_changed_ambr_to_a_live_session`.
+- [x] `Nudm_SDM_Subscribe` is sent at establishment and `Unsubscribe` at release, and neither is sent
+      unless the callback route exists (Decision 5 — the route is in the same commit, and the
+      notification test drives it to a `204`, which no unknown-endpoint fallback can produce).
+- [x] The PCF-present precedence question is answered — Decision 3, and guarded: the same
+      notification against a PCF-authorised session changes nothing.
+- [x] With `SMF_UDM` unset, none of the above is sent —
+      `a_disabled_udm_leg_neither_deregisters_nor_unsubscribes`.
+
+## Verification
+
+Workspace **6283 passed / 0 failed** (baseline 6278 on `3799767`; +5 — smfd 459 → 464). `cargo clippy
+-p nextgcore-smfd --all-targets` zero warnings; `cargo fmt --all -- --check` clean.
+
+Six whole-workspace runs: **five green at 6283, one failure that is not this change** —
+`amfd::ngap_path::tests::modify_release_notify_and_modify_indication_all_relay_to_the_smf` failed
+once with `Failed to bind: Address already in use`, the `free_port` TOCTOU flake CI already documents
+and retries for. This branch touches no amfd file. Recorded rather than re-run until it disappeared.
+
+| revert | expected to break | result |
+|---|---|---|
+| the UECM DELETE removed from the release path | `the_create_subscribes_..._deregisters_and_unsubscribes` | **1 failed** |
+| the unsubscribe removed from the release path | same | **1 failed** |
+| the subscribe removed from the create path | same | **1 failed** |
+| the subscription id stored as `None` on the binding (the orphan case) | same | **1 failed** |
+| the PCF-precedence early return removed | `a_sdm_notification_applies_the_changed_ambr_to_a_live_session` | **1 failed** |
+| the session's own `session_ambr` left stale by the notification | same | **1 failed** |
+| the binding left stale by the notification | same | **1 failed** |
+| the re-read scoped to a hardcoded `(sst 1, sd None)` again | same (via the decoy entry) | **1 failed** |
+
+## Ceilings
+
+- **The notification handler applies session-AMBR and default 5QI, and nothing else.** `SubscribedSmData`
+  models only those plus the ARP priority level (#79's deliberate narrowing), so a change to any other
+  `DnnConfiguration` member is fetched, ignored and not reported as ignored. Widening the struct
+  without widening what enforces it would make more members *read* as implemented.
+- **The ARP priority level is re-read but not re-applied.** It reaches `PolicyDecision` and is used at
+  establishment (for the EBI request, #117); a mid-session ARP change does not re-drive that, because
+  re-requesting an EBI would mean releasing and re-assigning one for a session that is up.
+- **A binding restored from a pre-#293 snapshot has `sst: 0`**, so a notification for it re-reads
+  unscoped and `parse_sm_data` falls back to the first entry — i.e. exactly the pre-#293 behaviour,
+  for restored sessions only. Not worth a snapshot version bump: `#[serde(default)]` absorbs the new
+  members, which is the recorded bar for not bumping.
+- **The PCF-side half is out of scope and filed separately** (Decision 3): nothing makes a PCF
+  re-authorise a live session when the subscription changes.
+- **No test drives a UDM and a PCF together**, so "a PCF-authorised session ignores the notification"
+  is asserted with a seeded `sm_policy_id` rather than against a live PCF association.

--- a/src/bins/nextgcore-smfd/src/context.rs
+++ b/src/bins/nextgcore-smfd/src/context.rs
@@ -1556,6 +1556,23 @@ pub struct PolicyBinding {
     /// that work will read from, and keeping it empty-by-default means a session
     /// that never got a report is indistinguishable from the pre-#114 state.
     pub easdf_reported_eas: Vec<String>,
+    /// The session's S-NSSAI, as the create request stated it (#293).
+    ///
+    /// Kept here because a re-read of the subscriber's SM data has to be scoped to the
+    /// same slice the session was created for: `sm-data` is one entry per S-NSSAI, and
+    /// a lookup that guessed would apply another slice's session-AMBR to this session.
+    /// The `sd` is the hex string as received, not a parsed integer, so the value
+    /// compared against the UDM's document is the one the AMF sent rather than a
+    /// re-formatting of it.
+    pub sst: u8,
+    pub sd: Option<String>,
+    /// The `Nudm_SDM_Subscribe` subscription id for this session (#293), or `None`
+    /// when the UDM leg is off, no UDM was discoverable, or the subscribe failed.
+    ///
+    /// Held here for the same reason as `easdf_dns_context_id`: it is removed with the
+    /// binding at release, and a subscription whose session is gone is an orphan that
+    /// keeps notifying a callback URI whose `smContextRef` no longer resolves.
+    pub sdm_subscription_id: Option<String>,
 }
 
 impl PolicyBinding {
@@ -1584,6 +1601,9 @@ impl PolicyBinding {
             easdf_dns_context_id: None,
             mapped_eps_bearer_id: None,
             easdf_reported_eas: Vec::new(),
+            sst: 0,
+            sd: None,
+            sdm_subscription_id: None,
         }
     }
 }

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -1579,6 +1579,20 @@ async fn smf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
             }
         }
 
+        // #293: Nudm_SDM_Notification sink (TS 29.503 §5.2.2.6). The SMF chooses
+        // this URI when it subscribes, so its shape is ours: per SM context, so a
+        // notification names the live session it has to be applied to. The route
+        // exists BEFORE any subscribe is sent -- a subscription whose callback 404s
+        // is strictly worse than no subscription, because the UDM then retries
+        // against us.
+        ("nsmf-callback", "sdm-notify", "POST") => {
+            if let Some(sm_context_ref) = resource_id {
+                handle_sdm_notification(sm_context_ref, &request).await
+            } else {
+                send_bad_request("Missing SM context reference", None)
+            }
+        }
+
         // N1N2 Transfer Failure Notification (from AMF)
         ("nsmf-callback", "n1-n2-failure", "POST") => {
             if let Some(sm_context_ref) = resource_id {
@@ -2844,6 +2858,30 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
     .await;
     let subscribed = udm::fetch_sm_data(&supi, &dnn, sst, snssai_sd.as_deref()).await;
 
+    // #293: subscribe to changes in what was just fetched, so an administrative edit
+    // reaches a session that is already up (TS 23.502 §4.3.2.2.1 step 4,
+    // Nudm_SDM_Subscribe). The callback URI is per SM context and points at the route
+    // this same change added -- #79 left the subscribe out precisely because
+    // subscribing without a handler creates a UDM resource that notifies into a 404,
+    // which is worse than not subscribing.
+    //
+    // Awaited BEFORE the binding is stored so the id is recorded with it; a
+    // subscription created and not recorded is an orphan on the UDM, because the
+    // release path would have nothing to delete. Same shape, and same reason, as the
+    // EASDF DNS context below.
+    let sdm_subscription_id = udm::subscribe_sm_data(
+        &supi,
+        &format!(
+            "{}/nsmf-callback/v1/sdm-notify/{}",
+            self_sbi_uri(),
+            sm_context_ref
+        ),
+        &dnn,
+        sst,
+        snssai_sd.as_deref(),
+    )
+    .await;
+
     // ---- Npcf_SMPolicyControl_Create (TS 29.512 §4.2.2) ----
     let notification_uri = format!(
         "{}/nsmf-callback/v1/sm-policy-notify/{}",
@@ -3215,6 +3253,9 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
                     easdf_dns_context_id: easdf_dns_context_id.clone(),
                     easdf_reported_eas: Vec::new(),
                     mapped_eps_bearer_id,
+                    sst,
+                    sd: snssai_sd.clone(),
+                    sdm_subscription_id: sdm_subscription_id.clone(),
                 },
             );
         }
@@ -4625,6 +4666,23 @@ async fn handle_sm_context_release(
         }
     }
 
+    // #293: tell the UDM this session is over — remove the serving-SMF record and
+    // delete the SDM subscription created at establishment. Both read off the binding
+    // taken above, both are best-effort for the same reason as the EASDF delete, and
+    // both name what is left behind on failure.
+    //
+    // Without the deregistration a UDM accumulates serving-SMF records for released
+    // sessions, so a procedure resolving the serving SMF through the UDM resolves a
+    // released session to this SMF. Without the unsubscribe the UDM keeps notifying a
+    // callback URI whose smContextRef no longer resolves — which the notification
+    // handler answers 404 to, deliberately.
+    if let Some(binding) = &binding {
+        udm::deregister_serving_smf(&binding.supi, binding.psi).await;
+        if let Some(sub_id) = &binding.sdm_subscription_id {
+            udm::unsubscribe_sm_data(&binding.supi, sub_id).await;
+        }
+    }
+
     // #291: give this session's EPS bearer identity back to the AMF, which owns the
     // space. Same shape as the EASDF delete above and for the same reason: read off
     // the binding taken above, so a session that never had an EBI costs nothing, and
@@ -5201,6 +5259,174 @@ async fn handle_sm_policy_notify(sm_context_ref: &str, request: &SbiRequest) -> 
                 b.ambr_dl_bps = dec.sess_ambr_dl_bps;
                 b.five_qi = dec.def_five_qi;
             }
+        }
+        // Issue #191: durable too, not just in memory.
+        ctx.persist();
+    }
+
+    SbiResponse::with_status(204)
+}
+
+/// `POST /nsmf-callback/v1/sdm-notify/{smContextRef}` — `Nudm_SDM_Notification`
+/// (issue #293, TS 29.503 §5.2.2.6).
+///
+/// The UDM tells us the subscriber's SM data changed; this applies the change to the
+/// LIVE session so an administrative edit to a session-AMBR or default 5QI takes
+/// effect without waiting for the UE to re-establish. Before #293 an edit was
+/// invisible until then — the same class of defect #56 fixed on the HSS side for EPS.
+///
+/// **The change is re-fetched, not read out of the notification.** A
+/// `ModificationNotification` carries `notifyItems[].changes[]` as
+/// operation/path/newValue triples over the `sm-data` document, so honouring it
+/// literally means implementing a patch interpreter over a free-form
+/// `dnnConfigurations` map — where a path this SMF fails to understand yields "no
+/// change" indistinguishably from "nothing changed". Re-reading the authoritative
+/// document with the same `fetch_sm_data` the establishment path uses has one
+/// behaviour to keep correct instead of two, and cannot silently apply half an edit.
+/// The notification's role is to say *when*, and for which resource.
+///
+/// **With a PCF configured this SMF deliberately does NOT apply the change.** See
+/// the log line and `specs/fix-smfd-udm-sdm-subscribe-uecm-dereg.md`: TS 23.503
+/// §6.1.3.2 makes the PCF the authority on session-AMBR and default QoS, and a
+/// subscription-driven override applied behind its back would leave the SMF enforcing
+/// something the PCF never authorised.
+async fn handle_sdm_notification(sm_context_ref: &str, request: &SbiRequest) -> SbiResponse {
+    log::info!("Nudm_SDM_Notification for ref={sm_context_ref}");
+
+    // The body is parsed before the context lookup so a malformed notification is a
+    // 400 rather than a 404 for a session that does exist.
+    let Some(body) = request
+        .http
+        .content
+        .as_deref()
+        .and_then(|c| serde_json::from_str::<serde_json::Value>(c).ok())
+    else {
+        return problem_400(
+            "INVALID_MSG_FORMAT",
+            "ModificationNotification body required",
+        );
+    };
+
+    let Some(binding) = lookup_policy_binding(sm_context_ref) else {
+        // A notification for a session this SMF no longer holds means the
+        // unsubscribe did not reach the UDM. Answering 404 is what tells it to stop.
+        log::warn!(
+            "Nudm_SDM_Notification for unknown ref={sm_context_ref}: the SDM \
+             subscription outlived its session"
+        );
+        return send_not_found(
+            &format!("No SM context for ref={sm_context_ref}"),
+            Some("CONTEXT_NOT_FOUND"),
+        );
+    };
+
+    // `notifyItems` is what names the changed resource. An empty or absent list is
+    // accepted (204) and applied anyway: the UDM has told us this subscription's
+    // monitored resource changed, and refusing to act on a shape difference would
+    // make the leg silently useless against a UDM that reports it differently.
+    let items = body["notifyItems"].as_array().map(Vec::len).unwrap_or(0);
+    log::debug!("Nudm_SDM_Notification ref={sm_context_ref}: {items} notify item(s)");
+
+    if binding.sm_policy_id.is_some() {
+        // TS 23.503 §6.1.3.2. The PCF authorised this session's QoS with the
+        // subscription as one of its inputs; re-deriving it here from the
+        // subscription alone would override a policy decision with the value that
+        // decision was made from. The PCF learns about subscription changes through
+        // its own policy-data subscription to the UDR.
+        log::info!(
+            "[{}] SM data changed, but a PCF authorised this session ({}): the change \
+             is NOT applied here — the PCF is the authority on session-AMBR and default \
+             QoS (TS 23.503 §6.1.3.2) and learns of subscription changes from the UDR",
+            binding.supi,
+            binding.sm_policy_id.as_deref().unwrap_or("")
+        );
+        return SbiResponse::with_status(204);
+    }
+
+    // Scoped to the DNN *and* the S-NSSAI the session was created for: `sm-data` is
+    // one entry per S-NSSAI, so a guessed slice would apply another slice's
+    // session-AMBR to this session -- and `parse_sm_data` falls back to the first
+    // entry rather than failing, so the mistake would look like a successful update.
+    let Some(subscribed) = udm::fetch_sm_data(
+        &binding.supi,
+        &binding.dnn,
+        binding.sst,
+        binding.sd.as_deref(),
+    )
+    .await
+    else {
+        log::warn!(
+            "[{}] SM data changed but could not be re-read: ref={sm_context_ref} keeps \
+             the QoS it was established with",
+            binding.supi
+        );
+        return SbiResponse::with_status(204);
+    };
+
+    // Rebuild the same decision the establishment path would build now, so one code
+    // path decides what a subscription means (`apply_subscribed_baseline` over the
+    // config default) rather than two.
+    let mut decision = policy::PolicyDecision::config_default_for_dnn(&binding.dnn);
+    decision.apply_subscribed_baseline(&subscribed);
+
+    if decision.sess_ambr_ul_bps == binding.ambr_ul_bps
+        && decision.sess_ambr_dl_bps == binding.ambr_dl_bps
+        && decision.def_five_qi == binding.five_qi
+    {
+        log::info!(
+            "[{}] SM data notification for ref={sm_context_ref} changes nothing this \
+             session enforces",
+            binding.supi
+        );
+        return SbiResponse::with_status(204);
+    }
+
+    log::info!(
+        "[{}] applying changed SM data to ref={sm_context_ref}: AMBR UL/DL {}/{} -> \
+         {}/{} bps, 5QI {} -> {}",
+        binding.supi,
+        binding.ambr_ul_bps,
+        binding.ambr_dl_bps,
+        decision.sess_ambr_ul_bps,
+        decision.sess_ambr_dl_bps,
+        binding.five_qi,
+        decision.def_five_qi
+    );
+
+    // The N4 QER, through the SAME function the PCF-update path uses: a second way to
+    // change a live session's QoS is a second thing to keep correct, and #293 asks
+    // for this one explicitly.
+    if let Some(seid) = lookup_upf_seid(sm_context_ref) {
+        if let Err(e) = pfcp_update_session_qer(
+            smf_n4_seid_for(sm_context_ref),
+            seid,
+            binding.qfi,
+            decision.sess_ambr_ul_bps,
+            decision.sess_ambr_dl_bps,
+        )
+        .await
+        {
+            log::error!("Failed to apply subscription-updated QoS: {e}");
+            return SbiResponse::with_status(504);
+        }
+    }
+
+    if let Ok(ctx) = smf_self().read() {
+        if let Ok(mut bindings) = ctx.policy_bindings.write() {
+            if let Some(b) = bindings.get_mut(sm_context_ref) {
+                b.ambr_ul_bps = decision.sess_ambr_ul_bps;
+                b.ambr_dl_bps = decision.sess_ambr_dl_bps;
+                b.five_qi = decision.def_five_qi;
+            }
+        }
+        // The session carries the AMBR the Retrieve and the EPS-interworking encoders
+        // read, so leaving it stale would make the two disagree about one value.
+        if let Some(mut sess) = ctx.sess_find_by_sm_context_ref(sm_context_ref) {
+            sess.session_ambr = context::SessionAmbr {
+                uplink: decision.sess_ambr_ul_bps,
+                downlink: decision.sess_ambr_dl_bps,
+            };
+            ctx.sess_update(&sess);
         }
         // Issue #191: durable too, not just in memory.
         ctx.persist();
@@ -6234,6 +6460,11 @@ mod tests {
                         easdf_dns_context_id: None,
                         mapped_eps_bearer_id: None,
                         easdf_reported_eas: Vec::new(),
+                        sst: 1,
+                        sd: Some("010203".to_string()),
+                        // #293: no SDM subscription by default, so the release path
+                        // has nothing to unsubscribe.
+                        sdm_subscription_id: None,
                     },
                 );
             }
@@ -6498,6 +6729,99 @@ mod tests {
         nrf.stop().await.expect("stop");
     }
 
+    /// A loopback UDM that records every request and answers the four operations the
+    /// SMF performs: `sm-data` (with whatever body the caller installs),
+    /// `sdm-subscriptions` (201 + Location), the UECM registration (201) and both
+    /// deletes (204). Returns the recorded `(method, uri, body)` list (#293).
+    ///
+    /// Points `UDM_SBI_*` at itself, which is how both discovery paths find a UDM in
+    /// tests; the caller must hold `crate::UDM_ENV_TEST_LOCK`.
+    async fn spawn_recording_udm(
+        sm_data: serde_json::Value,
+    ) -> (
+        nextgcore_sbi::server::SbiServer,
+        std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>>,
+    ) {
+        use nextgcore_sbi::message::SbiResponse;
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let port = nextgcore_sbi::test_support::free_port();
+        let udm = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            port,
+        ))));
+        udm.start(move |req: SbiRequest| {
+            let sink = sink.clone();
+            let sm_data = sm_data.clone();
+            async move {
+                sink.lock().unwrap_or_else(|e| e.into_inner()).push((
+                    req.header.method.clone(),
+                    req.header.uri.clone(),
+                    req.http.content.clone().unwrap_or_default(),
+                ));
+                if req.header.method == "DELETE" {
+                    return SbiResponse::with_status(204);
+                }
+                if req.header.uri.contains("/sdm-subscriptions") {
+                    return SbiResponse::with_status(201)
+                        .with_header(
+                            "Location",
+                            format!("{}/sub-293", req.header.uri.trim_end_matches('/')),
+                        )
+                        .with_json_body(&serde_json::json!({ "subscriptionId": "sub-293" }))
+                        .unwrap_or_else(|_| SbiResponse::with_status(201));
+                }
+                if req.header.uri.contains("/sm-data") {
+                    return SbiResponse::with_status(200)
+                        .with_json_body(&sm_data)
+                        .unwrap_or_else(|_| SbiResponse::with_status(200));
+                }
+                SbiResponse::with_status(201)
+            }
+        })
+        .await
+        .expect("udm start");
+
+        std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
+        std::env::set_var("UDM_SBI_PORT", port.to_string());
+        (udm, seen)
+    }
+
+    /// An `sm-data` body with the given session-AMBR and default 5QI for `internet` on
+    /// S-NSSAI `{sst:1, sd:010203}` — the slice `create_request` and `seed_binding`
+    /// use — behind a DECOY entry for a different slice.
+    ///
+    /// The decoy is the point (#293): `sm-data` is one entry per S-NSSAI and
+    /// `parse_sm_data` falls back to the FIRST entry when none matches, so a re-read
+    /// that lost the session's S-NSSAI would apply these decoy values and look like a
+    /// successful update. Any test asserting the real values therefore also asserts
+    /// that the re-read stayed scoped to the right slice.
+    fn sm_data_with(ul: &str, dl: &str, five_qi: u8) -> serde_json::Value {
+        serde_json::json!([
+            {
+                "singleNssai": { "sst": 2 },
+                "dnnConfigurations": {
+                    "internet": {
+                        "sessionAmbr": { "uplink": "1 Mbps", "downlink": "2 Mbps" },
+                        "5gQosProfile": { "5qi": 9, "arp": { "priorityLevel": 15 } }
+                    }
+                }
+            },
+            {
+                "singleNssai": { "sst": 1, "sd": "010203" },
+                "dnnConfigurations": {
+                    "internet": {
+                        "sessionAmbr": { "uplink": ul, "downlink": dl },
+                        "5gQosProfile": { "5qi": five_qi, "arp": { "priorityLevel": 8 } }
+                    }
+                }
+            }
+        ])
+    }
+
     /// Seed a binding that carries an assigned EBI and an AMF callback root, i.e.
     /// the state a session established with EPS interworking on leaves behind (#291).
     fn seed_binding_with_ebi(sm_context_ref: &str, psi: u8, ebi: u8, amf_uri: &str) {
@@ -6694,6 +7018,327 @@ mod tests {
         eps_iwk::set_for_test(false);
     }
 
+    /// #293 criteria 1 + 4: the create subscribes to SM data, and the release both
+    /// deregisters the serving-SMF record and deletes that subscription.
+    ///
+    /// End to end through the real handlers, which #289's UPF stand-in is what makes
+    /// possible: before it, no test could drive a create past its N4 leg, so a
+    /// subscribe on the establishment path could only have been asserted by calling
+    /// the helper — the shape that let #276's dead `create_dns_context` survive a month.
+    ///
+    /// Lock order (see `pfcp_path::N4_TEST_LOCK`): switch locks first, N4 last.
+    #[tokio::test]
+    async fn the_create_subscribes_to_sm_data_and_the_release_deregisters_and_unsubscribes() {
+        let _g = udm::SWITCH_LOCK.lock().await;
+        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let upf = pfcp_path::stand_in::associated_upf().await;
+        let (udm_srv, seen) = spawn_recording_udm(sm_data_with("100 Mbps", "500 Mbps", 7)).await;
+        udm::set_for_test(true);
+        smf_context_init(64, 256, 512);
+
+        let supi = "imsi-001010000000293";
+        let psi = 8u8;
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        let resp = handle_sm_context_create(&create_request(
+            supi,
+            psi,
+            &n1(
+                psi,
+                1,
+                gsm_build::message_type::PDU_SESSION_ESTABLISHMENT_REQUEST,
+                &[0x91, 0x00],
+            ),
+        ))
+        .await;
+        assert_eq!(resp.status, 201, "the create must reach the success path");
+        let sm_context_ref = serde_json::from_str::<serde_json::Value>(
+            resp.http.content.as_deref().expect("JSON root"),
+        )
+        .expect("json")["smContextRef"]
+            .as_str()
+            .expect("smContextRef")
+            .to_string();
+        assert!(
+            upf.seen()
+                .contains(&pfcp_path::pfcp_message_type::SESSION_ESTABLISHMENT_REQUEST),
+            "the 201 must have been earned on the N4 wire"
+        );
+
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let sub = requests
+            .iter()
+            .find(|(m, u, _)| m == "POST" && u.contains("/sdm-subscriptions"))
+            .unwrap_or_else(|| panic!("the create must send Nudm_SDM_Subscribe, got {requests:?}"));
+        assert_eq!(
+            sub.1,
+            format!("/nudm-sdm/v2/{supi}/sdm-subscriptions"),
+            "TS 29.503 §5.2.2.3's collection, at v2 like the rest of Nudm_SDM"
+        );
+        let body: serde_json::Value = serde_json::from_str(&sub.2).expect("json");
+        for required in ["nfInstanceId", "callbackReference", "monitoredResourceUris"] {
+            assert!(
+                body.get(required).is_some(),
+                "SdmSubscription.{required} is required, got {body}"
+            );
+        }
+        let callback = body["callbackReference"].as_str().unwrap_or_default();
+        assert!(
+            callback.ends_with(&format!("/nsmf-callback/v1/sdm-notify/{sm_context_ref}")),
+            "the callback must name the route this SMF serves and the session it is \
+             for, got {callback}"
+        );
+        assert!(
+            body["monitoredResourceUris"][0]
+                .as_str()
+                .unwrap_or_default()
+                .contains("/sm-data"),
+            "the monitored resource is the sm-data document this session depends on, \
+             got {body}"
+        );
+        // The subscription id is recorded on the binding, or the release could not
+        // delete it (the orphan case `subscribe_sm_data` warns about).
+        assert_eq!(
+            lookup_policy_binding(&sm_context_ref).and_then(|b| b.sdm_subscription_id),
+            Some("sub-293".to_string()),
+            "the id from the Location header must be stored with the binding"
+        );
+
+        // ---- release: the UECM record goes, and so does the subscription ----
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        assert_eq!(
+            handle_sm_context_release(&sm_context_ref, None)
+                .await
+                .status,
+            204
+        );
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            requests.iter().any(|(m, u, _)| m == "DELETE"
+                && u == &format!("/nudm-uecm/v1/{supi}/registrations/smf-registrations/{psi}")),
+            "the release must remove the serving-SMF record for its own pduSessionId, \
+             got {requests:?}"
+        );
+        assert!(
+            requests.iter().any(|(m, u, _)| m == "DELETE"
+                && u == &format!("/nudm-sdm/v2/{supi}/sdm-subscriptions/sub-293")),
+            "the release must delete the SDM subscription it created, got {requests:?}"
+        );
+
+        udm::set_for_test(false);
+        std::env::remove_var("UDM_SBI_ADDR");
+        std::env::remove_var("UDM_SBI_PORT");
+        udm_srv.stop().await.expect("stop");
+    }
+
+    /// #293 criterion 3: the notification callback applies a changed session-AMBR and
+    /// default 5QI to a LIVE session, read back off the session and the binding.
+    ///
+    /// Also the PCF-precedence half (criterion 5): the same notification against a
+    /// session a PCF authorised changes nothing, because TS 23.503 §6.1.3.2 makes the
+    /// PCF the authority and the subscription is one of its inputs.
+    #[tokio::test]
+    async fn a_sdm_notification_applies_the_changed_ambr_to_a_live_session() {
+        let _g = udm::SWITCH_LOCK.lock().await;
+        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        // The UDM now answers with DIFFERENT values from the ones the session holds.
+        let (udm_srv, seen) = spawn_recording_udm(sm_data_with("40 Mbps", "80 Mbps", 6)).await;
+        udm::set_for_test(true);
+        smf_context_init(64, 256, 512);
+
+        // A real registered session, so the fill-in the handler updates is there to
+        // read back.
+        let supi = "imsi-001010000000296";
+        let sm_context_ref = {
+            let ctx = smf_self();
+            let context = ctx.read().expect("context");
+            let (reference, _id) = register_sm_context(&context, supi, 9).expect("register");
+            reference
+        };
+        seed_binding(&sm_context_ref, 9);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut(&sm_context_ref) {
+                    b.supi = supi.to_string();
+                    b.sdm_subscription_id = Some("sub-293".to_string());
+                }
+            }
+        }
+
+        let notify = |reference: &str| {
+            SbiRequest::post(format!("/nsmf-callback/v1/sdm-notify/{reference}")).with_body(
+                serde_json::json!({
+                    "notifyItems": [{
+                        "resourceId": format!("/nudm-sdm/v2/{supi}/sm-data"),
+                        "changes": [{ "op": "REPLACE", "path": "/sessionAmbr" }],
+                    }]
+                })
+                .to_string(),
+                "application/json",
+            )
+        };
+
+        let resp = smf_sbi_request_handler(notify(&sm_context_ref)).await;
+        assert_eq!(
+            resp.status, 204,
+            "a notification for a live session is a 204"
+        );
+
+        // The session and the binding must BOTH carry the new values: the Retrieve and
+        // the EPS-interworking encoders read the session, the update and release paths
+        // read the binding, and a change applied to one leaves them disagreeing.
+        let binding = lookup_policy_binding(&sm_context_ref).expect("binding");
+        assert_eq!(
+            (binding.ambr_ul_bps, binding.ambr_dl_bps, binding.five_qi),
+            (40_000_000, 80_000_000, 6),
+            "the changed subscription must reach the binding"
+        );
+        let sess = smf_self()
+            .read()
+            .expect("context")
+            .sess_find_by_sm_context_ref(&sm_context_ref)
+            .expect("session");
+        assert_eq!(
+            (sess.session_ambr.uplink, sess.session_ambr.downlink),
+            (40_000_000, 80_000_000),
+            "and the session, which is what Retrieve answers with"
+        );
+        assert!(
+            seen.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .iter()
+                .any(|(m, u, _)| m == "GET" && u.contains("/sm-data")),
+            "the change is RE-READ from the UDM rather than parsed out of the \
+             notification -- see handle_sdm_notification"
+        );
+
+        // ---- PCF precedence: the same notification changes nothing ----
+        let pcf_ref = {
+            let ctx = smf_self();
+            let context = ctx.read().expect("context");
+            let (reference, _id) = register_sm_context(&context, supi, 10).expect("register");
+            reference
+        };
+        seed_binding(&pcf_ref, 10);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut(&pcf_ref) {
+                    b.supi = supi.to_string();
+                    b.sm_policy_id = Some("pol-1".to_string());
+                }
+            }
+        }
+        let before = lookup_policy_binding(&pcf_ref).expect("binding");
+        assert_eq!(smf_sbi_request_handler(notify(&pcf_ref)).await.status, 204);
+        let after = lookup_policy_binding(&pcf_ref).expect("binding");
+        assert_eq!(
+            (after.ambr_ul_bps, after.ambr_dl_bps, after.five_qi),
+            (before.ambr_ul_bps, before.ambr_dl_bps, before.five_qi),
+            "a PCF-authorised session must not be re-derived from the subscription: \
+             TS 23.503 §6.1.3.2 makes the PCF the authority, and the subscription is \
+             one of ITS inputs"
+        );
+
+        // A notification for a session this SMF does not hold is a 404, which is what
+        // tells the UDM to stop notifying a subscription that outlived its session.
+        assert_eq!(
+            smf_sbi_request_handler(notify("no-such-ref")).await.status,
+            404
+        );
+        // A malformed body is refused rather than silently accepted.
+        assert_eq!(
+            smf_sbi_request_handler(
+                SbiRequest::post(format!("/nsmf-callback/v1/sdm-notify/{sm_context_ref}"))
+                    .with_body("not json".to_string(), "application/json")
+            )
+            .await
+            .status,
+            400
+        );
+
+        udm::set_for_test(false);
+        std::env::remove_var("UDM_SBI_ADDR");
+        std::env::remove_var("UDM_SBI_PORT");
+        udm_srv.stop().await.expect("stop");
+    }
+
+    /// #293 criterion 2: a failed UDM teardown does not fail the session release.
+    ///
+    /// Port 1 is closed, so both the deregistration and the unsubscribe fail at
+    /// connect. The release must still answer 204 and still drop its local state — a
+    /// session whose teardown depends on the UDM answering would be a session the SMF
+    /// cannot release during a UDM outage.
+    #[tokio::test]
+    async fn a_failed_udm_teardown_does_not_fail_the_session_release() {
+        let _g = udm::SWITCH_LOCK.lock().await;
+        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        udm::set_for_test(true);
+        std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
+        std::env::set_var("UDM_SBI_PORT", "1");
+
+        seed_binding("udm-teardown-dead", 11);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut("udm-teardown-dead") {
+                    b.sdm_subscription_id = Some("sub-dead".to_string());
+                }
+            }
+        }
+
+        assert_eq!(
+            handle_sm_context_release("udm-teardown-dead", None)
+                .await
+                .status,
+            204,
+            "an unreachable UDM must not turn a session release into a failure"
+        );
+        assert!(
+            lookup_policy_binding("udm-teardown-dead").is_none(),
+            "the release must complete locally regardless"
+        );
+
+        udm::set_for_test(false);
+        std::env::remove_var("UDM_SBI_ADDR");
+        std::env::remove_var("UDM_SBI_PORT");
+    }
+
+    /// #293 criterion 6: with the UDM leg off, the release sends nothing — not even
+    /// for a binding that carries a subscription id from an earlier enabled run.
+    #[tokio::test]
+    async fn a_disabled_udm_leg_neither_deregisters_nor_unsubscribes() {
+        let _g = udm::SWITCH_LOCK.lock().await;
+        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let (udm_srv, seen) = spawn_recording_udm(sm_data_with("100 Mbps", "500 Mbps", 7)).await;
+        udm::set_for_test(false);
+
+        seed_binding("udm-off-ref", 12);
+        if let Ok(ctx) = smf_self().read() {
+            if let Ok(mut bindings) = ctx.policy_bindings.write() {
+                if let Some(b) = bindings.get_mut("udm-off-ref") {
+                    b.sdm_subscription_id = Some("sub-293".to_string());
+                }
+            }
+        }
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+        assert_eq!(
+            handle_sm_context_release("udm-off-ref", None).await.status,
+            204
+        );
+        let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            requests.is_empty(),
+            "a disabled UDM leg must not dial the UDM at all, got {requests:?}"
+        );
+
+        std::env::remove_var("UDM_SBI_ADDR");
+        std::env::remove_var("UDM_SBI_PORT");
+        udm_srv.stop().await.expect("stop");
+    }
+
     fn n1(psi: u8, pti: u8, message_type: u8, tail: &[u8]) -> Vec<u8> {
         let mut m = vec![0x2E, psi, pti, message_type];
         m.extend_from_slice(tail);
@@ -6714,6 +7359,11 @@ mod tests {
             "dnn": "internet",
             "anType": "3GPP_ACCESS",
             "ratType": "NR",
+            // #293: the serving PLMN, which `SmfRegistration.plmnId` is `required` to
+            // carry. A real AMF sends the GUAMI; without it the UECM registration is
+            // (correctly) not sent at all, so a create test that omitted it could not
+            // exercise the UDM leg.
+            "guami": { "plmnId": { "mcc": "001", "mnc": "01" } },
             "n1SmMsg": { "contentId": "n1SmMsg" },
         });
         SbiRequest::post("/nsmf-pdusession/v1/sm-contexts")

--- a/src/bins/nextgcore-smfd/src/udm.rs
+++ b/src/bins/nextgcore-smfd/src/udm.rs
@@ -364,9 +364,262 @@ pub async fn register_as_serving_smf(
     }
 }
 
+/// `Nudm_UECM_Deregistration` — remove the serving-SMF record when the PDU session
+/// is released (issue #293, TS 29.503 §5.3.2.4,
+/// `DELETE .../registrations/smf-registrations/{pduSessionId}`).
+///
+/// #79 added the registration and nothing removed it, so a UDM accumulated
+/// serving-SMF records for released sessions. The damage, in order of how badly it
+/// bites: a procedure resolving the serving SMF through the UDM resolves a
+/// **released** session to this SMF, which answers `404 CONTEXT_NOT_FOUND` at best;
+/// a re-established session with the same `pduSessionId` overwrites the stale record,
+/// so it self-heals for the common case and is permanent for a `pduSessionId` the UE
+/// never reuses; and `udmd`'s store grows without bound for long-lived subscribers.
+///
+/// Failure is non-fatal — the session is being released either way — and names the
+/// record that is now stale, because that is the only trace an operator gets.
+pub async fn deregister_serving_smf(supi: &str, pdu_session_id: u8) -> bool {
+    if !enabled() {
+        return false;
+    }
+    let Some((host, port)) = crate::discover_udm_uecm_endpoint().await else {
+        log::warn!(
+            "[{supi}] no UDM nudm-uecm endpoint: the serving-SMF record for PSI \
+             {pdu_session_id} is left behind and will resolve a released session to \
+             this SMF"
+        );
+        return false;
+    };
+    let path = format!("/nudm-uecm/v1/{supi}/registrations/smf-registrations/{pdu_session_id}");
+    let client = nextgcore_sbi::context::global_context()
+        .get_client(&host, port)
+        .await;
+    match client
+        .send_request(nextgcore_sbi::message::SbiRequest::delete(path))
+        .await
+    {
+        // 204 is the defined answer; 404 means the UDM does not hold it, which is the
+        // state this call wanted and not a failure worth reporting as one.
+        Ok(resp) if resp.is_success() || resp.status == 404 => {
+            log::info!(
+                "[{supi}] serving-SMF registration for PSI {pdu_session_id} removed \
+                 (status {})",
+                resp.status
+            );
+            true
+        }
+        Ok(resp) => {
+            log::warn!(
+                "[{supi}] Nudm_UECM_Deregistration for PSI {pdu_session_id} returned \
+                 status {}: the serving-SMF record is STALE and will resolve a released \
+                 session to this SMF",
+                resp.status
+            );
+            false
+        }
+        Err(e) => {
+            log::warn!(
+                "[{supi}] Nudm_UECM_Deregistration for PSI {pdu_session_id} failed: {e}: \
+                 the serving-SMF record is STALE and will resolve a released session to \
+                 this SMF"
+            );
+            false
+        }
+    }
+}
+
+/// `Nudm_SDM_Subscribe` — ask the UDM to notify this SMF when the subscriber's SM
+/// data changes (issue #293, TS 29.503 §5.2.2.3,
+/// `POST /nudm-sdm/v2/{supi}/sdm-subscriptions`).
+///
+/// Returns the subscription id, taken from the `Location` header the UDM must send
+/// (TS 29.503 §5.2.2.3.1), so the release path can delete the resource it created.
+/// `None` on any failure: a session without a subscription is a working session whose
+/// QoS simply does not follow a mid-session administrative edit, which is exactly the
+/// pre-#293 behaviour.
+///
+/// **The order matters and is the reason #79 left this out.** Subscribing creates a
+/// resource on the UDM whose notifications go to a callback URI, so a subscription
+/// sent by an SMF that serves no notification handler creates a resource that
+/// notifies into a `404` — strictly worse than not subscribing, because the UDM then
+/// retries against us. The handler
+/// (`nsmf-callback/v1/sdm-notify/{smContextRef}`) is therefore part of this same
+/// change, and `callback_uri` is the caller's proof that it has one.
+pub async fn subscribe_sm_data(
+    supi: &str,
+    callback_uri: &str,
+    dnn: &str,
+    sst: u8,
+    sd: Option<&str>,
+) -> Option<String> {
+    if !enabled() {
+        return None;
+    }
+    let (host, port) = crate::discover_udm_sdm_endpoint().await?;
+
+    // `nfInstanceId`, `callbackReference` and `monitoredResourceUris` are the three
+    // `required` members of SdmSubscription (TS 29.503). The monitored URI is the
+    // same `sm-data` resource `fetch_sm_data` reads, scoped to this session's DNN, so
+    // the UDM notifies about the document this session actually depends on.
+    let mut monitored = format!("/nudm-sdm/v2/{supi}/sm-data?dnn={dnn}&sst={sst}");
+    if let Some(sd) = sd {
+        monitored.push_str(&format!("&sd={sd}"));
+    }
+    let body = serde_json::json!({
+        "nfInstanceId": smf_instance_id(),
+        "callbackReference": callback_uri,
+        "monitoredResourceUris": [monitored],
+    });
+
+    let path = format!("/nudm-sdm/v2/{supi}/sdm-subscriptions");
+    let request = nextgcore_sbi::message::SbiRequest::post(path).with_body(
+        body.to_string(),
+        nextgcore_sbi::constants::content_type::APPLICATION_JSON,
+    );
+    let client = nextgcore_sbi::context::global_context()
+        .get_client(&host, port)
+        .await;
+    let response = match client.send_request(request).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            log::warn!(
+                "[{supi}] Nudm_SDM_Subscribe failed: {e}. Subscription changes will not \
+                 reach this session until it re-establishes."
+            );
+            return None;
+        }
+    };
+    if !response.is_success() {
+        log::warn!(
+            "[{supi}] Nudm_SDM_Subscribe returned status {}. Subscription changes will \
+             not reach this session until it re-establishes.",
+            response.status
+        );
+        return None;
+    }
+    let id =
+        subscription_id_from_location(response.http.get_header("Location").map(String::as_str))
+            .or_else(|| {
+                response
+                    .http
+                    .content
+                    .as_deref()
+                    .and_then(|c| serde_json::from_str::<serde_json::Value>(c).ok())
+                    .and_then(|v| {
+                        v.get("subscriptionId")
+                            .and_then(|s| s.as_str())
+                            .map(str::to_string)
+                    })
+            });
+    match id {
+        Some(id) => {
+            log::info!("[{supi}] subscribed to SM data changes (subscription {id})");
+            Some(id)
+        }
+        None => {
+            // A subscription whose id we do not know is a resource we can never
+            // delete: an orphan on the UDM, notifying a callback whose session is
+            // gone. Reported rather than stored as an empty string.
+            log::warn!(
+                "[{supi}] Nudm_SDM_Subscribe succeeded but named no subscription id \
+                 (no Location header): the subscription is an ORPHAN this SMF cannot delete"
+            );
+            None
+        }
+    }
+}
+
+/// Take the last non-empty path segment of a `Location` header as the resource id.
+///
+/// Separated so the shapes a conformant UDM may send are testable: an absolute URI,
+/// a relative path, and a path with a trailing slash all name the same id, and
+/// `udmd` itself answers with a relative one.
+pub fn subscription_id_from_location(location: Option<&str>) -> Option<String> {
+    let raw = location?.split('?').next().unwrap_or_default();
+    raw.trim_end_matches('/')
+        .rsplit('/')
+        .find(|seg| !seg.is_empty())
+        .map(str::to_string)
+}
+
+/// `Nudm_SDM_Unsubscribe` — delete the subscription created at establishment
+/// (issue #293, TS 29.503 §5.2.2.4,
+/// `DELETE /nudm-sdm/v2/{supi}/sdm-subscriptions/{subscriptionId}`).
+///
+/// Non-fatal, and the consequence named on failure is the one that matters: the
+/// subscription outlives the session, so the UDM keeps notifying a callback URI whose
+/// `smContextRef` no longer resolves.
+pub async fn unsubscribe_sm_data(supi: &str, subscription_id: &str) -> bool {
+    if !enabled() {
+        return false;
+    }
+    let Some((host, port)) = crate::discover_udm_sdm_endpoint().await else {
+        log::warn!(
+            "[{supi}] no UDM nudm-sdm endpoint: SDM subscription {subscription_id} is \
+             left behind and will notify a callback whose session is gone"
+        );
+        return false;
+    };
+    let path = format!("/nudm-sdm/v2/{supi}/sdm-subscriptions/{subscription_id}");
+    let client = nextgcore_sbi::context::global_context()
+        .get_client(&host, port)
+        .await;
+    match client
+        .send_request(nextgcore_sbi::message::SbiRequest::delete(path))
+        .await
+    {
+        Ok(resp) if resp.is_success() || resp.status == 404 => {
+            log::info!("[{supi}] SDM subscription {subscription_id} deleted");
+            true
+        }
+        Ok(resp) => {
+            log::warn!(
+                "[{supi}] Nudm_SDM_Unsubscribe({subscription_id}) returned status {}: the \
+                 subscription outlives its session and will notify a dead callback",
+                resp.status
+            );
+            false
+        }
+        Err(e) => {
+            log::warn!(
+                "[{supi}] Nudm_SDM_Unsubscribe({subscription_id}) failed: {e}: the \
+                 subscription outlives its session and will notify a dead callback"
+            );
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_subscription_id_is_the_last_segment_of_whatever_location_shape_arrives() {
+        assert_eq!(
+            subscription_id_from_location(Some(
+                "http://udm:7777/nudm-sdm/v2/imsi-1/sdm-subscriptions/sub-42"
+            )),
+            Some("sub-42".to_string())
+        );
+        assert_eq!(
+            subscription_id_from_location(Some("/nudm-sdm/v2/imsi-1/sdm-subscriptions/sub-42")),
+            Some("sub-42".to_string())
+        );
+        assert_eq!(
+            subscription_id_from_location(Some("/nudm-sdm/v2/imsi-1/sdm-subscriptions/sub-42/")),
+            Some("sub-42".to_string()),
+            "a trailing slash names the same resource"
+        );
+        assert_eq!(
+            subscription_id_from_location(Some("/sdm-subscriptions/sub-42?expires=1")),
+            Some("sub-42".to_string()),
+            "a query string is not part of the id"
+        );
+        assert_eq!(subscription_id_from_location(None), None);
+        assert_eq!(subscription_id_from_location(Some("")), None);
+        assert_eq!(subscription_id_from_location(Some("/")), None);
+    }
 
     #[test]
     fn bit_rates_parse_in_every_unit_and_refuse_nonsense() {


### PR DESCRIPTION
Closes #293.

#79 implemented the two UDM operations its criteria named and neither of the two that close the loop. Nothing deleted the serving-SMF record, so a UDM accumulated records for released sessions and a procedure resolving the serving SMF through the UDM resolved a **released** session to this SMF. And `sm-data` was fetched once, at establishment, so an administrative edit to a session-AMBR or default 5QI was invisible until the UE re-established — the same class of defect #56 fixed on the HSS side for EPS.

## The notification is a trigger to re-read, not a patch to apply

A `ModificationNotification` carries `notifyItems[].changes[]` as operation/path/newValue triples over the `sm-data` document, and `dnnConfigurations` is a **free-form map keyed by DNN** — so a path this SMF failed to understand would yield "no change" indistinguishably from "nothing changed", and a partly-understood patch would apply half an edit. Both silent.

The handler re-reads the authoritative document with the same `fetch_sm_data` the establishment path uses and applies it through the same `apply_subscribed_baseline`: one behaviour to keep correct instead of two. A test asserts the re-read actually happens (the recorded `GET /sm-data`) rather than trusting the comment.

## The re-read needed the session's S-NSSAI, and the binding did not have it

`sm-data` is one entry per S-NSSAI and `parse_sm_data` falls back to the **first** entry when none matches — so a re-read that lost the S-NSSAI would apply *another slice's* session-AMBR and look like a successful update. `PolicyBinding` now carries `sst` + `sd` (the hex string as received, not the parsed `u32` the session holds: `parse_sm_data` compares it as a string, and re-formatting risks a width/case mismatch against what the AMF sent).

**The guard is a decoy**: the test UDM answers with an array whose first entry is a different slice with different values, so every assertion on the real values also asserts the scoping. Restoring the hardcoded `(1, None)` fails a named test.

## With a PCF configured, the SMF deliberately does not apply the change

TS 23.503 §6.1.3.2 makes the PCF the authority on session-AMBR and default QoS, and the **subscription is one of its inputs** — re-deriving QoS from the subscription behind the PCF's back would have the SMF enforce something the PCF never authorised. The notification is accepted (`204`), logged, and not applied.

Consequence stated rather than implied: in a deployment whose PCF does not subscribe to policy-data changes, the edit reaches such a session only when it re-establishes. That is a **PCF-side gap and is filed separately**. Forwarding the change to the PCF was rejected because no such operation exists — an SMF sends `SmPolicyUpdateContextData` for triggers the PCF subscribed to, and "the subscribed QoS changed" is not one of them.

## Acceptance criteria

- [x] Releasing sends a UECM DELETE for its `pduSessionId`, asserted over the wire **from the release handler**
- [x] A failed deregistration does not fail the release, and names the leaked record
- [x] The SMF serves a `Nudm_SDM_Notification` callback that applies a changed session-AMBR / default 5QI to a live session, asserted by driving the callback and reading back the session
- [x] Subscribe at establishment, unsubscribe at release, and **neither before the handler exists** — the route ships in this commit, and the notification test drives it to a `204`, which no unknown-endpoint fallback can produce
- [x] The PCF-precedence question answered — and guarded: the same notification against a PCF-authorised session changes nothing
- [x] With `SMF_UDM` unset, none of it is sent

## Verification

Workspace **6283 passed / 0 failed** (baseline 6278 on `3799767`; +5 — smfd 459 → 464). clippy zero warnings for `nextgcore-smfd`, fmt clean.

**Six runs, five green at 6283.** One failure that is not this change: `amfd::ngap_path::tests::modify_release_notify_and_modify_indication_all_relay_to_the_smf` failed once with `Failed to bind: Address already in use` — the `free_port` TOCTOU flake CI already documents and retries for. This branch touches no amfd file. Recorded rather than re-run until it disappeared.

| revert | expected to break | result |
|---|---|---|
| UECM DELETE removed from the release path | `the_create_subscribes_..._deregisters_and_unsubscribes` | **1 failed** |
| unsubscribe removed from the release path | same | **1 failed** |
| subscribe removed from the create path | same | **1 failed** |
| subscription id stored as `None` (the orphan case) | same | **1 failed** |
| PCF-precedence early return removed | `a_sdm_notification_applies_the_changed_ambr_to_a_live_session` | **1 failed** |
| session's own `session_ambr` left stale | same | **1 failed** |
| binding left stale | same | **1 failed** |
| re-read scoped to a hardcoded `(sst 1, sd None)` | same, via the decoy | **1 failed** |

The end-to-end create → subscribe → release → unsubscribe test is only possible because of #289's UPF stand-in; before it, a subscribe on the establishment path could only have been asserted by calling the helper — the shape that let #276's dead `create_dns_context` survive a month.

## Ceilings

- The handler applies session-AMBR and default 5QI and **nothing else**: `SubscribedSmData` models only those plus the ARP priority level (#79's deliberate narrowing), so a change to any other `DnnConfiguration` member is fetched, ignored, and not reported as ignored.
- The ARP priority level is re-read but **not re-applied**: re-requesting an EBI would mean releasing and re-assigning one for a session that is up.
- A binding restored from a pre-#293 snapshot has `sst: 0`, so a notification for it re-reads unscoped — exactly the pre-#293 behaviour, for restored sessions only. No snapshot version bump: `#[serde(default)]` absorbs the new members, which is this repo's recorded bar.
- No test drives a UDM and a PCF together, so the precedence half uses a seeded `sm_policy_id` rather than a live PCF association.

Spec: `specs/fix-smfd-udm-sdm-subscribe-uecm-dereg.md`