### PR TITLE
fix(mbsmfd): release a shared MBS transport only when its last consumer leaves (#295)

### DIFF
--- a/specs/fix-mbsmfd-consumer-refcount.md
+++ b/specs/fix-mbsmfd-consumer-refcount.md
@@ -1,0 +1,119 @@
+# nextgcore #295 (mbsmfd): count the consumers on a shared MBS transport
+
+Verified against `main` @ `23148ce`.
+
+#295 is the other half of #76's gap 7. The SSM half ("SSM sessions are unmanageable") landed there;
+this is the consumer-counting half, left out because it needed a decision #76 did not settle.
+TS 23.247 §7.2.1.3 / §7.2.1.4.
+
+## Verified against current main
+
+| claim in the issue | site on `23148ce` | still true? |
+|---|---|---|
+| `ContextUpdateReqData.nfcInstanceId` is parsed and never tracked | `types.rs:374` (required, no default) | yes |
+| the terminate leg releases the transport unconditionally | `main.rs:1196-1223` | yes |
+| #76 made START idempotent (the establish side of the shared model) | `session_context_start` → `session_activate_n4mb` | yes |
+| `MbsSession.group_members` tracks UE SUPIs, not consumer NFs | `context.rs:163` | yes |
+| nothing on the ContextUpdate path touches `group_members` | grep: only `member_join`/`member_leave` | yes |
+| `session_context_terminate` marks ReleasePending; `release_n4mb_transport` clears | `context.rs:892`, `main.rs:1072` | yes |
+| the AMF N2 leg **also** releases the transport | `main.rs:1563` (`MbsDisRelReq`) | yes — **not stated in the issue**, see Ceilings |
+
+## Decision 1: a ContextUpdate START registers `nfcInstanceId`; TERMINATE deregisters; release on empty
+
+This is the decision #295 asks for, and it takes the issue's first option.
+
+Nothing in the tree registers a consumer, so the count has to start somewhere. TS 23.247 §7.2.1.3
+models the START as the establish side of a *shared* distribution session, which makes the START the
+honest place: the count becomes derivable from traffic the MB-SMF already sees, rather than from a
+member the schema does not have. The alternative — counting only an explicit `leaveInd` join/leave —
+would leave the shared-transport hazard on exactly the `leaveInd == false` path, which is the one
+most traffic takes.
+
+The risks the issue names are handled by **keying the set on `nfcInstanceId` rather than counting**:
+
+- a consumer that restarts and re-STARTs is the same entry, so it cannot inflate the count
+  (`a_repeated_start_from_one_consumer_does_not_double_count`);
+- a repeated TERMINATE removes an id that is no longer there, so it cannot release a transport another
+  consumer still holds. Reverting the set to counter semantics — remove *something* rather than the
+  named consumer — fails a named test.
+
+A session with **no** registered consumers yields "release", deliberately: sessions created before any
+START, and every existing single-consumer flow, keep releasing on the first TERMINATE. That is what
+makes criterion 6 hold without a special case.
+
+## Decision 2: the never-departing consumer is logged, not timed out
+
+#295 offers a TTL on the consumer entry, NRF liveness, or nothing-but-a-log.
+
+**Logged.** A TTL would have the MB-SMF tear down a transport that is still carrying data because a
+consumer was quiet — the failure it would introduce is worse than the one it fixes, and it is the same
+failure this issue exists to prevent (remaining consumers whose sessions look fine and stop
+receiving). NRF liveness is the principled answer and needs an NF-status subscription this daemon does
+not have; adding one is its own issue.
+
+So the pin is accepted and made visible: the terminate leg logs at `warn` with the remaining consumer
+ids, because nothing else in the system can name who is holding a transport open. Criterion 5 accepts
+either an implementation or an explicit log; this is the log, with the reasoning recorded rather than
+left as a shrug.
+
+## Decision 3: only the SMF leg registers, and the AMF N2 release stays unconditional
+
+The AMF leg's `nfcInstanceId` is the **AMF's**, and an AMF relaying N2 for shared delivery is not what
+pins the MB-UPF session. Counting it would let an AMF's silence hold a transport open, and — worse —
+deregistering it would find it absent from a set the SMF STARTs populate, so a legitimate N2-driven
+release would stop releasing anything. That would break `test_router_context_update_amf_release_golden_204`
+for a reason unrelated to what this issue is about.
+
+`session_context_terminate` therefore keeps its unconditional form for that leg, and
+`session_context_terminate_for` is the ref-counted one the SMF leg uses. The consequence is a real gap
+in a different dimension, filed separately — see Ceilings.
+
+## Acceptance criteria
+
+- [x] Two consumers START the same TMGI; the first to TERMINATE gets `204` and the transport stays up.
+      A test asserts `n4mb_session` is still present and no Session Deletion was sent.
+- [x] The second TERMINATE releases it; the test asserts the deletion is sent and the context is
+      cleared afterwards.
+- [x] A repeated TERMINATE from the same `nfcInstanceId` does not double-decrement.
+- [x] A START from an `nfcInstanceId` already in the set does not double-count.
+- [x] The never-departing-consumer decision is implemented or logged, and stated either way —
+      Decision 2.
+- [x] The existing release tests still pass: a session with exactly one consumer behaves as it does
+      today (95 → 97 tests, none changed).
+
+### How "no Session Deletion was sent" is asserted
+
+`release_n4mb_transport` is the only path that sends one, and it clears `n4mb_session` whether or not
+the MB-UPF answered — which is how the existing AMF-release test observes a release. So a context that
+is still present is a release that did not happen. Stated in the test rather than left as an
+inference, because it is the one assertion here that is indirect.
+
+## Verification
+
+Workspace **6285 passed / 0 failed** over three consecutive runs (baseline 6283 on `23148ce`; +2 —
+mbsmfd 95 → 97). `cargo clippy -p nextgcore-mbsmfd --all-targets` zero warnings; `cargo fmt --all --
+--check` clean.
+
+| revert | expected to break | result |
+|---|---|---|
+| the terminate ignores the consumer set (the #295 defect restored) | `two_consumers_share_a_transport_and_only_the_last_terminate_releases_it` | **1 failed** |
+| START does not register a consumer | both new tests | **2 failed** |
+| the set behaves as a counter (remove *something*, not the named id) | the two-consumer test | **1 failed** |
+| an empty `nfcInstanceId` is stored as a consumer | `a_repeated_start_from_one_consumer_does_not_double_count` | **1 failed** |
+
+## Ceilings
+
+- **The RAN-node dimension has the same first-writer-wins shape and is NOT fixed here.** The AMF leg
+  releases the shared transport on an `MbsDisRelReq` N2 container (`main.rs:1563`), which is one RAN
+  node's release of shared delivery — so it tears the MB-UPF session down for every other RAN node
+  still receiving. That needs a per-`ranNodeId` set, which nothing in the tree tracks, and it is a
+  different set from the `nfcInstanceId` one #295 scopes. Filed as its own issue.
+- **Nothing unpins a transport whose consumer never terminates** (Decision 2). The log names who holds
+  it; no timer or liveness check exists.
+- **The consumer set is memory-only**, like the rest of mbsmfd (`MbsSession` derives no serde and this
+  daemon has no `StateStore`). An MB-SMF restart loses the counts, so the first TERMINATE after a
+  restart releases a transport other consumers may still be using. Consistent with the whole daemon's
+  posture rather than a new gap, and worth naming because the recovery is worse than the steady state.
+- **A consumer sending an empty `nfcInstanceId`** cannot be tracked and keeps the pre-#295 behaviour.
+  The schema makes the member required, so this is a non-conformant peer; it is logged and accepted
+  rather than rejected, because rejecting it would be a new 400 for traffic that works today.

--- a/src/bins/nextgcore-mbsmfd/src/context.rs
+++ b/src/bins/nextgcore-mbsmfd/src/context.rs
@@ -174,6 +174,32 @@ pub struct MbsSession {
     /// thing, and matching on the received form is what makes a lookup agree with
     /// what was stored.
     pub ssm: Option<crate::types::Ssm>,
+    /// The NF consumers (`ContextUpdateReqData.nfcInstanceId`) currently receiving on
+    /// this session's shared N4mb transport (#295, TS 23.247 §7.2.1.3/§7.2.1.4).
+    ///
+    /// Distinct from [`Self::group_members`], which tracks UE SUPIs: a multicast MBS
+    /// session is a SHARED distribution session established once and reused across
+    /// joins, so the transport underneath it must outlive any single consumer's
+    /// departure. Before this set existed, the first consumer to send a ContextUpdate
+    /// TERMINATE released the MB-UPF session for every other consumer still receiving
+    /// on it — and the remaining consumers' sessions looked fine (state, SBI surface
+    /// and TMGI all unchanged) and simply stopped carrying data.
+    ///
+    /// Keyed on `nfcInstanceId` rather than counted, so a consumer that restarts and
+    /// re-STARTs is not counted twice and a repeated TERMINATE cannot decrement twice.
+    pub consumers: HashSet<String>,
+}
+
+/// What a consumer's ContextUpdate TERMINATE means for the shared transport (#295).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConsumerTerminate {
+    /// No MBS session matched the TMGI.
+    NotFound,
+    /// Other consumers are still receiving: the transport stays up. Carries who they
+    /// are, because nothing else in the system can name them.
+    ConsumerRemains { remaining: Vec<String> },
+    /// The set is now empty: this was the last consumer, so the transport is released.
+    LastConsumer,
 }
 
 impl MbsSession {
@@ -196,6 +222,7 @@ impl MbsSession {
             n4mb_session: None,
             group_members: HashSet::new(),
             ssm: None,
+            consumers: HashSet::new(),
         }
     }
 
@@ -886,9 +913,103 @@ impl MbSmfContext {
         self.session_activate_n4mb(id, upf_addr)
     }
 
+    /// Register a consumer NF on a session's shared transport (#295).
+    ///
+    /// Returns the consumer count after the insert, or `None` when no session matches
+    /// the TMGI. Idempotent: a consumer that restarts and re-STARTs the same session is
+    /// the same entry, which is what keying the set on `nfcInstanceId` buys.
+    ///
+    /// **Where the count starts, and why this leg.** #295 asks whether a ContextUpdate
+    /// START implicitly registers `nfcInstanceId` as a consumer. It does: nothing else
+    /// in the tree registers one, TS 23.247 §7.2.1.3 models the START as the establish
+    /// side of a shared session, and this makes the count derivable from traffic the
+    /// MB-SMF already sees rather than from a member the schema does not have. The
+    /// alternative — counting only an explicit `leaveInd` join/leave — would leave the
+    /// shared-transport hazard on exactly the `leaveInd == false` path that carries
+    /// most of the traffic.
+    pub fn session_consumer_register(&self, tmgi: &Tmgi, nfc_instance_id: &str) -> Option<usize> {
+        if nfc_instance_id.is_empty() {
+            return None;
+        }
+        let id = {
+            let tmgi_hash = self.tmgi_hash.read().ok()?;
+            *tmgi_hash.get(tmgi)?
+        };
+        let mut list = self.session_list.write().ok()?;
+        let session = list.get_mut(&id)?;
+        let fresh = session.consumers.insert(nfc_instance_id.to_string());
+        let count = session.consumers.len();
+        if fresh {
+            log::info!(
+                "[MBS] consumer {nfc_instance_id} registered on session {id} \
+                 (TMGI {:02x?}); {count} consumer(s) now hold its shared transport",
+                tmgi.mbs_service_id
+            );
+        }
+        Some(count)
+    }
+
+    /// ContextUpdate **Terminate** from one consumer (#295): deregister it and say
+    /// whether the shared transport may now be released.
+    ///
+    /// The transport is released only when the set becomes EMPTY. A consumer this
+    /// session does not hold does not decrement anything, so a repeated TERMINATE
+    /// cannot release a transport another consumer still holds.
+    ///
+    /// A session with no registered consumers at all yields [`ConsumerTerminate::
+    /// LastConsumer`], which is deliberately the pre-#295 behaviour: sessions created
+    /// before any START, and every existing single-consumer flow, must keep releasing
+    /// on the first TERMINATE.
+    pub fn session_context_terminate_for(
+        &self,
+        tmgi: &Tmgi,
+        nfc_instance_id: &str,
+    ) -> ConsumerTerminate {
+        let id = {
+            match self.tmgi_hash.read() {
+                Ok(h) => match h.get(tmgi) {
+                    Some(&id) => id,
+                    None => return ConsumerTerminate::NotFound,
+                },
+                Err(_) => return ConsumerTerminate::NotFound,
+            }
+        };
+        let remaining = {
+            let Ok(mut list) = self.session_list.write() else {
+                return ConsumerTerminate::NotFound;
+            };
+            let Some(session) = list.get_mut(&id) else {
+                return ConsumerTerminate::NotFound;
+            };
+            if !nfc_instance_id.is_empty() {
+                session.consumers.remove(nfc_instance_id);
+            }
+            let mut remaining: Vec<String> = session.consumers.iter().cloned().collect();
+            // Sorted so a log line and a test assertion are both deterministic over a
+            // HashSet.
+            remaining.sort();
+            remaining
+        };
+        if !remaining.is_empty() {
+            return ConsumerTerminate::ConsumerRemains { remaining };
+        }
+        // Last consumer: mark the transport for release exactly as the unconditional
+        // path does, so the two agree about what "terminating" means locally.
+        if self.session_context_terminate(tmgi) {
+            ConsumerTerminate::LastConsumer
+        } else {
+            ConsumerTerminate::NotFound
+        }
+    }
+
     /// ContextUpdate **Terminate** (SMF) / leave: resolve the MBS session by
     /// TMGI and release its N4mb multicast transport (drives the N4mb release
     /// path). Returns whether a session matched.
+    ///
+    /// Unconditional — it does not consult the consumer set (#295). Kept for the N2
+    /// (AMF) release leg, whose `nfcInstanceId` is the AMF's and therefore not a member
+    /// of the consumer set the SMF STARTs populate; see the spec's ceiling on the
+    /// per-RAN-node dimension.
     pub fn session_context_terminate(&self, tmgi: &Tmgi) -> bool {
         let id = {
             match self.tmgi_hash.read() {

--- a/src/bins/nextgcore-mbsmfd/src/main.rs
+++ b/src/bins/nextgcore-mbsmfd/src/main.rs
@@ -1192,17 +1192,49 @@ async fn handle_mbs_session_context_update(request: &SbiRequest) -> SbiResponse 
 
     let ctx = mbsmf_self();
 
-    // --- Terminate / leave: release the N4mb multicast transport.
+    // --- Terminate / leave: deregister this consumer, and release the N4mb
+    // multicast transport only when it was the LAST one (#295, TS 23.247
+    // §7.2.1.3/§7.2.1.4).
+    //
+    // A multicast MBS session is a SHARED distribution session established once and
+    // reused across joins. This leg used to release the transport for whichever
+    // consumer asked first, so one SMF leaving tore it down for every other SMF still
+    // receiving — and the remaining consumers' sessions looked fine (state, SBI
+    // surface, TMGI all unchanged) and simply stopped receiving, because the MB-UPF
+    // session underneath them had been deleted.
     if terminate {
-        let released = ctx
+        match ctx
             .read()
-            .map(|c| c.session_context_terminate(&tmgi))
-            .unwrap_or(false);
-        if !released {
-            return send_not_found(
-                "MBS session not found for ContextUpdate",
-                Some("CONTEXT_NOT_FOUND"),
-            );
+            .map(|c| c.session_context_terminate_for(&tmgi, &req.nfc_instance_id))
+            .unwrap_or(context::ConsumerTerminate::NotFound)
+        {
+            context::ConsumerTerminate::NotFound => {
+                return send_not_found(
+                    "MBS session not found for ContextUpdate",
+                    Some("CONTEXT_NOT_FOUND"),
+                );
+            }
+            context::ConsumerTerminate::ConsumerRemains { remaining } => {
+                // The never-departing-consumer decision (#295), logged rather than
+                // implemented: NOTHING unpins a transport whose remaining consumer
+                // never sends a TERMINATE. A TTL would have the MB-SMF tear down a
+                // transport that is still carrying data because a consumer was quiet,
+                // which is worse than the pin; tying it to NRF liveness needs an
+                // NF-status subscription this daemon does not have. So the pin is
+                // accepted and made visible, naming who holds it — nothing else in the
+                // system can.
+                log::warn!(
+                    "ContextUpdate Terminate from {} (TMGI {:02x?}): shared transport \
+                     stays UP for {} remaining consumer(s) {:?}. Nothing unpins it if \
+                     they never terminate (#295).",
+                    req.nfc_instance_id,
+                    tmgi.mbs_service_id,
+                    remaining.len(),
+                    remaining
+                );
+                return SbiResponse::with_status(204);
+            }
+            context::ConsumerTerminate::LastConsumer => {}
         }
         // #76: `session_context_terminate` now only marks the N4mb context
         // ReleasePending -- it used to zero it, discarding the remote SEID before
@@ -1230,6 +1262,33 @@ async fn handle_mbs_session_context_update(request: &SbiRequest) -> SbiResponse 
     }
 
     // --- SMF multicast Start: allocate cTeid + llSsm, drive N4mb establishment.
+    //
+    // #295: register this consumer FIRST, so the transport the establishment below
+    // brings up is already accounted for. Registering after would leave a window in
+    // which a second consumer's TERMINATE saw an empty set and released a transport
+    // this START had just asked for.
+    //
+    // Only this leg registers. The AMF leg's `nfcInstanceId` is the AMF's, and an AMF
+    // relaying N2 for shared delivery is not what pins the MB-UPF session — counting it
+    // would let an AMF's silence hold a transport open.
+    if ctx
+        .read()
+        .ok()
+        .and_then(|c| c.session_consumer_register(&tmgi, &req.nfc_instance_id))
+        .is_none()
+        && req.nfc_instance_id.is_empty()
+    {
+        // Not a rejection: `nfcInstanceId` is required by the schema, so an empty one
+        // is a peer sending a member it declares. Such a consumer cannot be counted and
+        // therefore cannot pin the transport — which is the pre-#295 behaviour for it.
+        log::warn!(
+            "ContextUpdate Start (TMGI {:02x?}) carried an empty nfcInstanceId: the \
+             consumer cannot be tracked, so the first Terminate releases the shared \
+             transport as it did before #295",
+            tmgi.mbs_service_id
+        );
+    }
+
     let upf_addr = configured_mb_upf_ip();
     let started = ctx
         .read()
@@ -2435,6 +2494,190 @@ mod tests {
             body,
             serde_json::to_string(&parsed).unwrap(),
             "byte-identical to the ContextUpdateRspData serde shape"
+        );
+    }
+
+    /// An SMF-leg ContextUpdate body for one consumer (#295).
+    fn smf_ctx_update_body(svc_hex: &str, nfc: &str, action: &str) -> String {
+        format!(
+            r#"{{"nfcInstanceId":"{nfc}","mbsSessionId":{{"tmgi":{{"mbsServiceId":"{svc_hex}","plmnId":{{"mcc":"001","mnc":"01"}}}}}},"requestedAction":"{action}"}}"#
+        )
+    }
+
+    /// The stored session for a service id seeded by `seed_global_session`.
+    fn stored_session(svc_id: [u8; 3]) -> MbsSession {
+        let tmgi = Tmgi {
+            mbs_service_id: svc_id,
+            plmn_id: PlmnId {
+                mcc: "001".to_string(),
+                mnc: "01".to_string(),
+            },
+        };
+        mbsmf_self()
+            .read()
+            .unwrap()
+            .session_find_by_tmgi(&tmgi)
+            .expect("session exists")
+    }
+
+    /// #295 criteria 1-3: two consumers share one transport, the first TERMINATE
+    /// leaves it up, the second releases it, and a repeated TERMINATE cannot release a
+    /// transport another consumer still holds.
+    ///
+    /// `n4mb_session.is_some()` is the assertion that no Session Deletion was sent:
+    /// `release_n4mb_transport` is the only path that sends one, and it clears the
+    /// context whether or not the MB-UPF answered (which is how the existing AMF-release
+    /// test observes a release). So a context that is still present is a release that
+    /// did not happen.
+    #[tokio::test]
+    async fn two_consumers_share_a_transport_and_only_the_last_terminate_releases_it() {
+        let svc_id = [0xC2, 0x95, 0x01];
+        let svc = seed_global_session(svc_id);
+
+        for nfc in ["smf-a", "smf-b"] {
+            let rsp = post_ctx_update(
+                SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update")
+                    .with_body(smf_ctx_update_body(&svc, nfc, "START"), "application/json"),
+            )
+            .await;
+            assert_eq!(rsp.status, 200, "{nfc}'s START must succeed");
+        }
+        let session = stored_session(svc_id);
+        assert_eq!(
+            session.consumers.len(),
+            2,
+            "both consumers hold the shared transport, got {:?}",
+            session.consumers
+        );
+        assert!(session.n4mb_session.is_some(), "the transport is up");
+
+        // --- first TERMINATE: 204, and the transport stays up ---
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body(&svc, "smf-a", "TERMINATE"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 204, "a consumer's departure is a 204");
+        let session = stored_session(svc_id);
+        assert!(
+            session.n4mb_session.is_some(),
+            "the MB-UPF session must survive one consumer leaving: the others are still \
+             receiving on it (TS 23.247 §7.2.1.4)"
+        );
+        assert_eq!(
+            session.consumers.iter().cloned().collect::<Vec<_>>(),
+            vec!["smf-b".to_string()],
+            "only the departing consumer is removed"
+        );
+        assert_ne!(
+            session.state,
+            MbsSessionState::Suspended,
+            "a session another consumer still receives on is not suspended"
+        );
+
+        // --- a REPEATED terminate from the same consumer changes nothing ---
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body(&svc, "smf-a", "TERMINATE"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session(svc_id).n4mb_session.is_some(),
+            "a repeated TERMINATE must not double-decrement and release a transport \
+             smf-b still holds"
+        );
+
+        // --- the LAST consumer's terminate releases it ---
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body(&svc, "smf-b", "TERMINATE"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        let session = stored_session(svc_id);
+        assert!(
+            session.n4mb_session.is_none(),
+            "the last consumer's departure releases the shared transport"
+        );
+        assert!(
+            session.consumers.is_empty(),
+            "and leaves no consumer behind"
+        );
+    }
+
+    /// #295 criterion 4: a START from a consumer already in the set does not
+    /// double-count, so a consumer that restarts and re-STARTs cannot pin the transport
+    /// past its own departure.
+    ///
+    /// Also the empty-`nfcInstanceId` fallback: such a consumer cannot be tracked, so
+    /// the first TERMINATE releases the transport exactly as it did before #295 —
+    /// stated here rather than left to be discovered.
+    #[tokio::test]
+    async fn a_repeated_start_from_one_consumer_does_not_double_count() {
+        let svc_id = [0xC2, 0x95, 0x02];
+        let svc = seed_global_session(svc_id);
+
+        for _ in 0..3 {
+            let rsp = post_ctx_update(
+                SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                    smf_ctx_update_body(&svc, "smf-a", "START"),
+                    "application/json",
+                ),
+            )
+            .await;
+            assert_eq!(rsp.status, 200);
+        }
+        assert_eq!(
+            stored_session(svc_id).consumers.len(),
+            1,
+            "three STARTs from one consumer are one consumer"
+        );
+
+        // One TERMINATE from it is therefore the last one.
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body(&svc, "smf-a", "TERMINATE"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session(svc_id).n4mb_session.is_none(),
+            "a consumer that STARTed three times still holds the transport once"
+        );
+
+        // ---- an untrackable consumer keeps the pre-#295 behaviour ----
+        let anon_id = [0xC2, 0x95, 0x03];
+        let anon = seed_global_session(anon_id);
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update")
+                .with_body(smf_ctx_update_body(&anon, "", "START"), "application/json"),
+        )
+        .await;
+        assert_eq!(rsp.status, 200, "an empty nfcInstanceId is not a rejection");
+        assert!(
+            stored_session(anon_id).consumers.is_empty(),
+            "an empty nfcInstanceId names no consumer and must not be stored as one"
+        );
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body(&anon, "", "TERMINATE"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session(anon_id).n4mb_session.is_none(),
+            "with no trackable consumer the first TERMINATE releases, as before #295"
         );
     }
 


### PR DESCRIPTION
Closes #295.

`ContextUpdateReqData.nfcInstanceId` was parsed and never tracked, so the terminate leg released the N4mb transport for whichever consumer asked **first**. TS 23.247 §7.2.1.3/§7.2.1.4 model a multicast MBS session as a *shared* distribution session established once and reused across joins — #76 made the START idempotent, which is the establish side of that model, and the release side was still first-writer-wins.

One SMF leaving tore the transport down for every other SMF still receiving, and the symptom is the worse kind: the remaining consumers' sessions look fine (state, SBI surface, TMGI all unchanged) and simply stop receiving, because the MB-UPF session underneath them was deleted.

## The decision #295 asks for

**A START registers `nfcInstanceId`, a TERMINATE deregisters it, and the transport is released when the set becomes empty.** Nothing in the tree registered a consumer, so the count had to start somewhere, and §7.2.1.3 makes the START the honest place: the count is derivable from traffic the MB-SMF already sees rather than from a member the schema does not have. Counting only an explicit `leaveInd` join/leave — the other option — would have left the hazard on exactly the `leaveInd == false` path that most traffic takes.

The risks the issue names are handled by **keying the set on `nfcInstanceId` rather than counting**: a consumer that restarts and re-STARTs is the same entry; a repeated TERMINATE removes an id that is no longer there. Reverting the set to counter semantics — remove *something* rather than the named id — fails a named test, which is the difference between having written the right thing and having verified it.

A session with **no** registered consumers releases on the first TERMINATE, deliberately: that is the pre-#295 behaviour for sessions created before any START and for every existing single-consumer flow, so criterion 6 holds without a special case. All 95 existing mbsmfd tests pass unchanged.

## The never-departing consumer is logged, not timed out

A TTL would have the MB-SMF tear down a transport that is **still carrying data** because a consumer was quiet — the very failure this change exists to prevent. NRF liveness is the principled answer and needs an NF-status subscription this daemon does not have. So the pin is accepted and made visible: the terminate leg logs at `warn` with the remaining consumer ids, because nothing else in the system can name who holds a transport open.

## Only the SMF leg registers

The AMF leg's `nfcInstanceId` is the **AMF's**. Counting it would let an AMF's silence hold a transport open, and deregistering it would find it absent from a set the SMF STARTs populate — so a legitimate N2-driven release would stop releasing anything and the existing golden AMF-release test would fail for an unrelated reason. `session_context_terminate` keeps its unconditional form for that leg.

**That leaves a real gap in a different dimension, which this change does not claim to fix:** the AMF leg releases the transport on one RAN node's `MbsDisRelReq`, so it is the same first-writer-wins shape per `ranNodeId`. It needs a per-RAN-node set that nothing in the tree has. Filed separately and named in the spec's ceilings rather than left for a reader to find.

## Acceptance criteria

- [x] Two consumers START the same TMGI; the first TERMINATE gets `204` and the transport stays up (`n4mb_session` still present, no Session Deletion sent)
- [x] The second TERMINATE releases it and the context is cleared
- [x] A repeated TERMINATE from the same `nfcInstanceId` does not double-decrement
- [x] A START from an already-registered `nfcInstanceId` does not double-count
- [x] The never-departing-consumer decision is logged and stated either way
- [x] The existing release tests still pass — a single-consumer session behaves as today

**How "no Session Deletion was sent" is asserted:** `release_n4mb_transport` is the only path that sends one and it clears `n4mb_session` whether or not the MB-UPF answered (which is how the existing AMF-release test observes a release). So a context that is still present is a release that did not happen — stated in the test, because it is the one indirect assertion here.

## Verification

Workspace **6285 passed / 0 failed over three consecutive runs** (baseline 6283 on `23148ce`; +2 — mbsmfd 95 → 97). clippy zero warnings for `nextgcore-mbsmfd`, fmt clean.

| revert | expected to break | result |
|---|---|---|
| the terminate ignores the consumer set (the #295 defect restored) | `two_consumers_share_a_transport_and_only_the_last_terminate_releases_it` | **1 failed** |
| START does not register a consumer | both new tests | **2 failed** |
| the set behaves as a counter (remove *something*, not the named id) | the two-consumer test | **1 failed** |
| an empty `nfcInstanceId` stored as a consumer | `a_repeated_start_from_one_consumer_does_not_double_count` | **1 failed** |

## Ceilings

- **The RAN-node dimension is not fixed here** (above) — filed separately.
- **Nothing unpins a transport whose consumer never terminates**; the log names who holds it.
- **The consumer set is memory-only**, like the rest of mbsmfd (`MbsSession` derives no serde; this daemon has no `StateStore`). A restart loses the counts, so the first TERMINATE afterwards releases a transport others may still be using — consistent with the daemon's posture, and worth naming because the recovery is worse than the steady state.
- **An empty `nfcInstanceId`** cannot be tracked and keeps the pre-#295 behaviour: logged and accepted rather than rejected, since rejecting would be a new 400 for traffic that works today.

Spec: `specs/fix-mbsmfd-consumer-refcount.md`