### PR TITLE
fix(pcfd): subscribe to the UDR for policy-data changes and re-authorise live sessions (#299)

### DIFF
--- a/specs/fix-pcfd-udr-policy-data-subscription.md
+++ b/specs/fix-pcfd-udr-policy-data-subscription.md
@@ -1,0 +1,186 @@
+# nextgcore #299 (pcfd): a policy-data change reaches a live SM policy association
+
+Verified against `main` @ `f5bf6ab`.
+
+#299 was split out of #293 by that issue's own instruction. Its **scope and criteria hold**; the
+example in its motivation does not, and that is the finding this spec leads with. TS 23.502
+§4.16.11, TS 23.503 §6.1.3.2, TS 29.519 §5.2 / §5.6.2, TS 29.512 §4.2.3.2.
+
+## Verified against current main
+
+| claim in the issue | site on `f5bf6ab` | still true? |
+|---|---|---|
+| pcfd has no UDR policy-data subscription and no notification sink | `grep -rn 'subs-to-notify' bins/nextgcore-pcfd/` → **nothing** | yes |
+| nothing re-drives `Npcf_SMPolicyControl_UpdateNotify` for a subscription change | `pcf_sbi_send_smpolicycontrol_update_notify` has callers, none of them a data change | yes |
+| the SMF side needs nothing new (`handle_sm_policy_notify` already serves) | smfd, unchanged here | yes |
+| "Check whether udrd can even notify" | **it can, fully** — see below | the pre-check passes |
+| an operator's edit reaches a live PCF-authorised session through no path | yes for policy data; **and still yes for session-AMBR after this PR** | see Decision 1 |
+
+**The pre-check the issue asks for comes back favourable.** udrd already implements the whole UDR
+half: `POST /nudr-dr/v2/policy-data/subs-to-notify` (`handle_policy_subs_to_notify`, validating
+`notificationUri` and a non-empty `monitoredResourceUris`, answering 201 + `Location`), and
+`notify_policy_data_change` emits a `PolicyDataChangeNotification` carrying `ueId`, `reportId` and
+`policyDataSubset` to every subscriber whose monitored URIs cover the changed path. Its own comment
+says why both notification trees are emitted: *"a `/policy-data/subs-to-notify` subscriber (the PCF)
+gets the `PolicyDataChangeNotification`. Emitting only the first is why a PCF could subscribe and
+never hear anything."* So this PR is the first in-tree producer of that subscription, and no udrd
+work was needed.
+
+## Decision 1: the issue's session-AMBR example is served by a different mechanism, and is filed separately
+
+#299's motivation leads with *"an operator editing a subscriber's session-AMBR reaches a live
+session through no path at all"*. Implementing the issue does **not** fix that, and it cannot:
+
+`SmPolicyDnnData` (TS 29.519 §5.6.2) carries `online`, `offline`, `gbrUl`/`gbrDl`,
+`allowedServices`, `subscCats` and charging/usage-monitoring references — and **no session-AMBR, no
+default 5QI, no ARP**. This tree already said so, in a comment older than both issues, at the create
+path that reads the resource:
+
+> "The QoS/ARP/AMBR/PCC decision is not re-derived from this resource (**SmPolicyDnnData does not
+> carry them**); only the spec-defined online/offline charging flags are."
+
+The subscribed session-AMBR lives in the **UDM's** session-management subscription data, and the
+PCF's input for it is `SmPolicyContextData.subsSessAmbr`, which the **SMF** supplies. So #293's
+deferral ("the PCF learns of subscription changes from the UDR") points at a path that structurally
+cannot carry that datum. The TS-conformant route is the SMF reporting `SE_AMBR_CH` on the
+`/sm-policies/{id}/update` leg — both halves of which exist in-tree and neither of which is wired.
+
+That contradicts a decision #293 recorded deliberately, so it is **not** silently overturned here:
+filed as its own `decision` issue with the three options and a recommendation.
+
+**What this PR therefore delivers** is the mechanism for what the UDR's policy data *does* carry:
+the charging flags this PCF maps, reaching a live association instead of only a new one.
+
+## Decision 2: selection by SUPI, evaluation per session scoped to its own S-NSSAI and DNN
+
+The notification names only `ueId` and the changed resource. A UE can hold PDU sessions on several
+slices, so re-authorising every session of that SUPI from an unscoped read would apply one slice's
+policy data to another slice's session — which is exactly what #293's Decision 2 records for the
+SMF's own re-read ("an unscoped lookup silently applies another slice's values").
+
+So: `ueId` selects the candidate sessions, and each candidate is evaluated against a read scoped to
+**its own** `(sst, sd, dnn)`. The guard asserts both halves: only the changed slice's session is
+notified, and the UDR saw one query per slice carrying that slice's S-NSSAI.
+
+## Decision 3: a session whose mapped data did not change is not notified
+
+An `SmPolicyUpdateNotify` carrying an unchanged decision is a re-authorisation the SMF processes for
+nothing, and at scale one UDR write would notify every session of every UE. So the re-read is
+compared against what the session holds, and only a difference produces a notify.
+
+This is what forced the create path to **store** the resource (below): without a stored baseline the
+first notification for any session is always a "change".
+
+## Decision 4: a failed read is not "nothing provisioned"
+
+`pcf_udr_sm_policy_dnn_data` returns `Option`, collapsing a 404 with an unreachable UDR. The first
+draft of the handler used it, and its own criterion-5 test caught the consequence: a transient UDR
+failure erased the session's stored policy data and sent a re-authorisation carrying the local
+default — a network blip silently reverting a subscriber's charging mode.
+
+So #299 adds `pcf_udr_sm_policy_dnn_data_from(ep, …) -> Result<Option<_>, String>`, which
+distinguishes them, and:
+
+- **no UDR discoverable** → nothing is read, nothing is stored, nothing is notified (criterion 5);
+- **discoverable but the read fails** → that session keeps the policy it was authorised with;
+- **404** → genuinely nothing provisioned for that slice, which is a change only if something was.
+
+It also takes an already-discovered endpoint, so a UE with several PDU sessions costs one NRF round
+trip rather than one per session.
+
+## The defect that made the mechanism observable
+
+`build_sm_policy_notification` rebuilt `chgDecs` from `pcf_get_session_data` and applied **none** of
+the UDR's charging flags, while the create path applied them inline and then **discarded** the
+resource. Two consequences, both pre-existing and both fixed here because #299 is unimplementable
+without it:
+
+1. Every `Npcf_SMPolicyControl_UpdateNotify` — from an AF, from a re-authorisation, from anything —
+   sent the SMF a decision with the charging mode reverted to the local default. A create said
+   "online charging on", any later notify said "off", and nothing logged it.
+2. A re-authorisation on a policy-data change would have been sent and changed nothing: the wired
+   mechanism with no effect this backlog keeps finding.
+
+The overlay now lives in one shared `apply_policy_dnn_charging`, used by both the create path and
+the notify builder, and the resource is stored on the session (`PcfSess.policy_dnn_data`, held as
+received JSON with `#[serde(default)]` for snapshot compatibility, like `access_type`).
+
+## Acceptance criteria
+
+- [x] pcfd serves a `Nudr_DM_Notification` sink for policy-data changes, and the subscribe is not
+      sent before the sink exists — the sink is a router arm on `POLICY_DATA_NOTIFY_PATH`, the
+      subscribe runs in `main` **after** `sbi_server.start()`, and
+      `the_advertised_policy_data_callback_is_a_path_this_pcf_serves` feeds the advertised URI's own
+      path back through the real router and refuses a 404/405. One constant serves both sides, so
+      they cannot drift.
+- [x] A policy-data change for a subscriber with a live SM policy association produces an
+      `Npcf_SMPolicyControl_UpdateNotify` to the SMF, asserted over the wire from the notification
+      handler — `a_policy_data_change_reauthorises_the_live_association_with_the_new_decision` drives
+      the real router and captures the POST on a stub SMF, asserting the path
+      (`{notificationUri}/update`), the `resourceUri`, and that the **changed** flag is in `chgDecs`.
+- [x] The SMF applies it through the existing `handle_sm_policy_notify` path — unchanged on that
+      side. **Seam stated**: the two daemons are not driven in one test process, so the assertion
+      stops at the wire (the body the SMF receives). What is NOT claimed is a changed **AMBR**: see
+      Decision 1.
+- [x] The affected-association lookup is scoped deliberately, and a change for one slice does not
+      re-authorise another slice's session —
+      `a_change_for_one_slice_does_not_reauthorise_another_slices_session`, one SUPI with two PDU
+      sessions on two slices.
+- [x] With no UDR configured/discoverable, pcfd behaves exactly as it does today —
+      `with_no_udr_a_policy_data_notification_changes_nothing`, which also asserts the stored data is
+      not erased.
+
+## Verification
+
+`cargo test --workspace`: **6306 passed / 0 failed** over three consecutive runs (baseline 6300 on
+`f5bf6ab`; pcfd 178 → 184). `cargo clippy --workspace --all-targets` introduces no new warning;
+`cargo fmt --all -- --check` clean.
+
+| revert | expected to break | result |
+|---|---|---|
+| the notify builder drops the UDR charging overlay | `a_policy_data_change_reauthorises_...` | **1 failed** |
+| the create path no longer stores the UDR policy data | `the_create_stores_the_udrs_policy_data_...` | **1 failed** |
+| the no-UDR case is not short-circuited | `a_change_for_one_slice_...` | **1 failed** |
+| a failed read is treated as "nothing provisioned" | `a_failed_udr_read_leaves_the_association_...` | **1 failed** |
+| the re-read is not scoped to the session's slice | `a_change_for_one_slice_...` | **1 failed** |
+| unchanged data still re-authorises | `a_policy_data_change_...`, `the_create_stores_...` | **2 failed** |
+
+Six reverts, six bites. One is worth reading precisely: the **no-UDR short-circuit** revert failed
+the *slice* test rather than the no-UDR test, because with the short-circuit gone the reads fail and
+Decision 4's error handling still protects the session. So the no-UDR *behaviour* is guarded by the
+combination of that check and the error handling, not by either alone — stated rather than left to
+look like one guard covering both.
+
+### Two of my own tests were wrong before they were right
+
+- The mock UDR asserted scoping by reading `req.header.uri`, and saw no query at all: the shared SBI
+  server decodes query values into `http.params` and leaves the path in `header.uri`. A correctly
+  scoped re-read looked unscoped, i.e. the harness lied in the shape of a product defect.
+- `seed_sm_policy_session` called `ue_sm_add` per session, and that function **always inserts** a
+  fresh UE-SM and overwrites `supi_sm_hash` — so the two-slice test orphaned the first session and
+  `ue_sm_find_by_supi` saw only the second. It passed in the per-crate run and failed in the
+  whole-workspace run, which is the shape a real flake takes. The helper now reuses an existing
+  UE-SM, which is also what "one UE, two PDU sessions" means.
+
+## Ceilings
+
+- **Only `online`/`offline` are mapped from `SmPolicyDnnData`**, because they are the only members
+  this PCF derives a decision from — unchanged by this issue, and the create path's comment already
+  said so. `gbrUl`/`gbrDl`, `subscCats`, `allowedServices` and the usage-monitoring references are
+  stored (the whole resource is held) but not mapped. A future issue that maps one gets the
+  notification path for free.
+- **The subscribed session-AMBR is not propagated** (Decision 1) — filed as a `decision` issue. This
+  PR does not touch `PcfSess.subscribed_sess_ambr`, which remains written-and-never-read.
+- **`monitoredResourceUris` is the whole per-UE collection**, not one entry per subscriber: the PCF
+  cannot enumerate the UEs it will serve. So a UDR write for a UE this PCF holds no session for
+  still costs a notification, answered 204 after one hash lookup.
+- **The subscription is not renewed or repaired.** It is created once at startup and deleted at
+  shutdown; a UDR that restarts and forgets it leaves this PCF subscribed to nothing until the PCF
+  restarts. Detecting that needs either a validity time (TS 29.519 has none for this resource) or an
+  NF-status subscription this daemon does not hold.
+- **One subscription per PCF process**, so two PCFs behind the same NRF each get their own — correct,
+  but the UDR then fans out to both and each re-reads. Not a defect; worth knowing before reading a
+  UDR's notification counters.
+- **No E2E.** The Docker jobs are `workflow_dispatch`-only, so every assertion here is a loopback
+  stub NRF/UDR and stub SMF in one process; the notification path against real udrd is unexercised
+  in CI, though udrd's half is unit-tested on its own side.

