### PR TITLE
fix(pfcp,sgwud): model Update/Remove QER and URR on a Session Modification (#304)

### DIFF
--- a/specs/fix-pfcp-modification-update-remove-qer-urr.md
+++ b/specs/fix-pfcp-modification-update-remove-qer-urr.md
@@ -1,0 +1,119 @@
+# nextgcore #304 (nextgcore-pfcp, sgwud): model Update/Remove QER and URR on a Session Modification
+
+Verified against `main` @ `b1b2bb5`.
+
+#304 was filed from #59's first ceiling. Every claim in it still holds; nothing was found to be
+stale. TS 29.244 Table 7.5.4.1-1, Tables 7.5.4.4-1 / 7.5.4.5-1 / 7.5.4.6-1 / 7.5.4.7-1.
+
+## Verified against current main
+
+| claim in the issue | site on `b1b2bb5` | still true? |
+|---|---|---|
+| `IeType::UpdateUrr = 13`, `UpdateQer = 14`, `RemoveUrr = 17`, `RemoveQer = 18` exist | `libs/nextgcore-pfcp/src/ie.rs:24,25,28,29` | yes |
+| the four structs do not exist | `grep 'struct UpdateQer\|struct RemoveQer\|struct UpdateUrr\|struct RemoveUrr' types.rs` → nothing | yes |
+| `SessionModificationRequest` models none of the four | `message.rs:702-714` (11 fields, none of them) | yes |
+| a request carrying them decodes cleanly with the lists empty | `decode`'s `_ => {}` arm at `message.rs:876` | yes |
+| sgwud's handler HAS the four lists and code that applies each | `sxa_handler.rs:226-234`, applied at `:430,518,526,535` | yes |
+| `modification_from_lib` fills all four with `Vec::new()` | `pfcp_path.rs:1417-1420`, with a comment naming this issue | yes |
+| upfd decodes modification IEs itself, so it is not affected the same way | `bins/nextgcore-upfd/src/pfcp_path.rs:1391` (its own `ParsedIe` walk) | yes — and see Decision 3 |
+
+## Decision 1: every Update member is optional, and absence is preserved end to end
+
+`UpdateQer` is not `CreateQer` reused, and `UpdateUrr` is not `CreateUrr` reused. TS 29.244's
+Update tables make each provisioning IE Conditional, and the sgwud handler already reads that
+correctly: `process_update_qer` / `process_update_urr` apply a `Some` and leave a `None` alone.
+
+Reusing the Create types would have made the wrong thing easy. `GateStatus` defaults to **open**,
+so an Update QER that named only an MBR would have re-opened a gate the CP function never
+mentioned — the exact defect this issue is about, inverted. Same for `MeasurementMethod`: an
+Update URR carrying only a new Volume Threshold would have reset the method to 0 and stopped the
+rule measuring anything.
+
+The mapping preserves it too. `urr_from_lib` flattens an absent Volume to a default (correct for a
+Create, which states the rule's whole shape); the new `volume_from_lib` keeps `Option`, because an
+Update that does not mention the Volume Quota must not revoke it. That is guarded by its own
+assertion, and the revert of it fails that assertion.
+
+## Decision 2: IE order follows Table 7.5.4.1-1, though nothing decodes by position
+
+Remove URR is encoded before Remove QER, and Update URR before Update QER, matching the table's
+row order. PFCP decoders are order-independent (this one included), so this buys nothing
+functionally — it is so that a capture from this SGW-C reads like the table for whoever compares
+them, and so the URR operations precede the QER ones consistently with how the handler sequences
+them (`sxa_handler.rs:422-540`).
+
+## Decision 3: upfd stays on its own decoder, and its own gap is filed separately
+
+Criterion 5 asks for a decision either way. **upfd is not moved onto the library decoder here.**
+
+- The issue itself sizes it separately ("a behaviour-preserving swap that needs its own revert
+  pass"), and it is not needed for anything in this issue's criteria.
+- upfd's establishment and modification handlers walk `ParsedIe` and feed a *different* internal
+  session model (`DataPlaneUrr` with `AtomicU64` counters, not sgwud's `SgwuUrr`), so the swap is
+  not a mapping change — it is a re-write of two handlers whose failure mode is silent.
+
+What the verification pass did find is that upfd has the **same functional gap this issue is
+about**, in a different place: `handle_session_modification_request`
+(`bins/nextgcore-upfd/src/pfcp_path.rs:1345-1508`) parses only Update FAR, Update QER, Create/Update
+BAR and the PFCPSMReq-Flags. It parses **no** Create/Update/Remove URR and **no** Remove
+QER/PDR/FAR on a modification — so a UPF answers `RequestAccepted` for those too, and unlike sgwud
+it has no handler code waiting for them. That is a upfd defect, not a library one, and this PR does
+not touch it: filed as its own issue.
+
+## Acceptance criteria
+
+- [x] The four IEs round-trip through `SessionModificationRequest::encode`/`decode`, asserted by a
+      test that encodes and then decodes —
+      `message::tests::a_session_modification_carries_update_and_remove_qer_and_urr_over_the_wire`.
+      Not a field read: each of the four decode arms was reverted individually and each failed it.
+- [x] sgwud's `modification_from_lib` populates all four lists, and the "not modelled" comment is
+      gone (`pfcp_path.rs`, the four `Vec::new()` lines replaced by mappers).
+- [x] A Session Modification that closes a QER gate reaches `SgwuQer.gate_status`, asserted over
+      the wire from the transport —
+      `pfcp_path::tests::a_modification_over_the_wire_closes_a_qer_gate_and_removes_a_urr` drives a
+      real datagram into a bound socket and asserts `0x05` in the store.
+- [x] A Remove URR over the wire detaches it: URR 4 is gone from the store and PDR 1's `urr_ids`
+      drops 4 while keeping 3.
+- [x] Whether upfd moves onto the library decoder is decided and stated — Decision 3: it does not,
+      with its own gap filed.
+
+## Verification
+
+`cargo test --workspace`: **6290 passed / 0 failed** (baseline 6288 on `b1b2bb5`; +1
+nextgcore-pfcp, +1 nextgcore-sgwud — neither replaces an existing test).
+`cargo clippy --workspace --all-targets` and `cargo fmt --all -- --check` clean.
+
+| revert | expected to break | result |
+|---|---|---|
+| library `UpdateQer` decode arm removed | `a_session_modification_carries_...` | **1 failed** |
+| library `UpdateUrr` decode arm removed | same | **1 failed** |
+| library `RemoveQer` decode arm removed | same | **1 failed** |
+| library `RemoveUrr` decode arm removed | same | **1 failed** |
+| `modification_from_lib`: `update_qers` back to `Vec::new()` | `a_modification_over_the_wire_...` | **1 failed** (gate read `Some(0)`) |
+| `modification_from_lib`: `update_urrs` back to `Vec::new()` | same | **1 failed** |
+| `modification_from_lib`: `remove_qers` back to `Vec::new()` | same | **1 failed** |
+| `modification_from_lib`: `remove_urrs` back to `Vec::new()` | same | **1 failed** |
+| `volume_from_lib` flattens absence to a default `Volume` | same | **1 failed** (quota revoked) |
+
+Nine reverts, nine bites. The two the run turned on: the four library decode arms are what separate
+"the codec carries the IE" from "the struct exists", which is the distinction #59's Volume Quota
+revert found the hard way; and the `volume_from_lib` revert is what makes Decision 1 a verified
+claim rather than a stated intention.
+
+## Ceilings
+
+- **`process_update_qer` ignores the GBR.** It applies Gate Status and MBR and drops `req.gbr` on
+  the floor — pre-existing (`sxa_handler.rs:1078-1084`), not introduced here, and out of this
+  issue's scope. The library and the mapping both carry it, so closing this is now a two-line
+  handler change; nothing in #304's criteria asked for it, so it was not made.
+- **QFI is carried by the library's `UpdateQer` but not mapped**, because sgwud's
+  `UpdateQerRequest` has no QFI member — the SGW-U is a 4G user plane and its QER store has none
+  either. Left as a modelled-but-unmapped IE rather than adding a field nothing reads.
+- **No Query URR / Query All URRs**, so a Remove URR still discards residual volume with a `warn`
+  (#215's compromise, unchanged). The removal now genuinely happens over the wire, which makes
+  that discard reachable in production for the first time — the existing TASKS entry for Query URR
+  is the fix, and its ceiling ("nothing transmits") was already struck by #59.
+- **upfd untouched**, per Decision 3. A UPF still ignores Remove QER, and every URR operation, on
+  a Session Modification.
+- **No E2E**: the Docker jobs are `workflow_dispatch`-only, so the wire assertions are in-process
+  datagrams through a bound loopback socket, not an SGW-C container talking to an SGW-U container.

--- a/src/bins/nextgcore-sgwud/src/pfcp_path.rs
+++ b/src/bins/nextgcore-sgwud/src/pfcp_path.rs
@@ -31,6 +31,7 @@ use nextgcore_pfcp::types::{
     ApplyAction as LibApplyAction, CreateFar as LibCreateFar, CreatePdr as LibCreatePdr,
     CreateQer as LibCreateQer, CreateUrr as LibCreateUrr, FSeid as LibFSeid, FTeid as LibFTeid,
     GateStatus as LibGateStatus, NodeId, PfcpCause, UpFunctionFeatures as LibUpFunctionFeatures,
+    UpdateQer as LibUpdateQer, UpdateUrr as LibUpdateUrr,
 };
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
@@ -1331,6 +1332,63 @@ fn urr_from_lib(urr: &LibCreateUrr) -> crate::sxa_handler::CreateUrrRequest {
     }
 }
 
+/// Volume Threshold / Volume Quota -> the store's `Volume`, preserving "absent".
+///
+/// `urr_from_lib` flattens `None` to a default `Volume` because a Create states the
+/// rule's whole shape; an Update must NOT, or an Update naming only a new Time
+/// Threshold would zero the volume thresholds it never mentioned.
+fn volume_from_lib(
+    v: Option<&nextgcore_pfcp::types::VolumeThreshold>,
+) -> Option<crate::context::Volume> {
+    v.map(|v| crate::context::Volume {
+        total: v.tovol.then_some(v.total_volume),
+        uplink: v.ulvol.then_some(v.uplink_volume),
+        downlink: v.dlvol.then_some(v.downlink_volume),
+    })
+}
+
+/// Update QER (#304). Every member stays `Option`: the handler's
+/// `process_update_qer` leaves a `None` alone, which is what TS 29.244
+/// Table 7.5.4.5-1's conditional IEs mean.
+fn update_qer_from_lib(qer: &LibUpdateQer) -> crate::sxa_handler::UpdateQerRequest {
+    crate::sxa_handler::UpdateQerRequest {
+        qer_id: qer.qer_id,
+        gate_status: qer.gate_status.as_ref().map(gate_status_octet),
+        mbr: qer
+            .maximum_bitrate
+            .as_ref()
+            .map(|br| crate::sxa_handler::Mbr {
+                ul: br.uplink,
+                dl: br.downlink,
+            }),
+        gbr: qer
+            .guaranteed_bitrate
+            .as_ref()
+            .map(|br| crate::sxa_handler::Gbr {
+                ul: br.uplink,
+                dl: br.downlink,
+            }),
+    }
+}
+
+/// Update URR (#304). Same `Option`-preserving rule as `update_qer_from_lib`.
+fn update_urr_from_lib(urr: &LibUpdateUrr) -> crate::sxa_handler::UpdateUrrRequest {
+    crate::sxa_handler::UpdateUrrRequest {
+        urr_id: urr.urr_id,
+        measurement_method: urr.measurement_method.as_ref().map(|m| m.encode()),
+        // As in `urr_from_lib`: the handler models the first TWO octets of Reporting
+        // Triggers (§8.2.41) as a u16 with octet 5 in the low byte.
+        reporting_triggers: urr.reporting_triggers.as_ref().map(|t| {
+            let t = t.encode();
+            u16::from(t[0]) | (u16::from(t[1]) << 8)
+        }),
+        volume_threshold: volume_from_lib(urr.volume_threshold.as_ref()),
+        volume_quota: volume_from_lib(urr.volume_quota.as_ref()),
+        time_threshold: urr.time_threshold,
+        measurement_period: urr.measurement_period,
+    }
+}
+
 fn establishment_from_lib(
     req: &LibSessionEstablishmentRequest,
     cp_f_seid: &crate::context::FSeid,
@@ -1408,16 +1466,10 @@ fn modification_from_lib(
         remove_fars: req.remove_fars.iter().map(|r| r.far_id).collect(),
         create_qers: req.create_qers.iter().map(qer_from_lib).collect(),
         create_urrs: req.create_urrs.iter().map(urr_from_lib).collect(),
-        // The library's SessionModificationRequest models no Update QER / Remove QER /
-        // Update URR / Remove URR (the IE types exist; the structs do not), so those
-        // lists arrive EMPTY however the SGW-C populated them. The handler's code for
-        // them is therefore still reachable only in-process. Filed as its own issue
-        // rather than hand-decoded here, which would put a second IE decoder beside
-        // the library one.
-        update_qers: Vec::new(),
-        remove_qers: Vec::new(),
-        update_urrs: Vec::new(),
-        remove_urrs: Vec::new(),
+        update_qers: req.update_qers.iter().map(update_qer_from_lib).collect(),
+        remove_qers: req.remove_qers.iter().map(|r| r.qer_id).collect(),
+        update_urrs: req.update_urrs.iter().map(update_urr_from_lib).collect(),
+        remove_urrs: req.remove_urrs.iter().map(|r| r.urr_id).collect(),
         create_bar: None,
         remove_bar: None,
     }
@@ -1841,6 +1893,188 @@ mod tests {
         assert!(
             ctx.pdr_find(sess.id, 1).is_some(),
             "the Create PDR must have been INSTALLED on the session, not just parsed"
+        );
+    }
+
+    /// #304: an Update QER closing a gate and a Remove URR arrive OVER THE WIRE and
+    /// reach the rule store.
+    ///
+    /// Before #304 the library's `SessionModificationRequest` modelled none of the four
+    /// Update/Remove QER/URR IEs, so `modification_from_lib` filled those lists with
+    /// `Vec::new()` unconditionally: the SGW-C got `REQUEST_ACCEPTED`, the gate stayed
+    /// OPEN and the session kept being measured on a URR the CP function had removed.
+    /// Asserted from a bound socket rather than by calling the handler, because calling
+    /// the handler is exactly what passed in that state.
+    #[tokio::test]
+    async fn a_modification_over_the_wire_closes_a_qer_gate_and_removes_a_urr() {
+        let (node, peer) = node_and_peer().await;
+
+        let mut assoc = BytesMut::new();
+        PfcpLibMessage::AssociationSetupRequest(AssociationSetupRequest::new(
+            NodeId::new_ipv4([127, 0, 0, 9]),
+            2000,
+        ))
+        .encode_body(&mut assoc);
+        deliver(
+            &node,
+            &peer,
+            &wire(pfcp_msg_type::ASSOCIATION_SETUP_REQUEST, None, 1, &assoc),
+        )
+        .await;
+        let _ = recv_decoded(&peer).await;
+
+        // Establish a session carrying a QER with both gates OPEN, a volume URR, and a
+        // PDR measured against that URR and policed by that QER.
+        let cp_seid = 0x0000_0000_0000_3040u64;
+        let mut req = LibSessionEstablishmentRequest::new(
+            NodeId::new_ipv4([127, 0, 0, 9]),
+            LibFSeid::new_ipv4(cp_seid, [127, 0, 0, 9]),
+        );
+        let mut pdi = Pdi::new(SourceInterface::Access);
+        let mut f_teid = FTeid::new_ipv4(0, [127, 0, 0, 1]);
+        f_teid.ch = true;
+        pdi.local_f_teid = Some(f_teid);
+        let mut pdr = CreatePdr::new(1, 100, pdi);
+        pdr.far_id = Some(1);
+        pdr.qer_id = Some(7);
+        pdr.urr_ids = vec![3, 4];
+        req.create_pdrs.push(pdr);
+        let mut far = CreateFar::new(1, ApplyAction::forward());
+        far.forwarding_parameters = Some(ForwardingParameters::new(DestinationInterface::Core));
+        req.create_fars.push(far);
+        req.create_qers
+            .push(CreateQer::new(7, GateStatus::both_open()));
+        req.create_qers
+            .push(CreateQer::new(8, GateStatus::both_open()));
+        for urr_id in [3u32, 4] {
+            let mut urr = CreateUrr::new(
+                urr_id,
+                MeasurementMethod {
+                    volum: true,
+                    ..Default::default()
+                },
+                ReportingTriggers::default(),
+            );
+            urr.volume_threshold = Some(VolumeThreshold::new_total(1_000));
+            urr.volume_quota = Some(VolumeThreshold::new_total(2_000));
+            req.create_urrs.push(urr);
+        }
+        let mut body = BytesMut::new();
+        req.encode(&mut body);
+        deliver(
+            &node,
+            &peer,
+            &wire(
+                pfcp_msg_type::SESSION_ESTABLISHMENT_REQUEST,
+                Some(0),
+                2,
+                &body,
+            ),
+        )
+        .await;
+        let _ = recv_decoded(&peer).await;
+
+        let ctx = sgwu_self();
+        let sess = ctx
+            .sess_find_by_sgwc_sxa_seid(cp_seid)
+            .expect("the Establishment must create a session");
+        assert_eq!(
+            ctx.qer_find(sess.id, 7).and_then(|q| q.gate_status),
+            Some(crate::context::gate_status::OPEN),
+            "the gate starts open, so the assertion after the modification is about the \
+             modification"
+        );
+        assert!(ctx.qer_find(sess.id, 8).is_some());
+        assert!(ctx.urr_find(sess.id, 3).is_some() && ctx.urr_find(sess.id, 4).is_some());
+        assert_eq!(
+            ctx.pdr_find(sess.id, 1).map(|p| p.urr_ids),
+            Some(vec![3, 4])
+        );
+
+        // One Session Modification exercising all four IEs #304 added: close both gates
+        // on QER 7, remove QER 8, re-threshold URR 3, remove URR 4.
+        let mut modification = LibSessionModificationRequest::new();
+        let mut uqer = LibUpdateQer::new(7);
+        uqer.gate_status = Some(LibGateStatus::both_closed());
+        modification.update_qers.push(uqer);
+        modification
+            .remove_qers
+            .push(nextgcore_pfcp::types::RemoveQer::new(8));
+        let mut uurr = LibUpdateUrr::new(3);
+        uurr.volume_threshold = Some(VolumeThreshold::new_total(9_000));
+        modification.update_urrs.push(uurr);
+        modification
+            .remove_urrs
+            .push(nextgcore_pfcp::types::RemoveUrr::new(4));
+        let mut body = BytesMut::new();
+        modification.encode(&mut body);
+        deliver(
+            &node,
+            &peer,
+            &wire(
+                pfcp_msg_type::SESSION_MODIFICATION_REQUEST,
+                Some(sess.sgwu_sxa_seid),
+                3,
+                &body,
+            ),
+        )
+        .await;
+
+        let (header, resp_body) = recv_decoded(&peer).await;
+        assert_eq!(
+            header.message_type as u8,
+            pfcp_msg_type::SESSION_MODIFICATION_RESPONSE
+        );
+        assert_eq!(
+            find_cause(&resp_body),
+            Some(sxa_build::pfcp_cause::REQUEST_ACCEPTED)
+        );
+
+        // The accepted response must be TRUE: both changes reached the store.
+        let qer = ctx
+            .qer_find(sess.id, 7)
+            .expect("the QER must still exist after an Update");
+        assert_eq!(
+            qer.gate_status,
+            Some(0x05),
+            "TS 29.244 §8.2.7: UL and DL both CLOSED — an accepted Update QER that left \
+             the gate open would police nothing"
+        );
+        assert!(
+            ctx.qer_find(sess.id, 8).is_none(),
+            "a Remove QER the SGW-U accepted must actually remove it"
+        );
+        assert!(
+            ctx.urr_find(sess.id, 4).is_none(),
+            "a Remove URR the SGW-U accepted must actually remove it, or the session \
+             keeps being measured on a rule the SGW-C believes is gone"
+        );
+        assert_eq!(
+            ctx.pdr_find(sess.id, 1).map(|p| p.urr_ids),
+            Some(vec![3]),
+            "and the PDR must be detached from the REMOVED URR only (#267), not left \
+             naming a dead one nor stripped of the live one"
+        );
+        let urr3 = ctx
+            .urr_find(sess.id, 3)
+            .expect("the updated URR must survive its Update");
+        assert_eq!(
+            urr3.volume_threshold.total,
+            Some(9_000),
+            "the Update URR's new Volume Threshold must reach the store"
+        );
+        assert_eq!(
+            urr3.measurement_method,
+            crate::context::measurement_method::VOLUME,
+            "and an Update naming only a threshold must leave the Measurement Method \
+             alone — `Some(0)` here would stop the rule measuring anything"
+        );
+        assert_eq!(
+            urr3.volume_quota.total,
+            Some(2_000),
+            "the Volume Quota the Establishment provisioned must SURVIVE an Update that \
+             does not mention it: mapping an absent IE to a default Volume would revoke \
+             the subscriber's allowance on every unrelated modification"
         );
     }
 

--- a/src/libs/nextgcore-pfcp/src/lib.rs
+++ b/src/libs/nextgcore-pfcp/src/lib.rs
@@ -54,8 +54,8 @@ pub mod prelude {
         ApplyAction, Bitrate, CpFunctionFeatures, CreateBar, CreateFar, CreatePdr, CreateQer,
         CreateUrr, DestinationInterface, DownlinkDataReport, FSeid, FTeid, ForwardingParameters,
         GateStatus, MeasurementMethod, NodeId, NodeIdType, OuterHeaderCreation, OuterHeaderRemoval,
-        Pdi, PfcpCause, RemoveFar, RemovePdr, ReportType, ReportingTriggers, SourceInterface,
-        UeIpAddress, UpFunctionFeatures, UpdateFar, UpdatePdr, UsageReportSrr, VolumeMeasurement,
-        VolumeThreshold,
+        Pdi, PfcpCause, RemoveFar, RemovePdr, RemoveQer, RemoveUrr, ReportType, ReportingTriggers,
+        SourceInterface, UeIpAddress, UpFunctionFeatures, UpdateFar, UpdatePdr, UpdateQer,
+        UpdateUrr, UsageReportSrr, VolumeMeasurement, VolumeThreshold,
     };
 }

--- a/src/libs/nextgcore-pfcp/src/message.rs
+++ b/src/libs/nextgcore-pfcp/src/message.rs
@@ -9,8 +9,9 @@ use crate::types::{
     ApplicationIdsPfds, CpFunctionFeatures, CreateBar, CreateFar, CreatePdr, CreateQer, CreateUrr,
     DownlinkDataReport, FSeid, FqCsid, GracefulReleasePeriod, LoadControlInformation, NodeId,
     NodeReportType, PfcpAssociationReleaseRequest, PfcpCause, PfcpSessionChangeInfo,
-    PfdPartialFailureInformation, RemoveFar, RemovePdr, ReportType, UpFunctionFeatures, UpdateFar,
-    UpdatePdr, UsageReportSrr, UserPlanePathFailureReport,
+    PfdPartialFailureInformation, RemoveFar, RemovePdr, RemoveQer, RemoveUrr, ReportType,
+    UpFunctionFeatures, UpdateFar, UpdatePdr, UpdateQer, UpdateUrr, UsageReportSrr,
+    UserPlanePathFailureReport,
 };
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
@@ -710,6 +711,17 @@ pub struct SessionModificationRequest {
     pub create_bar: Option<CreateBar>,
     pub update_pdrs: Vec<UpdatePdr>,
     pub update_fars: Vec<UpdateFar>,
+    /// Update QER(s) (TS 29.244 Table 7.5.4.1-1, IE type 14). #304: absent before,
+    /// so a Session Modification closing a gate decoded to an empty list and the UP
+    /// function answered `RequestAccepted` for a policing change it never applied.
+    pub update_qers: Vec<UpdateQer>,
+    /// Update URR(s) (IE type 13).
+    pub update_urrs: Vec<UpdateUrr>,
+    /// Remove QER(s) (IE type 18).
+    pub remove_qers: Vec<RemoveQer>,
+    /// Remove URR(s) (IE type 17). A removal the UP function silently drops keeps
+    /// the session measured on a rule the CP function believes is gone.
+    pub remove_urrs: Vec<RemoveUrr>,
     pub pfcp_smreq_flags: Option<u8>,
 }
 
@@ -732,6 +744,10 @@ impl SessionModificationRequest {
             create_bar: None,
             update_pdrs: Vec::new(),
             update_fars: Vec::new(),
+            update_qers: Vec::new(),
+            update_urrs: Vec::new(),
+            remove_qers: Vec::new(),
+            remove_urrs: Vec::new(),
             pfcp_smreq_flags: None,
         }
     }
@@ -759,6 +775,23 @@ impl SessionModificationRequest {
             let header = IeHeader::new(IeType::RemoveFar as u16, rfar_buf.len() as u16);
             header.encode(buf);
             buf.put_slice(&rfar_buf);
+        }
+
+        // Remove URR before Remove QER, as in TS 29.244 Table 7.5.4.1-1.
+        for rurr in &self.remove_urrs {
+            let mut rurr_buf = BytesMut::new();
+            rurr.encode(&mut rurr_buf);
+            let header = IeHeader::new(IeType::RemoveUrr as u16, rurr_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&rurr_buf);
+        }
+
+        for rqer in &self.remove_qers {
+            let mut rqer_buf = BytesMut::new();
+            rqer.encode(&mut rqer_buf);
+            let header = IeHeader::new(IeType::RemoveQer as u16, rqer_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&rqer_buf);
         }
 
         for pdr in &self.create_pdrs {
@@ -817,6 +850,23 @@ impl SessionModificationRequest {
             buf.put_slice(&ufar_buf);
         }
 
+        // Update URR before Update QER, as in TS 29.244 Table 7.5.4.1-1.
+        for uurr in &self.update_urrs {
+            let mut uurr_buf = BytesMut::new();
+            uurr.encode(&mut uurr_buf);
+            let header = IeHeader::new(IeType::UpdateUrr as u16, uurr_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&uurr_buf);
+        }
+
+        for uqer in &self.update_qers {
+            let mut uqer_buf = BytesMut::new();
+            uqer.encode(&mut uqer_buf);
+            let header = IeHeader::new(IeType::UpdateQer as u16, uqer_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&uqer_buf);
+        }
+
         if let Some(flags) = self.pfcp_smreq_flags {
             encode_u8_ie(buf, IeType::PfcpSmreqFlags, flags);
         }
@@ -867,6 +917,22 @@ impl SessionModificationRequest {
                 t if t == IeType::UpdateFar as u16 => {
                     let mut data = ie.data;
                     result.update_fars.push(UpdateFar::decode(&mut data)?);
+                }
+                t if t == IeType::UpdateUrr as u16 => {
+                    let mut data = ie.data;
+                    result.update_urrs.push(UpdateUrr::decode(&mut data)?);
+                }
+                t if t == IeType::UpdateQer as u16 => {
+                    let mut data = ie.data;
+                    result.update_qers.push(UpdateQer::decode(&mut data)?);
+                }
+                t if t == IeType::RemoveUrr as u16 => {
+                    let mut data = ie.data;
+                    result.remove_urrs.push(RemoveUrr::decode(&mut data)?);
+                }
+                t if t == IeType::RemoveQer as u16 => {
+                    let mut data = ie.data;
+                    result.remove_qers.push(RemoveQer::decode(&mut data)?);
                 }
                 t if t == IeType::PfcpSmreqFlags as u16 => {
                     if !ie.data.is_empty() {
@@ -2456,6 +2522,94 @@ mod tests {
         } else {
             panic!("Wrong message type");
         }
+    }
+
+    /// #304: Update QER / Update URR / Remove QER / Remove URR survive
+    /// `encode` -> `decode` on a Session Modification Request (TS 29.244
+    /// Table 7.5.4.1-1).
+    ///
+    /// A ROUND TRIP rather than a field read, deliberately: before this, the four IE
+    /// *types* existed in `ie.rs` while the structs and the message fields did not, so
+    /// a request carrying them decoded cleanly with the lists EMPTY and the UP
+    /// function answered `RequestAccepted` for a modification it never applied. A test
+    /// that builds the struct and reads a field back passes in exactly that state.
+    #[test]
+    fn a_session_modification_carries_update_and_remove_qer_and_urr_over_the_wire() {
+        let mut msg = SessionModificationRequest::new();
+
+        // Close both gates on QER 7 and drop its MBR to a policing rate.
+        let mut uqer = UpdateQer::new(7);
+        uqer.gate_status = Some(GateStatus::both_closed());
+        uqer.maximum_bitrate = Some(Bitrate::new(5_000, 10_000));
+        msg.update_qers.push(uqer);
+
+        // Re-provision URR 3's volume threshold only: everything else must stay absent
+        // so the UP function leaves the measurement method it already has alone.
+        let mut uurr = UpdateUrr::new(3);
+        uurr.volume_threshold = Some(VolumeThreshold::new_total(9_000));
+        uurr.time_threshold = Some(60);
+        msg.update_urrs.push(uurr);
+
+        msg.remove_qers.push(RemoveQer::new(8));
+        msg.remove_urrs.push(RemoveUrr::new(4));
+
+        let buf = build_message(
+            &PfcpMessage::SessionModificationRequest(msg),
+            102,
+            Some(0xABCD),
+        );
+        let mut bytes = buf.freeze();
+        let (header, decoded) = parse_message(&mut bytes).unwrap();
+        assert_eq!(
+            header.message_type,
+            PfcpMessageType::SessionModificationRequest
+        );
+
+        let PfcpMessage::SessionModificationRequest(req) = decoded else {
+            panic!("Wrong message type");
+        };
+
+        assert_eq!(req.update_qers.len(), 1, "Update QER (IE type 14)");
+        assert_eq!(req.update_qers[0].qer_id, 7);
+        let gate = req.update_qers[0]
+            .gate_status
+            .expect("the Gate Status must survive the wire, or the gate stays open");
+        assert!(
+            !gate.ul_gate && !gate.dl_gate,
+            "both gates must decode as CLOSED (TS 29.244 §8.2.7: 1 = closed)"
+        );
+        let mbr = req.update_qers[0]
+            .maximum_bitrate
+            .as_ref()
+            .expect("MBR present");
+        assert_eq!((mbr.uplink, mbr.downlink), (5_000, 10_000));
+        assert!(
+            req.update_qers[0].guaranteed_bitrate.is_none(),
+            "an IE the CP function did not send must decode as absent, not as zero: \
+             `Some(0)` would re-provision a GBR of nothing"
+        );
+
+        assert_eq!(req.update_urrs.len(), 1, "Update URR (IE type 13)");
+        assert_eq!(req.update_urrs[0].urr_id, 3);
+        assert_eq!(
+            req.update_urrs[0]
+                .volume_threshold
+                .as_ref()
+                .map(|v| v.total_volume),
+            Some(9_000)
+        );
+        assert_eq!(req.update_urrs[0].time_threshold, Some(60));
+        assert!(
+            req.update_urrs[0].measurement_method.is_none()
+                && req.update_urrs[0].reporting_triggers.is_none()
+                && req.update_urrs[0].volume_quota.is_none(),
+            "an Update that names only a threshold must not restate the whole rule"
+        );
+
+        assert_eq!(req.remove_qers.len(), 1, "Remove QER (IE type 18)");
+        assert_eq!(req.remove_qers[0].qer_id, 8);
+        assert_eq!(req.remove_urrs.len(), 1, "Remove URR (IE type 17)");
+        assert_eq!(req.remove_urrs[0].urr_id, 4);
     }
 
     #[test]

--- a/src/libs/nextgcore-pfcp/src/types.rs
+++ b/src/libs/nextgcore-pfcp/src/types.rs
@@ -2929,6 +2929,309 @@ impl RemoveFar {
     }
 }
 
+/// Update QER - grouped IE for Session Modification (TS 29.244 Table 7.5.4.5-1)
+///
+/// Every provisioning member is optional except the QER ID: an Update QER that
+/// names only a new Gate Status must leave the bitrates alone. That is why this is
+/// not `CreateQer` reused — a `GateStatus` that defaults to open would re-open a
+/// gate the CP function never mentioned, which is the opposite of the intent.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct UpdateQer {
+    pub qer_id: u32,
+    pub gate_status: Option<GateStatus>,
+    pub maximum_bitrate: Option<Bitrate>,
+    pub guaranteed_bitrate: Option<Bitrate>,
+    pub qfi: Option<u8>,
+}
+
+impl UpdateQer {
+    pub fn new(qer_id: u32) -> Self {
+        Self {
+            qer_id,
+            gate_status: None,
+            maximum_bitrate: None,
+            guaranteed_bitrate: None,
+            qfi: None,
+        }
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        use crate::ie::{encode_u32_ie, encode_u8_ie, IeHeader, IeType};
+
+        encode_u32_ie(buf, IeType::QerId, self.qer_id);
+
+        if let Some(gate_status) = &self.gate_status {
+            encode_u8_ie(buf, IeType::GateStatus, gate_status.encode());
+        }
+
+        if let Some(mbr) = &self.maximum_bitrate {
+            let mut mbr_buf = BytesMut::new();
+            mbr.encode(&mut mbr_buf);
+            let header = IeHeader::new(IeType::Mbr as u16, mbr_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&mbr_buf);
+        }
+
+        if let Some(gbr) = &self.guaranteed_bitrate {
+            let mut gbr_buf = BytesMut::new();
+            gbr.encode(&mut gbr_buf);
+            let header = IeHeader::new(IeType::Gbr as u16, gbr_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&gbr_buf);
+        }
+
+        if let Some(qfi) = self.qfi {
+            encode_u8_ie(buf, IeType::Qfi, qfi);
+        }
+    }
+
+    pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
+        use crate::ie::{IeHeader, IeType, RawIe};
+
+        let mut qer_id = 0u32;
+        let mut gate_status = None;
+        let mut maximum_bitrate = None;
+        let mut guaranteed_bitrate = None;
+        let mut qfi = None;
+
+        while buf.remaining() >= IeHeader::LEN {
+            let ie = RawIe::decode(buf)?;
+            match ie.ie_type {
+                t if t == IeType::QerId as u16 => {
+                    if ie.data.len() >= 4 {
+                        let mut data = ie.data;
+                        qer_id = data.get_u32();
+                    }
+                }
+                t if t == IeType::GateStatus as u16 => {
+                    if !ie.data.is_empty() {
+                        gate_status = Some(GateStatus::decode(ie.data[0]));
+                    }
+                }
+                t if t == IeType::Mbr as u16 => {
+                    let mut data = ie.data;
+                    maximum_bitrate = Some(Bitrate::decode(&mut data)?);
+                }
+                t if t == IeType::Gbr as u16 => {
+                    let mut data = ie.data;
+                    guaranteed_bitrate = Some(Bitrate::decode(&mut data)?);
+                }
+                t if t == IeType::Qfi as u16 => {
+                    if !ie.data.is_empty() {
+                        qfi = Some(ie.data[0]);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            qer_id,
+            gate_status,
+            maximum_bitrate,
+            guaranteed_bitrate,
+            qfi,
+        })
+    }
+}
+
+/// Update URR - grouped IE for Session Modification (TS 29.244 Table 7.5.4.4-1)
+///
+/// Optional members for the same reason as `UpdateQer`: an Update URR carrying only
+/// a new Volume Threshold must not reset the Measurement Method, and must not
+/// disturb the volume measured so far.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct UpdateUrr {
+    pub urr_id: u32,
+    pub measurement_method: Option<MeasurementMethod>,
+    pub reporting_triggers: Option<ReportingTriggers>,
+    pub measurement_period: Option<u32>,
+    pub volume_threshold: Option<VolumeThreshold>,
+    /// Volume Quota (TS 29.244 §8.2.14) — same wire structure as the §8.2.13
+    /// threshold, as in `CreateUrr`.
+    pub volume_quota: Option<VolumeThreshold>,
+    pub time_threshold: Option<u32>,
+}
+
+impl UpdateUrr {
+    pub fn new(urr_id: u32) -> Self {
+        Self {
+            urr_id,
+            measurement_method: None,
+            reporting_triggers: None,
+            measurement_period: None,
+            volume_threshold: None,
+            volume_quota: None,
+            time_threshold: None,
+        }
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        use crate::ie::{encode_u32_ie, encode_u8_ie, IeHeader, IeType};
+
+        encode_u32_ie(buf, IeType::UrrId, self.urr_id);
+
+        if let Some(method) = &self.measurement_method {
+            encode_u8_ie(buf, IeType::MeasurementMethod, method.encode());
+        }
+
+        if let Some(triggers) = &self.reporting_triggers {
+            // Reporting Triggers is a 3-octet bitmask (TS 29.244 §8.2.19).
+            let rt = triggers.encode();
+            let header = IeHeader::new(IeType::ReportingTriggers as u16, rt.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&rt);
+        }
+
+        if let Some(period) = self.measurement_period {
+            encode_u32_ie(buf, IeType::MeasurementPeriod, period);
+        }
+
+        if let Some(vt) = &self.volume_threshold {
+            let mut vt_buf = BytesMut::new();
+            vt.encode(&mut vt_buf);
+            let header = IeHeader::new(IeType::VolumeThreshold as u16, vt_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&vt_buf);
+        }
+
+        if let Some(vq) = &self.volume_quota {
+            let mut vq_buf = BytesMut::new();
+            vq.encode(&mut vq_buf);
+            let header = IeHeader::new(IeType::VolumeQuota as u16, vq_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&vq_buf);
+        }
+
+        if let Some(tt) = self.time_threshold {
+            encode_u32_ie(buf, IeType::TimeThreshold, tt);
+        }
+    }
+
+    pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
+        use crate::ie::{IeHeader, IeType, RawIe};
+
+        let mut urr_id = 0u32;
+        let mut measurement_method = None;
+        let mut reporting_triggers = None;
+        let mut measurement_period = None;
+        let mut volume_threshold = None;
+        let mut volume_quota = None;
+        let mut time_threshold = None;
+
+        while buf.remaining() >= IeHeader::LEN {
+            let ie = RawIe::decode(buf)?;
+            match ie.ie_type {
+                t if t == IeType::UrrId as u16 => {
+                    if ie.data.len() >= 4 {
+                        let mut data = ie.data;
+                        urr_id = data.get_u32();
+                    }
+                }
+                t if t == IeType::MeasurementMethod as u16 => {
+                    if !ie.data.is_empty() {
+                        measurement_method = Some(MeasurementMethod::decode(ie.data[0]));
+                    }
+                }
+                t if t == IeType::ReportingTriggers as u16 => {
+                    reporting_triggers = Some(ReportingTriggers::decode(&ie.data)?);
+                }
+                t if t == IeType::MeasurementPeriod as u16 => {
+                    if ie.data.len() >= 4 {
+                        let mut data = ie.data;
+                        measurement_period = Some(data.get_u32());
+                    }
+                }
+                t if t == IeType::VolumeThreshold as u16 => {
+                    let mut data = ie.data;
+                    volume_threshold = Some(VolumeThreshold::decode(&mut data)?);
+                }
+                t if t == IeType::VolumeQuota as u16 => {
+                    let mut data = ie.data;
+                    volume_quota = Some(VolumeThreshold::decode(&mut data)?);
+                }
+                t if t == IeType::TimeThreshold as u16 => {
+                    if ie.data.len() >= 4 {
+                        let mut data = ie.data;
+                        time_threshold = Some(data.get_u32());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            urr_id,
+            measurement_method,
+            reporting_triggers,
+            measurement_period,
+            volume_threshold,
+            volume_quota,
+            time_threshold,
+        })
+    }
+}
+
+/// Remove QER - grouped IE for Session Modification (TS 29.244 Table 7.5.4.7-1)
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RemoveQer {
+    pub qer_id: u32,
+}
+
+impl RemoveQer {
+    pub fn new(qer_id: u32) -> Self {
+        Self { qer_id }
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        use crate::ie::{encode_u32_ie, IeType};
+        encode_u32_ie(buf, IeType::QerId, self.qer_id);
+    }
+
+    pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
+        use crate::ie::{IeHeader, IeType, RawIe};
+        let mut qer_id = 0u32;
+        while buf.remaining() >= IeHeader::LEN {
+            let ie = RawIe::decode(buf)?;
+            if ie.ie_type == IeType::QerId as u16 && ie.data.len() >= 4 {
+                let mut data = ie.data;
+                qer_id = data.get_u32();
+            }
+        }
+        Ok(Self { qer_id })
+    }
+}
+
+/// Remove URR - grouped IE for Session Modification (TS 29.244 Table 7.5.4.6-1)
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RemoveUrr {
+    pub urr_id: u32,
+}
+
+impl RemoveUrr {
+    pub fn new(urr_id: u32) -> Self {
+        Self { urr_id }
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        use crate::ie::{encode_u32_ie, IeType};
+        encode_u32_ie(buf, IeType::UrrId, self.urr_id);
+    }
+
+    pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
+        use crate::ie::{IeHeader, IeType, RawIe};
+        let mut urr_id = 0u32;
+        while buf.remaining() >= IeHeader::LEN {
+            let ie = RawIe::decode(buf)?;
+            if ie.ie_type == IeType::UrrId as u16 && ie.data.len() >= 4 {
+                let mut data = ie.data;
+                urr_id = data.get_u32();
+            }
+        }
+        Ok(Self { urr_id })
+    }
+}
+
 /// Usage Report (Session Report) - grouped IE in Session Report Request
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UsageReportSrr {


### PR DESCRIPTION
Closes #304. Spec: `specs/fix-pfcp-modification-update-remove-qer-urr.md`.

## The defect

`nextgcore_pfcp::message::SessionModificationRequest` modelled none of Update QER (14), Update URR (13), Remove QER (18) or Remove URR (17). The `IeType` entries existed; the structs and the message fields did not. So a Session Modification carrying any of them **decoded cleanly with those lists empty**, and the UP function answered `REQUEST_ACCEPTED` for a modification it never applied:

- an SGW-C closing a gate (Update QER) got an accepted response and an **open gate**;
- an SGW-C removing a URR got an accepted response and **kept being billed on it** — the same shape #267 fixed for Update PDR's URR ID.

sgwud's `sxa_handler` has had the four lists and the code that applies each since #215; #59 wired the wire path onto the shared codec, so `modification_from_lib` filled all four with `Vec::new()` and that handler code was reachable only in-process.

## What changed

- **nextgcore-pfcp**: `UpdateQer`, `UpdateUrr`, `RemoveQer`, `RemoveUrr` with `encode`/`decode`, and the four lists on `SessionModificationRequest` (encoded in TS 29.244 Table 7.5.4.1-1 row order, decoded).
- **Every Update member is optional** (Decision 1). Reusing `CreateQer` would have made the wrong thing easy: `GateStatus` defaults to **open**, so an Update naming only an MBR would have re-opened a gate the CP function never mentioned — this issue's defect, inverted. Same for `MeasurementMethod` defaulting to 0, which would stop a rule measuring anything.
- **sgwud**: `modification_from_lib` maps all four; the "not modelled" comment is gone. A new `volume_from_lib` preserves absence, so an Update that does not mention the Volume Quota no longer revokes it (`urr_from_lib` still flattens, which is correct for a Create).

## Guards, and the reverts

Two tests, nine reverts, nine bites — the table is in the spec.

- `nextgcore_pfcp::message::tests::a_session_modification_carries_update_and_remove_qer_and_urr_over_the_wire` — encode then decode, **not** a field read. #59 learned that the hard way: a mapping test that builds the library struct directly passes whether or not the codec carries the IE. Each of the four decode arms was reverted individually; each failed this test.
- `nextgcore-sgwud pfcp_path::tests::a_modification_over_the_wire_closes_a_qer_gate_and_removes_a_urr` — a real datagram into a bound socket, asserting the **store**: QER 7's gate reads `0x05`, QER 8 and URR 4 are gone, PDR 1's `urr_ids` drops 4 and keeps 3, URR 3's new threshold landed while its Measurement Method and its Volume Quota survived untouched. Each of the four mappings reverted individually fails it; so does flattening `volume_from_lib`.

## Criterion 5: upfd is deliberately not moved onto the library decoder

Stated either way, as the criterion asks. **It is not**, in this PR: the issue sizes that swap separately, and upfd's handlers feed a different internal model (`DataPlaneUrr` with atomics, not `SgwuUrr`), so it is a re-write of two handlers rather than a mapping change.

The verification pass did find that **upfd has the same functional gap in a different place**: its `handle_session_modification_request` parses only Update FAR, Update QER, Create/Update BAR and the SMReq flags — no URR operation at all, and no Remove QER/PDR/FAR. Filed as its own issue rather than folded in.

## Verification

`cargo test --workspace`: **6290 passed / 0 failed** (baseline 6288). `cargo clippy --workspace --all-targets` introduces no new warning; `cargo fmt --all -- --check` clean.

Ceilings are in the spec — chiefly that `process_update_qer` still ignores the GBR (pre-existing, `sxa_handler.rs`), and that Remove URR still discards residual volume with a `warn` because there is no Query URR (#215's compromise, now reachable in production for the first time).