### PR TITLE
fix(mbsmfd): release shared delivery per RAN node, not per session (#301)

### DIFF
--- a/specs/fix-mbsmfd-per-ran-node-shared-delivery.md
+++ b/specs/fix-mbsmfd-per-ran-node-shared-delivery.md
@@ -1,0 +1,148 @@
+# nextgcore #301 (mbsmfd): release shared delivery per RAN node, not per session
+
+Verified against `main` @ `a724778`.
+
+#301 was filed from #295's own first ceiling. Every claim in it still holds. TS 23.247 §7.2.1.4 /
+§7.2.2.4, TS 38.413 §9.3.5.7 / §9.3.5.10 / §9.3.1.5, TS 29.571 `GlobalRanNodeId`.
+
+## Verified against current main
+
+| claim in the issue | site on `a724778` | still true? |
+|---|---|---|
+| the `MbsDisRelReq` arm calls the unconditional `session_context_terminate` | `main.rs:1646` | yes |
+| …then `release_n4mb_transport`, so one RAN node tears down shared delivery for all | `main.rs:1658-1663` | yes |
+| #295's set is keyed on `nfcInstanceId`, which on this leg is the AMF's | `context.rs:190`, registered only on the SMF leg (`main.rs:1277`) | yes |
+| nothing in the tree tracks a RAN node | `grep ran_node_id` → one `Option<serde_json::Value>` field, read only for the `is_amf` decision | yes |
+| `session_context_terminate`'s own doc names this gap and points at the spec's ceiling | `context.rs:1009-1012` | yes |
+| `test_router_context_update_amf_release_golden_204` exists and must keep passing | `main.rs:3049` | yes |
+
+The issue's diagnosis of **why #295 could not fix it** is also correct as written: deregistering
+the AMF's `nfcInstanceId` finds it absent (SMF STARTs populate that set), so a legitimate N2-driven
+release would stop releasing anything and that golden test would fail; and registering it would let
+an AMF's silence pin the transport open, which #295's Decision 2 explicitly declines to create.
+
+## Decision 1: the key is a canonical string, not the decoded structure
+
+`ranNodeId` arrives as an untyped `serde_json::Value` and `GlobalRanNodeId` (TS 29.571) is a choice
+of `gNbId` / `ngeNbId` / `n3IwfId` / `wagfId` / `tngfId` / `eNbId` / `nid`. `canonical_ran_node_key`
+renders one string per node: `<mcc>-<mnc>/<member>:<normalised value>`, with `gNbId` normalised as
+`bitLength:GNBVALUE` and every textual id upper-cased.
+
+Why not the structure: two JSON objects that mean the same node can differ in member order and in
+hex case, and **a key that does not agree with what was stored silently fails to match** — the
+symptom being a release that answers 204 and releases nothing. That is exactly what `MbsSession.ssm`
+records for the SSM, and #295's note asks for it to be considered here.
+
+Three specifics the guard pins:
+
+- The **PLMN scopes the node id**. A gNB id is only unique within its PLMN (TS 38.413 §9.3.1.5), so
+  the same `gNBValue` in two PLMNs is two holders.
+- **`bitLength` is part of the identity**, not decoration: a 22-bit and a 24-bit gNB id with the
+  same value are different nodes, not one truncated.
+- An **unrecognised shape still keys consistently with itself** (via a sorted-member rendering)
+  rather than being dropped. It only has to match its own release. `Value::to_string()` is not used
+  for this — it is not guaranteed to order members independently of how they were parsed, and it
+  preserves hex case.
+
+Not stored: the received `ranNodeId` value. Nothing echoes it back to a peer (unlike the SSM, which
+a ContextUpdate response carries), so a `HashSet<String>` is the whole requirement. If a future
+issue needs to echo it, the set becomes a map from key to received value.
+
+## Decision 2: either set being non-empty keeps the transport up — stated, and guarded both ways
+
+The issue asks for this explicitly ("the safe reading is that either set being non-empty keeps the
+transport up, but that is a decision, not an obvious truth — say which and why"). **Adopted**, and
+applied on both legs.
+
+The reason: the two sets count different things at different layers — SMF consumers of the MBS
+session, and RAN nodes receiving the shared NG-U tunnel — and there is exactly **one** MB-UPF
+session underneath serving both. Releasing it while either side still needs it stops that side's
+data, which is the defect #295 and #301 each fix in their own dimension. Consulting only one set
+would leave the other's version of the bug open, and the tests prove it: reverting either half of
+the cross-check fails `either_a_consumer_or_a_ran_node_keeps_the_shared_transport_up`.
+
+So `session_context_terminate_for` (the #295 SMF leg) now also refuses while a RAN node holds the
+transport, and `session_ran_node_release` refuses while a consumer does. Both share one
+`transport_holders` helper that returns the union, prefixed `consumer:` / `ran-node:` so the warn
+line and the assertions can tell them apart.
+
+**This changes #295's behaviour**, deliberately: an SMF's last TERMINATE used to release
+unconditionally once its own set emptied. It no longer does when a RAN node is still receiving. The
+`ConsumerTerminate::ConsumerRemains` variant's doc was widened from "other consumers" to "other
+holders" rather than adding a second near-identical enum.
+
+## Decision 3: untracked means pre-#301 behaviour, not a silent non-match
+
+A setup or release whose `ranNodeId` is absent (the schema makes it optional; a release can arrive
+identified only by its N2 container) or is not an object cannot be keyed. Such a leg is **not**
+inserted into the set, and the first release therefore still tears the transport down — the same
+"cannot be tracked, so behave as it did before" rule #295 states for an empty `nfcInstanceId`,
+warned about at both ends and guarded by its own test.
+
+The alternative — keying an untracked node on the empty string — would make **every** untracked RAN
+node the same holder, so two of them would share one entry and the first release would strand the
+second. Refusing to key is the honest option.
+
+## Decision 4: register on the establish side, before the transport exists
+
+`session_ran_node_register` runs at the top of `amf_shared_delivery_setup`, before
+`session_context_start` brings the N4mb transport up — mirroring where #295 registers a consumer,
+and for the same reason it gives: registering afterwards leaves a window in which a second RAN
+node's release sees an empty set and tears down a transport this setup had just asked for.
+
+Both entries into `amf_shared_delivery_setup` register: the `MBS_DIS_SETUP_REQ` arm and the legacy
+JSON-only AMF request (`ranNodeId` with no container), which is also a shared-delivery setup.
+
+## Acceptance criteria
+
+- [x] Two RAN nodes are set up for one TMGI; the first `MBS_DIS_REL_REQ` answers `204` and the
+      transport stays up (`n4mb_session` still present) —
+      `two_ran_nodes_share_delivery_and_only_the_last_release_tears_it_down`.
+- [x] The second releases it, and the context is cleared (same test).
+- [x] A repeated release for the same `ranNodeId` does not double-decrement (same test: a second
+      release from gNB 000001 leaves gNB 000002's delivery up).
+- [x] A setup from a `ranNodeId` already in the set does not double-count —
+      `a_repeated_setup_from_one_ran_node_does_not_double_count`.
+- [x] The interaction with #295's consumer set is stated (Decision 2) and guarded by a test in both
+      directions — `either_a_consumer_or_a_ran_node_keeps_the_shared_transport_up`.
+- [x] `test_router_context_update_amf_release_golden_204` still passes: a session with exactly one
+      RAN node behaves as it does today. So does
+      `mbs_context_update_strict_peer_release_204`, the golden-bytes version of the same flow.
+
+## Verification
+
+`cargo test --workspace`: **6300 passed / 0 failed** (baseline 6295 on `a724778`; mbsmfd 97 → 102).
+`cargo clippy --workspace --all-targets` introduces no new warning; `cargo fmt --all -- --check`
+clean.
+
+| revert | expected to break | result |
+|---|---|---|
+| the release arm calls the unconditional `session_context_terminate` again | `two_ran_nodes_...`, `either_a_consumer_...` | **2 failed** |
+| the setup leg no longer registers the RAN node | both of those plus `a_repeated_setup_...` | **3 failed** |
+| the SMF terminate ignores the RAN-node set (#295 alone) | `either_a_consumer_...` | **1 failed** |
+| the RAN-node release ignores the consumer set | `either_a_consumer_...` | **1 failed** |
+| the key is `value.to_string()` with no canonicalisation | `the_ran_node_key_is_stable_...` | **1 failed** |
+
+Five reverts, five bites. The two middle ones are what make Decision 2 a verified claim rather than
+a stated preference: each direction of the cross-check has a test that only it can fail.
+
+## Ceilings
+
+- **Nothing unpins a transport whose RAN node never releases.** #295's never-departing-consumer
+  decision is followed unchanged: the pin is logged at `warn` naming every remaining holder rather
+  than timed out, because tearing down a transport that is still carrying data because a RAN node
+  went quiet is worse than the pin. No NGAP-level liveness signal reaches this daemon to do better.
+- **The RAN-node set is not driven by anything except ContextUpdate.** An AMF that loses its NG
+  connection to a gNB does not tell the MB-SMF, so the entry persists. Same shape as the point
+  above and out of this issue's scope.
+- **`MbsDistributionReleaseRequestTransfer`'s own contents are not consulted** beyond the TMGI
+  match that already existed. The container names the session, not the node; the node comes from
+  the JSON `ranNodeId`, which is the only place TS 29.532 carries it.
+- **No test drives two AMFs**, only two RAN nodes through one AMF's `nfcInstanceId`. The set is
+  keyed on the RAN node precisely so that does not matter, but it is asserted at the router rather
+  than across two peers.
+- **The MB-UPF is not asked to prune per RAN node.** TS 23.247 §7.2.2.4 releases shared delivery
+  toward one node; this makes the MB-UPF *session* survive, but the N4mb Create FAR's gNB endpoint
+  list (`N4mbSession.gnb_teids`) is not trimmed when one node leaves. Nothing populates that list
+  per RAN node today either, so trimming it would be inventing state; worth its own issue if
+  per-node NG-U pruning is wanted.

--- a/src/bins/nextgcore-mbsmfd/src/context.rs
+++ b/src/bins/nextgcore-mbsmfd/src/context.rs
@@ -188,6 +188,114 @@ pub struct MbsSession {
     /// Keyed on `nfcInstanceId` rather than counted, so a consumer that restarts and
     /// re-STARTs is not counted twice and a repeated TERMINATE cannot decrement twice.
     pub consumers: HashSet<String>,
+    /// The RAN nodes currently receiving shared delivery on this session's transport
+    /// (#301, TS 23.247 §7.2.1.4/§7.2.2.4), keyed on a canonical form of the
+    /// ContextUpdate's `ranNodeId`.
+    ///
+    /// A SECOND, independent dimension from [`Self::consumers`], not a rename of it.
+    /// #295 keyed that set on `nfcInstanceId`, which on the N2 leg is the **AMF's** —
+    /// so the AMF leg could not consult it (deregistering the AMF's id finds it absent,
+    /// since SMF STARTs populate the set) and must not register into it (an AMF's
+    /// silence would then pin the transport open, which #295 explicitly declined to
+    /// create). Before this set existed, one RAN node's `MBS_DIS_REL_REQ` deleted the
+    /// MB-UPF session for every other RAN node still receiving on it — the same defect
+    /// shape as #295's, in a different dimension, and just as quiet: the remaining
+    /// RAN nodes' contexts, the `MbsSession` state and the TMGI were all unchanged and
+    /// the data simply stopped.
+    ///
+    /// Keyed on a canonical STRING rather than the decoded structure: `GlobalRanNodeId`
+    /// (TS 29.571) is a choice of `gNbId` / `ngeNbId` / `n3IwfId` / `wagfId` / `tngfId`
+    /// / `eNbId`, so two JSON objects that mean the same node can differ in member
+    /// order and in hex case — and a key that does not agree with what was stored
+    /// silently fails to match, which is what [`Self::ssm`] records for the SSM.
+    /// Nothing echoes a `ranNodeId` back to a peer, so unlike the SSM there is no
+    /// reason to keep the received form; if a future issue needs to, this becomes a map
+    /// from key to the received value.
+    pub ran_nodes: HashSet<String>,
+}
+
+/// Canonical key for a `GlobalRanNodeId` (#301).
+///
+/// One string per RAN node, stable across member order and hex case, so the key a
+/// setup stores is the key a release looks up. Returns `None` for a `ranNodeId` that is
+/// not an object — the caller then treats the release as untracked, which is the
+/// pre-#301 behaviour rather than a silent non-match.
+pub fn canonical_ran_node_key(value: &serde_json::Value) -> Option<String> {
+    let obj = value.as_object()?;
+
+    // The PLMN scopes the node id: a gNB id is only unique within its PLMN
+    // (TS 38.413 §9.3.1.5), and a session can carry RAN nodes from more than one in a
+    // shared-PLMN deployment.
+    let plmn = obj
+        .get("plmnId")
+        .and_then(|p| p.as_object())
+        .map(|p| {
+            format!(
+                "{}-{}",
+                p.get("mcc").and_then(|v| v.as_str()).unwrap_or(""),
+                p.get("mnc").and_then(|v| v.as_str()).unwrap_or("")
+            )
+        })
+        .unwrap_or_default();
+
+    // gNB id is a structure (bitLength + gNBValue); the rest are plain strings. Checked
+    // in a fixed order so a peer that (wrongly) sends two never keys inconsistently.
+    if let Some(g) = obj.get("gNbId").and_then(|g| g.as_object()) {
+        let bits = g.get("bitLength").and_then(|v| v.as_u64()).unwrap_or(0);
+        let val = g
+            .get("gNBValue")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_ascii_uppercase();
+        return Some(format!("{plmn}/gNbId:{bits}:{val}"));
+    }
+    for member in ["ngeNbId", "n3IwfId", "wagfId", "tngfId", "eNbId", "nid"] {
+        if let Some(v) = obj.get(member).and_then(|v| v.as_str()) {
+            return Some(format!("{plmn}/{member}:{}", v.to_ascii_uppercase()));
+        }
+    }
+
+    // No known id member. Key on a canonical rendering of the whole object rather than
+    // giving up: an unrecognised-but-consistent RAN node still matches ITSELF, which is
+    // all the set needs. `to_string` is not used because it is not guaranteed to order
+    // members independently of how they were parsed.
+    let mut canonical = String::new();
+    canonical_json(value, &mut canonical);
+    Some(format!("{plmn}/raw:{canonical}"))
+}
+
+/// Render a JSON value with object members in sorted order, so equal values render
+/// equal regardless of how they were parsed.
+fn canonical_json(value: &serde_json::Value, out: &mut String) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(k);
+                out.push(':');
+                if let Some(v) = map.get(*k) {
+                    canonical_json(v, out);
+                }
+            }
+            out.push('}');
+        }
+        serde_json::Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                canonical_json(item, out);
+            }
+            out.push(']');
+        }
+        other => out.push_str(&other.to_string()),
+    }
 }
 
 /// What a consumer's ContextUpdate TERMINATE means for the shared transport (#295).