--- a/src/bins/nextgcore-pcfd/src/app.rs
+++ b/src/bins/nextgcore-pcfd/src/app.rs
@@ -481,6 +481,14 @@ pub async fn run() -> Result<()> {
         }
     }
 
+    // #299: subscribe to the UDR for policy-data changes, AFTER the SBI server is
+    // listening. The ordering is the point: the subscription advertises this PCF's own
+    // callback URI, and a UDR that notified before the route existed would post into a
+    // 404 -- the same constraint #293 hit on the SMF's SDM subscribe. Best effort: with
+    // no UDR or no NRF the PCF behaves exactly as it did before, which is the gap this
+    // closes rather than a startup failure.
+    let policy_data_subscription = sbi_path::pcf_subscribe_udr_policy_data().await;
+
     log::info!("NextGCore PCF ready");
 
     // Issue #24: intent-driven closed-loop policy controller (feature
@@ -499,6 +507,14 @@ pub async fn run() -> Result<()> {
 
     // Graceful shutdown
     log::info!("Shutting down...");
+
+    // #299: drop the policy-data subscription before the listener goes away, for the
+    // same reason as the NRF deregistration below -- a UDR still holding it would post
+    // notifications at a socket that has closed, and udrd only logs a delivery failure,
+    // so the subscription would linger for the life of that UDR.
+    if let Some(resource) = policy_data_subscription {
+        sbi_path::pcf_unsubscribe_udr_policy_data(&resource).await;
+    }
 
     // #235: NFDeregister (TS 29.510 5.2.2.2.3) BEFORE the listener goes
     // away, so the NRF stops handing this profile to consumers instead of
@@ -645,6 +661,14 @@ pub async fn pcf_sbi_request_handler(request: SbiRequest) -> SbiResponse {
         // Policy Authorization Service (npcf-policyauthorization)
         ("npcf-policyauthorization", "app-sessions", _) => {
             route_policy_authorization(&parts, method, &request, uri).await
+        }
+
+        // Nudr_DM_Notification sink for policy-data changes (#299, TS 29.519 §5.2).
+        // Its path is `sbi_path::POLICY_DATA_NOTIFY_PATH`, the same constant the
+        // subscription advertises, so the URI the UDR is told about is one this router
+        // serves.
+        ("npcf-callback", "policy-data-change-notify", "POST") => {
+            handle_policy_data_change_notify(&request).await
         }
 
         // Policy Control Event Exposure Service (npcf-eventexposure, TS 29.523)
@@ -1916,21 +1940,17 @@ pub async fn handle_sm_policy_create(request: &SbiRequest) -> SbiResponse {
 
             // Map the TS 29.519 SmPolicyDnnData online/offline flags into the
             // ChargingData decisions when the UDR provided them.
+            //
+            // #299: through the shared helper, and the resource is STORED on the
+            // session. It used to be applied here and discarded, so every later
+            // Npcf_SMPolicyControl_UpdateNotify rebuilt `chgDecs` without it and
+            // silently reverted this subscriber's charging mode.
             let mut decision = decision;
-            if let Some(ref d) = udr_dnn_data {
-                let online = d.get("online").and_then(|v| v.as_bool());
-                let offline = d.get("offline").and_then(|v| v.as_bool());
-                if online.is_some() || offline.is_some() {
-                    if let Some(map) = decision.chg_decs.as_object_mut() {
-                        for (_id, chg) in map.iter_mut() {
-                            if let Some(o) = online {
-                                chg["online"] = serde_json::json!(o);
-                            }
-                            if let Some(o) = offline {
-                                chg["offline"] = serde_json::json!(o);
-                            }
-                        }
-                    }
+            sbi_path::apply_policy_dnn_charging(&mut decision.chg_decs, udr_dnn_data.as_ref());
+            if let Ok(ctx) = pcf_self().read() {
+                if let Some(mut stored) = ctx.sess_find_by_id(sess.id) {
+                    stored.policy_dnn_data = udr_dnn_data.clone();
+                    ctx.sess_update(&stored);
                 }
             }
 
@@ -2076,6 +2096,144 @@ pub async fn handle_sm_policy_delete(sm_policy_id: &str) -> SbiResponse {
             Some("POLICY_NOT_FOUND"),
         ),
     }
+}
+
+/// `Nudr_DM_Notification` sink for policy-data changes (#299, TS 23.502 §4.16.11,
+/// TS 29.519 §5.2): the UDR POSTs a `PolicyDataChangeNotification` here when a
+/// subscriber's provisioned policy data changes, and every affected live SM policy
+/// association is re-authorised toward its SMF.
+///
+/// Before this, an operator editing a subscriber's policy data reached a **live**
+/// session through no path at all: the SMF sees the UDM's subscription notification and
+/// correctly defers to the PCF (TS 23.503 §6.1.3.2, #293), and the PCF never learned.
+/// The edit took effect when the UE re-established.
+///
+/// **Selection is by SUPI; evaluation is per session, scoped to its own S-NSSAI and
+/// DNN.** The notification names only `ueId` and the changed resource, and a UE can hold
+/// PDU sessions on several slices — so re-authorising every session of that SUPI from an
+/// unscoped read would apply one slice's policy data to another slice's session, which
+/// is the defect #293's Decision 2 records for the SMF's own re-read.
+///
+/// A session whose mapped policy data did not change is deliberately NOT notified: an
+/// `SmPolicyUpdateNotify` carrying an unchanged decision is a re-authorisation the SMF
+/// has to process for nothing, and at scale a UDR edit touching one slice would notify
+/// every session of every UE.
+pub async fn handle_policy_data_change_notify(request: &SbiRequest) -> SbiResponse {
+    let Some(content) = request.http.content.as_deref() else {
+        return send_bad_request("Missing request body", Some("MISSING_BODY"));
+    };
+    let body: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(e) => return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_JSON")),
+    };
+    // `ueId` is the correlator; without it there is nothing to look up. Answered 400
+    // rather than 204 because silently accepting it would make a malformed notification
+    // indistinguishable from one that changed nothing.
+    let Some(ue_id) = body.get("ueId").and_then(|v| v.as_str()) else {
+        return send_bad_request(
+            "PolicyDataChangeNotification.ueId is required",
+            Some("MANDATORY_IE_MISSING"),
+        );
+    };
+    let report_id = body.get("reportId").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Sessions of this SUPI, resolved before any await: the guard must not be held
+    // across one (the crate's lock rule), and the re-read below is async.
+    let sessions: Vec<crate::context::PcfSess> = {
+        let ctx = pcf_self();
+        let Ok(guard) = ctx.read() else {
+            return SbiResponse::with_status(204);
+        };
+        match guard.ue_sm_find_by_supi(ue_id) {
+            Some(ue_sm) => ue_sm
+                .sess_ids
+                .iter()
+                .filter_map(|id| guard.sess_find_by_id(*id))
+                .collect(),
+            None => Vec::new(),
+        }
+    };
+    if sessions.is_empty() {
+        log::debug!(
+            "Policy-data change for {ue_id} ({report_id}): no live SM policy association, \
+             nothing to re-authorise"
+        );
+        return SbiResponse::with_status(204);
+    }
+
+    // ONE discovery for the whole notification, before the loop: a UE with several PDU
+    // sessions would otherwise cost one NRF round trip each. And when no UDR is
+    // discoverable there is nothing to re-read the decision FROM, so nothing is touched —
+    // sending the old decision as a re-authorisation, or storing the failed read, would
+    // both be worse than doing nothing (criterion 5).
+    let udr = match sbi_path::pcf_discover_endpoint("UDR", "nudr-dr").await {
+        Ok(Some(ep)) => ep,
+        Ok(None) => {
+            log::warn!(
+                "Policy-data change for {ue_id} ({report_id}): no UDR discoverable, so the \
+                 new decision cannot be read. {} live association(s) keep the policy they \
+                 were authorised with.",
+                sessions.len()
+            );
+            return SbiResponse::with_status(204);
+        }
+        Err(e) => {
+            log::warn!("Policy-data change for {ue_id}: UDR discovery failed: {e}");
+            return SbiResponse::with_status(204);
+        }
+    };
+
+    let mut reauthorised = 0usize;
+    for sess in sessions {
+        let dnn = sess.dnn.clone().unwrap_or_else(|| "internet".to_string());
+        // Scoped to THIS session's slice and DNN (see the doc comment).
+        let fresh = match sbi_path::pcf_udr_sm_policy_dnn_data_from(
+            &udr,
+            ue_id,
+            sess.s_nssai.sst,
+            sess.s_nssai.sd,
+            &dnn,
+        )
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                // A failed read is NOT "nothing provisioned": treating it as one would
+                // erase what the session holds and re-authorise it with the local
+                // default, i.e. revert the subscriber on a transient error.
+                log::warn!(
+                    "Policy-data change for {ue_id}: re-reading session {} (dnn={dnn}) \
+                     failed: {e}. It keeps the policy it was authorised with.",
+                    sess.id
+                );
+                continue;
+            }
+        };
+        if fresh == sess.policy_dnn_data {
+            log::debug!(
+                "Policy-data change for {ue_id}: session {} (dnn={dnn}, sst={}) unchanged",
+                sess.id,
+                sess.s_nssai.sst
+            );
+            continue;
+        }
+        if let Ok(ctx) = pcf_self().read() {
+            if let Some(mut stored) = ctx.sess_find_by_id(sess.id) {
+                stored.policy_dnn_data = fresh;
+                ctx.sess_update(&stored);
+            }
+        }
+        // The existing leg (TS 29.512 §4.2.3.2). The SMF's `handle_sm_policy_notify`
+        // consumes it, so nothing is needed on that side.
+        if sbi_path::pcf_sbi_send_smpolicycontrol_update_notify(sess.id) {
+            reauthorised += 1;
+        }
+    }
+    log::info!(
+        "Policy-data change for {ue_id} ({report_id}): re-authorised {reauthorised} SM policy \
+         association(s)"
+    );
+    SbiResponse::with_status(204)
 }
 
 pub async fn handle_sm_policy_update_notify(
@@ -4104,6 +4262,648 @@ mod tests {
             .set_nrf_uri(format!("http://127.0.0.1:{port}"))
             .await;
         server
+    }
+
+    // ====================================================================
+    // #299: a policy-data change reaches a live SM policy association
+    // ====================================================================
+
+    /// A mock NRF+UDR whose `sm-data` leg answers per-`snssai` query, plus a captured
+    /// stub SMF for the `SmPolicyUpdateNotify`.
+    ///
+    /// One port for the NRF and the UDR (the SearchResult points back at itself), a
+    /// second for the SMF, so a test can assert both that the PCF re-read the right
+    /// slice and that it notified the right session.
+    struct PolicyDataPeers {
+        udr: nextgcore_sbi::server::SbiServer,
+        smf: nextgcore_sbi::server::SbiServer,
+        smf_port: u16,
+        /// Every SM policy notification the stub SMF received: (path, body).
+        notified: std::sync::Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>,
+        /// Every UDR sm-data GET, with its raw query, so a test can prove the re-read
+        /// was scoped rather than blanket.
+        udr_queries: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    /// `sm_data_for` maps the `snssai` query value to the body to answer with; a slice
+    /// it does not name gets a 404, which is how "unchanged for that slice" is expressed.
+    async fn start_policy_data_peers(
+        sm_data_for: std::collections::HashMap<String, serde_json::Value>,
+    ) -> PolicyDataPeers {
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+
+        let notified = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let smf_port = nextgcore_sbi::test_support::free_port();
+        let smf_addr = SocketAddr::from(([127, 0, 0, 1], smf_port));
+        let smf = SbiServer::new(SbiServerConfig::new(smf_addr));
+        let seen = notified.clone();
+        smf.start(move |req: SbiRequest| {
+            let seen = seen.clone();
+            async move {
+                let path = req.header.uri.split('?').next().unwrap_or("").to_string();
+                let body = req
+                    .http
+                    .content
+                    .as_deref()
+                    .and_then(|c| serde_json::from_str::<serde_json::Value>(c).ok())
+                    .unwrap_or(serde_json::Value::Null);
+                seen.lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push((path, body));
+                SbiResponse::with_status(204)
+            }
+        })
+        .await
+        .expect("stub SMF starts");
+
+        let udr_queries = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let udr_port = nextgcore_sbi::test_support::free_port();
+        let udr_addr = SocketAddr::from(([127, 0, 0, 1], udr_port));
+        let udr = SbiServer::new(SbiServerConfig::new(udr_addr));
+        let queries = udr_queries.clone();
+        udr.start(move |req: SbiRequest| {
+            let sm_data_for = sm_data_for.clone();
+            let queries = queries.clone();
+            async move {
+                let uri = req.header.uri.clone();
+                let path = uri.split('?').next().unwrap_or("").to_string();
+                if path == "/nnrf-disc/v1/nf-instances" {
+                    return SbiResponse::with_status(200)
+                        .with_json_body(&serde_json::json!({
+                            "nfInstances": [{
+                                "nfInstanceId": "udr-mock",
+                                "nfType": "UDR",
+                                "ipv4Addresses": ["127.0.0.1"],
+                                "nfServices": [{
+                                    "serviceName": "nudr-dr",
+                                    "scheme": "http",
+                                    "ipEndPoints": [{ "ipv4Address": "127.0.0.1", "port": udr_port }]
+                                }]
+                            }]
+                        }))
+                        .unwrap_or_else(|_| SbiResponse::with_status(500));
+                }
+                if path.starts_with("/nudr-dr/v2/policy-data/") && path.ends_with("/sm-data") {
+                    // The server decodes query values into `http.params`, so the JSON
+                    // `snssai` arrives already decoded -- reading it off `header.uri`
+                    // finds nothing, which is how the first draft of this mock made a
+                    // correctly scoped re-read look unscoped.
+                    let snssai = req.http.params.get("snssai").cloned().unwrap_or_default();
+                    queries
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push(snssai.clone());
+                    let key = sm_data_for
+                        .keys()
+                        .find(|k| snssai.contains(k.as_str()))
+                        .cloned();
+                    return match key.and_then(|k| sm_data_for.get(&k).cloned()) {
+                        Some(body) => SbiResponse::with_status(200)
+                            .with_json_body(&body)
+                            .unwrap_or_else(|_| SbiResponse::with_status(500)),
+                        None => SbiResponse::with_status(404),
+                    };
+                }
+                SbiResponse::with_status(404)
+            }
+        })
+        .await
+        .expect("mock NRF/UDR starts");
+
+        for addr in [udr_addr, smf_addr] {
+            for _ in 0..200 {
+                if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+        nextgcore_sbi::context::global_context()
+            .set_nrf_uri(format!("http://127.0.0.1:{udr_port}"))
+            .await;
+
+        PolicyDataPeers {
+            udr,
+            smf,
+            smf_port,
+            notified,
+            udr_queries,
+        }
+    }
+
+    /// An `smPolicySnssaiData` body carrying one DNN entry with the charging flags this
+    /// PCF maps (TS 29.519 SmPolicyDnnData).
+    fn sm_policy_body(sst: u8, dnn: &str, online: bool, offline: bool) -> serde_json::Value {
+        serde_json::json!({
+            "smPolicySnssaiData": {
+                format!("{sst:02}"): {
+                    "snssai": { "sst": sst },
+                    "smPolicyDnnData": {
+                        dnn: { "dnn": dnn, "online": online, "offline": offline }
+                    }
+                }
+            }
+        })
+    }
+
+    /// Seed a live SM policy association whose notification URI points at the stub SMF.
+    fn seed_sm_policy_session(
+        supi: &str,
+        psi: u8,
+        sst: u8,
+        dnn: &str,
+        smf_port: u16,
+        stored: Option<serde_json::Value>,
+    ) -> String {
+        let ctx = pcf_self();
+        let guard = ctx.read().expect("context");
+        // REUSE the UE-SM when this SUPI already has one: `ue_sm_add` always inserts a
+        // fresh record and overwrites `supi_sm_hash`, so calling it twice for one SUPI
+        // orphans the first and `ue_sm_find_by_supi` then sees only the second session.
+        // Two PDU sessions of ONE UE is exactly what the multi-slice test needs.
+        let ue_sm = match guard.ue_sm_find_by_supi(supi) {
+            Some(existing) => existing,
+            None => guard.ue_sm_add(supi).expect("ue_sm"),
+        };
+        let mut sess = guard.sess_add(ue_sm.id, psi).expect("sess");
+        sess.dnn = Some(dnn.to_string());
+        sess.s_nssai = SNssai { sst, sd: None };
+        sess.notification_uri = Some(format!(
+            "http://127.0.0.1:{smf_port}/nsmf-callback/v1/sm-policy-notify/{psi}"
+        ));
+        sess.policy_dnn_data = stored;
+        guard.sess_update(&sess);
+        sess.sm_policy_id.clone()
+    }
+
+    /// Every notification received by the stub SMF, after giving the detached POST a
+    /// bounded chance to arrive (`spawn_notification` is fire-and-forget).
+    async fn drain_notifications(
+        peers: &PolicyDataPeers,
+        expected: usize,
+    ) -> Vec<(String, serde_json::Value)> {
+        for _ in 0..200 {
+            let got = peers
+                .notified
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone();
+            if got.len() >= expected {
+                return got;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        peers
+            .notified
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// #299 criterion 1: the URI the subscription advertises is one this router serves.
+    ///
+    /// The ordering constraint the issue names ("the handler ships before the subscribe,
+    /// or the subscription notifies into a 404") is not a timing property that a unit
+    /// test can observe — but the failure it protects against is: a subscription naming
+    /// a path nothing serves. So the guard feeds the advertised URI's own path back
+    /// through the real router and refuses a 404/405.
+    #[tokio::test]
+    async fn the_advertised_policy_data_callback_is_a_path_this_pcf_serves() {
+        let body = sbi_path::policy_data_subscription_body("http://10.0.0.1:7777/x");
+        assert_eq!(
+            body["monitoredResourceUris"],
+            serde_json::json!(["/nudr-dr/v2/policy-data/ues"]),
+            "the PCF cannot enumerate its future subscribers, so it monitors the collection"
+        );
+
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            sbi_path::POLICY_DATA_NOTIFY_PATH,
+            Some(serde_json::json!({ "ueId": "imsi-001010000000299" })),
+        ))
+        .await;
+        assert_ne!(
+            resp.status, 404,
+            "the advertised callback path must be routed, or the UDR notifies into a 404"
+        );
+        assert_ne!(resp.status, 405, "and with the method it is advertised for");
+        assert_eq!(
+            resp.status, 204,
+            "an unknown SUPI is not an error: there is simply nothing to re-authorise"
+        );
+
+        // A notification with no ueId cannot be acted on and says so, rather than being
+        // indistinguishable from one that changed nothing.
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            sbi_path::POLICY_DATA_NOTIFY_PATH,
+            Some(serde_json::json!({ "reportId": "x" })),
+        ))
+        .await;
+        assert_eq!(resp.status, 400);
+    }
+
+    /// #299 criteria 2 and 3: a policy-data change re-authorises the live association
+    /// over the wire, and the notification CARRIES the changed decision.
+    ///
+    /// The second half is the one that matters: `build_sm_policy_notification` rebuilt
+    /// `chgDecs` from the local default and dropped the UDR's charging flags, so before
+    /// this the notify would have been sent and changed nothing — a wired mechanism with
+    /// no effect, which is the shape this backlog keeps finding.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize the process-global NRF URI / PCF context
+    async fn a_policy_data_change_reauthorises_the_live_association_with_the_new_decision() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pcf_context_init(64, 64);
+        let supi = "imsi-001010000000299";
+
+        // The UDR now says online charging is ON for slice 1 / internet.
+        let mut answers = std::collections::HashMap::new();
+        answers.insert(
+            "\"sst\":1".to_string(),
+            sm_policy_body(1, "internet", true, false),
+        );
+        let peers = start_policy_data_peers(answers).await;
+
+        // The session was created when the UDR said OFF, and that is what it holds.
+        let sm_policy_id = seed_sm_policy_session(
+            supi,
+            5,
+            1,
+            "internet",
+            peers.smf_port,
+            Some(serde_json::json!({ "dnn": "internet", "online": false, "offline": false })),
+        );
+
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            sbi_path::POLICY_DATA_NOTIFY_PATH,
+            Some(serde_json::json!({
+                "ueId": supi,
+                "reportId": format!("/nudr-dr/v2/policy-data/ues/{supi}/sm-data"),
+            })),
+        ))
+        .await;
+        assert_eq!(resp.status, 204);
+
+        let got = drain_notifications(&peers, 1).await;
+        assert_eq!(
+            got.len(),
+            1,
+            "the live association must be re-authorised toward its SMF, got {got:?}"
+        );
+        let (path, body) = &got[0];
+        assert_eq!(
+            path, "/nsmf-callback/v1/sm-policy-notify/5/update",
+            "TS 29.512 §4.2.3.2 POSTs to {{notificationUri}}/update"
+        );
+        assert_eq!(
+            body["resourceUri"],
+            serde_json::json!(format!(
+                "/npcf-smpolicycontrol/v1/sm-policies/{sm_policy_id}"
+            )),
+            "and names the association it re-authorises"
+        );
+        let chg = body["smPolicyDecision"]["chgDecs"]
+            .as_object()
+            .expect("chgDecs present");
+        assert!(
+            !chg.is_empty(),
+            "a decision with no chgDecs carries nothing"
+        );
+        for (_id, dec) in chg {
+            assert_eq!(
+                dec["online"],
+                serde_json::json!(true),
+                "the UDR's changed online flag must reach the SMF, or the notify is a \
+                 re-authorisation that authorises the OLD decision: {body}"
+            );
+        }
+
+        // And the session now holds what the UDR says, so a second notification for the
+        // same (unchanged) data does not re-notify.
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            sbi_path::POLICY_DATA_NOTIFY_PATH,
+            Some(serde_json::json!({ "ueId": supi })),
+        ))
+        .await;
+        assert_eq!(resp.status, 204);
+        let got = drain_notifications(&peers, 2).await;
+        assert_eq!(
+            got.len(),
+            1,
+            "an edit that changes nothing this PCF maps must not re-authorise: at scale \
+             that is every session of every UE per UDR write"
+        );
+
+        peers.udr.stop().await.ok();
+        peers.smf.stop().await.ok();
+    }
+
+    /// #299: the create path STORES the UDR's SmPolicyDnnData, so the first policy-data
+    /// notification for an unchanged subscriber is not a spurious re-authorisation — and
+    /// so a later re-authorisation can carry what the create carried.
+    ///
+    /// Driven through the real `handle_sm_policy_create` rather than by seeding, because
+    /// seeding is what hides the hole: the field would look populated in every test while
+    /// no production path ever wrote it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize the process-global NRF URI / PCF context
+    async fn the_create_stores_the_udrs_policy_data_so_an_unchanged_edit_is_not_a_reauthorisation()
+    {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pcf_context_init(64, 64);
+        let supi = "imsi-001010000000296";
+
+        let mut answers = std::collections::HashMap::new();
+        answers.insert(
+            "\"sst\":1".to_string(),
+            sm_policy_body(1, "internet", true, false),
+        );
+        let peers = start_policy_data_peers(answers).await;
+
+        let create = serde_json::json!({
+            "supi": supi,
+            "pduSessionId": 9,
+            "pduSessionType": "IPV4",
+            "dnn": "internet",
+            "notificationUri": format!(
+                "http://127.0.0.1:{}/nsmf-callback/v1/sm-policy-notify/9", peers.smf_port),
+            "sliceInfo": { "sst": 1 },
+        });
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            "/npcf-smpolicycontrol/v1/sm-policies",
+            Some(create),
+        ))
+        .await;
+        assert_eq!(resp.status, 201, "create: {:?}", resp.http.content);
+
+        // The decision the SMF got on create carries the UDR's flags...
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
+        for (_id, dec) in body["chgDecs"].as_object().expect("chgDecs") {
+            assert_eq!(dec["online"], serde_json::json!(true), "create: {body}");
+        }
+
+        // ...and the session HOLDS the resource that produced them.
+        let held = pcf_self()
+            .read()
+            .ok()
+            .and_then(|c| c.ue_sm_find_by_supi(supi))
+            .and_then(|u| u.sess_ids.first().copied())
+            .and_then(|id| pcf_self().read().ok().and_then(|c| c.sess_find_by_id(id)))
+            .expect("session");
+        assert_eq!(
+            held.policy_dnn_data
+                .as_ref()
+                .and_then(|d| d.get("online"))
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "the create read this resource and used to DISCARD it, so every later notify \
+             rebuilt the decision without it: {:?}",
+            held.policy_dnn_data
+        );
+
+        // A notification for data that has not changed therefore re-authorises nothing.
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            sbi_path::POLICY_DATA_NOTIFY_PATH,
+            Some(serde_json::json!({ "ueId": supi })),
+        ))
+        .await;
+        assert_eq!(resp.status, 204);
+        let got = drain_notifications(&peers, 1).await;
+        assert!(
+            got.is_empty(),
+            "nothing changed, so nothing is re-authorised: {got:?}"
+        );
+
+        peers.udr.stop().await.ok();
+        peers.smf.stop().await.ok();
+    }
+
+    /// #299: a UDR that is discoverable but whose read FAILS leaves the session alone.
+    ///
+    /// Distinct from "no UDR" (the criterion-5 test): here discovery succeeds and the GET
+    /// does not. Treating the failure as "nothing is provisioned" would erase the
+    /// session's stored policy data and re-authorise it with the local default — a
+    /// transient error silently reverting a subscriber's charging mode.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize the process-global NRF URI / PCF context
+    async fn a_failed_udr_read_leaves_the_association_authorised_as_it_was() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pcf_context_init(64, 64);
+        let supi = "imsi-001010000000295";
+
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        // An NRF that advertises a UDR on a port with nothing listening: discovery
+        // succeeds, every nudr-dr GET fails.
+        let dead_udr_port = nextgcore_sbi::test_support::free_port();
+        let nrf_port = nextgcore_sbi::test_support::free_port();
+        let nrf_addr = SocketAddr::from(([127, 0, 0, 1], nrf_port));
+        let nrf = SbiServer::new(SbiServerConfig::new(nrf_addr));
+        nrf.start(move |_req: SbiRequest| async move {
+            SbiResponse::with_status(200)
+                .with_json_body(&serde_json::json!({
+                    "nfInstances": [{
+                        "nfInstanceId": "udr-dead",
+                        "nfType": "UDR",
+                        "ipv4Addresses": ["127.0.0.1"],
+                        "nfServices": [{
+                            "serviceName": "nudr-dr",
+                            "scheme": "http",
+                            "ipEndPoints": [{ "ipv4Address": "127.0.0.1", "port": dead_udr_port }]
+                        }]
+                    }]
+                }))
+                .unwrap_or_else(|_| SbiResponse::with_status(500))
+        })
+        .await
+        .expect("mock NRF starts");
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(nrf_addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        nextgcore_sbi::context::global_context()
+            .set_nrf_uri(format!("http://127.0.0.1:{nrf_port}"))
+            .await;
+
+        let peers = start_policy_data_peers(std::collections::HashMap::new()).await;
+        // `start_policy_data_peers` points the NRF URI at its own mock; put it back at
+        // the one advertising the dead UDR.
+        nextgcore_sbi::context::global_context()
+            .set_nrf_uri(format!("http://127.0.0.1:{nrf_port}"))
+            .await;
+
+        let stored = serde_json::json!({ "dnn": "internet", "online": true, "offline": false });
+        seed_sm_policy_session(supi, 3, 1, "internet", peers.smf_port, Some(stored.clone()));
+
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            sbi_path::POLICY_DATA_NOTIFY_PATH,
+            Some(serde_json::json!({ "ueId": supi })),
+        ))
+        .await;
+        assert_eq!(resp.status, 204);
+
+        let got = drain_notifications(&peers, 1).await;
+        assert!(
+            got.is_empty(),
+            "a failed re-read must not produce a re-authorisation: {got:?}"
+        );
+        let held = pcf_self()
+            .read()
+            .ok()
+            .and_then(|c| c.ue_sm_find_by_supi(supi))
+            .and_then(|u| u.sess_ids.first().copied())
+            .and_then(|id| pcf_self().read().ok().and_then(|c| c.sess_find_by_id(id)))
+            .expect("session");
+        assert_eq!(
+            held.policy_dnn_data,
+            Some(stored),
+            "and must not erase what the session holds"
+        );
+
+        nrf.stop().await.ok();
+        peers.udr.stop().await.ok();
+        peers.smf.stop().await.ok();
+    }
+
+    /// #299 criterion 4: the affected-association lookup is scoped, so a change for one
+    /// slice does not re-authorise another slice's session.
+    ///
+    /// Both sessions belong to ONE SUPI, which is what makes an unscoped selection look
+    /// correct: the notification names only `ueId`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize the process-global NRF URI / PCF context
+    async fn a_change_for_one_slice_does_not_reauthorise_another_slices_session() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pcf_context_init(64, 64);
+        let supi = "imsi-001010000000298";
+
+        // Only slice 2's data is provisioned/changed; slice 1's read 404s, which is
+        // "nothing provisioned for that slice" and must leave it alone.
+        let mut answers = std::collections::HashMap::new();
+        answers.insert(
+            "\"sst\":2".to_string(),
+            sm_policy_body(2, "internet", true, false),
+        );
+        let peers = start_policy_data_peers(answers).await;
+
+        seed_sm_policy_session(supi, 1, 1, "internet", peers.smf_port, None);
+        seed_sm_policy_session(
+            supi,
+            2,
+            2,
+            "internet",
+            peers.smf_port,
+            Some(serde_json::json!({ "dnn": "internet", "online": false, "offline": false })),
+        );
+
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            sbi_path::POLICY_DATA_NOTIFY_PATH,
+            Some(serde_json::json!({ "ueId": supi })),
+        ))
+        .await;
+        assert_eq!(resp.status, 204);
+
+        let got = drain_notifications(&peers, 1).await;
+        assert_eq!(
+            got.len(),
+            1,
+            "exactly the session whose slice data changed is re-authorised, got {got:?}"
+        );
+        assert_eq!(
+            got[0].0, "/nsmf-callback/v1/sm-policy-notify/2/update",
+            "and it is slice 2's session (psi=2), not slice 1's"
+        );
+
+        // The re-read itself was scoped: each session's own S-NSSAI appears in its query.
+        let queries = peers
+            .udr_queries
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        assert!(
+            queries.iter().any(|q| q.contains("\"sst\":1")),
+            "slice 1's session must be evaluated against SLICE 1's data: {queries:?}"
+        );
+        assert!(
+            queries.iter().any(|q| q.contains("\"sst\":2")),
+            "and slice 2's against slice 2's: {queries:?}"
+        );
+
+        peers.udr.stop().await.ok();
+        peers.smf.stop().await.ok();
+    }
+
+    /// #299 criterion 5: with no UDR configured or discoverable, the PCF behaves exactly
+    /// as it did before — the notification is accepted and nothing is re-authorised,
+    /// because there is nothing to re-read the decision from.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize the process-global NRF URI / PCF context
+    async fn with_no_udr_a_policy_data_notification_changes_nothing() {
+        let _guard = crate::test_support::CONTEXT_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pcf_context_init(64, 64);
+        let supi = "imsi-001010000000297";
+
+        // A stub SMF only: no NRF URI is set, so discovery yields nothing.
+        let peers = start_policy_data_peers(std::collections::HashMap::new()).await;
+        nextgcore_sbi::context::global_context()
+            .set_nrf_uri(String::new())
+            .await;
+
+        let stored = serde_json::json!({ "dnn": "internet", "online": true, "offline": false });
+        seed_sm_policy_session(supi, 7, 1, "internet", peers.smf_port, Some(stored.clone()));
+
+        let resp = pcf_sbi_request_handler(make_request(
+            "POST",
+            sbi_path::POLICY_DATA_NOTIFY_PATH,
+            Some(serde_json::json!({ "ueId": supi })),
+        ))
+        .await;
+        assert_eq!(resp.status, 204);
+
+        let got = drain_notifications(&peers, 1).await;
+        assert!(
+            got.is_empty(),
+            "with no UDR there is no new decision to send, and sending the old one as a \
+             re-authorisation would be worse than silence: {got:?}"
+        );
+        let held = pcf_self()
+            .read()
+            .ok()
+            .and_then(|c| c.ue_sm_find_by_supi(supi))
+            .and_then(|u| u.sess_ids.first().copied())
+            .and_then(|id| pcf_self().read().ok().and_then(|c| c.sess_find_by_id(id)))
+            .expect("session");
+        assert_eq!(
+            held.policy_dnn_data,
+            Some(stored),
+            "and an unreachable UDR must NOT erase what the session already holds: a \
+             404-or-unreachable read returns None, and storing that would revert the \
+             subscriber's charging mode on every failed notification"
+        );
+
+        peers.udr.stop().await.ok();
+        peers.smf.stop().await.ok();
     }
 
     /// AM policy Create and GET both carry the negotiated `suppFeat` and the

--- a/src/bins/nextgcore-pcfd/src/context.rs
+++ b/src/bins/nextgcore-pcfd/src/context.rs
@@ -483,6 +483,23 @@ pub struct PcfSess {
     /// loads as `None` rather than failing the whole record.
     #[serde(default)]
     pub access_type: Option<AccessType>,
+    /// The UDR's `SmPolicyDnnData` for this session's S-NSSAI and DNN, as last read
+    /// over Nudr_DataRepository (TS 29.519 §5.2).
+    ///
+    /// #299: stored so a RE-authorisation can carry what the create carried. The create
+    /// path reads this resource and maps its `online`/`offline` flags into the
+    /// ChargingData decisions, then DISCARDED it — so every later
+    /// `Npcf_SMPolicyControl_UpdateNotify` rebuilt the decision without them and
+    /// silently reverted the subscriber's charging mode to the local default. It is also
+    /// what a policy-data change notification is compared against, so an operator's edit
+    /// that changes nothing this PCF maps does not produce a spurious notify.
+    ///
+    /// Held as the received JSON rather than parsed into fields: only two members are
+    /// mapped today, and a struct would have to be widened for every future one while
+    /// silently dropping the rest. `#[serde(default)]` for the same snapshot reason as
+    /// `access_type`.
+    #[serde(default)]
+    pub policy_dnn_data: Option<serde_json::Value>,
 }
 
 impl PcfSess {
@@ -513,6 +530,7 @@ impl PcfSess {
             stream_id: None,
             af_pcc_rules: Vec::new(),
             access_type: None,
+            policy_dnn_data: None,
         }
     }
 