@@ -195,11 +303,30 @@ pub struct MbsSession {
 pub enum ConsumerTerminate {
     /// No MBS session matched the TMGI.
     NotFound,
-    /// Other consumers are still receiving: the transport stays up. Carries who they
-    /// are, because nothing else in the system can name them.
+    /// Something is still receiving: the transport stays up. Carries who, because
+    /// nothing else in the system can name them.
+    ///
+    /// #301 widened this from "other consumers" to "other HOLDERS": entries are
+    /// prefixed `consumer:` or `ran-node:`, since either dimension being non-empty
+    /// keeps the transport up.
     ConsumerRemains { remaining: Vec<String> },
-    /// The set is now empty: this was the last consumer, so the transport is released.
+    /// Nothing holds it any more, so the transport is released.
     LastConsumer,
+}
+
+/// Who still holds a session's shared N4mb transport (#301).
+///
+/// Both dimensions in one list, prefixed so a log line and a test assertion can tell
+/// them apart. Sorted, because both sides come from `HashSet`s.
+fn transport_holders(session: &MbsSession) -> Vec<String> {
+    let mut holders: Vec<String> = session
+        .consumers
+        .iter()
+        .map(|c| format!("consumer:{c}"))
+        .collect();
+    holders.extend(session.ran_nodes.iter().map(|r| format!("ran-node:{r}")));
+    holders.sort();
+    holders
 }
 
 impl MbsSession {
@@ -223,6 +350,7 @@ impl MbsSession {
             group_members: HashSet::new(),
             ssm: None,
             consumers: HashSet::new(),
+            ran_nodes: HashSet::new(),
         }
     }
 
@@ -984,11 +1112,10 @@ impl MbSmfContext {
             if !nfc_instance_id.is_empty() {
                 session.consumers.remove(nfc_instance_id);
             }
-            let mut remaining: Vec<String> = session.consumers.iter().cloned().collect();
-            // Sorted so a log line and a test assertion are both deterministic over a
-            // HashSet.
-            remaining.sort();
-            remaining
+            // #301: the RAN-node set counts too. An SMF's last consumer leaving while a
+            // RAN node is still receiving shared delivery must NOT delete the MB-UPF
+            // session underneath that RAN node.
+            transport_holders(session)
         };
         if !remaining.is_empty() {
             return ConsumerTerminate::ConsumerRemains { remaining };
@@ -1002,14 +1129,86 @@ impl MbSmfContext {
         }
     }
 
+    /// Shared delivery toward one RAN node is being established (#301, TS 23.247
+    /// §7.2.1.4): record it as a holder of the session's shared transport.
+    ///
+    /// Mirrors [`Self::session_consumer_register`], and for the same reason: the set is
+    /// keyed, not counted, so a RAN node whose AMF re-sends `MBS_DIS_SETUP_REQ` is not
+    /// counted twice and a repeated `MBS_DIS_REL_REQ` cannot decrement twice.
+    pub fn session_ran_node_register(&self, tmgi: &Tmgi, ran_node_key: &str) -> Option<usize> {
+        if ran_node_key.is_empty() {
+            return None;
+        }
+        let id = {
+            let tmgi_hash = self.tmgi_hash.read().ok()?;
+            *tmgi_hash.get(tmgi)?
+        };
+        let mut list = self.session_list.write().ok()?;
+        let session = list.get_mut(&id)?;
+        let fresh = session.ran_nodes.insert(ran_node_key.to_string());
+        let count = session.ran_nodes.len();
+        if fresh {
+            log::info!(
+                "[MBS] RAN node {ran_node_key} registered on session {id} (TMGI {:02x?}); \
+                 {count} RAN node(s) now receive its shared delivery",
+                tmgi.mbs_service_id
+            );
+        }
+        Some(count)
+    }
+
+    /// `MBS_DIS_REL_REQ` from one RAN node (#301): deregister it and say whether the
+    /// shared transport may now be released.
+    ///
+    /// Released only when NOTHING holds it — neither another RAN node nor an SMF
+    /// consumer. A RAN node this session does not hold decrements nothing, so a repeated
+    /// release cannot tear down delivery another RAN node is still receiving.
+    ///
+    /// A session with no registered RAN nodes at all yields
+    /// [`ConsumerTerminate::LastConsumer`] when no consumer holds it either, which is
+    /// deliberately the pre-#301 behaviour: sessions established before any tracked
+    /// setup, and every existing single-RAN-node flow, must keep releasing on the first
+    /// `MBS_DIS_REL_REQ`.
+    pub fn session_ran_node_release(&self, tmgi: &Tmgi, ran_node_key: &str) -> ConsumerTerminate {
+        let id = {
+            match self.tmgi_hash.read() {
+                Ok(h) => match h.get(tmgi) {
+                    Some(&id) => id,
+                    None => return ConsumerTerminate::NotFound,
+                },
+                Err(_) => return ConsumerTerminate::NotFound,
+            }
+        };
+        let remaining = {
+            let Ok(mut list) = self.session_list.write() else {
+                return ConsumerTerminate::NotFound;
+            };
+            let Some(session) = list.get_mut(&id) else {
+                return ConsumerTerminate::NotFound;
+            };
+            if !ran_node_key.is_empty() {
+                session.ran_nodes.remove(ran_node_key);
+            }
+            transport_holders(session)
+        };
+        if !remaining.is_empty() {
+            return ConsumerTerminate::ConsumerRemains { remaining };
+        }
+        if self.session_context_terminate(tmgi) {
+            ConsumerTerminate::LastConsumer
+        } else {
+            ConsumerTerminate::NotFound
+        }
+    }
+
     /// ContextUpdate **Terminate** (SMF) / leave: resolve the MBS session by
     /// TMGI and release its N4mb multicast transport (drives the N4mb release
     /// path). Returns whether a session matched.
     ///
-    /// Unconditional — it does not consult the consumer set (#295). Kept for the N2
-    /// (AMF) release leg, whose `nfcInstanceId` is the AMF's and therefore not a member
-    /// of the consumer set the SMF STARTs populate; see the spec's ceiling on the
-    /// per-RAN-node dimension.
+    /// Unconditional — it consults neither the consumer set (#295) nor the RAN-node set
+    /// (#301). Both `session_context_terminate_for` and `session_ran_node_release` call
+    /// it once they have decided nothing holds the transport, so this is the "mark it
+    /// released" half rather than the decision.
     pub fn session_context_terminate(&self, tmgi: &Tmgi) -> bool {
         let id = {
             match self.tmgi_hash.read() {
@@ -1126,6 +1325,82 @@ mod tests {
         let ctx = MbSmfContext::new();
         assert!(!ctx.is_initialized());
         assert_eq!(ctx.session_count(), 0);
+    }
+
+    /// #301: the RAN-node key is canonical, so a setup and a release for the same node
+    /// match even when the AMF renders the JSON differently.
+    ///
+    /// This is the decision the issue asks to make deliberately ("the whole decoded
+    /// structure, or a canonical string"), and the reason it matters is `ssm`'s: a key
+    /// that does not agree with what was stored silently fails to match, and the symptom
+    /// is a release that releases nothing while answering 204.
+    #[test]
+    fn the_ran_node_key_is_stable_across_member_order_and_hex_case() {
+        let a: serde_json::Value = serde_json::from_str(
+            r#"{"plmnId":{"mcc":"208","mnc":"93"},"gNbId":{"bitLength":24,"gNBValue":"00abcd"}}"#,
+        )
+        .unwrap();
+        // Same node: members in the other order, hex in the other case.
+        let b: serde_json::Value = serde_json::from_str(
+            r#"{"gNbId":{"gNBValue":"00ABCD","bitLength":24},"plmnId":{"mnc":"93","mcc":"208"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            canonical_ran_node_key(&a),
+            canonical_ran_node_key(&b),
+            "one RAN node must produce one key, or its release matches nothing"
+        );
+
+        // A different gNB is a different key.
+        let c: serde_json::Value = serde_json::from_str(
+            r#"{"plmnId":{"mcc":"208","mnc":"93"},"gNbId":{"bitLength":24,"gNBValue":"00abce"}}"#,
+        )
+        .unwrap();
+        assert_ne!(canonical_ran_node_key(&a), canonical_ran_node_key(&c));
+
+        // Same gNB value in a different PLMN is a different node (TS 38.413 §9.3.1.5:
+        // a gNB id is only unique within its PLMN).
+        let d: serde_json::Value = serde_json::from_str(
+            r#"{"plmnId":{"mcc":"001","mnc":"01"},"gNbId":{"bitLength":24,"gNBValue":"00abcd"}}"#,
+        )
+        .unwrap();
+        assert_ne!(canonical_ran_node_key(&a), canonical_ran_node_key(&d));
+
+        // A different bitLength is a different node, not the same one truncated.
+        let e: serde_json::Value = serde_json::from_str(
+            r#"{"plmnId":{"mcc":"208","mnc":"93"},"gNbId":{"bitLength":22,"gNBValue":"00abcd"}}"#,
+        )
+        .unwrap();
+        assert_ne!(canonical_ran_node_key(&a), canonical_ran_node_key(&e));
+
+        // The other choice members key on their own name, so an ng-eNB and an N3IWF
+        // with the same textual id are not the same holder.
+        let ngenb: serde_json::Value =
+            serde_json::from_str(r#"{"plmnId":{"mcc":"208","mnc":"93"},"ngeNbId":"macroNgeNB-1"}"#)
+                .unwrap();
+        let n3iwf: serde_json::Value =
+            serde_json::from_str(r#"{"plmnId":{"mcc":"208","mnc":"93"},"n3IwfId":"macroNgeNB-1"}"#)
+                .unwrap();
+        assert_ne!(
+            canonical_ran_node_key(&ngenb),
+            canonical_ran_node_key(&n3iwf)
+        );
+
+        // An unrecognised shape still keys consistently with ITSELF rather than being
+        // dropped: it only has to match its own release.
+        let odd: serde_json::Value =
+            serde_json::from_str(r#"{"plmnId":{"mcc":"208","mnc":"93"},"someFutureId":"x"}"#)
+                .unwrap();
+        let odd_reordered: serde_json::Value =
+            serde_json::from_str(r#"{"someFutureId":"x","plmnId":{"mnc":"93","mcc":"208"}}"#)
+                .unwrap();
+        assert_eq!(
+            canonical_ran_node_key(&odd),
+            canonical_ran_node_key(&odd_reordered)
+        );
+
+        // Not an object: untracked rather than keyed on nonsense.
+        assert_eq!(canonical_ran_node_key(&serde_json::json!("gnb-1")), None);
     }
 
     #[test]

--- a/src/bins/nextgcore-mbsmfd/src/main.rs
+++ b/src/bins/nextgcore-mbsmfd/src/main.rs
@@ -1449,8 +1449,26 @@ fn context_update_n2_response(ie_type: types::NgapIeType, ngap_bytes: Vec<u8>) -
 /// answer with an `MBS_DIS_SETUP_RSP` (TS 38.413 §9.3.5.8) built from the
 /// session's real N4mb transport (llSsm + cTeid), or an `MBS_DIS_SETUP_FAIL`
 /// (§9.3.5.9) with a real Cause when establishment cannot be started.
-fn amf_shared_delivery_setup(tmgi: &Tmgi) -> SbiResponse {
+///
+/// #301: registers `ran_node_key` as a holder of the session's shared transport
+/// BEFORE the establishment below brings it up, mirroring where #295 registers a
+/// consumer. Registering afterwards would leave a window in which a second RAN node's
+/// `MBS_DIS_REL_REQ` saw an empty set and released a transport this setup had just
+/// asked for.
+fn amf_shared_delivery_setup(tmgi: &Tmgi, ran_node_key: Option<&str>) -> SbiResponse {
     let ctx = mbsmf_self();
+    match ran_node_key {
+        Some(key) => {
+            let _ = ctx
+                .read()
+                .ok()
+                .and_then(|c| c.session_ran_node_register(tmgi, key));
+        }
+        None => log::warn!(
+            "ContextUpdate AMF setup (TMGI {:02x?}) carried no usable ranNodeId: this RAN              node cannot be tracked, so the first MBS_DIS_REL_REQ releases the shared              transport as it did before #301",
+            tmgi.mbs_service_id
+        ),
+    }
     let upf_addr = configured_mb_upf_ip();
     let started = ctx
         .read()
@@ -1565,11 +1583,19 @@ async fn handle_context_update_amf(
         );
     }
 
+    // #301: one canonical key per RAN node, computed once for both legs. `None` means
+    // the request carried no `ranNodeId` at all (the schema makes it optional, and the
+    // release leg can arrive with only the N2 container), which is the untracked case.
+    let ran_node_key = req
+        .ran_node_id
+        .as_ref()
+        .and_then(context::canonical_ran_node_key);
+
     let Some(n2) = req.n2_mbs_sm_info.as_ref() else {
         // Legacy JSON-only AMF request (ranNodeId only, no inbound container):
         // still a shared-delivery setup — the response now carries a REAL
         // container part (no dangling contentId). [G1-2 step 8]
-        return amf_shared_delivery_setup(tmgi);
+        return amf_shared_delivery_setup(tmgi, ran_node_key.as_deref());
     };
 
     let part = match resolve_n2_part(request, &n2.ngap_data.content_id) {
@@ -1596,7 +1622,7 @@ async fn handle_context_update_amf(
                     Some("INVALID_MSG_FORMAT"),
                 );
             }
-            amf_shared_delivery_setup(tmgi)
+            amf_shared_delivery_setup(tmgi, ran_node_key.as_deref())
         }
         // Release of shared delivery toward the RAN node (TS 23.247
         // §7.2.2.4): decode the Release Request Transfer (§9.3.5.10),
@@ -1617,15 +1643,38 @@ async fn handle_context_update_amf(
                     Some("INVALID_MSG_FORMAT"),
                 );
             }
-            let released = ctx
+            // #301: deregister THIS RAN node and release the shared transport only
+            // when nothing holds it any more. This arm used to call the unconditional
+            // `session_context_terminate`, so one RAN node's release deleted the MB-UPF
+            // session for every other RAN node still receiving on it (TS 23.247
+            // §7.2.2.4 releases shared delivery toward ONE node).
+            let key = ran_node_key.clone().unwrap_or_default();
+            match ctx
                 .read()
-                .map(|c| c.session_context_terminate(tmgi))
-                .unwrap_or(false);
-            if !released {
-                return send_not_found(
-                    "MBS session not found for ContextUpdate",
-                    Some("CONTEXT_NOT_FOUND"),
-                );
+                .map(|c| c.session_ran_node_release(tmgi, &key))
+                .unwrap_or(context::ConsumerTerminate::NotFound)
+            {
+                context::ConsumerTerminate::NotFound => {
+                    return send_not_found(
+                        "MBS session not found for ContextUpdate",
+                        Some("CONTEXT_NOT_FOUND"),
+                    );
+                }
+                context::ConsumerTerminate::ConsumerRemains { remaining } => {
+                    // #295's never-departing-holder decision applies unchanged here:
+                    // logged rather than timed out, because tearing down a transport
+                    // that is still carrying data because a RAN node went quiet is
+                    // worse than the pin.
+                    log::warn!(
+                        "ContextUpdate AMF release from RAN node {} (TMGI {:02x?}): shared                          transport stays UP for {} remaining holder(s) {:?}. Nothing unpins                          it if they never release (#301).",
+                        if key.is_empty() { "<untracked>" } else { &key },
+                        tmgi.mbs_service_id,
+                        remaining.len(),
+                        remaining
+                    );
+                    return SbiResponse::with_status(204);
+                }
+                context::ConsumerTerminate::LastConsumer => {}
             }
             // #76: same as the SMF terminate leg above -- the wire release, then the
             // local clear.
@@ -1637,7 +1686,7 @@ async fn handle_context_update_amf(
                 release_n4mb_transport(id).await;
             }
             log::info!(
-                "ContextUpdate AMF release (TMGI {:02x?})",
+                "ContextUpdate AMF release (TMGI {:02x?}): last holder gone, shared                  transport released",
                 tmgi.mbs_service_id
             );
             SbiResponse::with_status(204)
@@ -2609,6 +2658,358 @@ mod tests {
         assert!(
             session.consumers.is_empty(),
             "and leaves no consumer behind"
+        );
+    }
+
+    // ================================================================
+    // #301: shared delivery is released per RAN NODE, not per session
+    // ================================================================
+
+    /// An AMF ContextUpdate body with an explicit `ranNodeId`, so a test can be two
+    /// different RAN nodes. `amf_ctx_update_body` hardcodes one gNB.
+    fn amf_ctx_update_body_gnb(
+        svc_hex: &str,
+        mcc: &str,
+        mnc: &str,
+        ie_type: &str,
+        content_id: &str,
+        gnb_value: &str,
+    ) -> String {
+        format!(
+            r#"{{"nfcInstanceId":"amf-x","mbsSessionId":{{"tmgi":{{"mbsServiceId":"{svc_hex}","plmnId":{{"mcc":"{mcc}","mnc":"{mnc}"}}}}}},"ranNodeId":{{"plmnId":{{"mcc":"{mcc}","mnc":"{mnc}"}},"gNbId":{{"bitLength":24,"gNBValue":"{gnb_value}"}}}},"n2MbsSmInfo":{{"ngapIeType":"{ie_type}","ngapData":{{"contentId":"{content_id}"}}}}}}"#
+        )
+    }
+
+    /// An SMF ContextUpdate body for an explicit PLMN, so the SMF and AMF legs in one
+    /// test can address the same session.
+    fn smf_ctx_update_body_plmn(
+        svc_hex: &str,
+        nfc: &str,
+        action: &str,
+        mcc: &str,
+        mnc: &str,
+    ) -> String {
+        format!(
+            r#"{{"nfcInstanceId":"{nfc}","mbsSessionId":{{"tmgi":{{"mbsServiceId":"{svc_hex}","plmnId":{{"mcc":"{mcc}","mnc":"{mnc}"}}}}}},"requestedAction":"{action}"}}"#
+        )
+    }
+
+    /// The minimal §9.3.5.7 Setup Request Transfer for a TMGI in PLMN 208/93:
+    /// presence/preamble octet, then the PLMN in BCD (02 F8 39) and the service id.
+    fn setup_container_208_93(svc_id: [u8; 3]) -> Vec<u8> {
+        vec![0x00, 0x02, 0xF8, 0x39, svc_id[0], svc_id[1], svc_id[2]]
+    }
+
+    /// The §9.3.5.10 Release Request Transfer for the same TMGI — the setup container
+    /// plus the trailing octet the golden constant carries.
+    fn rel_container_208_93(svc_id: [u8; 3]) -> Vec<u8> {
+        let mut v = setup_container_208_93(svc_id);
+        v.push(0x40);
+        v
+    }
+
+    async fn amf_leg(body: String, container: Vec<u8>) -> SbiResponse {
+        post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update")
+                .with_body(body, "application/json")
+                .with_part(SbiPart::with_content(
+                    "n2SmInfo",
+                    APPLICATION_NGAP,
+                    bytes::Bytes::from(container),
+                )),
+        )
+        .await
+    }
+
+    fn stored_session_plmn(svc_id: [u8; 3], mcc: &str, mnc: &str) -> MbsSession {
+        let tmgi = Tmgi {
+            mbs_service_id: svc_id,
+            plmn_id: PlmnId {
+                mcc: mcc.to_string(),
+                mnc: mnc.to_string(),
+            },
+        };
+        mbsmf_self()
+            .read()
+            .unwrap()
+            .session_find_by_tmgi(&tmgi)
+            .expect("session exists")
+    }
+
+    /// #301 criteria 1-3: two RAN nodes receive one TMGI's shared delivery; the first
+    /// `MBS_DIS_REL_REQ` answers 204 with the transport UP, a repeated one from the same
+    /// node changes nothing, and the second releases it.
+    ///
+    /// `n4mb_session.is_some()` is the assertion that no Session Deletion was sent, as
+    /// in #295's test: `release_n4mb_transport` is the only path that sends one and it
+    /// clears the context either way, so a context still present is a release that did
+    /// not happen.
+    #[tokio::test]
+    async fn two_ran_nodes_share_delivery_and_only_the_last_release_tears_it_down() {
+        let svc_id = [0xC3, 0x01, 0x01];
+        let svc = seed_global_session_plmn(svc_id, "208", "93");
+
+        for gnb in ["000001", "000002"] {
+            let rsp = amf_leg(
+                amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_SETUP_REQ", "n2SmInfo", gnb),
+                setup_container_208_93(svc_id),
+            )
+            .await;
+            assert_eq!(rsp.status, 200, "gNB {gnb}'s shared-delivery setup");
+        }
+        let session = stored_session_plmn(svc_id, "208", "93");
+        assert_eq!(
+            session.ran_nodes.len(),
+            2,
+            "both RAN nodes receive this session's shared delivery, got {:?}",
+            session.ran_nodes
+        );
+        assert!(session.n4mb_session.is_some(), "the transport is up");
+
+        // --- the first RAN node releases: 204, and delivery continues ---
+        let rsp = amf_leg(
+            amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_REL_REQ", "n2SmInfo", "000001"),
+            rel_container_208_93(svc_id),
+        )
+        .await;
+        assert_eq!(
+            rsp.status, 204,
+            "release → 204 (spec 2b: nothing to return)"
+        );
+        let session = stored_session_plmn(svc_id, "208", "93");
+        assert!(
+            session.n4mb_session.is_some(),
+            "the MB-UPF session must survive one RAN node's release: the others are still \
+             receiving on it (TS 23.247 §7.2.2.4 releases delivery toward ONE node)"
+        );
+        assert_eq!(
+            session.ran_nodes.len(),
+            1,
+            "only the releasing node is removed, got {:?}",
+            session.ran_nodes
+        );
+
+        // --- a REPEATED release from the same node changes nothing ---
+        let rsp = amf_leg(
+            amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_REL_REQ", "n2SmInfo", "000001"),
+            rel_container_208_93(svc_id),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session_plmn(svc_id, "208", "93")
+                .n4mb_session
+                .is_some(),
+            "a repeated release must not double-decrement and tear down delivery gNB \
+             000002 is still receiving"
+        );
+
+        // --- the last RAN node releases it ---
+        let rsp = amf_leg(
+            amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_REL_REQ", "n2SmInfo", "000002"),
+            rel_container_208_93(svc_id),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        let session = stored_session_plmn(svc_id, "208", "93");
+        assert!(
+            session.n4mb_session.is_none(),
+            "the last RAN node's release tears the shared transport down"
+        );
+        assert!(session.ran_nodes.is_empty(), "and leaves no node behind");
+    }
+
+    /// #301 criterion 4: a setup from a `ranNodeId` already in the set does not
+    /// double-count, so an AMF that re-sends `MBS_DIS_SETUP_REQ` cannot pin the
+    /// transport past its own release.
+    #[tokio::test]
+    async fn a_repeated_setup_from_one_ran_node_does_not_double_count() {
+        let svc_id = [0xC3, 0x01, 0x02];
+        let svc = seed_global_session_plmn(svc_id, "208", "93");
+
+        for _ in 0..3 {
+            let rsp = amf_leg(
+                amf_ctx_update_body_gnb(
+                    &svc,
+                    "208",
+                    "93",
+                    "MBS_DIS_SETUP_REQ",
+                    "n2SmInfo",
+                    "000001",
+                ),
+                setup_container_208_93(svc_id),
+            )
+            .await;
+            assert_eq!(rsp.status, 200);
+        }
+        assert_eq!(
+            stored_session_plmn(svc_id, "208", "93").ran_nodes.len(),
+            1,
+            "three setups from one RAN node are one RAN node"
+        );
+
+        // So one release is therefore the last one.
+        let rsp = amf_leg(
+            amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_REL_REQ", "n2SmInfo", "000001"),
+            rel_container_208_93(svc_id),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session_plmn(svc_id, "208", "93")
+                .n4mb_session
+                .is_none(),
+            "one node, one release, transport gone"
+        );
+    }
+
+    /// #301 criterion 5: the two sets interact, and EITHER being non-empty keeps the
+    /// shared transport up. Guarded in both directions, because the safe reading is a
+    /// decision rather than an obvious truth.
+    ///
+    /// The reason for it: the sets count different things at different layers — SMF
+    /// consumers of the MBS session, and RAN nodes receiving the shared NG-U tunnel —
+    /// and the ONE MB-UPF session underneath serves both. Releasing it while either
+    /// still needs it stops data for that side, which is the defect #295 and #301 each
+    /// fix in their own dimension; consulting only one set would leave the other's
+    /// version of it open.
+    #[tokio::test]
+    async fn either_a_consumer_or_a_ran_node_keeps_the_shared_transport_up() {
+        // --- direction 1: the RAN node releases while an SMF consumer remains ---
+        let svc_id = [0xC3, 0x01, 0x03];
+        let svc = seed_global_session_plmn(svc_id, "208", "93");
+
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body_plmn(&svc, "smf-a", "START", "208", "93"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 200, "the SMF's START");
+        let rsp = amf_leg(
+            amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_SETUP_REQ", "n2SmInfo", "000001"),
+            setup_container_208_93(svc_id),
+        )
+        .await;
+        assert_eq!(rsp.status, 200, "the RAN node's setup");
+
+        let session = stored_session_plmn(svc_id, "208", "93");
+        assert_eq!(session.consumers.len(), 1);
+        assert_eq!(session.ran_nodes.len(), 1);
+
+        let rsp = amf_leg(
+            amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_REL_REQ", "n2SmInfo", "000001"),
+            rel_container_208_93(svc_id),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session_plmn(svc_id, "208", "93")
+                .n4mb_session
+                .is_some(),
+            "the last RAN node leaving must not delete the MB-UPF session an SMF consumer \
+             is still using"
+        );
+
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body_plmn(&svc, "smf-a", "TERMINATE", "208", "93"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session_plmn(svc_id, "208", "93")
+                .n4mb_session
+                .is_none(),
+            "and once neither holds it, it goes"
+        );
+
+        // --- direction 2: the SMF consumer terminates while a RAN node remains ---
+        let svc_id = [0xC3, 0x01, 0x04];
+        let svc = seed_global_session_plmn(svc_id, "208", "93");
+
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body_plmn(&svc, "smf-a", "START", "208", "93"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 200);
+        let rsp = amf_leg(
+            amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_SETUP_REQ", "n2SmInfo", "000001"),
+            setup_container_208_93(svc_id),
+        )
+        .await;
+        assert_eq!(rsp.status, 200);
+
+        let rsp = post_ctx_update(
+            SbiRequest::post("/nmbsmf-mbssession/v1/mbs-sessions/contexts/update").with_body(
+                smf_ctx_update_body_plmn(&svc, "smf-a", "TERMINATE", "208", "93"),
+                "application/json",
+            ),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session_plmn(svc_id, "208", "93")
+                .n4mb_session
+                .is_some(),
+            "the last SMF consumer leaving must not stop delivery a RAN node is still \
+             receiving: #295's set alone would have released here"
+        );
+
+        let rsp = amf_leg(
+            amf_ctx_update_body_gnb(&svc, "208", "93", "MBS_DIS_REL_REQ", "n2SmInfo", "000001"),
+            rel_container_208_93(svc_id),
+        )
+        .await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session_plmn(svc_id, "208", "93")
+                .n4mb_session
+                .is_none(),
+            "and the RAN node's release is then the last holder's"
+        );
+    }
+
+    /// An AMF release carrying no usable `ranNodeId` releases on the first request, as
+    /// it did before #301 — the same "cannot be tracked, so behave as before" rule #295
+    /// states for an empty `nfcInstanceId`, and stated here rather than left to be
+    /// discovered.
+    #[tokio::test]
+    async fn an_untracked_ran_node_releases_on_the_first_request() {
+        let svc_id = [0xC3, 0x01, 0x05];
+        let svc = seed_global_session_plmn(svc_id, "208", "93");
+
+        // Setup with no ranNodeId at all: only the N2 container identifies the leg.
+        let no_ran_node = format!(
+            r#"{{"nfcInstanceId":"amf-x","mbsSessionId":{{"tmgi":{{"mbsServiceId":"{svc}","plmnId":{{"mcc":"208","mnc":"93"}}}}}},"n2MbsSmInfo":{{"ngapIeType":"MBS_DIS_SETUP_REQ","ngapData":{{"contentId":"n2SmInfo"}}}}}}"#
+        );
+        let rsp = amf_leg(no_ran_node, setup_container_208_93(svc_id)).await;
+        assert_eq!(rsp.status, 200);
+        let session = stored_session_plmn(svc_id, "208", "93");
+        assert!(
+            session.ran_nodes.is_empty(),
+            "an untracked RAN node is not in the set: keying it on nothing would make \
+             every such node the SAME holder"
+        );
+        assert!(session.n4mb_session.is_some());
+
+        let rel_no_ran_node = format!(
+            r#"{{"nfcInstanceId":"amf-x","mbsSessionId":{{"tmgi":{{"mbsServiceId":"{svc}","plmnId":{{"mcc":"208","mnc":"93"}}}}}},"n2MbsSmInfo":{{"ngapIeType":"MBS_DIS_REL_REQ","ngapData":{{"contentId":"n2SmInfo"}}}}}}"#
+        );
+        let rsp = amf_leg(rel_no_ran_node, rel_container_208_93(svc_id)).await;
+        assert_eq!(rsp.status, 204);
+        assert!(
+            stored_session_plmn(svc_id, "208", "93")
+                .n4mb_session
+                .is_none(),
+            "with nothing tracked there is nothing to keep it up, which is the pre-#301 \
+             behaviour"
         );
     }
 


### PR DESCRIPTION
Closes #301. Spec: `specs/fix-mbsmfd-per-ran-node-shared-delivery.md`.

## The defect

`handle_context_update_amf`'s `MBS_DIS_REL_REQ` arm called the unconditional `session_context_terminate` and then `release_n4mb_transport`. That is **one RAN node** releasing shared delivery (TS 23.247 §7.2.2.4), so it deleted the MB-UPF session for every other RAN node still receiving on it. As quiet as #295's version: the remaining RAN nodes' shared-delivery contexts, the `MbsSession` state and the TMGI are all unchanged, and the data simply stops.

#295's consumer set genuinely could not fix it, exactly as the issue says — it is keyed on `nfcInstanceId`, which on this leg is the **AMF's**. Deregistering it finds it absent (SMF STARTs populate the set) so a legitimate N2 release would stop releasing anything; registering it would let an AMF's silence pin the transport, which #295's Decision 2 declines to create.

## What changed

- **`MbsSession.ran_nodes`** — a second, independent set, populated on the establish side (both the `MBS_DIS_SETUP_REQ` arm and the legacy JSON-only AMF request) *before* `session_context_start` brings the transport up, mirroring where #295 registers a consumer and for the same reason it gives.
- **`canonical_ran_node_key`** (Decision 1) — the key is a canonical **string**, not the decoded structure: `<mcc>-<mnc>/<member>:<value>`, `gNbId` as `bitLength:GNBVALUE`, textual ids upper-cased. Two JSON objects meaning the same node can differ in member order and hex case, and a key that disagrees with what was stored fails to match **silently** — a release that answers 204 and releases nothing. That is what `MbsSession.ssm` records for the SSM. The guard also pins that the PLMN scopes the id (TS 38.413 §9.3.1.5), that `bitLength` is part of the identity rather than decoration, and that an unrecognised shape still keys consistently with itself instead of being dropped.
- **Either set non-empty keeps the transport up** (Decision 2, which #301 asks to be decided explicitly) — enforced on *both* legs through one `transport_holders` helper. One MB-UPF session serves both dimensions, so consulting a single set leaves the other's version of the bug open. This **deliberately changes #295's behaviour**: an SMF's last TERMINATE no longer releases while a RAN node is still receiving.
- **Untracked stays pre-#301** (Decision 3) — a `ranNodeId` that is absent or not an object is not keyed, and the first release still tears the transport down, warned about at both ends. Keying it on the empty string would make every untracked node the *same* holder, so the first release would strand the second.

## Verification

`cargo test --workspace`: **6300 passed / 0 failed** (baseline 6295). mbsmfd 97 → 102. clippy adds no warning; fmt clean. Both golden AMF-release tests (`test_router_context_update_amf_release_golden_204`, `mbs_context_update_strict_peer_release_204`) pass unchanged — criterion 6.

**Five reverts, five bites** (table in the spec). The two that matter most are one per direction of the cross-set check: reverting the SMF leg's awareness of RAN nodes, and reverting the RAN-node leg's awareness of consumers, each fails `either_a_consumer_or_a_ran_node_keeps_the_shared_transport_up` and nothing else. That is what makes Decision 2 a verified claim rather than a stated preference.

## Note on the whole-workspace suite

Two **pre-existing** flakes were observed across 5 whole-workspace runs on this branch, in `nextgcore-smfd` and `nextgcore-lmfd`. Both crates are green in isolation (smfd 6/6, lmfd 4/4) and neither is touched here; both are process-global test races that only the whole-workspace run provokes. Tracked in #308 (measured against `main` in a clean worktree during #217).

Ceilings are in the spec — chiefly that nothing unpins a transport whose RAN node never releases (#295's precedent, logged rather than timed out), and that the MB-UPF's per-gNB NG-U endpoint list is not trimmed when one node leaves, because nothing populates it per RAN node today.