--- a/src/bins/nextgcore-pcfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-pcfd/src/sbi_path.rs
@@ -607,11 +607,17 @@ fn build_sm_policy_notification(sess: &crate::context::PcfSess) -> serde_json::V
     let decision = crate::nudr_handler::pcf_get_session_data("", None, &sess.s_nssai, &dnn)
         .map(|sd| {
             let parts = crate::sm_policy_build::build_sm_policy_decision(&sess.sm_policy_id, &sd);
+            let mut chg_decs = parts.chg_decs;
+            // #299: overlay the UDR's SmPolicyDnnData charging flags, exactly as the
+            // create path does. Without this a re-authorisation rebuilt `chgDecs` from
+            // the local default and silently reverted a subscriber whose policy data
+            // says otherwise -- so the notify LOOKED like a decision and undid one.
+            apply_policy_dnn_charging(&mut chg_decs, sess.policy_dnn_data.as_ref());
             serde_json::json!({
                 "sessRules": parts.sess_rules,
                 "pccRules": parts.pcc_rules,
                 "qosDecs": parts.qos_decs,
-                "chgDecs": parts.chg_decs,
+                "chgDecs": chg_decs,
                 "traffContDecs": parts.traff_cont_decs,
             })
         })
@@ -621,6 +627,39 @@ fn build_sm_policy_notification(sess: &crate::context::PcfSess) -> serde_json::V
         "resourceUri": format!("/npcf-smpolicycontrol/v1/sm-policies/{}", sess.sm_policy_id),
         "smPolicyDecision": decision,
     })
+}
+
+/// Map a `SmPolicyDnnData`'s `online`/`offline` flags (TS 29.519 §5.6.2.x) onto every
+/// ChargingData decision (TS 29.512 §5.6.2.11).
+///
+/// The two members are the ONLY ones this PCF derives from that resource — the create
+/// path says so at its call site, because `SmPolicyDnnData` carries no session-AMBR, no
+/// 5QI and no ARP. Shared by the create path and the update-notify builder so the two
+/// cannot drift: they drifting is the #299 defect.
+pub(crate) fn apply_policy_dnn_charging(
+    chg_decs: &mut serde_json::Value,
+    dnn_data: Option<&serde_json::Value>,
+) -> bool {
+    let Some(d) = dnn_data else {
+        return false;
+    };
+    let online = d.get("online").and_then(|v| v.as_bool());
+    let offline = d.get("offline").and_then(|v| v.as_bool());
+    if online.is_none() && offline.is_none() {
+        return false;
+    }
+    let Some(map) = chg_decs.as_object_mut() else {
+        return false;
+    };
+    for (_id, chg) in map.iter_mut() {
+        if let Some(o) = online {
+            chg["online"] = serde_json::json!(o);
+        }
+        if let Some(o) = offline {
+            chg["offline"] = serde_json::json!(o);
+        }
+    }
+    true
 }
 
 /// Send SM policy control update notify to the SMF over HTTP
@@ -925,6 +964,133 @@ pub(crate) fn client_for(
     )
 }
 
+/// The path this PCF serves its `Nudr_DM_Notification` (PolicyDataChangeNotification)
+/// sink on, and the path its subscription advertises. One constant, so the two cannot
+/// disagree — a subscription naming a URI nothing serves is the exact failure #293 hit
+/// and is invisible until an operator edits a subscriber.
+pub const POLICY_DATA_NOTIFY_PATH: &str = "/npcf-callback/v1/policy-data-change-notify";
+
+/// This PCF's policy-data notification URI, or `None` when the self identity was never
+/// published (no config) — the caller then skips the subscribe rather than subscribing
+/// with an address no one can reach.
+pub fn policy_data_notify_uri() -> Option<String> {
+    let info = pcf_self_info()?;
+    Some(format!(
+        "http://{}:{}{POLICY_DATA_NOTIFY_PATH}",
+        info.sbi_addr, info.sbi_port
+    ))
+}
+
+/// The `PolicyDataSubscription` body this PCF subscribes with (TS 29.519 §5.2.x,
+/// `POST /nudr-dr/v2/policy-data/subs-to-notify`).
+///
+/// `monitoredResourceUris` names the per-UE policy-data collection rather than one
+/// subscriber: the PCF cannot enumerate the UEs it will serve in advance, and udrd's
+/// `uri_covers` treats a prefix as covering everything under it.
+pub fn policy_data_subscription_body(notification_uri: &str) -> serde_json::Value {
+    serde_json::json!({
+        "notificationUri": notification_uri,
+        "monitoredResourceUris": ["/nudr-dr/v2/policy-data/ues"],
+    })
+}
+
+/// Subscribe to the UDR for policy-data changes (TS 23.502 §4.16.11, TS 29.519 §5.2).
+///
+/// Called from `main` AFTER the SBI server is listening, so the URI in the subscription
+/// is already being served when the UDR can first use it. Best-effort: no UDR, no NRF,
+/// or a refusal leaves the PCF behaving exactly as it did before #299 — an operator's
+/// edit then reaches a live session through no path, which is the gap, not a crash.
+///
+/// Returns the created subscription's resource URI when the UDR reported one, so
+/// shutdown can delete it.
+pub async fn pcf_subscribe_udr_policy_data() -> Option<String> {
+    let notification_uri = policy_data_notify_uri()?;
+    let ep = match pcf_discover_endpoint("UDR", "nudr-dr").await {
+        Ok(Some(ep)) => ep,
+        Ok(None) => {
+            log::info!(
+                "No UDR discoverable: not subscribing to policy-data changes. An operator \
+                 edit will reach a live SM policy association through no path (#299)."
+            );
+            return None;
+        }
+        Err(e) => {
+            log::warn!("UDR discovery for the policy-data subscription failed: {e}");
+            return None;
+        }
+    };
+    let client = client_for(&ep, NfType::Udr);
+    let body = policy_data_subscription_body(&notification_uri);
+    match client
+        .post_json("/nudr-dr/v2/policy-data/subs-to-notify", &body)
+        .await
+    {
+        Ok(resp) if resp.status == 201 => {
+            let location = resp
+                .http
+                .headers
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case("location"))
+                .map(|(_, v)| v.clone());
+            log::info!(
+                "Subscribed to UDR policy-data changes; notifications arrive at \
+                 {notification_uri} (subscription {})",
+                location.as_deref().unwrap_or("<no Location>")
+            );
+            location
+        }
+        Ok(resp) => {
+            log::warn!(
+                "UDR refused the policy-data subscription: status {} — subscription changes \
+                 will not reach live SM policy associations",
+                resp.status
+            );
+            None
+        }
+        Err(e) => {
+            log::warn!("UDR policy-data subscription failed: {e}");
+            None
+        }
+    }
+}
+
+/// Delete this PCF's policy-data subscription at shutdown (#299).
+///
+/// `resource` is the `Location` the UDR returned. Best effort and logged: a UDR that
+/// keeps the subscription only logs a delivery failure per notification, so failing
+/// loudly here would be noise, but staying silent would hide a leak that outlives the
+/// process.
+pub async fn pcf_unsubscribe_udr_policy_data(resource: &str) {
+    let Ok(Some(ep)) = pcf_discover_endpoint("UDR", "nudr-dr").await else {
+        log::warn!("No UDR discoverable at shutdown: policy-data subscription {resource} leaks");
+        return;
+    };
+    let client = client_for(&ep, NfType::Udr);
+    let path = uri_path_only(resource);
+    match client.delete(&path).await {
+        Ok(resp) if (200..300).contains(&resp.status) => {
+            log::info!("Policy-data subscription {resource} deleted");
+        }
+        Ok(resp) => log::warn!(
+            "UDR answered {} to DELETE {path}: the policy-data subscription may linger",
+            resp.status
+        ),
+        Err(e) => log::warn!("DELETE {path} failed: {e}; the policy-data subscription may linger"),
+    }
+}
+
+/// The path part of a possibly-absolute resource URI, so a `Location` given either way
+/// can be used as a request target.
+fn uri_path_only(uri: &str) -> String {
+    match uri.find("://") {
+        Some(i) => match uri[i + 3..].find('/') {
+            Some(j) => uri[i + 3 + j..].to_string(),
+            None => "/".to_string(),
+        },
+        None => uri.to_string(),
+    }
+}
+
 /// Discover a UDR and GET the SM PolicyData for `(supi, snssai, dnn)`
 /// (TS 29.519 nudr-dr: `GET /nudr-dr/v2/policy-data/ues/{ueId}/sm-data`).
 /// Returns the decoded body on 200, `Ok(None)` on 404 or when no UDR is
@@ -964,6 +1130,50 @@ pub async fn pcf_udr_get_sm_policy_data(
             log::warn!("nudr-dr returned 404 for SUPI {supi}; using config defaults");
             Ok(None)
         }
+        other => Err(format!("nudr-dr GET returned status {other}")),
+    }
+}
+
+/// GET the `SmPolicyDnnData` for `(supi, snssai, dnn)` from an ALREADY DISCOVERED UDR.
+///
+/// Separate from [`pcf_udr_sm_policy_dnn_data`] on two counts that matter to #299:
+///
+/// - it does not re-discover per call, so re-authorising a UE with several PDU sessions
+///   is one NRF round trip rather than one per session;
+/// - it distinguishes **"the UDR says nothing is provisioned"** (`Ok(None)`, a 404) from
+///   **"the read failed"** (`Err`). Collapsing those is what made the first draft of the
+///   notification handler erase a session's stored policy data whenever the UDR was
+///   briefly unreachable, and send a re-authorisation carrying the local default.
+pub async fn pcf_udr_sm_policy_dnn_data_from(
+    ep: &DiscoveredEndpoint,
+    supi: &str,
+    sst: u8,
+    sd: Option<u32>,
+    dnn: &str,
+) -> Result<Option<serde_json::Value>, String> {
+    let client = client_for(ep, NfType::Udr);
+    let snssai = match sd {
+        Some(sd) => format!("{{\"sst\":{sst},\"sd\":\"{sd:06x}\"}}"),
+        None => format!("{{\"sst\":{sst}}}"),
+    };
+    let path = format!(
+        "/nudr-dr/v2/policy-data/ues/{}/sm-data?snssai={}&dnn={}",
+        percent_encode(supi),
+        percent_encode(&snssai),
+        percent_encode(dnn),
+    );
+    let resp = client
+        .get(&path)
+        .await
+        .map_err(|e| format!("nudr-dr GET failed: {e}"))?;
+    match resp.status {
+        200 => {
+            let body = resp.http.content.ok_or("empty nudr-dr body")?;
+            let json: serde_json::Value =
+                serde_json::from_str(&body).map_err(|e| format!("invalid nudr-dr body: {e}"))?;
+            Ok(extract_sm_policy_dnn_data(&json, dnn))
+        }
+        404 => Ok(None),
         other => Err(format!("nudr-dr GET returned status {other}")),
     }
 }


### PR DESCRIPTION
Closes #299. Spec: `specs/fix-pcfd-udr-policy-data-subscription.md`. Files #310 (`decision`).

## The pre-check the issue asks for comes back favourable

#299 says *"Check whether udrd can even notify: if `policy-data` subscriptions are unimplemented on the UDR side too, that is a prerequisite in this issue's scope."* **udrd already implements the whole UDR half** — `POST /nudr-dr/v2/policy-data/subs-to-notify` with validation and a `Location`, and `notify_policy_data_change` emitting a `PolicyDataChangeNotification` to every subscriber whose monitored URIs cover the changed path. Its own comment even anticipates this PR: *"a `/policy-data/subs-to-notify` subscriber (the PCF) gets the `PolicyDataChangeNotification`."* No udrd work was needed; this is the first in-tree producer of that subscription.

## What changed in pcfd

- A **`Nudr_DM_Notification` sink** on `sbi_path::POLICY_DATA_NOTIFY_PATH`, and a **subscribe** sent from `main` *after* `sbi_server.start()` — the ordering constraint #299 names. One constant serves both the route and the advertised URI, so a subscription cannot name a path this router does not serve; the subscription is deleted at shutdown, before the listener goes away.
- **On notification**: `ueId` selects candidate sessions; each is evaluated against a UDR read scoped to **its own** `(sst, sd, dnn)`. A UE can hold sessions on several slices and the notification names only the UE, so an unscoped read would apply one slice's data to another slice's session — #293's Decision 2, in a new place. Only a session whose mapped data actually changed is re-authorised; otherwise one UDR write would notify every session of every UE.
- **A failed read is not "nothing provisioned"**: the new `pcf_udr_sm_policy_dnn_data_from` returns a `Result` and takes an already-discovered endpoint (one NRF round trip per notification, not per session). Caught by this issue's own criterion-5 test: the first draft erased a session's stored policy data on a transient UDR failure and re-authorised it with the local default — a network blip silently reverting a subscriber.

## The defect that made the mechanism observable

`build_sm_policy_notification` rebuilt `chgDecs` from the local default and applied **none** of the UDR's charging flags, while the create path applied them inline and then **discarded** the resource. Two pre-existing consequences, both fixed here because #299 is unimplementable without it:

1. Every `Npcf_SMPolicyControl_UpdateNotify` — from an AF, from a re-authorisation, from anything — sent the SMF a decision with the subscriber's charging mode reverted to the local default, unlogged.
2. A re-authorisation on a policy-data change would have been sent and changed nothing: a wired mechanism with no effect.

The overlay is now one shared `apply_policy_dnn_charging` used by both paths, and the resource is stored on the session.

## ⚠️ The issue's session-AMBR example is NOT fixed by this, and cannot be

#299's motivation leads with an operator editing a **session-AMBR**. Implementing the issue does not fix that: `SmPolicyDnnData` carries no session-AMBR, no default 5QI and no ARP — and this tree already said so, in a comment older than both issues, at the create path that reads the resource:

> "The QoS/ARP/AMBR/PCC decision is not re-derived from this resource (**SmPolicyDnnData does not carry them**); only the spec-defined online/offline charging flags are."

That datum lives in the UDM's subscription data and reaches the PCF as `subsSessAmbr` from the **SMF**. So #293's deferral ("the PCF learns of subscription changes from the UDR") points at a path that structurally cannot carry it. The TS route is the SMF reporting `SE_AMBR_CH`; smfd **has** the sender (`policy::sm_policy_update`) and pcfd **has** the receiver arm, and neither is wired — and pcfd's `SE_AMBR_CH` arm re-derives from `pcf_get_session_data("")` with an **empty SUPI**, so it could not change the AMBR even if reported.

Wiring it overturns a decision #293 made deliberately, so it is **not** decided silently: filed as **#310**, tagged `decision`, with three options and a recommendation.

## Verification

`cargo test --workspace`: **6306 passed / 0 failed** over three consecutive runs (baseline 6300). pcfd 178 → 184. clippy adds no warning; fmt clean.

**Six reverts, six bites** (table in the spec). One reads precisely rather than neatly: the no-UDR short-circuit revert failed the *slice* test, not the no-UDR test, because with it gone the reads fail and the error handling still protects the session — so that behaviour is guarded by the combination, which the spec says rather than implying one guard covers both.

Two of my own tests were wrong before they were right, and both are recorded in the spec: the mock UDR read the query off `header.uri` where the server puts it in `http.params` (a correctly scoped re-read looked unscoped — the harness lying in the shape of a product defect), and the seeding helper called `ue_sm_add` per session, which **always inserts** a fresh UE-SM and overwrites `supi_sm_hash`, so the two-slice test orphaned its first session and passed per-crate while failing whole-workspace.

Ceilings are in the spec — chiefly that only `online`/`offline` are mapped from the resource (unchanged, and the whole resource is now stored so a future mapping gets this path free), and that the subscription is created once at startup with no renewal or repair.