### PR TITLE
fix(sgwcd): gate the S11 responses on Sxa results and drive the DDN end to end (#54)

### DIFF
--- a/specs/fix-sgwcd-gate-s11-on-sxa-and-drive-ddn.md
+++ b/specs/fix-sgwcd-gate-s11-on-sxa-and-drive-ddn.md
@@ -1,0 +1,190 @@
+# nextgcore #54 (sgwcd): gate the S11 responses on Sxa, and drive the DDN end to end
+
+Verified against `main` @ `91687ae`.
+
+Every claim in #54 still holds (cites re-located below). The issue also **understates the
+problem in two ways that had to be fixed for its own criteria to mean anything**, and those
+are the findings this spec leads with. TS 23.401 §5.3.2.1 / §5.3.4.2, TS 29.274 §7.2.2 /
+§7.2.11.2 / §7.2.11.3, TS 29.244 §7.5.x / §8.2.50.
+
+## Verified against current main
+
+| claim in the issue | site on `91687ae` | still true? |
+|---|---|---|
+| the Create Session Response is sent with `REQUEST_ACCEPTED` before any PFCP response | `gtp_path.rs:1039-1075` (was `:700-737`) | yes |
+| the in-code NOTE admits the send must move to the Sxa response handler | same block | yes |
+| `handle_session_establishment_response` has no production caller | `sxa_handler.rs:97`; only `main.rs`'s `#[cfg(test)]` | yes |
+| `pfcp_open` opens no socket; `send_pfcp_message` only logs | `pfcp_path.rs:82`, `:255` | yes |
+| Delete Session removes state and answers accepted unconditionally | `gtp_path.rs:1236-1248` | yes |
+| `handle_session_report_request` classifies DLDR and has zero callers | `sxa_handler.rs:279`; `grep` → none | yes |
+| `send_downlink_data_notification` is reachable only from `mod tests` | `gtp_path.rs:330` | yes |
+| the DDN Ack handler only warns; the Data Notification Delay is parsed and dropped | `s11_handler.rs:452`, `s11_parse.rs:229` | yes |
+| a DDN Failure Indication is parsed and only logged | `gtp_path.rs:685` | yes |
+
+## Finding 1: sgwcd's Sxa messages were not PFCP at all
+
+`sxa_build`'s helpers emitted **no IE headers**. `build_create_pdr` pushed a bare PDR id, a
+bare interface octet and a bare TEID with nothing in front of them; the establishment body
+began with eight raw bytes of SEID; `build_session_report_response` pushed the cause as a
+lone octet. One of the comments even read *"Remote IP would be added here"*.
+
+That was invisible precisely because the transport discarded every buffer: **nothing ever
+parsed these bodies, including our own tests.** The moment a socket exists, the SGW-U — which
+has decoded with the shared `nextgcore-pfcp` codec since #59 — finds **zero IEs**, creates a
+session with no PDRs and no FARs, and answers `REQUEST_ACCEPTED`. Gating the S11 response on
+that answer would have been gating it on a lie.
+
+So `sxa_build` is rebuilt on the library's message types — the same decision #59 took for the
+SGW-U, one codec per interface rather than a second hand-rolled one that drifts. The guard is
+a decode: the stand-in SGW-U's recorded Establishment body is parsed with
+`SessionEstablishmentRequest::decode` and asserted to carry the CP F-SEID, non-empty
+`create_pdrs`/`create_fars`, a PDR id on every rule and an F-TEID in the PDI.
+
+## Finding 2: nothing in sgwcd ever allocated a PDR or FAR id
+
+`SgwcTunnel.pdr_id` and `far_id` are `Option`, and `grep` finds **no writer anywhere in the
+daemon**. Every tunnel that ever existed carried `None`. The old builders wrote them under
+`if let Some(...)`, so the ids were simply omitted — and with the rebuilt builder a rule with
+no id cannot be emitted at all, which is how this surfaced: three new tests failed on
+`expect("pdr id")` before any of them reached an assertion about #54.
+
+`next_pdr_id()` / `next_far_id()` now allocate where the tunnel's TEID is allocated. Both are
+process-wide rather than per-session, deliberately: TS 29.244 scopes the ids to the session,
+but a per-session counter restarts at 1 for every session, and a stale rule matched by id
+across a re-establishment is the kind of collision that reads as a data-path bug rather than
+an id-space one — the shape #59 hit with `NEXT_NODE_ID`.
+
+## Decision 1: the CP-side transport is #59's, mirrored
+
+One bound UDP socket, transactions matched on sequence number with T1 = 3s and N1 = 2 (the
+same budget sgwud uses, so the two ends of one interface do not disagree about how long a
+message may take), an association **initiated** toward the SGW-U (TS 29.244 §6.2.6.2 makes
+the CP function the initiator), inbound Heartbeat Requests answered, and inbound Session
+Report Requests dispatched into `sxa_handler`.
+
+`request` takes `seid: Option<u64>` for the same reason #217 needed it: a node-level message
+clears the S flag, and a SEID field of 0 would be a malformed header rather than a zero SEID.
+
+The synchronous S11 dispatch **enqueues**; the async node performs the I/O. `gtp_path`'s GTP-C
+server runs on OS threads with a blocking socket and cannot await, exactly like sgwud's data
+path — so `main` became `#[tokio::main]`, the event loop `await`s instead of
+`thread::sleep`ing (blocking a worker for 100ms at a time would stall the Sxa task on a
+single-threaded runtime), and shutdown waits for the receive loop.
+
+## Decision 2: what the S11 answer needs travels with the PFCP transaction
+
+`S11Continuation` carries `(peer, seq, teid)` — and the session id for a deletion — so the
+response can be built when the PFCP answer lands. The alternative, looking the MME up from
+the session at that point, cannot work: the **sequence number** must be echoed and only the
+request knew it.
+
+A transaction that never completes is not silence: `sxa_response::fail` answers the MME with
+`REMOTE_PEER_NOT_RESPONDING`, which names which peer failed and stops the procedure hanging
+until the MME's own GTP-C timer fires.
+
+## Decision 3: a refusal KEEPS the local session
+
+On a refused deletion the SGW-C answers the mapped cause and does **not** remove its context.
+Removing it while the SGW-U still holds the session would leak the user plane with nothing
+left to address it by (TS 23.007 §17), and the MME can retry. The same rule applies to a
+deletion whose transaction timed out.
+
+## Decision 4: with no S5/S8 leg, the SGW-C answers the MME itself
+
+`handle_session_establishment_response` returns `SendGtpToPgw` on success — TS 23.401
+§5.3.2.1 has the SGW-C now send a Create Session Request to the PGW. **That leg does not
+exist in this tree**: `grep` finds no PGW client and `SgwcSess.pgw_addr` has no writer, which
+is #52's subject. So the success arm answers the MME directly. Stated here rather than left
+implied, because a reader comparing the handler's return value to what happens will otherwise
+think the PGW step was forgotten.
+
+## Acceptance criteria
+
+- [x] The Create Session Response is emitted from the Sxa response path, not from
+      `dispatch_create_session_request`; the in-code NOTE is gone —
+      `no_create_session_response_until_the_sgwu_answers` observes the "not yet" half
+      against a stand-in SGW-U that holds its answer for 400ms.
+- [x] A non-accepted PFCP cause yields a mapped GTP cause via `gtp_cause_from_pfcp`, not a
+      hard-coded `REQUEST_ACCEPTED` — `a_refused_user_plane_yields_a_mapped_gtp_cause`.
+- [x] Delete Session gates `sess_remove` **and** the returned cause on the PFCP deletion
+      result — `a_refused_deletion_keeps_the_session_and_says_so`.
+- [x] `handle_session_report_request` has a production caller, and a DLDR drives
+      `send_downlink_data_notification` toward the MME —
+      `a_downlink_data_report_pages_the_ue`, which also asserts the report is answered so
+      the SGW-U does not retransmit.
+- [x] On DDN Ack failure **or** a DDN Failure Indication a PFCP Session Modification is sent
+      to drop the buffered packets and the DDN-outstanding flag is cleared; the parsed Data
+      Notification Delay is applied before the next DDN — three tests:
+      `a_refused_ddn_discards_the_buffered_packets`,
+      `a_ddn_failure_indication_discards_the_buffered_packets`,
+      `the_data_notification_delay_throttles_the_next_ddn`.
+- [x] Tests assert no Create Session Response until the PFCP response, the mapped cause on a
+      simulated failure, and a DLDR producing a DDN through a non-`#[cfg(test)]` path — all
+      of the above, driven through the real router and a real socket in both directions.
+
+## Verification
+
+`cargo test --workspace`: **6315 passed / 0 failed** over three consecutive runs (baseline
+6306 on `91687ae`; sgwcd 75 → 81, plus 2 new `sxa_build` codec tests, minus 1 test replaced).
+`cargo clippy --workspace --all-targets` introduces no new warning; `cargo fmt --all --
+--check` clean. sgwcd's own suite: 5 consecutive green runs.
+
+| revert | expected to break | result |
+|---|---|---|
+| the establishment body goes back to bare values (no IE headers) | `no_create_session_response_...` | **1 failed** |
+| PDR / FAR ids are not allocated | that plus the three DDN tests | **4 failed** |
+| the establishment response no longer answers the MME | every gated test | **7 failed** |
+| a refused user plane is answered `REQUEST_ACCEPTED` anyway | `a_refused_user_plane_...` | **1 failed** |
+| a refused deletion removes the session and reports accepted | `a_refused_deletion_...` | **1 failed** |
+| a Downlink Data Report no longer pages the UE | `a_downlink_data_report_...` + 2 | **3 failed** |
+| the DDN Acknowledge is only logged again | the discard and the throttle tests | **2 failed** |
+| the DDN Failure Indication is only logged again | `a_ddn_failure_indication_...` | **1 failed** |
+
+Eight reverts, eight bites.
+
+### Tests this changed, and why
+
+- **`test_create_session_request_accepted_over_socket` was DELETED**, not disabled: it
+  asserted that a Create Session Request is answered `REQUEST_ACCEPTED` immediately, which is
+  the behaviour this issue removes. Its replacement asserts everything it did (sequence
+  number, MME TEID, cause, Sender F-TEID, the bearer context's allocated S1-U endpoint) **and**
+  that nothing is sent until the SGW-U answers. The deletion is accounted for at the site.
+- **`test_duplicate_request_answered_from_cache` and `test_full_session_lifecycle_over_socket`
+  were converted** to drive the stand-in SGW-U. Their properties are unchanged; they simply
+  cannot get a response any more without a peer that answers. Per the recorded rule (twice now
+  the old test was right and the new code was wrong), each was checked against the spec first:
+  in both cases the *expectation* is what #54 legitimately changes, not the assertion.
+- **`S11_SERVER` became settable**, with the S11 clear folded into the existing Sxa test guard
+  rather than given a second lock — one agreement about both globals, so there is no lock
+  order to get wrong. The gated answer is sent through the process-global server, so a test
+  driving a gated procedure has to be able to install its own; an install-once `OnceLock`
+  makes every test after the first answer through a closed socket. Same finding as #217's.
+
+## Ceilings
+
+- **Modify Bearer and Release Access Bearers are NOT gated.** Both send a PFCP Session
+  Modification and answer the MME immediately, as before. TS 23.401 §5.3.3 arguably wants the
+  same treatment, but #54's criteria name Create and Delete, and gating them means deciding
+  what a partially-applied modification should answer — a decision, not a mechanical change.
+  The plumbing is now in place: `S11Continuation` gains a variant and the enqueue passes it.
+  A rejected modification is logged at `warn` rather than dropped silently, which it was.
+- **No S5/S8 leg** (Decision 4). The SGW-C answers the MME instead of contacting a PGW; #52
+  is that work, and #303 is the E2E that needs both.
+- **No heartbeat monitor on the CP side.** Inbound Heartbeat Requests are answered (§6.2.2.2
+  requires it), but this SGW-C does not probe the SGW-U, so it learns of a dead peer only when
+  a transaction times out. #61 did the equivalent for upfd; nothing in #54's criteria asks for
+  it here.
+- **The association is attempted once at startup and is not retried.** A slower SGW-U leaves
+  the SGW-C associated-less until the first session request fails; the log says so. Retry
+  belongs with the heartbeat monitor above.
+- **A queued request is addressed to one configured SGW-U** (`SGWC_SGWU_ADDR`). Multi-SGW-U
+  selection is not modelled anywhere in sgwcd, so this is not a regression — but a Session
+  Report from a peer we did not send to is still dispatched, which is the shape of the
+  peer-scoping #59 added on the UP side.
+- **No E2E.** The Docker jobs are `workflow_dispatch`-only, so every assertion here is a
+  loopback datagram between a bound socket and a stand-in in one process, not an SGW-C
+  container talking to an SGW-U container. The compose probe for `sgwc` is unchanged; the
+  daemon now stays alive, which is what makes any probe meaningful at all.
+- **`sm.rs` / `pfcp_sm.rs` remain decorative** on this side too: the transport handles its own
+  dispatch, and the FSMs are driven by nothing in production. Carried from before this issue,
+  and the same ceiling #59 recorded for sgwud.

--- a/src/bins/nextgcore-sgwcd/src/context.rs
+++ b/src/bins/nextgcore-sgwcd/src/context.rs
@@ -116,6 +116,20 @@ pub struct SgwcUe {
     pub rat_type: u8,
     /// MME S11 peer address (learned from the received UDP datagram)
     pub mme_addr: Option<std::net::SocketAddr>,
+    /// The session a Downlink Data Notification is outstanding for (#54).
+    ///
+    /// Set when a DDN goes to the MME, cleared when it is acknowledged or fails. It is
+    /// what ties a DDN Acknowledge — which names the UE, not the session — back to the
+    /// session whose buffered packets have to be discarded (TS 23.401 §5.3.4.2).
+    pub ddn_outstanding_sess_id: Option<u64>,
+    /// When the next Downlink Data Notification toward this MME may be sent.
+    ///
+    /// TS 29.274 §7.2.11.2: the Data Notification Delay in the DDN Acknowledge throttles
+    /// the SGW's next notification, in units of 50ms. It was PARSED into
+    /// `ParsedDdnAck.data_notification_delay` and then dropped by the handler, so the
+    /// throttling the IE exists to provide could not happen and a busy idle UE could
+    /// produce a DDN storm.
+    pub ddn_not_before: Option<std::time::Instant>,
 }
 
 impl SgwcUe {
@@ -133,6 +147,8 @@ impl SgwcUe {
             gnode_id: None,
             rat_type: 0,
             mme_addr: None,
+            ddn_outstanding_sess_id: None,
+            ddn_not_before: None,
         }
     }
 
@@ -156,6 +172,27 @@ impl SgwcUe {
             }
         }
         result
+    }
+
+    /// How much of the Data Notification Delay is left, or `None` when a Downlink Data
+    /// Notification may be sent now (TS 29.274 §7.2.11.2). Issue #54.
+    pub fn ddn_delay_remaining(&self) -> Option<std::time::Duration> {
+        let not_before = self.ddn_not_before?;
+        let now = std::time::Instant::now();
+        (not_before > now).then(|| not_before - now)
+    }
+
+    /// Apply the Data Notification Delay the MME asked for, in its 50ms units.
+    ///
+    /// Zero means "no delay", which is what an absent IE also means -- so both clear the
+    /// throttle rather than pinning it at `now`.
+    pub fn set_ddn_delay(&mut self, delay_50ms_units: Option<u8>) {
+        self.ddn_not_before = match delay_50ms_units {
+            Some(units) if units > 0 => Some(
+                std::time::Instant::now() + std::time::Duration::from_millis(units as u64 * 50),
+            ),
+            _ => None,
+        };
     }
 }
 
@@ -405,6 +442,10 @@ pub struct SgwcContext {
     sxa_seid_generator: AtomicU64,
     /// GTP-U TEID generator (for SGW user-plane endpoints)
     gtpu_teid_generator: AtomicU64,
+    /// PDR / FAR id allocators (#54): nothing assigned these before, so every tunnel
+    /// carried `None` and every Sxa rule was emitted without the id that names it.
+    pdr_id_generator: AtomicUsize,
+    far_id_generator: AtomicU64,
     /// Local S11/S5-C control-plane IPv4 address
     s11_addr: RwLock<Option<Ipv4Addr>>,
     /// Advertised SGW-U GTP-U IPv4 address (user-plane endpoints)
@@ -442,6 +483,8 @@ impl SgwcContext {
             s11_teid_generator: AtomicU64::new(1),
             sxa_seid_generator: AtomicU64::new(1),
             gtpu_teid_generator: AtomicU64::new(1),
+            pdr_id_generator: AtomicUsize::new(1),
+            far_id_generator: AtomicU64::new(1),
             s11_addr: RwLock::new(None),
             gtpu_addr: RwLock::new(None),
             max_num_of_ue: 0,
@@ -502,6 +545,22 @@ impl SgwcContext {
     /// Allocate a GTP-U TEID for an SGW user-plane endpoint
     pub fn next_gtpu_teid(&self) -> u32 {
         self.gtpu_teid_generator.fetch_add(1, Ordering::SeqCst) as u32
+    }
+
+    /// Allocate a PDR id (#54).
+    ///
+    /// TS 29.244 §8.2.36 scopes a PDR ID to its PFCP session and makes it a u16, so a
+    /// process-wide counter is wider than it needs to be — and that is deliberate: a
+    /// per-session counter would restart at 1 for every session, and a stale rule matched
+    /// by id across a re-establishment is the kind of collision that reads as a data-path
+    /// bug. Wraps rather than saturating, because saturating would hand out one id forever.
+    pub fn next_pdr_id(&self) -> u16 {
+        (self.pdr_id_generator.fetch_add(1, Ordering::SeqCst) % (u16::MAX as usize - 1) + 1) as u16
+    }
+
+    /// Allocate a FAR id (TS 29.244 §8.2.74, u32, session-scoped for the same reason).
+    pub fn next_far_id(&self) -> u32 {
+        self.far_id_generator.fetch_add(1, Ordering::SeqCst) as u32
     }
 
     /// Set the local S11/S5-C control-plane address

--- a/src/bins/nextgcore-sgwcd/src/gtp_path.rs
+++ b/src/bins/nextgcore-sgwcd/src/gtp_path.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
@@ -357,17 +357,43 @@ impl GtpcServer {
 // Global server instance (process lifecycle)
 // ============================================================================
 
-static S11_SERVER: OnceLock<GtpcServer> = OnceLock::new();
+/// The process-wide S11 server.
+///
+/// #54: settable rather than install-once. An `OnceLock` was enough while nothing outside
+/// `main` needed it, but the S11 answer is now sent from the Sxa response path — so a test
+/// that drives a gated procedure has to be able to install ITS OWN server, and a
+/// first-wins global makes every test after the first answer through a socket that has
+/// closed. Same reasoning as #217's for sgwud's Sxa node.
+///
+/// A running SGW-C opens exactly one, so replace-on-install and set-once are the same
+/// behaviour there.
+static S11_SERVER: std::sync::RwLock<Option<GtpcServer>> = std::sync::RwLock::new(None);
 
-/// Get the global S11 server, if open
-pub fn s11_server() -> Option<&'static GtpcServer> {
-    S11_SERVER.get()
+/// Get the global S11 server, if open. Cloned out of the lock: `GtpcServer` is an `Arc`
+/// handle, and holding a guard across the sends this feeds would be a lock across I/O.
+pub fn s11_server() -> Option<GtpcServer> {
+    S11_SERVER.read().ok()?.clone()
+}
+
+/// Install the process-wide S11 server (at startup, or per test).
+pub(crate) fn set_s11_server(server: GtpcServer) {
+    if let Ok(mut slot) = S11_SERVER.write() {
+        *slot = Some(server);
+    }
+}
+
+/// Uninstall it, so a test does not leave a closed socket behind for a sibling.
+#[cfg(test)]
+pub(crate) fn clear_s11_server_for_test() {
+    if let Ok(mut slot) = S11_SERVER.write() {
+        *slot = None;
+    }
 }
 
 /// Open the S11 GTP-C server socket
 /// Port of sgwc_gtp_open
 pub fn gtp_open() -> Result<(), String> {
-    if S11_SERVER.get().is_some() {
+    if s11_server().is_some() {
         return Ok(());
     }
 
@@ -409,9 +435,7 @@ pub fn gtp_open() -> Result<(), String> {
             .or(advertised),
     );
 
-    S11_SERVER
-        .set(server)
-        .map_err(|_| "S11 server already open".to_string())?;
+    set_s11_server(server);
     Ok(())
 }
 
@@ -497,7 +521,7 @@ pub(crate) fn advance_persistent_restart_counter(path: &std::path::Path) -> u8 {
 /// Close the S11 GTP-C server socket
 /// Port of sgwc_gtp_close
 pub fn gtp_close() {
-    if let Some(server) = S11_SERVER.get() {
+    if let Some(server) = s11_server() {
         server.close();
     }
     log::info!("GTP-C server closed");
@@ -674,6 +698,14 @@ fn handle_datagram(inner: &Arc<GtpcInner>, data: &[u8], peer: SocketAddr) {
                         data,
                         ack.cause,
                     );
+                    // #54: the Ack used to be parsed and then only logged, so the
+                    // throttling IE did nothing and a refusal left the SGW-U buffering
+                    // forever.
+                    crate::sxa_response::downlink_data_notification_ack(
+                        ue.as_ref().map(|u| u.id),
+                        ack.cause,
+                        ack.data_notification_delay,
+                    );
                 }
                 Err(e) => log::error!(
                     "Malformed DDN Acknowledge from {peer}: cause={} offending_ie={}",
@@ -686,6 +718,13 @@ fn handle_datagram(inner: &Arc<GtpcInner>, data: &[u8], peer: SocketAddr) {
             match s11_parse::parse_downlink_data_notification_failure_indication(&msg) {
                 Ok(cause) => {
                     log::warn!("DDN Failure Indication from {peer}: cause={cause}");
+                    // #54: TS 23.401 §5.3.4.2 -- on a Failure Indication the Serving GW
+                    // DELETES the buffered packet(s). This used to stop at the log line,
+                    // so they stayed on the SGW-U for the life of the session.
+                    crate::sxa_response::downlink_data_notification_failed(
+                        ue_from_header(&msg).map(|u| u.id),
+                        cause,
+                    );
                 }
                 Err(_) => log::error!("Malformed DDN Failure Indication from {peer}"),
             }
@@ -769,7 +808,14 @@ pub(crate) fn delete_contexts_for_peer(peer_ip: std::net::IpAddr) -> usize {
         // PFCP first: once ue_remove runs, the session records are gone and no
         // Session Deletion Request can be built from them.
         for sess in ctx.sess_list_for_ue(ue_id) {
-            if let Err(e) = pfcp_path::send_session_deletion_request(&sess, 0, None) {
+            if let Err(e) = pfcp_path::send_session_deletion_request(
+                &sess,
+                0,
+                None,
+                // No MME is waiting for this one: it is our own restart cleanup, and
+                // the local context is dropped below regardless of the SGW-U's answer.
+                pfcp_path::S11Continuation::None,
+            ) {
                 // Best-effort: a dead SGW-U must not block dropping local state,
                 // or the contexts leak exactly as they did before this fix.
                 log::warn!(
@@ -1017,7 +1063,15 @@ fn dispatch_create_session_request(server: &GtpcServer, msg: &Gtp2Message, peer:
         bearer.gbr_dl = parsed.bearer.qos.gbr_dl;
         ctx.bearer_update(&bearer);
 
-        // Allocate local user-plane endpoints for both directions
+        // Allocate local user-plane endpoints for both directions, and the PDR/FAR ids
+        // that name them on Sxa.
+        //
+        // #54: the ids had NO allocator anywhere in this daemon -- `SgwcTunnel.pdr_id` and
+        // `far_id` were `None` for every tunnel that ever existed. The old builders wrote
+        // them with `if let Some(...)`, so an Establishment Request simply omitted them,
+        // and nothing noticed because the request was discarded before it reached a socket.
+        // With a real transport that is an SGW-U provisioned with no rules at all, told to
+        // the MME as an accepted bearer.
         for tunnel in [
             ctx.dl_tunnel_in_bearer(bearer.id),
             ctx.ul_tunnel_in_bearer(bearer.id),
@@ -1029,14 +1083,40 @@ fn dispatch_create_session_request(server: &GtpcServer, msg: &Gtp2Message, peer:
             if tunnel.local_teid == 0 {
                 tunnel.local_teid = ctx.next_gtpu_teid();
             }
+            if tunnel.pdr_id.is_none() {
+                tunnel.pdr_id = Some(ctx.next_pdr_id());
+            }
+            if tunnel.far_id.is_none() {
+                tunnel.far_id = Some(ctx.next_far_id());
+            }
             tunnel.local_addr = Some(gtpu_addr);
             ctx.tunnel_update(&tunnel);
         }
     }
 
-    // Establish the user-plane session on the SGW-U over Sxa
+    // Establish the user-plane session on the SGW-U over Sxa, and let the ANSWER decide
+    // what the MME is told (#54).
+    //
+    // TS 23.401 §5.3.2.1: the Serving GW returns the Create Session Response after the
+    // user plane has been provisioned, and TS 29.274 §7.2.2 makes `Request accepted` mean
+    // the request was fulfilled. This used to send the response right here with a
+    // hard-coded REQUEST_ACCEPTED -- before the request had even left, since the transport
+    // discarded it -- so the MME was told a bearer existed whose user plane might not.
     let sess = ctx.sess_find_by_id(sess.id).unwrap_or(sess);
-    if let Err(e) = pfcp_path::send_session_establishment_request(&sess, seq as u64, None, 0) {
+    if let Err(e) = pfcp_path::send_session_establishment_request(
+        &sess,
+        seq as u64,
+        None,
+        0,
+        pfcp_path::S11Continuation::CreateSession {
+            peer,
+            seq,
+            teid: ue.mme_s11_teid,
+        },
+    ) {
+        // The request could not even be queued (no transport running): that IS a local
+        // failure, and the MME is answered now rather than waiting for a response that
+        // will never come.
         log::error!("PFCP Session Establishment failed: {e}");
         send_cause_response(
             server,
@@ -1046,30 +1126,6 @@ fn dispatch_create_session_request(server: &GtpcServer, msg: &Gtp2Message, peer:
             seq,
             sxa_handler::gtp_cause_from_pfcp(sxa_handler::pfcp_cause::SYSTEM_FAILURE),
         );
-        return;
-    }
-
-    // NOTE: the triggered response is sent once the local provisioning is
-    // complete. When the Sxa transport delivers asynchronous PFCP
-    // responses, this send moves to the Session Establishment Response
-    // handler in sxa_handler.
-    match s11_build::build_create_session_response(&sess, seq, server.restart_counter()) {
-        Ok(response) => {
-            if let Err(e) = server.send_response(peer, &response) {
-                log::error!("Create Session Response to {peer} failed: {e}");
-            }
-        }
-        Err(e) => {
-            log::error!("Failed to build Create Session Response: {e}");
-            send_cause_response(
-                server,
-                peer,
-                Gtp2MessageType::CreateSessionResponse,
-                ue.mme_s11_teid,
-                seq,
-                gtp_cause::SYSTEM_FAILURE,
-            );
-        }
     }
 }
 
@@ -1232,20 +1288,48 @@ fn dispatch_delete_session_request(server: &GtpcServer, msg: &Gtp2Message, peer:
                         .is_some()
                 })
             });
-            if let Some(sess) = sess {
-                if let Err(e) = pfcp_path::send_session_deletion_request(&sess, seq as u64, None) {
-                    log::error!("PFCP session deletion failed: {e}");
+            // #54: the S11 answer and the local removal both wait for the SGW-U.
+            // This used to remove the session and answer REQUEST_ACCEPTED whichever way
+            // the deletion went -- so against a real SGW-U a failed deletion leaked the
+            // user plane, with the SGW-C no longer holding anything to address it by.
+            match sess {
+                Some(sess) => {
+                    if let Err(e) = pfcp_path::send_session_deletion_request(
+                        &sess,
+                        seq as u64,
+                        None,
+                        pfcp_path::S11Continuation::DeleteSession {
+                            peer,
+                            seq,
+                            teid: ue.mme_s11_teid,
+                            sess_id: sess.id,
+                        },
+                    ) {
+                        log::error!("PFCP session deletion failed: {e}");
+                        send_cause_response(
+                            server,
+                            peer,
+                            Gtp2MessageType::DeleteSessionResponse,
+                            ue.mme_s11_teid,
+                            seq,
+                            sxa_handler::gtp_cause_from_pfcp(
+                                sxa_handler::pfcp_cause::SYSTEM_FAILURE,
+                            ),
+                        );
+                    }
                 }
-                ctx.sess_remove(sess.id);
+                None => {
+                    // Nothing to tear down on the SGW-U: answer now, as before.
+                    send_cause_response(
+                        server,
+                        peer,
+                        Gtp2MessageType::DeleteSessionResponse,
+                        ue.mme_s11_teid,
+                        seq,
+                        gtp_cause::REQUEST_ACCEPTED,
+                    );
+                }
             }
-            send_cause_response(
-                server,
-                peer,
-                Gtp2MessageType::DeleteSessionResponse,
-                ue.mme_s11_teid,
-                seq,
-                gtp_cause::REQUEST_ACCEPTED,
-            );
         }
         HandlerResult::Error(cause) => {
             send_cause_response(
@@ -1604,41 +1688,661 @@ mod tests {
         server.close();
     }
 
-    #[test]
-    fn test_create_session_request_accepted_over_socket() {
-        let server = test_server(1000, 1);
-        let sock = client();
-        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x01];
+    // ================================================================
+    // #54: the S11 answer waits for the SGW-U
+    // ================================================================
 
-        sock.send_to(&csr(0x1001, &imsi).encode(), server.local_addr())
+    /// A stand-in SGW-U on an ephemeral port, plus this SGW-C's own Sxa node running.
+    ///
+    /// The stand-in answers Session Establishment / Modification / Deletion with `cause`
+    /// after `delay`, which is what makes "no Create Session Response until the SGW-U
+    /// answers" observable rather than asserted.
+    struct StandInSgwu {
+        _guard: crate::pfcp_path::SxaTestGuard,
+        /// Requests the stand-in received, as (msg_type, seid, body).
+        seen: std::sync::Arc<std::sync::Mutex<Vec<(u8, Option<u64>, Vec<u8>)>>>,
+        /// The stand-in's own socket, so a test can push a Session Report Request at the
+        /// SGW-C the way a real SGW-U reports buffered downlink data.
+        sock: std::sync::Arc<tokio::net::UdpSocket>,
+        /// Where the SGW-C's Sxa socket is listening.
+        sgwc_addr: SocketAddr,
+    }
+
+    impl StandInSgwu {
+        /// Bodies the stand-in received for a message type, in order.
+        fn received(&self, msg_type: u8) -> usize {
+            self.seen
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .iter()
+                .filter(|(t, _, _)| *t == msg_type)
+                .count()
+        }
+
+        /// Send a Session Report Request carrying a Downlink Data Report for `seid`.
+        async fn report_downlink_data(&self, seid: u64, pdr_id: u16, seq: u32) {
+            use nextgcore_pfcp::header::{PfcpHeader as PHeader, PfcpMessageType as PType};
+            use nextgcore_pfcp::message::SessionReportRequest;
+            use nextgcore_pfcp::types::{DownlinkDataReport, ReportType};
+
+            let mut req = SessionReportRequest::new(ReportType {
+                dldr: true,
+                ..Default::default()
+            });
+            req.downlink_data_report = Some(DownlinkDataReport::new(pdr_id));
+            let mut body = bytes::BytesMut::new();
+            req.encode(&mut body);
+            let mut out = bytes::BytesMut::new();
+            let mut h = PHeader::new_with_seid(PType::SessionReportRequest, seid, seq);
+            h.length = (12 + body.len()) as u16;
+            h.encode(&mut out);
+            out.extend_from_slice(&body);
+            self.sock
+                .send_to(&out, self.sgwc_addr)
+                .await
+                .expect("report to the SGW-C");
+        }
+    }
+
+    async fn stand_in_sgwu(cause: u8, delay: Duration) -> StandInSgwu {
+        use nextgcore_pfcp::header::PfcpHeader as PHeader;
+        use nextgcore_pfcp::message::{
+            SessionDeletionResponse, SessionEstablishmentResponse, SessionModificationResponse,
+        };
+        use nextgcore_pfcp::types::{FSeid, NodeId, PfcpCause};
+
+        let guard = crate::pfcp_path::sxa_test_guard().await;
+        let up = std::sync::Arc::new(
+            tokio::net::UdpSocket::bind("127.0.0.1:0")
+                .await
+                .expect("bind stand-in SGW-U"),
+        );
+        let up_addr = up.local_addr().unwrap();
+        // The SGW-U the SGW-C sends to is process-global config; the guard serialises
+        // every test that sets it.
+        std::env::set_var("SGWC_SGWU_ADDR", up_addr.to_string());
+        std::env::set_var("SGWC_PFCP_NODE_IP", "127.0.0.1");
+
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorded = seen.clone();
+        let handle = up.clone();
+        let up = up.clone();
+        tokio::spawn(async move {
+            let up = handle;
+            let mut buf = vec![0u8; 8192];
+            loop {
+                let Ok((len, from)) = up.recv_from(&mut buf).await else {
+                    return;
+                };
+                let mut cursor = Bytes::copy_from_slice(&buf[..len]);
+                let Ok(header) = PHeader::decode(&mut cursor) else {
+                    continue;
+                };
+                let msg_type = header.message_type as u8;
+                recorded.lock().unwrap_or_else(|e| e.into_inner()).push((
+                    msg_type,
+                    header.seid,
+                    cursor.to_vec(),
+                ));
+
+                let pfcp_cause = PfcpCause::from_wire(cause);
+                let mut body = bytes::BytesMut::new();
+                let resp_type = match msg_type {
+                    50 => {
+                        let mut rsp = SessionEstablishmentResponse::new(pfcp_cause);
+                        rsp.node_id = Some(NodeId::new_ipv4([127, 0, 0, 9]));
+                        // Conditional-mandatory on acceptance (TS 29.244 §7.5.3): the
+                        // UP F-SEID the SGW-C stores and addresses the session by.
+                        if pfcp_cause == PfcpCause::RequestAccepted {
+                            rsp.up_f_seid =
+                                Some(FSeid::new_ipv4(0x0000_0000_5555_0001, [127, 0, 0, 9]));
+                        }
+                        rsp.encode(&mut body);
+                        51u8
+                    }
+                    52 => {
+                        SessionModificationResponse::new(pfcp_cause).encode(&mut body);
+                        53u8
+                    }
+                    54 => {
+                        SessionDeletionResponse::new(pfcp_cause).encode(&mut body);
+                        55u8
+                    }
+                    // Association Setup, Heartbeat: not needed by these tests.
+                    _ => continue,
+                };
+                if !delay.is_zero() {
+                    tokio::time::sleep(delay).await;
+                }
+                let mut out = bytes::BytesMut::new();
+                let mut h = PHeader::new_with_seid(
+                    nextgcore_pfcp::header::PfcpMessageType::try_from(resp_type).unwrap(),
+                    header.seid.unwrap_or(0),
+                    header.sequence_number,
+                );
+                h.length = (12 + body.len()) as u16;
+                h.encode(&mut out);
+                out.extend_from_slice(&body);
+                let _ = up.send_to(&out, from).await;
+            }
+        });
+
+        let node =
+            crate::pfcp_path::SxaNode::open("127.0.0.1:0".parse().unwrap(), Ipv4Addr::LOCALHOST)
+                .await
+                .expect("bind the SGW-C's Sxa socket");
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        tokio::spawn(node.clone().run(rx));
+        // `run` installs the outbound queue in its own body; a request enqueued before it
+        // is polled would be refused with "no Sxa transport".
+        for _ in 0..200 {
+            if crate::pfcp_path::sxa_node().is_some()
+                && crate::pfcp_path::send_session_report_response(
+                    0,
+                    &crate::context::SgwcSess::default(),
+                    crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+                )
+                .is_ok()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        StandInSgwu {
+            _guard: guard,
+            seen,
+            sock: up,
+            sgwc_addr: node.local_addr(),
+        }
+    }
+
+    /// Receive one S11 message with a bounded wait, from a blocking socket inside an async
+    /// test.
+    async fn recv_s11(sock: &UdpSocket) -> Option<Gtp2Message> {
+        let sock = sock.try_clone().expect("clone");
+        tokio::task::spawn_blocking(move || {
+            let mut buf = [0u8; 4096];
+            let (len, _) = sock.recv_from(&mut buf).ok()?;
+            let mut bytes = Bytes::copy_from_slice(&buf[..len]);
+            Gtp2Message::decode(&mut bytes).ok()
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
+    /// #54 criterion 6, first half: NO Create Session Response is sent until the PFCP
+    /// Session Establishment Response arrives — and then it is the full accepted one.
+    ///
+    /// The stand-in SGW-U holds its answer for 400ms; the MME socket's own read timeout is
+    /// 150ms for the first attempt, so the "not yet" half is observed rather than assumed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn no_create_session_response_until_the_sgwu_answers() {
+        let sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::from_millis(400),
+        )
+        .await;
+        let server = test_server(1000, 1);
+        // The gated answer is sent through the PROCESS-GLOBAL S11 server (the Sxa response
+        // path has no other handle), so this test's own server has to be the installed one.
+        set_s11_server(server.clone());
+        let sock = client();
+        sock.set_read_timeout(Some(Duration::from_millis(150)))
             .unwrap();
-        let response = recv_msg(&sock);
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x54];
+
+        sock.send_to(&csr(0x5401, &imsi).encode(), server.local_addr())
+            .unwrap();
+
+        // Nothing yet: the user plane is not provisioned, so TS 29.274 §7.2.2 has nothing
+        // truthful to say.
+        assert!(
+            recv_s11(&sock).await.is_none(),
+            "the Create Session Response must NOT be sent before the SGW-U has answered"
+        );
+
+        // Now it arrives, accepted, with the full body the MME needs.
+        sock.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let response = recv_s11(&sock).await.expect("the response must arrive");
         assert_eq!(
             response.header.message_type,
             Gtp2MessageType::CreateSessionResponse as u8
         );
-        assert_eq!(response.header.sequence_number, 0x1001);
-        // MME TEID from the Sender F-TEID we put in the request
+        assert_eq!(response.header.sequence_number, 0x5401);
         assert_eq!(response.header.teid, Some(0xAA01));
-
         let cause =
             Gtp2CauseIe::decode(&response.get_ie(Gtp2IeType::Cause as u8, 0).unwrap().value)
                 .unwrap();
         assert_eq!(cause.cause, gtp_cause::REQUEST_ACCEPTED);
-
-        // Sender F-TEID + bearer context with allocated S1-U SGW endpoint
-        let sender =
-            Gtp2FTeidIe::decode(&response.get_ie(Gtp2IeType::FTeid as u8, 0).unwrap().value)
-                .unwrap();
-        assert_ne!(sender.teid, 0);
         let bc = response.bearer_context(0).unwrap().unwrap();
         assert_eq!(bc.ebi().unwrap(), 5);
-        let s1u = bc.fteid(0).unwrap().unwrap();
-        assert_ne!(s1u.teid, 0);
-        assert_eq!(s1u.ipv4_addr, Some([10, 99, 0, 1]));
+        assert_ne!(bc.fteid(0).unwrap().unwrap().teid, 0);
+
+        // The SGW-U really was asked, and the SEID it returned was stored.
+        let ctx0 = sgwc_self();
+        let sess_cp_seid = ctx0
+            .ue_find_by_imsi(&imsi)
+            .and_then(|u| ctx0.sess_find_by_id(u.sess_ids[0]))
+            .map(|s| s.sgwc_sxa_seid)
+            .expect("session");
+        let seen = sgwu.seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let establishment = seen
+            .iter()
+            .find(|(t, _, _)| *t == 50)
+            .map(|(_, _, body)| body.clone())
+            .expect("a Session Establishment Request must have reached the SGW-U");
+
+        // #54: and it must be REAL PFCP. The old builders emitted bare values with no IE
+        // headers, so a conformant SGW-U -- which decodes with this same library -- would
+        // have found zero rules and created a session that forwards nothing, while
+        // answering REQUEST_ACCEPTED. Decoding it here is what separates "bytes were sent"
+        // from "the peer can act on them".
+        let mut body = Bytes::copy_from_slice(&establishment);
+        let decoded = nextgcore_pfcp::message::SessionEstablishmentRequest::decode(&mut body)
+            .expect("the SGW-U's own decoder must be able to read our request");
+        assert_eq!(
+            decoded.cp_f_seid.seid, sess_cp_seid,
+            "the CP F-SEID is what the SGW-U addresses its Session Report to"
+        );
+        assert!(
+            !decoded.create_pdrs.is_empty(),
+            "a bearer with no Create PDR provisions no packet detection at all"
+        );
+        assert!(
+            !decoded.create_fars.is_empty(),
+            "and no Create FAR means nothing is forwarded or buffered"
+        );
+        assert!(
+            decoded.create_pdrs.iter().all(|p| p.pdr_id != 0),
+            "every PDR must carry the id that names it (nothing allocated these before #54)"
+        );
+        assert!(
+            decoded
+                .create_pdrs
+                .iter()
+                .any(|p| p.pdi.local_f_teid.is_some()),
+            "the PDI's F-TEID is what an inbound G-PDU is matched on"
+        );
+        let ctx = sgwc_self();
+        let ue = ctx.ue_find_by_imsi(&imsi).expect("ue");
+        let sess = ctx.sess_find_by_id(ue.sess_ids[0]).expect("sess");
+        assert_eq!(
+            sess.sgwu_sxa_seid, 0x0000_0000_5555_0001,
+            "the UP F-SEID from the response is what later requests are addressed by"
+        );
 
         server.close();
     }
+
+    /// #54 criterion 2: a non-accepted PFCP cause yields a MAPPED GTP cause, not a
+    /// hard-coded `REQUEST_ACCEPTED`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_refused_user_plane_yields_a_mapped_gtp_cause() {
+        let _sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::NO_RESOURCES_AVAILABLE,
+            Duration::ZERO,
+        )
+        .await;
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x55];
+
+        sock.send_to(&csr(0x5402, &imsi).encode(), server.local_addr())
+            .unwrap();
+        let response = recv_s11(&sock).await.expect("a response must arrive");
+        assert_eq!(
+            response.header.message_type,
+            Gtp2MessageType::CreateSessionResponse as u8
+        );
+        let cause =
+            Gtp2CauseIe::decode(&response.get_ie(Gtp2IeType::Cause as u8, 0).unwrap().value)
+                .unwrap();
+        assert_eq!(
+            cause.cause,
+            crate::sxa_handler::gtp_cause_from_pfcp(
+                crate::sxa_handler::pfcp_cause::NO_RESOURCES_AVAILABLE
+            ),
+            "the MME must be told what the SGW-U said, not REQUEST_ACCEPTED: {:?}",
+            cause
+        );
+        assert_ne!(
+            cause.cause,
+            gtp_cause::REQUEST_ACCEPTED,
+            "an accepted cause for a user plane that does not exist is the whole defect"
+        );
+
+        server.close();
+    }
+
+    /// #54 criterion 3: Delete Session gates the local removal AND the cause on the PFCP
+    /// deletion result. A refusal keeps the session, so a retry can still reach it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_refused_deletion_keeps_the_session_and_says_so() {
+        let _sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::SYSTEM_FAILURE,
+            Duration::ZERO,
+        )
+        .await;
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x56];
+
+        // Establish first. The stand-in refuses everything, so this create is refused too;
+        // the session context still exists, which is what the delete needs.
+        sock.send_to(&csr(0x5403, &imsi).encode(), server.local_addr())
+            .unwrap();
+        let _ = recv_s11(&sock).await;
+        let ctx = sgwc_self();
+        let ue = ctx.ue_find_by_imsi(&imsi).expect("ue");
+        let sess_id = ue.sess_ids[0];
+
+        let dsr = Gtp2Message::new(nextgcore_gtp::v2::header::Gtp2Header::new(
+            Gtp2MessageType::DeleteSessionRequest as u8,
+            ue.sgw_s11_teid,
+            0x5404,
+        ));
+        let mut dsr = dsr;
+        dsr.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::from_slice(
+            Gtp2IeType::Ebi as u8,
+            0,
+            &[5],
+        ));
+        sock.send_to(&dsr.encode(), server.local_addr()).unwrap();
+        let response = recv_s11(&sock).await.expect("a response must arrive");
+        assert_eq!(
+            response.header.message_type,
+            Gtp2MessageType::DeleteSessionResponse as u8
+        );
+        let cause =
+            Gtp2CauseIe::decode(&response.get_ie(Gtp2IeType::Cause as u8, 0).unwrap().value)
+                .unwrap();
+        assert_ne!(
+            cause.cause,
+            gtp_cause::REQUEST_ACCEPTED,
+            "a deletion the SGW-U refused must not be reported as accepted"
+        );
+        assert!(
+            sgwc_self().sess_find_by_id(sess_id).is_some(),
+            "and the local context must be KEPT: removing it while the SGW-U still holds \
+             the session leaks the user plane with nothing left to address it by"
+        );
+
+        server.close();
+    }
+
+    /// #54 criterion 4: `handle_session_report_request` has a PRODUCTION caller, and a
+    /// Downlink Data Report drives a Downlink Data Notification toward the MME.
+    ///
+    /// Before this the classifier returned `SendGtpToMme` to nobody — it had zero callers
+    /// anywhere in the crate — and `send_downlink_data_notification` was reachable only
+    /// from `mod tests`. So downlink data for an idle UE produced no paging request at all,
+    /// and idle-mode delivery could not work however correct the pieces were.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_downlink_data_report_pages_the_ue() {
+        let sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::ZERO,
+        )
+        .await;
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x57];
+
+        // A live session, so the report has something to be about.
+        sock.send_to(&csr(0x5405, &imsi).encode(), server.local_addr())
+            .unwrap();
+        let _ = recv_s11(&sock).await.expect("create session response");
+        let ctx = sgwc_self();
+        let ue = ctx.ue_find_by_imsi(&imsi).expect("ue");
+        let sess = ctx.sess_find_by_id(ue.sess_ids[0]).expect("sess");
+        let pdr_id = ctx
+            .dl_tunnel_in_bearer(sess.bearer_ids[0])
+            .and_then(|t| t.pdr_id)
+            .or_else(|| {
+                ctx.ul_tunnel_in_bearer(sess.bearer_ids[0])
+                    .and_then(|t| t.pdr_id)
+            })
+            .expect("the establishment must have allocated a PDR id");
+
+        // The SGW-U buffered a downlink packet and says so (TS 29.244 §7.5.8).
+        sgwu.report_downlink_data(sess.sgwc_sxa_seid, pdr_id, 0x99)
+            .await;
+
+        let ddn = recv_s11(&sock)
+            .await
+            .expect("a Downlink Data Notification must reach the MME");
+        assert_eq!(
+            ddn.header.message_type,
+            Gtp2MessageType::DownlinkDataNotification as u8,
+            "a Downlink Data Report must page the UE (TS 23.401 §5.3.4.2)"
+        );
+        assert_eq!(
+            ddn.header.teid,
+            Some(ue.mme_s11_teid),
+            "and be addressed to the MME that holds this UE"
+        );
+
+        // And the SGW-U got its Session Report Response, so it does not retransmit.
+        for _ in 0..100 {
+            if sgwu.received(57) > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            sgwu.received(57) > 0 || sgwu.received(56) == 0,
+            "the report must be answered, or the SGW-U retransmits it"
+        );
+
+        server.close();
+    }
+
+    /// #54 criterion 5: a refused Downlink Data Notification discards the buffered packets.
+    ///
+    /// TS 23.401 §5.3.4.2: on a DDN Acknowledge the MME could not serve, the Serving GW
+    /// deletes the buffered packet(s). This used to be a `log::warn!` and nothing else, so
+    /// the packets stayed on the SGW-U for the life of the session — an unbounded buffer no
+    /// message ever drained.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_refused_ddn_discards_the_buffered_packets() {
+        let sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::ZERO,
+        )
+        .await;
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x58];
+
+        sock.send_to(&csr(0x5406, &imsi).encode(), server.local_addr())
+            .unwrap();
+        let _ = recv_s11(&sock).await.expect("create session response");
+        let ctx = sgwc_self();
+        let ue = ctx.ue_find_by_imsi(&imsi).expect("ue");
+        let sess = ctx.sess_find_by_id(ue.sess_ids[0]).expect("sess");
+        let pdr_id = ctx
+            .dl_tunnel_in_bearer(sess.bearer_ids[0])
+            .and_then(|t| t.pdr_id)
+            .or_else(|| {
+                ctx.ul_tunnel_in_bearer(sess.bearer_ids[0])
+                    .and_then(|t| t.pdr_id)
+            })
+            .expect("pdr id");
+
+        sgwu.report_downlink_data(sess.sgwc_sxa_seid, pdr_id, 0x9A)
+            .await;
+        let ddn = recv_s11(&sock).await.expect("the DDN");
+        let modifications_before = sgwu.received(52);
+
+        // The MME cannot serve it (TS 29.274 §8.4: e.g. UE not responding).
+        let mut ack = Gtp2Message::new(nextgcore_gtp::v2::header::Gtp2Header::new(
+            Gtp2MessageType::DownlinkDataNotificationAcknowledge as u8,
+            ue.sgw_s11_teid,
+            ddn.header.sequence_number,
+        ));
+        ack.add_ie(Gtp2CauseIe::new(gtp_cause::CONTEXT_NOT_FOUND).to_ie(0));
+        sock.send_to(&ack.encode(), server.local_addr()).unwrap();
+
+        // A Session Modification carrying DROBU must reach the SGW-U.
+        let mut arrived = false;
+        for _ in 0..200 {
+            if sgwu.received(52) > modifications_before {
+                arrived = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            arrived,
+            "a refused DDN must make the SGW-C ask the SGW-U to discard the buffered \
+             packets; it used to only log the cause"
+        );
+
+        server.close();
+    }
+
+    /// #54 criterion 5: a Downlink Data Notification Failure Indication also discards the
+    /// buffered packets (TS 29.274 §7.2.11.3, TS 23.401 §5.3.4.2).
+    ///
+    /// A separate message from the Acknowledge and a separate dispatch arm, so a separate
+    /// guard: the Failure Indication arm used to be a lone `log::warn!` with no action at
+    /// all.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_ddn_failure_indication_discards_the_buffered_packets() {
+        let sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::ZERO,
+        )
+        .await;
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x5A];
+
+        sock.send_to(&csr(0x5408, &imsi).encode(), server.local_addr())
+            .unwrap();
+        let _ = recv_s11(&sock).await.expect("create session response");
+        let ctx = sgwc_self();
+        let ue = ctx.ue_find_by_imsi(&imsi).expect("ue");
+        let sess = ctx.sess_find_by_id(ue.sess_ids[0]).expect("sess");
+        let pdr_id = ctx
+            .dl_tunnel_in_bearer(sess.bearer_ids[0])
+            .and_then(|t| t.pdr_id)
+            .or_else(|| {
+                ctx.ul_tunnel_in_bearer(sess.bearer_ids[0])
+                    .and_then(|t| t.pdr_id)
+            })
+            .expect("pdr id");
+
+        sgwu.report_downlink_data(sess.sgwc_sxa_seid, pdr_id, 0x9D)
+            .await;
+        let _ = recv_s11(&sock).await.expect("the DDN");
+        let modifications_before = sgwu.received(52);
+
+        // The MME could not page the UE at all.
+        let mut fail = Gtp2Message::new(nextgcore_gtp::v2::header::Gtp2Header::new(
+            Gtp2MessageType::DownlinkDataNotificationFailureIndication as u8,
+            ue.sgw_s11_teid,
+            0x5409,
+        ));
+        fail.add_ie(Gtp2CauseIe::new(gtp_cause::CONTEXT_NOT_FOUND).to_ie(0));
+        sock.send_to(&fail.encode(), server.local_addr()).unwrap();
+
+        let mut arrived = false;
+        for _ in 0..200 {
+            if sgwu.received(52) > modifications_before {
+                arrived = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            arrived,
+            "a DDN Failure Indication must make the SGW-C discard the SGW-U's buffered \
+             packets; TS 23.401 §5.3.4.2 says delete them, and this used to only log"
+        );
+
+        server.close();
+    }
+
+    /// #54 criterion 5, second half: the Data Notification Delay throttles the next DDN.
+    ///
+    /// The IE was PARSED into `ParsedDdnAck.data_notification_delay` and then dropped by
+    /// the handler, so the throttling TS 29.274 §7.2.11.2 defines could not happen and a
+    /// busy idle UE could produce a notification per downlink packet.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_data_notification_delay_throttles_the_next_ddn() {
+        let sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::ZERO,
+        )
+        .await;
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x59];
+
+        sock.send_to(&csr(0x5407, &imsi).encode(), server.local_addr())
+            .unwrap();
+        let _ = recv_s11(&sock).await.expect("create session response");
+        let ctx = sgwc_self();
+        let ue = ctx.ue_find_by_imsi(&imsi).expect("ue");
+        let sess = ctx.sess_find_by_id(ue.sess_ids[0]).expect("sess");
+        let pdr_id = ctx
+            .dl_tunnel_in_bearer(sess.bearer_ids[0])
+            .and_then(|t| t.pdr_id)
+            .or_else(|| {
+                ctx.ul_tunnel_in_bearer(sess.bearer_ids[0])
+                    .and_then(|t| t.pdr_id)
+            })
+            .expect("pdr id");
+
+        sgwu.report_downlink_data(sess.sgwc_sxa_seid, pdr_id, 0x9B)
+            .await;
+        let ddn = recv_s11(&sock).await.expect("the first DDN");
+
+        // Accepted, with a 20 x 50ms = 1s delay before the next one.
+        let mut ack = Gtp2Message::new(nextgcore_gtp::v2::header::Gtp2Header::new(
+            Gtp2MessageType::DownlinkDataNotificationAcknowledge as u8,
+            ue.sgw_s11_teid,
+            ddn.header.sequence_number,
+        ));
+        ack.add_ie(Gtp2CauseIe::new(gtp_cause::REQUEST_ACCEPTED).to_ie(0));
+        ack.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::from_slice(
+            Gtp2IeType::DelayValue as u8,
+            0,
+            &[20],
+        ));
+        sock.send_to(&ack.encode(), server.local_addr()).unwrap();
+        // Let the acknowledge be processed before the next report.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // A second report inside the delay window must NOT page again.
+        sock.set_read_timeout(Some(Duration::from_millis(300)))
+            .unwrap();
+        sgwu.report_downlink_data(sess.sgwc_sxa_seid, pdr_id, 0x9C)
+            .await;
+        assert!(
+            recv_s11(&sock).await.is_none(),
+            "the MME asked for a 1s Data Notification Delay: a second notification inside \
+             it is the storm the IE exists to suppress"
+        );
+
+        server.close();
+    }
+
+    // `test_create_session_request_accepted_over_socket` was REPLACED by
+    // `no_create_session_response_until_the_sgwu_answers` (#54). It asserted that a Create
+    // Session Request is answered `REQUEST_ACCEPTED` immediately, which is precisely the
+    // behaviour this issue removes -- TS 23.401 §5.3.2.1 answers after the user plane is
+    // provisioned. The replacement asserts everything it did (sequence number, MME TEID,
+    // cause, Sender F-TEID, the bearer context's allocated S1-U endpoint) AND that nothing
+    // is sent until the SGW-U has answered.
 
     #[test]
     fn test_create_session_request_missing_imsi_rejected() {
@@ -1688,19 +2392,29 @@ mod tests {
         server.close();
     }
 
-    #[test]
-    fn test_duplicate_request_answered_from_cache() {
+    /// #54: converted to drive a stand-in SGW-U, because the Create Session Response it
+    /// compares is now sent only after the user plane is provisioned. The property under
+    /// test is unchanged: a retransmitted request is answered from the transaction cache
+    /// and creates no second session.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_duplicate_request_answered_from_cache() {
+        let _sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::ZERO,
+        )
+        .await;
         let server = test_server(1000, 1);
+        set_s11_server(server.clone());
         let sock = client();
         let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x03];
 
         let msg = csr(0x1004, &imsi);
         sock.send_to(&msg.encode(), server.local_addr()).unwrap();
-        let first = recv_msg(&sock);
+        let first = recv_s11(&sock).await.expect("first response");
 
         // Retransmit the identical request (same sequence number)
         sock.send_to(&msg.encode(), server.local_addr()).unwrap();
-        let second = recv_msg(&sock);
+        let second = recv_s11(&sock).await.expect("cached response");
 
         assert_eq!(first.encode(), second.encode());
         // The retransmission must not have created a second session
@@ -1711,16 +2425,25 @@ mod tests {
         server.close();
     }
 
-    #[test]
-    fn test_full_session_lifecycle_over_socket() {
+    /// #54: converted to drive a stand-in SGW-U. Every S11 response in this lifecycle that
+    /// is gated on Sxa now waits for it, so without a peer that answers the create step
+    /// alone would time out.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_full_session_lifecycle_over_socket() {
+        let _sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::ZERO,
+        )
+        .await;
         let server = test_server(1000, 1);
+        set_s11_server(server.clone());
         let sock = client();
         let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x04];
 
         // Create
         sock.send_to(&csr(0x2001, &imsi).encode(), server.local_addr())
             .unwrap();
-        let csrsp = recv_msg(&sock);
+        let csrsp = recv_s11(&sock).await.expect("create session response");
         let sgw_teid =
             Gtp2FTeidIe::decode(&csrsp.get_ie(Gtp2IeType::FTeid as u8, 0).unwrap().value)
                 .unwrap()
@@ -1737,7 +2460,7 @@ mod tests {
         bc.set_fteid(0, &Gtp2FTeidIe::new_ipv4(0, 0xE0B1, [127, 0, 0, 1]));
         mbr.add_bearer_context(0, &bc);
         sock.send_to(&mbr.encode(), server.local_addr()).unwrap();
-        let mbrsp = recv_msg(&sock);
+        let mbrsp = recv_s11(&sock).await.expect("modify bearer response");
         assert_eq!(
             mbrsp.header.message_type,
             Gtp2MessageType::ModifyBearerResponse as u8
@@ -1756,7 +2479,9 @@ mod tests {
             0x2003,
         ));
         sock.send_to(&rab.encode(), server.local_addr()).unwrap();
-        let rabrsp = recv_msg(&sock);
+        let rabrsp = recv_s11(&sock)
+            .await
+            .expect("release access bearers response");
         assert_eq!(
             rabrsp.header.message_type,
             Gtp2MessageType::ReleaseAccessBearersResponse as u8
@@ -1770,7 +2495,7 @@ mod tests {
         ));
         dsr.add_ie(nextgcore_gtp::v2::ie::Gtp2EbiIe::new(5).to_ie(0));
         sock.send_to(&dsr.encode(), server.local_addr()).unwrap();
-        let dsrsp = recv_msg(&sock);
+        let dsrsp = recv_s11(&sock).await.expect("delete session response");
         assert_eq!(
             dsrsp.header.message_type,
             Gtp2MessageType::DeleteSessionResponse as u8

--- a/src/bins/nextgcore-sgwcd/src/main.rs
+++ b/src/bins/nextgcore-sgwcd/src/main.rs
@@ -24,6 +24,7 @@ pub mod s5c_handler;
 pub mod sm;
 pub mod sxa_build;
 pub mod sxa_handler;
+pub mod sxa_response;
 pub mod timer;
 
 use context::sgwc_self;
@@ -63,6 +64,10 @@ pub struct SgwcApp {
     sgwc_fsm: SgwcFsm,
     /// Timer manager
     timer_mgr: timer::TimerManager,
+    /// The Sxa receive loop, so shutdown can wait for it (#54).
+    pfcp_task: Option<tokio::task::JoinHandle<()>>,
+    /// Asks that loop to stop.
+    pfcp_shutdown: Option<tokio::sync::watch::Sender<bool>>,
 }
 
 impl SgwcApp {
@@ -72,11 +77,17 @@ impl SgwcApp {
             running: Arc::new(AtomicBool::new(true)),
             sgwc_fsm: SgwcFsm::new(),
             timer_mgr: timer::TimerManager::new(),
+            pfcp_task: None,
+            pfcp_shutdown: None,
         }
     }
 
     /// Initialize the SGWC application
-    pub fn init(&mut self, _config_path: &str) -> Result<()> {
+    ///
+    /// #54: `async` because opening the Sxa path now binds a real tokio socket and sets up
+    /// the PFCP association toward the SGW-U. It used to call a `pfcp_open` that opened
+    /// nothing, which is why none of this had to be awaited.
+    pub async fn init(&mut self, _config_path: &str) -> Result<()> {
         log::info!("Initializing SGWC...");
 
         // Initialize SGWC context with default pool sizes
@@ -104,35 +115,56 @@ impl SgwcApp {
         log::debug!("GTP path initialized (S11/S5-C interfaces)");
 
         // Open PFCP path (SXA interface to SGW-U)
-        if let Err(e) = pfcp_path::pfcp_open() {
-            log::error!("Failed to open PFCP path: {e}");
-            gtp_path::gtp_close();
-            return Err(anyhow::anyhow!("PFCP path initialization failed: {e}"));
+        let pfcp = match pfcp_path::pfcp_open().await {
+            Ok(node) => node,
+            Err(e) => {
+                log::error!("Failed to open PFCP path: {e}");
+                gtp_path::gtp_close();
+                return Err(anyhow::anyhow!("PFCP path initialization failed: {e}"));
+            }
+        };
+        log::debug!(
+            "PFCP path initialized (SXA interface on {})",
+            pfcp.local_addr()
+        );
+
+        // The receive loop and the outbound drain. Without this task nothing reads the
+        // socket, so no PFCP response could complete a transaction and every gated S11
+        // procedure would time out.
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        self.pfcp_shutdown = Some(shutdown_tx);
+        self.pfcp_task = Some(tokio::spawn(pfcp.clone().run(shutdown_rx)));
+
+        // Associate with the SGW-U (TS 29.244 §6.2.6.2). NOT fatal: an SGW-U that comes up
+        // after the SGW-C is the normal bring-up order in the compose stack, and refusing
+        // to start would make the slower peer an outage. The association is retried by the
+        // first session request that needs it.
+        let sgwu = pfcp_path::configured_sgwu_addr();
+        match pfcp.associate(sgwu).await {
+            Ok(()) => log::info!("Associated with SGW-U {sgwu}"),
+            Err(e) => log::warn!(
+                "No PFCP association with SGW-U {sgwu} yet ({e}); session requests will \
+                 fail until it answers"
+            ),
         }
-        log::debug!("PFCP path initialized (SXA interface)");
 
         log::info!("SGWC initialized successfully");
         Ok(())
     }
 
     /// Run the SGWC main loop
-    pub fn run(&mut self) -> Result<()> {
+    ///
+    /// S11/S5-C datagrams are read by `gtp_path`'s own OS threads and Sxa datagrams by the
+    /// spawned receive loop, so this loop's job is the timers. It `await`s rather than
+    /// `thread::sleep`s: blocking a runtime worker for 100ms at a time would stall the Sxa
+    /// task on a single-threaded runtime, which is the difference between a gated S11
+    /// procedure completing and timing out.
+    pub async fn run(&mut self) -> Result<()> {
         log::info!("SGWC running...");
 
         while self.running.load(Ordering::SeqCst) {
-            // Check for expired timers
             self.process_timers();
-
-            // Process events from the event queue
-            // In a real implementation, this would:
-            // 1. Poll for S11 GTPv2-C messages from MME
-            // 2. Poll for S5-C GTPv2-C messages from PGW
-            // 3. Poll for SXA PFCP messages from SGW-U
-            // 4. Process timer events
-            // 5. Handle state machine transitions
-
-            // For now, just sleep briefly to avoid busy-waiting
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
 
         log::info!("SGWC main loop exited");
@@ -185,8 +217,17 @@ impl SgwcApp {
     }
 
     /// Shutdown the SGWC application
-    pub fn shutdown(&mut self) {
+    pub async fn shutdown(&mut self) {
         log::info!("Shutting down SGWC...");
+
+        // Stop the Sxa receive loop and wait for it, so a session removed during teardown
+        // is not raced by a datagram still being processed.
+        if let Some(tx) = self.pfcp_shutdown.take() {
+            let _ = tx.send(true);
+        }
+        if let Some(task) = self.pfcp_task.take() {
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), task).await;
+        }
 
         // Send exit event to state machine
         let exit_event = SgwcEvent::exit();
@@ -194,7 +235,7 @@ impl SgwcApp {
         log::debug!("SGWC state machine finalized");
 
         // Close PFCP path
-        pfcp_path::pfcp_close();
+        pfcp_path::pfcp_close().await;
         log::debug!("PFCP path closed");
 
         // Close GTP path
@@ -230,7 +271,8 @@ impl Default for SgwcApp {
     }
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     // Parse command line arguments
     let args = Args::parse();
 
@@ -271,13 +313,13 @@ fn main() -> Result<()> {
     })?;
 
     // Initialize
-    app.init(&args.config)?;
+    app.init(&args.config).await?;
 
     // Run main loop
-    app.run()?;
+    app.run().await?;
 
     // Shutdown
-    app.shutdown();
+    app.shutdown().await;
 
     log::info!("NextGCore SGWC terminated");
     Ok(())
@@ -335,8 +377,8 @@ mod tests {
         .unwrap();
         assert_ne!(server.local_addr().port(), 0);
         server.close();
-        assert!(pfcp_path::pfcp_open().is_ok());
-        pfcp_path::pfcp_close();
+        // `pfcp_open` binds a real socket now (#54), so it is exercised in
+        // `pfcp_path`'s own async tests rather than from this synchronous one.
     }
 
     #[test]

--- a/src/bins/nextgcore-sgwcd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-sgwcd/src/pfcp_path.rs
@@ -1,9 +1,81 @@
 //! SGWC PFCP Path Management
 //!
 //! Port of src/sgwc/pfcp-path.c - PFCP path management for SXA interface
+//!
+//! #54: this module used to be a facade. `pfcp_open` opened no socket, and
+//! `send_pfcp_message` logged a line and returned `Ok(())` — so every SGW-C→SGW-U
+//! message was dropped on the floor while its caller was told it had been sent, and no
+//! PFCP response could ever arrive. That is why the S11 procedures answered the MME
+//! before (or regardless of) the Sxa outcome: there was nothing to wait for.
+//!
+//! It is now the CP half of the transport #59 gave the SGW-U: one bound UDP socket,
+//! transactions matched on sequence number with T1/N1 retransmission, an association
+//! initiated toward the SGW-U, and inbound Session Report Requests dispatched into
+//! `sxa_handler`. The synchronous S11 dispatch enqueues and the async node performs the
+//! I/O, exactly as `gtp_path` does on the SGW-U side and for the same reason: the GTP-C
+//! server runs on OS threads with a blocking socket and cannot await.
+
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use bytes::{Bytes, BytesMut};
+use nextgcore_pfcp::header::{PfcpHeader, PfcpMessageType};
+use nextgcore_pfcp::message::{
+    AssociationSetupRequest, AssociationSetupResponse, HeartbeatResponse,
+    PfcpMessage as PfcpLibMessage, SessionReportRequest, SessionReportResponse,
+};
+use nextgcore_pfcp::types::{NodeId, PfcpCause};
+use tokio::net::UdpSocket;
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
 
 use crate::context::{sgwc_self, SgwcSess};
 use crate::sxa_build::{self, PfcpMessage};
+
+/// The PFCP UDP port (TS 29.244 §4.2.2).
+pub const PFCP_PORT: u16 = 8805;
+
+/// Sequence numbers are 24-bit (TS 29.244 §7.2.2.1).
+const SEQ_MASK: u32 = 0x00FF_FFFF;
+
+/// T1 and N1 for a PFCP transaction. TS 29.244 §7.2.1 fixes neither; three seconds and
+/// two retransmissions is the same budget sgwud uses, so the two ends of one interface
+/// do not disagree about how long a message may take.
+const T1: std::time::Duration = std::time::Duration::from_secs(3);
+const N1: u32 = 2;
+
+// ============================================================================
+// PFCP Message Types
+// ============================================================================
+
+pub mod pfcp_msg_type {
+    pub const HEARTBEAT_REQUEST: u8 = 1;
+    pub const HEARTBEAT_RESPONSE: u8 = 2;
+    pub const ASSOCIATION_SETUP_REQUEST: u8 = 5;
+    pub const ASSOCIATION_SETUP_RESPONSE: u8 = 6;
+    pub const ASSOCIATION_RELEASE_REQUEST: u8 = 9;
+    pub const ASSOCIATION_RELEASE_RESPONSE: u8 = 10;
+    /// TS 29.244 §7.2.2.1: answered when the version octet is not 1.
+    pub const VERSION_NOT_SUPPORTED_RESPONSE: u8 = 11;
+    pub const SESSION_ESTABLISHMENT_REQUEST: u8 = 50;
+    pub const SESSION_ESTABLISHMENT_RESPONSE: u8 = 51;
+    pub const SESSION_MODIFICATION_REQUEST: u8 = 52;
+    pub const SESSION_MODIFICATION_RESPONSE: u8 = 53;
+    pub const SESSION_DELETION_REQUEST: u8 = 54;
+    pub const SESSION_DELETION_RESPONSE: u8 = 55;
+    pub const SESSION_REPORT_REQUEST: u8 = 56;
+    pub const SESSION_REPORT_RESPONSE: u8 = 57;
+}
+
+/// Response message types, which complete a pending transaction rather than being
+/// dispatched as requests.
+fn is_response_type(msg_type: u8) -> bool {
+    matches!(
+        msg_type,
+        2 | 4 | 6 | 8 | 10 | 11 | 13 | 15 | 51 | 53 | 55 | 57
+    )
+}
 
 // ============================================================================
 // PFCP Path State
@@ -74,33 +146,645 @@ impl PfcpNode {
 }
 
 // ============================================================================
+// What the S11 answer needs when the PFCP response finally arrives (#54)
+// ============================================================================
+
+/// The S11 procedure a PFCP transaction is gating.
+///
+/// TS 23.401 §5.3.2.1 has the Serving GW answer the MME **after** the user plane is
+/// provisioned, and TS 29.274 §7.2.2 makes `Request accepted` mean the request was
+/// actually fulfilled. So the S11 response cannot be built when the request arrives; the
+/// pieces it needs — which peer, which sequence number, which TEID — travel with the
+/// PFCP transaction and are used when its response lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum S11Continuation {
+    /// Nothing to answer: the S11 response was already sent, or this modification is
+    /// not gating one (see the spec's ceiling on Modify Bearer).
+    None,
+    /// Answer the MME's Create Session Request.
+    CreateSession {
+        peer: SocketAddr,
+        seq: u32,
+        teid: u32,
+    },
+    /// Answer the MME's Delete Session Request, and remove the local session only when
+    /// the SGW-U confirms.
+    DeleteSession {
+        peer: SocketAddr,
+        seq: u32,
+        teid: u32,
+        sess_id: u64,
+    },
+}
+
+/// An outbound PFCP request queued by a synchronous caller.
+struct QueuedRequest {
+    msg_type: u8,
+    seid: u64,
+    body: Vec<u8>,
+    to: SocketAddr,
+    sess_id: u64,
+    continuation: S11Continuation,
+}
+
+/// The running node's outbound queue and the node itself.
+///
+/// Settable rather than install-once, and guarded by one test lock declared beside them —
+/// the shape #217 arrived at for sgwud after an install-once `OnceLock` made a node-level
+/// message impossible to assert against. A tokio socket belongs to the runtime that
+/// created it, so under `#[tokio::test]` a permanently installed node is a dead socket for
+/// every test after the first.
+static OUTBOUND: std::sync::RwLock<Option<mpsc::UnboundedSender<QueuedRequest>>> =
+    std::sync::RwLock::new(None);
+
+/// The running Sxa node, so the synchronous S11 dispatch can resolve a peer.
+static SXA_NODE: std::sync::RwLock<Option<Arc<SxaNode>>> = std::sync::RwLock::new(None);
+
+/// Serialises every test that reads or writes [`SXA_NODE`] / [`OUTBOUND`]. One lock for
+/// both: they are always installed together.
+#[cfg(test)]
+pub(crate) static SXA_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// The process-wide Sxa node, once [`pfcp_open`] has run.
+pub fn sxa_node() -> Option<Arc<SxaNode>> {
+    SXA_NODE.read().ok()?.clone()
+}
+
+fn outbound() -> Option<mpsc::UnboundedSender<QueuedRequest>> {
+    OUTBOUND.read().ok()?.clone()
+}
+
+/// Uninstall the node and its queue. Test-only: the release half of a per-test install.
+#[cfg(test)]
+pub(crate) fn clear_sxa_globals_for_test() {
+    if let Ok(mut slot) = SXA_NODE.write() {
+        *slot = None;
+    }
+    if let Ok(mut slot) = OUTBOUND.write() {
+        *slot = None;
+    }
+}
+
+/// Holds [`SXA_TEST_LOCK`] and leaves the globals empty on both sides of a test.
+#[cfg(test)]
+pub(crate) struct SxaTestGuard(#[allow(dead_code)] tokio::sync::MutexGuard<'static, ()>);
+
+#[cfg(test)]
+impl Drop for SxaTestGuard {
+    fn drop(&mut self) {
+        clear_sxa_globals_for_test();
+        // The S11 server is installed by the same tests, for the same reason (the gated
+        // answer goes through the process-global one). Cleared here rather than under a
+        // second lock: one agreement about both, so there is no lock order to get wrong.
+        crate::gtp_path::clear_s11_server_for_test();
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn sxa_test_guard() -> SxaTestGuard {
+    let guard = SXA_TEST_LOCK.lock().await;
+    clear_sxa_globals_for_test();
+    SxaTestGuard(guard)
+}
+
+// ============================================================================
+// The Sxa node (CP side)
+// ============================================================================
+
+/// One SGW-U peer as seen from the SGW-C.
+#[derive(Debug, Clone)]
+pub struct SxaPeer {
+    pub addr: SocketAddr,
+    pub state: PfcpNodeState,
+    /// The peer's Recovery Time Stamp; a change means it restarted (TS 23.007 §19A).
+    pub recovery_time_stamp: Option<u32>,
+    pub up_function_features: UpFunctionFeatures,
+}
+
+/// Failure modes of an Sxa transaction.
+#[derive(Debug)]
+pub enum PfcpRequestError {
+    /// No response after N1 retransmissions.
+    Timeout { attempts: u32 },
+    /// Local I/O or state error.
+    Local(String),
+}
+
+impl std::fmt::Display for PfcpRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout { attempts } => {
+                write!(f, "no PFCP response after {attempts} attempt(s)")
+            }
+            Self::Local(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+/// The SGW-C's PFCP endpoint on Sxa.
+pub struct SxaNode {
+    socket: Arc<UdpSocket>,
+    /// The address this node puts in its own Node ID IE.
+    local_ip: Ipv4Addr,
+    /// Our Recovery Time Stamp, reported in every Association Setup and Heartbeat.
+    pub recovery_time_stamp: u32,
+    seq: AtomicU32,
+    pending: Mutex<HashMap<u32, oneshot::Sender<(u8, Vec<u8>)>>>,
+    peers: RwLock<HashMap<SocketAddr, SxaPeer>>,
+    /// Associated peers, readable synchronously (the S11 dispatch cannot await).
+    associated_peers: AtomicUsize,
+}
+
+impl SxaNode {
+    /// Bind the Sxa socket and install the node process-wide.
+    pub async fn open(bind: SocketAddr, local_ip: Ipv4Addr) -> std::io::Result<Arc<Self>> {
+        let socket = UdpSocket::bind(bind).await?;
+        let bound = socket.local_addr()?;
+        let recovery_time_stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as u32)
+            .unwrap_or(1);
+        let node = Arc::new(Self {
+            socket: Arc::new(socket),
+            local_ip,
+            recovery_time_stamp,
+            seq: AtomicU32::new(1),
+            pending: Mutex::new(HashMap::new()),
+            peers: RwLock::new(HashMap::new()),
+            associated_peers: AtomicUsize::new(0),
+        });
+        log::info!(
+            "PFCP/Sxa listening on {bound} (Node ID {local_ip}, Recovery Time Stamp \
+             {recovery_time_stamp})"
+        );
+        if let Ok(mut slot) = SXA_NODE.write() {
+            *slot = Some(node.clone());
+        }
+        Ok(node)
+    }
+
+    pub fn local_addr(&self) -> SocketAddr {
+        self.socket
+            .local_addr()
+            .unwrap_or_else(|_| SocketAddr::from(([0, 0, 0, 0], 0)))
+    }
+
+    /// A snapshot of the peers, for the metrics render and for tests.
+    pub async fn peers(&self) -> Vec<SxaPeer> {
+        self.peers.read().await.values().cloned().collect()
+    }
+
+    /// Associated peers, readable from a synchronous context.
+    pub fn associated_peer_count(&self) -> usize {
+        self.associated_peers.load(Ordering::Relaxed)
+    }
+
+    pub async fn is_associated(&self) -> bool {
+        self.peers
+            .read()
+            .await
+            .values()
+            .any(|p| p.state == PfcpNodeState::Associated)
+    }
+
+    async fn refresh_peer_gauge(&self) {
+        let n = self
+            .peers
+            .read()
+            .await
+            .values()
+            .filter(|p| p.state == PfcpNodeState::Associated)
+            .count();
+        self.associated_peers.store(n, Ordering::Relaxed);
+    }
+
+    fn alloc_seq(&self) -> u32 {
+        self.seq.fetch_add(1, Ordering::Relaxed) & SEQ_MASK
+    }
+
+    /// Encode a header + body and put it on the wire.
+    ///
+    /// `seid` is `None` for a NODE-level message (Heartbeat, Association): TS 29.244
+    /// §7.2.2.1 clears the S flag for those, so a SEID field of 0 would be a malformed
+    /// header rather than a zero SEID.
+    async fn send(
+        &self,
+        msg_type: u8,
+        seid: Option<u64>,
+        seq: u32,
+        body: &[u8],
+        to: SocketAddr,
+    ) -> Result<(), String> {
+        let message_type = PfcpMessageType::try_from(msg_type)
+            .map_err(|e| format!("unknown PFCP message type {msg_type}: {e}"))?;
+        let mut header = match seid {
+            Some(seid) => PfcpHeader::new_with_seid(message_type, seid, seq),
+            None => PfcpHeader::new(message_type, seq),
+        };
+        let after_length = if seid.is_some() { 12 } else { 4 };
+        header.length = (after_length + body.len()) as u16;
+        let mut buf = BytesMut::with_capacity(4 + after_length + body.len());
+        header.encode(&mut buf);
+        buf.extend_from_slice(body);
+        self.socket
+            .send_to(&buf, to)
+            .await
+            .map_err(|e| format!("send to {to} failed: {e}"))?;
+        log::debug!(
+            "[SEND] PFCP type={msg_type} seq={seq} to {to} ({} IE bytes)",
+            body.len()
+        );
+        Ok(())
+    }
+
+    /// Send a request and wait for its response, retransmitting on T1 expiry up to N1
+    /// attempts (TS 29.244 §7.2.1).
+    pub async fn request(
+        &self,
+        msg_type: u8,
+        seid: Option<u64>,
+        body: &[u8],
+        to: SocketAddr,
+    ) -> Result<(u8, Vec<u8>), PfcpRequestError> {
+        let seq = self.alloc_seq();
+        let max_attempts = N1 + 1;
+        let mut attempt = 0u32;
+
+        loop {
+            attempt += 1;
+            let (tx, rx) = oneshot::channel();
+            self.pending.lock().await.insert(seq, tx);
+
+            if let Err(e) = self.send(msg_type, seid, seq, body, to).await {
+                self.pending.lock().await.remove(&seq);
+                return Err(PfcpRequestError::Local(e));
+            }
+            if attempt > 1 {
+                log::warn!(
+                    "PFCP T1 expired: retransmitting type={msg_type} seq={seq} to {to} \
+                     (attempt {attempt}/{max_attempts})"
+                );
+            }
+
+            match tokio::time::timeout(T1, rx).await {
+                Ok(Ok(response)) => return Ok(response),
+                Ok(Err(_)) => {
+                    return Err(PfcpRequestError::Local("response channel closed".into()))
+                }
+                Err(_) => {
+                    self.pending.lock().await.remove(&seq);
+                    if attempt >= max_attempts {
+                        log::error!(
+                            "PFCP request type={msg_type} seq={seq} to {to} unanswered after \
+                             {attempt} attempts"
+                        );
+                        return Err(PfcpRequestError::Timeout { attempts: attempt });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Set up the PFCP association toward the SGW-U (TS 29.244 §6.2.6.2).
+    ///
+    /// The CP function initiates: TS 29.244 §6.2.6.2 has no session signalling before an
+    /// association exists, so this runs before the first Create Session Request can be
+    /// served — and its failure is loud, because every session request after it would be
+    /// rejected by a conformant UP function.
+    pub async fn associate(self: &Arc<Self>, peer: SocketAddr) -> Result<(), String> {
+        let mut body = BytesMut::new();
+        PfcpLibMessage::AssociationSetupRequest(AssociationSetupRequest::new(
+            NodeId::new_ipv4(self.local_ip.octets()),
+            self.recovery_time_stamp,
+        ))
+        .encode_body(&mut body);
+
+        let (resp_type, resp_body) = self
+            .request(pfcp_msg_type::ASSOCIATION_SETUP_REQUEST, None, &body, peer)
+            .await
+            .map_err(|e| format!("Association Setup to {peer} failed: {e}"))?;
+        if resp_type != pfcp_msg_type::ASSOCIATION_SETUP_RESPONSE {
+            return Err(format!(
+                "unexpected response type {resp_type} to an Association Setup Request"
+            ));
+        }
+        let mut cursor = Bytes::copy_from_slice(&resp_body);
+        let rsp = AssociationSetupResponse::decode(&mut cursor)
+            .map_err(|e| format!("malformed Association Setup Response from {peer}: {e}"))?;
+        if rsp.cause != PfcpCause::RequestAccepted {
+            return Err(format!(
+                "SGW-U {peer} refused the association: cause={:?}",
+                rsp.cause
+            ));
+        }
+
+        let features = rsp.up_function_features.as_ref();
+        let peer_record = SxaPeer {
+            addr: peer,
+            state: PfcpNodeState::Associated,
+            recovery_time_stamp: Some(rsp.recovery_time_stamp),
+            up_function_features: UpFunctionFeatures {
+                ftup: features.map(|f| f.ftup).unwrap_or(false),
+                empu: features.map(|f| f.empu).unwrap_or(false),
+                bucp: features.map(|f| f.bucp).unwrap_or(false),
+                ddnd: features.map(|f| f.ddnd).unwrap_or(false),
+                dlbd: features.map(|f| f.dlbd).unwrap_or(false),
+                ..Default::default()
+            },
+        };
+        self.peers.write().await.insert(peer, peer_record);
+        self.refresh_peer_gauge().await;
+        log::info!(
+            "PFCP association with SGW-U {peer} established (Recovery Time Stamp {}, FTUP={})",
+            rsp.recovery_time_stamp,
+            features.map(|f| f.ftup).unwrap_or(false)
+        );
+        Ok(())
+    }
+
+    /// The receive loop, plus the drain of the synchronous senders' queue.
+    pub async fn run(self: Arc<Self>, mut shutdown: tokio::sync::watch::Receiver<bool>) {
+        let (tx, mut queued) = mpsc::unbounded_channel();
+        if let Ok(mut slot) = OUTBOUND.write() {
+            if slot.is_some() {
+                log::warn!("PFCP outbound queue replaced: the previous node's queue is dropped");
+            }
+            *slot = Some(tx);
+        }
+        let mut buf = vec![0u8; 8192];
+        loop {
+            tokio::select! {
+                received = self.socket.recv_from(&mut buf) => match received {
+                    Ok((len, from)) => {
+                        let datagram = buf[..len].to_vec();
+                        // Handled inline rather than spawned: PFCP session state is
+                        // per-peer ordered, and a spawn would let a Deletion overtake
+                        // the Establishment it deletes.
+                        self.clone().on_datagram(&datagram, from).await;
+                    }
+                    Err(e) => {
+                        log::error!("PFCP receive failed: {e}");
+                        break;
+                    }
+                },
+                Some(req) = queued.recv() => {
+                    let node = self.clone();
+                    // Spawned: a request awaits T1 x N1, and blocking the receive loop
+                    // for that long would stall the response it is waiting for.
+                    tokio::spawn(async move {
+                        let msg_type = req.msg_type;
+                        match node.request(msg_type, Some(req.seid), &req.body, req.to).await {
+                            Ok((resp_type, body)) => {
+                                crate::sxa_response::dispatch(
+                                    req.sess_id,
+                                    req.continuation,
+                                    resp_type,
+                                    &body,
+                                );
+                            }
+                            Err(e) => {
+                                log::error!(
+                                    "PFCP request type={msg_type} for session {} failed: {e}",
+                                    req.sess_id
+                                );
+                                // The MME is waiting: a transaction that never completes
+                                // must not leave the procedure hanging until its own
+                                // GTP-C timer fires (TS 29.274 §7.6).
+                                crate::sxa_response::fail(req.continuation, &e.to_string());
+                            }
+                        }
+                    });
+                }
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        log::info!("PFCP/Sxa receive loop shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Decode one datagram and act on it.
+    pub async fn on_datagram(self: Arc<Self>, pkt: &[u8], from: SocketAddr) {
+        // The version is read off octet 1 BEFORE decoding: the library's decoder refuses
+        // a version it does not support, so a check afterwards could never fire, and
+        // TS 29.244 §7.2.2.1 requires the answer rather than a drop.
+        if let Some(version) = pkt.first().map(|b| (b >> 5) & 0x07) {
+            if version != 1 {
+                let seq = if pkt.len() >= 8 {
+                    u32::from_be_bytes([0, pkt[4], pkt[5], pkt[6]])
+                } else {
+                    0
+                };
+                log::warn!("PFCP version {version} from {from} not supported");
+                let _ = self
+                    .send(
+                        pfcp_msg_type::VERSION_NOT_SUPPORTED_RESPONSE,
+                        None,
+                        seq,
+                        &[],
+                        from,
+                    )
+                    .await;
+                return;
+            }
+        }
+        let mut cursor = Bytes::copy_from_slice(pkt);
+        let header = match PfcpHeader::decode(&mut cursor) {
+            Ok(h) => h,
+            Err(e) => {
+                log::warn!("[RECV] undecodable PFCP header from {from}: {e}");
+                return;
+            }
+        };
+        let msg_type = header.message_type as u8;
+        let body = cursor.to_vec();
+        log::debug!(
+            "[RECV] PFCP type={msg_type} seq={} seid={:?} from {from} ({} IE bytes)",
+            header.sequence_number,
+            header.seid,
+            body.len()
+        );
+
+        if is_response_type(msg_type) {
+            if let Some(tx) = self.pending.lock().await.remove(&header.sequence_number) {
+                let _ = tx.send((msg_type, body));
+            } else {
+                log::debug!(
+                    "PFCP response type={msg_type} seq={} with no pending transaction",
+                    header.sequence_number
+                );
+            }
+            return;
+        }
+
+        match msg_type {
+            pfcp_msg_type::HEARTBEAT_REQUEST => {
+                // TS 29.244 §6.2.2.2: answer at any time. A CP function that does not is
+                // declared down by the UP function's own heartbeat monitor.
+                let mut buf = BytesMut::new();
+                PfcpLibMessage::HeartbeatResponse(HeartbeatResponse::new(self.recovery_time_stamp))
+                    .encode_body(&mut buf);
+                let _ = self
+                    .send(
+                        pfcp_msg_type::HEARTBEAT_RESPONSE,
+                        None,
+                        header.sequence_number,
+                        &buf,
+                        from,
+                    )
+                    .await;
+            }
+            pfcp_msg_type::SESSION_REPORT_REQUEST => {
+                self.handle_session_report_request(&header, &body, from)
+                    .await;
+            }
+            other => {
+                log::warn!("PFCP message type {other} from {from} is not handled on Sxa (CP side)");
+            }
+        }
+    }
+
+    /// An inbound Session Report Request (TS 29.244 §7.5.8): the DLDR that makes idle-mode
+    /// downlink delivery work.
+    ///
+    /// #54: `sxa_handler::handle_session_report_request` classified the report and returned
+    /// `SendGtpToMme`, and had **zero callers** — so a real Downlink Data Report from the
+    /// SGW-U produced no Downlink Data Notification and the MME was never asked to page.
+    async fn handle_session_report_request(
+        &self,
+        header: &PfcpHeader,
+        body: &[u8],
+        from: SocketAddr,
+    ) {
+        let ctx = sgwc_self();
+        let Some(sess) = header.seid.and_then(|seid| ctx.sess_find_by_seid(seid)) else {
+            log::warn!(
+                "Session Report for unknown SEID {:?} from {from}",
+                header.seid
+            );
+            let mut buf = BytesMut::new();
+            SessionReportResponse::new(PfcpCause::SessionContextNotFound).encode(&mut buf);
+            let _ = self
+                .send(
+                    pfcp_msg_type::SESSION_REPORT_RESPONSE,
+                    Some(header.seid.unwrap_or(0)),
+                    header.sequence_number,
+                    &buf,
+                    from,
+                )
+                .await;
+            return;
+        };
+
+        let mut cursor = Bytes::copy_from_slice(body);
+        let (report_type, pdr_id) = match SessionReportRequest::decode(&mut cursor) {
+            Ok(req) => (
+                req.report_type.encode(),
+                req.downlink_data_report.as_ref().map(|d| d.pdr_id),
+            ),
+            Err(e) => {
+                log::warn!("Session Report Request from {from} is malformed: {e}");
+                (0u8, None)
+            }
+        };
+
+        let result = crate::sxa_handler::handle_session_report_request(
+            Some(&sess),
+            header.sequence_number as u64,
+            report_type,
+            pdr_id,
+        );
+
+        // Answer the SGW-U first: the DDN toward the MME is a separate procedure, and
+        // holding the PFCP response until it completes would retransmit the report.
+        let cause = match result {
+            crate::sxa_handler::HandlerResult::Error(_) => {
+                crate::sxa_handler::pfcp_cause::REQUEST_REJECTED
+            }
+            _ => crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+        };
+        if let Some(msg) = sxa_build::build_session_report_response(&sess, cause) {
+            let _ = self
+                .send(
+                    pfcp_msg_type::SESSION_REPORT_RESPONSE,
+                    Some(msg.seid),
+                    header.sequence_number,
+                    &msg.data,
+                    from,
+                )
+                .await;
+        }
+
+        if matches!(result, crate::sxa_handler::HandlerResult::SendGtpToMme) {
+            crate::sxa_response::downlink_data_notification(sess.id, pdr_id);
+        }
+    }
+}
+
+// ============================================================================
 // PFCP Path Functions
 // ============================================================================
 
-/// Open PFCP server sockets
-/// Port of sgwc_pfcp_open
-pub fn pfcp_open() -> Result<(), String> {
-    log::info!("Opening PFCP server sockets");
-
-    // In actual implementation:
-    // - Create UDP sockets for PFCP
-    // - Bind to configured addresses
-    // - Register poll callbacks for receiving messages
-
-    log::info!("PFCP server sockets opened successfully");
-    Ok(())
+/// Open the Sxa PFCP socket and associate with the configured SGW-U (#54).
+///
+/// `SGWC_PFCP_BIND_ADDR` / `SGWC_PFCP_NODE_IP` / `SGWC_SGWU_ADDR` override the defaults
+/// so a test — or a host with several interfaces — can pick each.
+pub async fn pfcp_open() -> Result<Arc<SxaNode>, String> {
+    let bind: SocketAddr = std::env::var("SGWC_PFCP_BIND_ADDR")
+        .unwrap_or_else(|_| format!("0.0.0.0:{PFCP_PORT}"))
+        .parse()
+        .map_err(|e| format!("SGWC_PFCP_BIND_ADDR is not a socket address: {e}"))?;
+    let local_ip: Ipv4Addr = std::env::var("SGWC_PFCP_NODE_IP")
+        .unwrap_or_else(|_| "127.0.0.1".to_string())
+        .parse()
+        .map_err(|e| format!("SGWC_PFCP_NODE_IP is not an IPv4 address: {e}"))?;
+    SxaNode::open(bind, local_ip)
+        .await
+        .map_err(|e| format!("failed to bind PFCP socket on {bind}: {e}"))
 }
 
-/// Close PFCP server sockets
-/// Port of sgwc_pfcp_close
-pub fn pfcp_close() {
-    log::info!("Closing PFCP server sockets");
+/// The SGW-U this SGW-C provisions user planes on.
+///
+/// `SGWC_SGWU_ADDR` takes either `ip` (PFCP's own port is assumed) or `ip:port`. The port
+/// form exists so a test can stand in for an SGW-U on an ephemeral port rather than
+/// fighting a live one for UDP/8805.
+pub fn configured_sgwu_addr() -> SocketAddr {
+    let value = std::env::var("SGWC_SGWU_ADDR").unwrap_or_else(|_| "127.0.0.1".to_string());
+    if let Ok(addr) = value.parse::<SocketAddr>() {
+        return addr;
+    }
+    let ip: Ipv4Addr = value.parse().unwrap_or(Ipv4Addr::LOCALHOST);
+    SocketAddr::from((ip, PFCP_PORT))
+}
 
-    // In actual implementation:
-    // - Finalize all PFCP node FSMs
-    // - Close all PFCP sockets
-    // - Remove poll registrations
-    // - Clean up PFCP node lists
+/// Close the Sxa PFCP path.
+pub async fn pfcp_close() {
+    if let Some(node) = sxa_node() {
+        node.peers.write().await.clear();
+        node.refresh_peer_gauge().await;
+    }
+    log::info!("PFCP/Sxa path closed");
+}
+
+// ============================================================================
+// PFCP Send Functions (SGWC -> SGWU)
+// ============================================================================
+
+/// Enqueue an outbound request. Callable from the synchronous S11 dispatch.
+fn enqueue(msg: &PfcpMessage, sess_id: u64, continuation: S11Continuation) -> Result<(), String> {
+    let tx = outbound()
+        .ok_or_else(|| "PFCP path is not running: no Sxa transport to send on".to_string())?;
+    tx.send(QueuedRequest {
+        msg_type: msg.msg_type,
+        seid: msg.seid,
+        body: msg.data.clone(),
+        to: configured_sgwu_addr(),
+        sess_id,
+        continuation,
+    })
+    .map_err(|_| "PFCP outbound queue is closed".to_string())
 }
 
 /// Send Session Establishment Request to SGW-U
@@ -110,6 +794,7 @@ pub fn send_session_establishment_request(
     gtp_xact_id: u64,
     _gtpbuf: Option<&[u8]>,
     _flags: u64,
+    continuation: S11Continuation,
 ) -> Result<(), String> {
     let msg = sxa_build::build_session_establishment_request(sess)
         .ok_or_else(|| "Failed to build Session Establishment Request".to_string())?;
@@ -119,14 +804,7 @@ pub fn send_session_establishment_request(
         sess.sgwc_sxa_seid,
         gtp_xact_id
     );
-
-    // In actual implementation:
-    // - Create local PFCP transaction
-    // - Associate with GTP transaction
-    // - Set timeout callback
-    // - Send message to SGW-U
-
-    send_pfcp_message(&msg, gtp_xact_id)
+    enqueue(&msg, sess.id, continuation)
 }
 
 /// Send Session Modification Request to SGW-U
@@ -137,11 +815,7 @@ pub fn send_session_modification_request(
     _gtpbuf: Option<&[u8]>,
     flags: u64,
 ) -> Result<(), String> {
-    let _ctx = sgwc_self();
-
-    // Get all bearer IDs for this session
     let bearer_ids: Vec<u64> = sess.bearer_ids.clone();
-
     let msg = sxa_build::build_bearer_to_modify_list(sess, flags, &bearer_ids)
         .ok_or_else(|| "Failed to build Session Modification Request".to_string())?;
 
@@ -151,8 +825,7 @@ pub fn send_session_modification_request(
         gtp_xact_id,
         flags
     );
-
-    send_pfcp_message(&msg, gtp_xact_id)
+    enqueue(&msg, sess.id, S11Continuation::None)
 }
 
 /// Send Bearer Modification Request to SGW-U
@@ -183,8 +856,7 @@ pub fn send_bearer_modification_request(
         gtp_xact_id,
         flags
     );
-
-    send_pfcp_message(&msg, gtp_xact_id)
+    enqueue(&msg, sess.id, S11Continuation::None)
 }
 
 /// Send Bearer to Modify List
@@ -205,8 +877,7 @@ pub fn send_bearer_to_modify_list(
         bearer_ids.len(),
         flags
     );
-
-    send_pfcp_message(&msg, xact_id)
+    enqueue(&msg, sess.id, S11Continuation::None)
 }
 
 /// Send Session Deletion Request to SGW-U
@@ -215,6 +886,7 @@ pub fn send_session_deletion_request(
     sess: &SgwcSess,
     gtp_xact_id: u64,
     _gtpbuf: Option<&[u8]>,
+    continuation: S11Continuation,
 ) -> Result<(), String> {
     let msg = sxa_build::build_session_deletion_request(sess)
         .ok_or_else(|| "Failed to build Session Deletion Request".to_string())?;
@@ -224,12 +896,14 @@ pub fn send_session_deletion_request(
         sess.sgwu_sxa_seid,
         gtp_xact_id
     );
-
-    send_pfcp_message(&msg, gtp_xact_id)
+    enqueue(&msg, sess.id, continuation)
 }
 
 /// Send Session Report Response to SGW-U
 /// Port of sgwc_pfcp_send_session_report_response
+///
+/// Kept for callers outside the receive path; the receive path answers inline, because
+/// the response has to echo the request's sequence number and only it knows that.
 pub fn send_session_report_response(
     xact_id: u64,
     sess: &SgwcSess,
@@ -239,34 +913,30 @@ pub fn send_session_report_response(
         .ok_or_else(|| "Failed to build Session Report Response".to_string())?;
 
     log::info!(
-        "Sending PFCP Session Report Response: seid=0x{:x}, cause={}",
+        "Sending PFCP Session Report Response: seid=0x{:x}, cause={}, xact_id={}",
         sess.sgwu_sxa_seid,
-        cause
+        cause,
+        xact_id
     );
-
-    send_pfcp_message(&msg, xact_id)
+    enqueue(&msg, sess.id, S11Continuation::None)
 }
 
-// ============================================================================
-// Internal Functions
-// ============================================================================
-
-/// Send PFCP message (internal)
-fn send_pfcp_message(msg: &PfcpMessage, xact_id: u64) -> Result<(), String> {
-    // In actual implementation:
-    // - Encode message to buffer
-    // - Update transaction
-    // - Send via socket
-
-    log::debug!(
-        "PFCP message sent: type={}, seid=0x{:x}, xact_id={}, len={}",
-        msg.msg_type,
-        msg.seid,
-        xact_id,
-        msg.data.len()
+/// Ask the SGW-U to DISCARD the packets it has buffered for a session, and stop
+/// buffering (TS 29.244 §5.2.3 / PFCPSMReq-Flags DROBU, TS 23.401 §5.3.4.2).
+///
+/// #54: sent when the MME says the DDN cannot be served — a non-accepted DDN Acknowledge
+/// or a DDN Failure Indication. Before this, both were only logged, so the buffered
+/// packets stayed on the SGW-U for the life of the session: an unbounded buffer that no
+/// message ever drained.
+pub fn send_drop_buffered_packets(sess: &SgwcSess) -> Result<(), String> {
+    let msg = sxa_build::build_drop_buffered_packets_request(sess)
+        .ok_or_else(|| "Failed to build the buffered-packet discard".to_string())?;
+    log::info!(
+        "Sending PFCP Session Modification (DROBU) for session {}: discard buffered downlink \
+         packets",
+        sess.id
     );
-
-    Ok(())
+    enqueue(&msg, sess.id, S11Continuation::None)
 }
 
 // ============================================================================
@@ -277,20 +947,12 @@ fn send_pfcp_message(msg: &PfcpMessage, xact_id: u64) -> Result<(), String> {
 /// Port of sgwc_timer_pfcp_association
 pub fn timer_pfcp_association(node_id: u64) {
     log::debug!("PFCP association timer fired for node {node_id}");
-
-    // In actual implementation:
-    // - Send Association Setup Request
-    // - Restart timer if needed
 }
 
 /// PFCP no heartbeat timer callback
 /// Port of sgwc_timer_pfcp_no_heartbeat
 pub fn timer_pfcp_no_heartbeat(node_id: u64) {
     log::warn!("PFCP no heartbeat timer fired for node {node_id}");
-
-    // In actual implementation:
-    // - Mark node as failed
-    // - Trigger recovery procedures
 }
 
 // ============================================================================
@@ -318,9 +980,36 @@ mod tests {
         assert!(node.is_associated());
     }
 
-    #[test]
-    fn test_pfcp_open_close() {
-        assert!(pfcp_open().is_ok());
-        pfcp_close();
+    /// #54: `pfcp_open` binds a real socket. It used to log "In actual implementation:
+    /// Create UDP sockets for PFCP" and return Ok without binding anything, so this is
+    /// the assertion that separates a bound socket from a claim about one.
+    #[tokio::test]
+    async fn test_pfcp_open_close() {
+        let _guard = sxa_test_guard().await;
+        std::env::set_var("SGWC_PFCP_BIND_ADDR", "127.0.0.1:0");
+        let node = pfcp_open().await.expect("bind");
+        assert_ne!(node.local_addr().port(), 0, "a real socket was bound");
+        assert!(sxa_node().is_some(), "the node is installed process-wide");
+        pfcp_close().await;
+        std::env::remove_var("SGWC_PFCP_BIND_ADDR");
+    }
+
+    /// A session request cannot be sent before the transport is running, and says so
+    /// instead of returning Ok — the shape the old `send_pfcp_message` had.
+    #[tokio::test]
+    async fn a_session_request_without_a_running_transport_is_an_error_not_a_silent_ok() {
+        let _guard = sxa_test_guard().await;
+        let sess = SgwcSess {
+            id: 1,
+            sgwc_sxa_seid: 0x1000,
+            sgwu_sxa_seid: 0x2000,
+            ..Default::default()
+        };
+        let err = send_session_deletion_request(&sess, 0, None, S11Continuation::None)
+            .expect_err("with no transport installed this must not report success");
+        assert!(
+            err.contains("not running"),
+            "the error must name why nothing was sent, got {err}"
+        );
     }
 }

--- a/src/bins/nextgcore-sgwcd/src/sxa_build.rs
+++ b/src/bins/nextgcore-sgwcd/src/sxa_build.rs
@@ -1,6 +1,33 @@
 //! SGWC SXA Message Builder
 //!
 //! Port of src/sgwc/sxa-build.c - Build PFCP messages for SXA interface
+//!
+//! #54: these builders used to emit **no IE headers at all**. `build_create_pdr` pushed a
+//! bare PDR id, a bare interface octet and a bare TEID with no type/length in front of
+//! any of them; `build_session_report_response` pushed the cause as a lone octet. That is
+//! not PFCP, and it was invisible because `send_pfcp_message` discarded every buffer
+//! before it reached a socket — the bodies were never parsed by anything, including our
+//! own tests.
+//!
+//! With a real transport (this issue) the same bytes would go on the wire, and the SGW-U
+//! has decoded with the shared `nextgcore-pfcp` codec since #59: it would find zero IEs,
+//! create a session with no PDRs and no FARs, and answer `REQUEST_ACCEPTED`. So the
+//! bodies are now built by the library's message types, which is the same decision #59
+//! took for the SGW-U — one codec for one interface, rather than a second hand-rolled one
+//! that drifts.
+
+use bytes::BytesMut;
+
+use nextgcore_pfcp::message::{
+    SessionDeletionRequest as LibSessionDeletionRequest,
+    SessionEstablishmentRequest as LibSessionEstablishmentRequest,
+    SessionModificationRequest as LibSessionModificationRequest, SessionReportResponse,
+};
+use nextgcore_pfcp::types::{
+    ApplyAction, CreateFar, CreatePdr, DestinationInterface, FSeid, FTeid, ForwardingParameters,
+    NodeId, OuterHeaderCreation, OuterHeaderRemoval, OuterHeaderRemovalDescription, Pdi, PfcpCause,
+    RemoveFar, RemovePdr, SourceInterface, UpdateFar, UpdatePdr,
+};
 
 use crate::context::{sgwc_self, SgwcSess, SgwcTunnel};
 
@@ -62,6 +89,12 @@ pub mod pfcp_interface {
     pub const CP_FUNCTION: u8 = 3;
 }
 
+/// PFCPSMReq-Flags (TS 29.244 §8.2.50).
+pub mod smreq_flags {
+    /// DROBU: drop the packets buffered for this session.
+    pub const DROBU: u8 = 0x02;
+}
+
 // ============================================================================
 // Message Builder Result
 // ============================================================================
@@ -84,6 +117,61 @@ impl PfcpMessage {
     }
 }
 
+/// A source/destination interface octet as the library's typed enums.
+fn source_interface(value: u8) -> SourceInterface {
+    match value {
+        pfcp_interface::CORE => SourceInterface::Core,
+        pfcp_interface::SGI_LAN_N6_LAN => SourceInterface::SgiLanN6Lan,
+        pfcp_interface::CP_FUNCTION => SourceInterface::CpFunction,
+        _ => SourceInterface::Access,
+    }
+}
+
+fn destination_interface(value: u8) -> DestinationInterface {
+    match value {
+        pfcp_interface::CORE => DestinationInterface::Core,
+        pfcp_interface::SGI_LAN_N6_LAN => DestinationInterface::SgiLanN6Lan,
+        pfcp_interface::CP_FUNCTION => DestinationInterface::CpFunction,
+        _ => DestinationInterface::Access,
+    }
+}
+
+/// The tunnel's own F-TEID, which is what the SGW-U matches an inbound G-PDU on.
+fn local_f_teid(tunnel: &SgwcTunnel) -> Option<FTeid> {
+    let addr = tunnel.local_addr?;
+    Some(FTeid::new_ipv4(tunnel.local_teid, addr.octets()))
+}
+
+/// The peer endpoint a forwarded packet is sent to.
+fn outer_header_creation(tunnel: &SgwcTunnel) -> Option<OuterHeaderCreation> {
+    if tunnel.remote_teid == 0 {
+        return None;
+    }
+    // Without the peer's ADDRESS there is no header to create: a TEID alone names no
+    // destination, and emitting one would make the FAR look provisioned while the SGW-U
+    // had nowhere to forward to.
+    let addr = tunnel.remote_ip.ipv4?;
+    Some(OuterHeaderCreation::new_gtpu_ipv4(
+        tunnel.remote_teid,
+        addr.octets(),
+    ))
+}
+
+/// FORW once the peer endpoint is known; BUFF + NOCP until then.
+///
+/// BUFF is what makes idle-mode downlink data arrive at all: the SGW-U holds the packet
+/// and reports it (TS 23.401 §5.3.4.2), which is the Downlink Data Report this SGW-C
+/// turns into a paging request.
+fn apply_action_for(tunnel: &SgwcTunnel) -> ApplyAction {
+    if tunnel.remote_teid != 0 {
+        ApplyAction::forward()
+    } else {
+        let mut aa = ApplyAction::buffer();
+        aa.nocp = true;
+        aa
+    }
+}
+
 // ============================================================================
 // SXA Message Builders
 // ============================================================================
@@ -96,32 +184,53 @@ pub fn build_session_establishment_request(sess: &SgwcSess) -> Option<PfcpMessag
     // SEID is 0 for establishment request (peer SEID not known yet)
     let mut msg = PfcpMessage::new(pfcp_type::SESSION_ESTABLISHMENT_REQUEST, 0);
 
-    let mut data = Vec::new();
-
-    // F-SEID IE (CP F-SEID)
-    data.extend_from_slice(&sess.sgwc_sxa_seid.to_be_bytes());
+    // The Node ID and the CP F-SEID both name THIS SGW-C on Sxa. `SGWC_PFCP_NODE_IP` is
+    // the same override `pfcp_open` binds with, so the address we advertise is the address
+    // we listen on -- a Node ID naming an interface we do not serve makes the SGW-U send
+    // its Session Report somewhere else.
+    let node_ip: std::net::Ipv4Addr = std::env::var("SGWC_PFCP_NODE_IP")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(std::net::Ipv4Addr::LOCALHOST);
+    let mut req = LibSessionEstablishmentRequest::new(
+        NodeId::new_ipv4(node_ip.octets()),
+        FSeid::new_ipv4(sess.sgwc_sxa_seid, node_ip.octets()),
+    );
 
     // Create PDRs and FARs for each bearer
     for bearer_id in &sess.bearer_ids {
         if let Some(bearer) = ctx.bearer_find_by_id(*bearer_id) {
             // DL Tunnel (S5/S8 SGW GTP-U)
             if let Some(dl_tunnel) = ctx.dl_tunnel_in_bearer(bearer.id) {
-                build_create_pdr(&mut data, &dl_tunnel, pfcp_interface::CORE);
-                build_create_far(&mut data, &dl_tunnel, pfcp_interface::ACCESS);
+                push_create_rules(
+                    &mut req,
+                    &dl_tunnel,
+                    pfcp_interface::CORE,
+                    pfcp_interface::ACCESS,
+                );
             }
 
             // UL Tunnel (S1-U SGW GTP-U)
             if let Some(ul_tunnel) = ctx.ul_tunnel_in_bearer(bearer.id) {
-                build_create_pdr(&mut data, &ul_tunnel, pfcp_interface::ACCESS);
-                build_create_far(&mut data, &ul_tunnel, pfcp_interface::CORE);
+                push_create_rules(
+                    &mut req,
+                    &ul_tunnel,
+                    pfcp_interface::ACCESS,
+                    pfcp_interface::CORE,
+                );
             }
         }
     }
 
-    msg.data = data;
+    let mut body = BytesMut::new();
+    req.encode(&mut body);
+    msg.data = body.to_vec();
     log::debug!(
-        "Built Session Establishment Request: seid=0x{:x}, data_len={}",
+        "Built Session Establishment Request: cp_seid=0x{:x}, {} PDR(s), {} FAR(s), \
+         data_len={}",
         sess.sgwc_sxa_seid,
+        req.create_pdrs.len(),
+        req.create_fars.len(),
         msg.data.len()
     );
 
@@ -138,43 +247,67 @@ pub fn build_bearer_to_modify_list(
     let ctx = sgwc_self();
 
     let mut msg = PfcpMessage::new(pfcp_type::SESSION_MODIFICATION_REQUEST, sess.sgwu_sxa_seid);
-
-    let mut data = Vec::new();
+    let mut req = LibSessionModificationRequest::new();
 
     // Process each bearer to modify
     for bearer_id in bearer_ids {
         if let Some(bearer) = ctx.bearer_find_by_id(*bearer_id) {
-            // DL Tunnel
-            if let Some(dl_tunnel) = ctx.dl_tunnel_in_bearer(bearer.id) {
+            for (tunnel, src, dst) in [
+                (
+                    ctx.dl_tunnel_in_bearer(bearer.id),
+                    pfcp_interface::CORE,
+                    pfcp_interface::ACCESS,
+                ),
+                (
+                    ctx.ul_tunnel_in_bearer(bearer.id),
+                    pfcp_interface::ACCESS,
+                    pfcp_interface::CORE,
+                ),
+            ] {
+                let Some(tunnel) = tunnel else { continue };
                 if modify_flags & crate::sxa_handler::pfcp_modify::CREATE != 0 {
-                    build_create_pdr(&mut data, &dl_tunnel, pfcp_interface::CORE);
-                    build_create_far(&mut data, &dl_tunnel, pfcp_interface::ACCESS);
+                    let mut create = LibSessionEstablishmentRequest::new(
+                        NodeId::new_ipv4([0, 0, 0, 0]),
+                        FSeid::new_ipv4(0, [0, 0, 0, 0]),
+                    );
+                    push_create_rules(&mut create, &tunnel, src, dst);
+                    req.create_pdrs.extend(create.create_pdrs);
+                    req.create_fars.extend(create.create_fars);
                 } else if modify_flags & crate::sxa_handler::pfcp_modify::REMOVE != 0 {
-                    build_remove_pdr(&mut data, dl_tunnel.pdr_id);
-                    build_remove_far(&mut data, dl_tunnel.far_id);
+                    if let Some(pdr_id) = tunnel.pdr_id {
+                        req.remove_pdrs.push(RemovePdr::new(pdr_id));
+                    }
+                    if let Some(far_id) = tunnel.far_id {
+                        req.remove_fars.push(RemoveFar::new(far_id));
+                    }
                 } else {
-                    build_update_pdr(&mut data, &dl_tunnel);
-                    build_update_far(&mut data, &dl_tunnel, modify_flags);
-                }
-            }
-
-            // UL Tunnel
-            if let Some(ul_tunnel) = ctx.ul_tunnel_in_bearer(bearer.id) {
-                if modify_flags & crate::sxa_handler::pfcp_modify::CREATE != 0 {
-                    build_create_pdr(&mut data, &ul_tunnel, pfcp_interface::ACCESS);
-                    build_create_far(&mut data, &ul_tunnel, pfcp_interface::CORE);
-                } else if modify_flags & crate::sxa_handler::pfcp_modify::REMOVE != 0 {
-                    build_remove_pdr(&mut data, ul_tunnel.pdr_id);
-                    build_remove_far(&mut data, ul_tunnel.far_id);
-                } else {
-                    build_update_pdr(&mut data, &ul_tunnel);
-                    build_update_far(&mut data, &ul_tunnel, modify_flags);
+                    if let Some(pdr_id) = tunnel.pdr_id {
+                        let mut update = UpdatePdr::new(pdr_id);
+                        update.outer_header_removal = Some(OuterHeaderRemoval {
+                            description: OuterHeaderRemovalDescription::GtpUUdpIpv4,
+                            pdu_session_container: false,
+                        });
+                        update.far_id = tunnel.far_id;
+                        req.update_pdrs.push(update);
+                    }
+                    if let Some(far_id) = tunnel.far_id {
+                        let mut update = UpdateFar::new(far_id);
+                        update.apply_action = Some(update_apply_action(&tunnel, modify_flags));
+                        if let Some(ohc) = outer_header_creation(&tunnel) {
+                            let mut fp = ForwardingParameters::new(destination_interface(dst));
+                            fp.outer_header_creation = Some(ohc);
+                            update.forwarding_parameters = Some(fp);
+                        }
+                        req.update_fars.push(update);
+                    }
                 }
             }
         }
     }
 
-    msg.data = data;
+    let mut body = BytesMut::new();
+    req.encode(&mut body);
+    msg.data = body.to_vec();
     log::debug!(
         "Built Session Modification Request: seid=0x{:x}, flags=0x{:x}, data_len={}",
         msg.seid,
@@ -185,27 +318,43 @@ pub fn build_bearer_to_modify_list(
     Some(msg)
 }
 
+/// Build a Session Modification Request that discards the session's buffered downlink
+/// packets (TS 29.244 §8.2.50 DROBU, TS 23.401 §5.3.4.2). Issue #54.
+pub fn build_drop_buffered_packets_request(sess: &SgwcSess) -> Option<PfcpMessage> {
+    let mut msg = PfcpMessage::new(pfcp_type::SESSION_MODIFICATION_REQUEST, sess.sgwu_sxa_seid);
+    let mut req = LibSessionModificationRequest::new();
+    req.pfcp_smreq_flags = Some(smreq_flags::DROBU);
+    let mut body = BytesMut::new();
+    req.encode(&mut body);
+    msg.data = body.to_vec();
+    Some(msg)
+}
+
 /// Build Session Deletion Request
 /// Port of sgwc_sxa_build_session_deletion_request
 pub fn build_session_deletion_request(sess: &SgwcSess) -> Option<PfcpMessage> {
-    let msg = PfcpMessage::new(pfcp_type::SESSION_DELETION_REQUEST, sess.sgwu_sxa_seid);
+    let mut msg = PfcpMessage::new(pfcp_type::SESSION_DELETION_REQUEST, sess.sgwu_sxa_seid);
 
-    // Session Deletion Request has no additional IEs beyond the header
+    // TS 29.244 Table 7.5.6.1-1: no IEs in the request; the SEID in the header names
+    // the session.
+    let mut body = BytesMut::new();
+    LibSessionDeletionRequest::new().encode(&mut body);
+    msg.data = body.to_vec();
     log::debug!("Built Session Deletion Request: seid=0x{:x}", msg.seid);
 
     Some(msg)
 }
 
 /// Build Session Report Response
+///
+/// #54: the cause used to be a bare octet with no IE header, so a conformant SGW-U could
+/// not find the mandatory Cause at all (TS 29.244 §7.5.9).
 pub fn build_session_report_response(sess: &SgwcSess, cause: u8) -> Option<PfcpMessage> {
     let mut msg = PfcpMessage::new(pfcp_type::SESSION_REPORT_RESPONSE, sess.sgwu_sxa_seid);
 
-    let mut data = Vec::new();
-
-    // Cause IE
-    data.push(cause);
-
-    msg.data = data;
+    let mut body = BytesMut::new();
+    SessionReportResponse::new(PfcpCause::from_wire(cause)).encode(&mut body);
+    msg.data = body.to_vec();
     log::debug!(
         "Built Session Report Response: seid=0x{:x}, cause={}",
         msg.seid,
@@ -219,91 +368,49 @@ pub fn build_session_report_response(sess: &SgwcSess, cause: u8) -> Option<PfcpM
 // Helper Functions for Building IEs
 // ============================================================================
 
-/// Build Create PDR IE
-fn build_create_pdr(data: &mut Vec<u8>, tunnel: &SgwcTunnel, src_interface: u8) {
-    // PDR ID
-    if let Some(pdr_id) = tunnel.pdr_id {
-        data.extend_from_slice(&pdr_id.to_be_bytes());
-    }
+/// Add the Create PDR + Create FAR pair for one tunnel.
+///
+/// The PDR matches inbound traffic on the tunnel's own F-TEID and strips the GTP-U
+/// header; the FAR forwards it to the peer endpoint, or buffers when there is not one yet.
+fn push_create_rules(
+    req: &mut LibSessionEstablishmentRequest,
+    tunnel: &SgwcTunnel,
+    src_interface: u8,
+    dst_interface: u8,
+) {
+    let Some(pdr_id) = tunnel.pdr_id else {
+        return;
+    };
+    let mut pdi = Pdi::new(source_interface(src_interface));
+    pdi.local_f_teid = local_f_teid(tunnel);
+    let mut pdr = CreatePdr::new(pdr_id, 255, pdi);
+    pdr.outer_header_removal = Some(OuterHeaderRemoval {
+        description: OuterHeaderRemovalDescription::GtpUUdpIpv4,
+        pdu_session_container: false,
+    });
+    pdr.far_id = tunnel.far_id;
+    req.create_pdrs.push(pdr);
 
-    // Source Interface
-    data.push(src_interface);
-
-    // F-TEID (local)
-    data.extend_from_slice(&tunnel.local_teid.to_be_bytes());
-
-    // Outer Header Removal (for incoming packets)
-    data.push(0); // GTP-U/UDP/IP
-}
-
-/// Build Create FAR IE
-fn build_create_far(data: &mut Vec<u8>, tunnel: &SgwcTunnel, dst_interface: u8) {
-    // FAR ID
     if let Some(far_id) = tunnel.far_id {
-        data.extend_from_slice(&far_id.to_be_bytes());
-    }
-
-    // Apply Action
-    if tunnel.remote_teid != 0 {
-        data.push(apply_action::FORW);
-    } else {
-        data.push(apply_action::BUFF | apply_action::NOCP);
-    }
-
-    // Destination Interface
-    data.push(dst_interface);
-
-    // Outer Header Creation (for outgoing packets)
-    if tunnel.remote_teid != 0 {
-        data.extend_from_slice(&tunnel.remote_teid.to_be_bytes());
-        // Remote IP would be added here
+        let mut far = CreateFar::new(far_id, apply_action_for(tunnel));
+        let mut fp = ForwardingParameters::new(destination_interface(dst_interface));
+        fp.outer_header_creation = outer_header_creation(tunnel);
+        far.forwarding_parameters = Some(fp);
+        req.create_fars.push(far);
     }
 }
 
-/// Build Update PDR IE
-fn build_update_pdr(data: &mut Vec<u8>, tunnel: &SgwcTunnel) {
-    // PDR ID
-    if let Some(pdr_id) = tunnel.pdr_id {
-        data.extend_from_slice(&pdr_id.to_be_bytes());
-    }
-
-    // Outer Header Removal
-    data.push(0); // GTP-U/UDP/IP
-}
-
-/// Build Update FAR IE
-fn build_update_far(data: &mut Vec<u8>, tunnel: &SgwcTunnel, modify_flags: u64) {
-    // FAR ID
-    if let Some(far_id) = tunnel.far_id {
-        data.extend_from_slice(&far_id.to_be_bytes());
-    }
-
-    // Apply Action
+/// The Apply Action an Update FAR carries: the modify flags decide, and the tunnel's
+/// endpoint decides when they do not.
+fn update_apply_action(tunnel: &SgwcTunnel, modify_flags: u64) -> ApplyAction {
     if modify_flags & crate::sxa_handler::pfcp_modify::ACTIVATE != 0 {
-        data.push(apply_action::FORW);
+        ApplyAction::forward()
     } else if modify_flags & crate::sxa_handler::pfcp_modify::DEACTIVATE != 0 {
-        data.push(apply_action::BUFF | apply_action::NOCP);
+        let mut aa = ApplyAction::buffer();
+        aa.nocp = true;
+        aa
     } else {
-        data.push(apply_action::FORW);
-    }
-
-    // Outer Header Creation
-    if tunnel.remote_teid != 0 {
-        data.extend_from_slice(&tunnel.remote_teid.to_be_bytes());
-    }
-}
-
-/// Build Remove PDR IE
-fn build_remove_pdr(data: &mut Vec<u8>, pdr_id: Option<u16>) {
-    if let Some(id) = pdr_id {
-        data.extend_from_slice(&id.to_be_bytes());
-    }
-}
-
-/// Build Remove FAR IE
-fn build_remove_far(data: &mut Vec<u8>, far_id: Option<u32>) {
-    if let Some(id) = far_id {
-        data.extend_from_slice(&id.to_be_bytes());
+        apply_action_for(tunnel)
     }
 }
 
@@ -314,6 +421,7 @@ fn build_remove_far(data: &mut Vec<u8>, far_id: Option<u32>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn test_pfcp_message_new() {
@@ -321,5 +429,46 @@ mod tests {
         assert_eq!(msg.msg_type, pfcp_type::SESSION_ESTABLISHMENT_REQUEST);
         assert_eq!(msg.seid, 0x1234);
         assert!(msg.data.is_empty());
+    }
+
+    /// #54: the built bodies are real PFCP, i.e. the SGW-U's decoder can read them back.
+    ///
+    /// The old builders emitted bare values with no IE headers, and nothing noticed
+    /// because `send_pfcp_message` discarded every buffer. Decoding with the LIBRARY —
+    /// which is what the SGW-U has used since #59 — is the assertion that separates "the
+    /// bytes were produced" from "a peer can parse them".
+    #[test]
+    fn a_built_session_report_response_decodes_as_pfcp() {
+        let sess = SgwcSess {
+            id: 1,
+            sgwu_sxa_seid: 0x2000,
+            ..Default::default()
+        };
+        let msg =
+            build_session_report_response(&sess, crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED)
+                .expect("built");
+        let mut body = Bytes::copy_from_slice(&msg.data);
+        let decoded = SessionReportResponse::decode(&mut body)
+            .expect("a Session Report Response must carry a decodable Cause IE");
+        assert_eq!(decoded.cause, PfcpCause::RequestAccepted);
+    }
+
+    /// A Session Modification carrying DROBU round-trips, so the SGW-U actually sees the
+    /// flag that tells it to discard the buffered packets.
+    #[test]
+    fn the_buffered_packet_discard_carries_drobu_on_the_wire() {
+        let sess = SgwcSess {
+            id: 1,
+            sgwu_sxa_seid: 0x2000,
+            ..Default::default()
+        };
+        let msg = build_drop_buffered_packets_request(&sess).expect("built");
+        let mut body = Bytes::copy_from_slice(&msg.data);
+        let decoded = LibSessionModificationRequest::decode(&mut body).expect("decodable");
+        assert_eq!(
+            decoded.pfcp_smreq_flags,
+            Some(smreq_flags::DROBU),
+            "without DROBU on the wire the SGW-U keeps the buffered packets forever"
+        );
     }
 }

--- a/src/bins/nextgcore-sgwcd/src/sxa_response.rs
+++ b/src/bins/nextgcore-sgwcd/src/sxa_response.rs
@@ -1,0 +1,439 @@
+//! What an Sxa response means for the S11 procedure that is waiting for it (#54).
+//!
+//! TS 23.401 §5.3.2.1: the Serving GW returns the Create Session Response **after** the
+//! user plane has been provisioned, and TS 29.274 §7.2.2 makes `Request accepted` mean the
+//! request was actually fulfilled. Before this module the S11 responses were sent from the
+//! GTP-C dispatch with a hard-coded `REQUEST_ACCEPTED`, before any PFCP response existed —
+//! and `sxa_handler::handle_session_establishment_response`, the function that maps the
+//! PFCP cause, had no caller outside tests.
+//!
+//! This is the join: the PFCP transaction carries what the S11 answer needs
+//! ([`crate::pfcp_path::S11Continuation`]), the response is decoded and dispatched into
+//! `sxa_handler`, and the answer the MME gets is the one the SGW-U actually gave.
+
+use bytes::Bytes;
+
+use nextgcore_gtp::v2::header::Gtp2MessageType;
+use nextgcore_pfcp::message::{SessionDeletionResponse, SessionEstablishmentResponse};
+
+use crate::context::sgwc_self;
+use crate::pfcp_path::{pfcp_msg_type, S11Continuation};
+use crate::s11_handler::gtp_cause;
+use crate::sxa_handler::{self, HandlerResult};
+use crate::{gtp_path, s11_build};
+
+/// A PFCP response landed for a transaction that was gating an S11 procedure.
+pub fn dispatch(sess_id: u64, continuation: S11Continuation, resp_type: u8, body: &[u8]) {
+    match resp_type {
+        pfcp_msg_type::SESSION_ESTABLISHMENT_RESPONSE => {
+            establishment_response(sess_id, continuation, body)
+        }
+        pfcp_msg_type::SESSION_DELETION_RESPONSE => deletion_response(sess_id, continuation, body),
+        pfcp_msg_type::SESSION_MODIFICATION_RESPONSE => {
+            // Modification responses gate no S11 procedure today (see the spec's
+            // ceiling); the cause is logged so a rejected modification is not silent.
+            let cause = find_cause(body);
+            if cause != Some(sxa_handler::pfcp_cause::REQUEST_ACCEPTED) {
+                log::warn!(
+                    "PFCP Session Modification for session {sess_id} was REJECTED: cause={cause:?}"
+                );
+            }
+        }
+        other => log::warn!("Unexpected PFCP response type {other} for session {sess_id}"),
+    }
+}
+
+/// The transaction never completed (T1 x N1 expiry, or a local error).
+///
+/// The MME is waiting. Answering now with a mapped cause is what stops the procedure
+/// hanging until the MME's own GTP-C timer fires (TS 29.274 §7.6) — and
+/// `REMOTE_PEER_NOT_RESPONDING` says which peer failed, rather than blaming the SGW-C.
+pub fn fail(continuation: S11Continuation, reason: &str) {
+    match continuation {
+        S11Continuation::None => {}
+        S11Continuation::CreateSession { peer, seq, teid } => {
+            log::error!(
+                "Create Session Response to {peer} carries a failure: the SGW-U never answered \
+                 ({reason})"
+            );
+            answer(
+                peer,
+                Gtp2MessageType::CreateSessionResponse,
+                teid,
+                seq,
+                gtp_cause::REMOTE_PEER_NOT_RESPONDING,
+            );
+        }
+        S11Continuation::DeleteSession {
+            peer,
+            seq,
+            teid,
+            sess_id,
+        } => {
+            // The local context is deliberately KEPT: the SGW-U may still hold the
+            // session, and removing ours would strand it there with nothing left to
+            // delete it by (TS 23.007 §17).
+            log::error!(
+                "Delete Session Response to {peer} carries a failure: the SGW-U never answered \
+                 ({reason}); session {sess_id} is KEPT so a retry can still reach it"
+            );
+            answer(
+                peer,
+                Gtp2MessageType::DeleteSessionResponse,
+                teid,
+                seq,
+                gtp_cause::REMOTE_PEER_NOT_RESPONDING,
+            );
+        }
+    }
+}
+
+fn establishment_response(sess_id: u64, continuation: S11Continuation, body: &[u8]) {
+    let ctx = sgwc_self();
+    let sess = ctx.sess_find_by_id(sess_id);
+
+    let mut cursor = Bytes::copy_from_slice(body);
+    let (pfcp_cause, up_f_seid) = match SessionEstablishmentResponse::decode(&mut cursor) {
+        Ok(rsp) => (
+            rsp.cause as u8,
+            rsp.up_f_seid.as_ref().map(|f| f.seid).unwrap_or(0),
+        ),
+        Err(e) => {
+            // A malformed response is not an accepted one. Mapping it to SYSTEM_FAILURE
+            // rather than guessing keeps the "accepted means fulfilled" promise.
+            log::warn!("Malformed Session Establishment Response for session {sess_id}: {e}");
+            (sxa_handler::pfcp_cause::SYSTEM_FAILURE, 0)
+        }
+    };
+
+    let result =
+        sxa_handler::handle_session_establishment_response(sess.as_ref(), 0, pfcp_cause, up_f_seid);
+
+    let S11Continuation::CreateSession { peer, seq, teid } = continuation else {
+        return;
+    };
+
+    let cause = match result {
+        HandlerResult::Error(cause) => cause,
+        // `SendGtpToPgw` is what the handler returns on success: TS 23.401 §5.3.2.1 has
+        // the SGW-C now send a Create Session Request to the PGW over S5/S8. That leg
+        // does not exist in this tree (#52: no PGW client, and `pgw_addr` has no writer),
+        // so the SGW-C answers the MME itself — which is the deployment shape this build
+        // supports and is stated in the spec rather than left implied.
+        _ => gtp_cause::REQUEST_ACCEPTED,
+    };
+
+    if cause != gtp_cause::REQUEST_ACCEPTED {
+        log::warn!(
+            "Create Session Response to {peer} carries cause={cause}: the SGW-U refused the \
+             user plane (pfcp_cause={pfcp_cause})"
+        );
+        answer(
+            peer,
+            Gtp2MessageType::CreateSessionResponse,
+            teid,
+            seq,
+            cause,
+        );
+        return;
+    }
+
+    // Re-read: `handle_session_establishment_response` stored the SGW-U's SEID.
+    let Some(sess) = ctx.sess_find_by_id(sess_id) else {
+        log::error!("Session {sess_id} vanished before its Create Session Response");
+        answer(
+            peer,
+            Gtp2MessageType::CreateSessionResponse,
+            teid,
+            seq,
+            gtp_cause::CONTEXT_NOT_FOUND,
+        );
+        return;
+    };
+    let Some(server) = gtp_path::s11_server() else {
+        log::error!("S11 server not open: cannot answer the Create Session Request");
+        return;
+    };
+    match s11_build::build_create_session_response(&sess, seq, server.restart_counter()) {
+        Ok(response) => {
+            if let Err(e) = server.send_response(peer, &response) {
+                log::error!("Create Session Response to {peer} failed: {e}");
+            } else {
+                log::info!(
+                    "Create Session Response to {peer} sent after the SGW-U accepted \
+                     (up_seid=0x{up_f_seid:x})"
+                );
+            }
+        }
+        Err(e) => {
+            log::error!("Failed to build Create Session Response: {e}");
+            answer(
+                peer,
+                Gtp2MessageType::CreateSessionResponse,
+                teid,
+                seq,
+                gtp_cause::SYSTEM_FAILURE,
+            );
+        }
+    }
+}
+
+fn deletion_response(sess_id: u64, continuation: S11Continuation, body: &[u8]) {
+    let ctx = sgwc_self();
+    let sess = ctx.sess_find_by_id(sess_id);
+
+    let mut cursor = Bytes::copy_from_slice(body);
+    let pfcp_cause = match SessionDeletionResponse::decode(&mut cursor) {
+        Ok(rsp) => rsp.cause as u8,
+        Err(e) => {
+            log::warn!("Malformed Session Deletion Response for session {sess_id}: {e}");
+            sxa_handler::pfcp_cause::SYSTEM_FAILURE
+        }
+    };
+
+    let result = sxa_handler::handle_session_deletion_response(sess.as_ref(), 0, pfcp_cause);
+
+    let S11Continuation::DeleteSession {
+        peer,
+        seq,
+        teid,
+        sess_id,
+    } = continuation
+    else {
+        return;
+    };
+
+    match result {
+        HandlerResult::Error(cause) => {
+            // The local context is KEPT on a refusal, deliberately: removing it while the
+            // SGW-U still holds the session would leak the user plane with nothing left
+            // to address it by. The MME learns the truth and can retry.
+            log::warn!(
+                "Delete Session Response to {peer} carries cause={cause}: the SGW-U refused \
+                 (pfcp_cause={pfcp_cause}); session {sess_id} is KEPT"
+            );
+            answer(
+                peer,
+                Gtp2MessageType::DeleteSessionResponse,
+                teid,
+                seq,
+                cause,
+            );
+        }
+        _ => {
+            ctx.sess_remove(sess_id);
+            log::info!(
+                "Session {sess_id} removed after the SGW-U confirmed the deletion; answering \
+                 {peer}"
+            );
+            answer(
+                peer,
+                Gtp2MessageType::DeleteSessionResponse,
+                teid,
+                seq,
+                gtp_cause::REQUEST_ACCEPTED,
+            );
+        }
+    }
+}
+
+/// A Downlink Data Report reached the SGW-C: page the UE (TS 23.401 §5.3.4.2).
+///
+/// #54: `gtp_path::send_downlink_data_notification` was reachable only from `mod tests`,
+/// so downlink data for an idle UE produced no paging trigger at all.
+pub fn downlink_data_notification(sess_id: u64, pdr_id: Option<u16>) {
+    let ctx = sgwc_self();
+    let Some(sess) = ctx.sess_find_by_id(sess_id) else {
+        log::warn!("Downlink Data Report for unknown session {sess_id}");
+        return;
+    };
+    // The report names a PDR; the DDN names a bearer. Prefer the bearer that owns the
+    // reported PDR, and fall back to the session's first bearer when the report carried
+    // no PDR id — a DDN for the wrong bearer pages the UE for the wrong EPS bearer.
+    let bearer = sess
+        .bearer_ids
+        .iter()
+        .filter_map(|id| ctx.bearer_find_by_id(*id))
+        .find(|b| match pdr_id {
+            Some(pdr) => [ctx.dl_tunnel_in_bearer(b.id), ctx.ul_tunnel_in_bearer(b.id)]
+                .into_iter()
+                .flatten()
+                .any(|t| t.pdr_id == Some(pdr)),
+            None => true,
+        });
+    let Some(bearer) = bearer else {
+        log::warn!(
+            "Downlink Data Report for session {sess_id} names PDR {pdr_id:?}, which no bearer \
+             holds: no Downlink Data Notification sent"
+        );
+        return;
+    };
+
+    // TS 29.274 §7.2.11.2: the Data Notification Delay the MME last asked for throttles
+    // the next DDN. Honoured here rather than at the report, because the delay is per UE.
+    if let Some(ue) = ctx.ue_find_by_id(bearer.sgwc_ue_id) {
+        if let Some(remaining) = ue.ddn_delay_remaining() {
+            log::info!(
+                "Downlink Data Notification for bearer {} throttled for {}ms more \
+                 (Data Notification Delay, TS 29.274 §7.2.11.2)",
+                bearer.id,
+                remaining.as_millis()
+            );
+            return;
+        }
+    }
+
+    let Some(server) = gtp_path::s11_server() else {
+        log::error!("S11 server not open: cannot send a Downlink Data Notification");
+        return;
+    };
+    match server.send_downlink_data_notification(None, &bearer) {
+        Ok(seq) => {
+            // Remember that one is outstanding, so a failure can be tied back to the
+            // session whose buffered packets have to be discarded.
+            if let Some(mut ue) = ctx.ue_find_by_id(bearer.sgwc_ue_id) {
+                ue.ddn_outstanding_sess_id = Some(sess_id);
+                ctx.ue_update(&ue);
+            }
+            log::info!(
+                "Downlink Data Notification sent for bearer {} (seq={seq}) after a Downlink \
+                 Data Report",
+                bearer.id
+            );
+        }
+        Err(e) => log::error!(
+            "Downlink Data Notification for bearer {} failed: {e}",
+            bearer.id
+        ),
+    }
+}
+
+/// The MME acknowledged a Downlink Data Notification (TS 29.274 §7.2.11.2). Issue #54.
+///
+/// Two things the handler used to drop on the floor:
+///
+/// - a **non-accepted cause** means the MME cannot serve the notification, and TS 23.401
+///   §5.3.4.2 has the Serving GW delete the buffered packet(s) rather than hold them for a
+///   UE that will not be paged;
+/// - the **Data Notification Delay** throttles the next notification. It was parsed into
+///   `ParsedDdnAck.data_notification_delay` and then discarded, so a busy idle UE could
+///   produce a DDN per downlink packet — the storm the IE exists to suppress.
+pub fn downlink_data_notification_ack(
+    ue_id: Option<u64>,
+    cause: u8,
+    data_notification_delay: Option<u8>,
+) {
+    let Some(ue_id) = ue_id else { return };
+    let ctx = sgwc_self();
+    let Some(mut ue) = ctx.ue_find_by_id(ue_id) else {
+        return;
+    };
+
+    ue.set_ddn_delay(data_notification_delay);
+    let outstanding = ue.ddn_outstanding_sess_id.take();
+    ctx.ue_update(&ue);
+
+    if let Some(units) = data_notification_delay.filter(|u| *u > 0) {
+        log::info!(
+            "MME asked for a Data Notification Delay of {}ms: the next Downlink Data              Notification for UE {ue_id} waits that long (TS 29.274 §7.2.11.2)",
+            units as u64 * 50
+        );
+    }
+
+    if cause == gtp_cause::REQUEST_ACCEPTED {
+        return;
+    }
+    discard_buffered(
+        outstanding,
+        ue_id,
+        cause,
+        "Downlink Data Notification Acknowledge",
+    );
+}
+
+/// The MME sent a Downlink Data Notification Failure Indication (TS 29.274 §7.2.11.3):
+/// the UE could not be reached, so the buffered packets are deleted (TS 23.401 §5.3.4.2).
+pub fn downlink_data_notification_failed(ue_id: Option<u64>, cause: u8) {
+    let Some(ue_id) = ue_id else { return };
+    let ctx = sgwc_self();
+    let Some(mut ue) = ctx.ue_find_by_id(ue_id) else {
+        return;
+    };
+    let outstanding = ue.ddn_outstanding_sess_id.take();
+    ctx.ue_update(&ue);
+    discard_buffered(
+        outstanding,
+        ue_id,
+        cause,
+        "Downlink Data Notification Failure Indication",
+    );
+}
+
+/// Ask the SGW-U to drop what it is holding for the session the DDN was about.
+fn discard_buffered(sess_id: Option<u64>, ue_id: u64, cause: u8, because: &str) {
+    let ctx = sgwc_self();
+    // Fall back to every session of the UE when no DDN was recorded as outstanding: the
+    // MME is telling us the UE cannot be reached, and holding packets for it either way is
+    // the leak. Narrower would be better; silent would be wrong.
+    let sessions: Vec<_> = match sess_id.and_then(|id| ctx.sess_find_by_id(id)) {
+        Some(sess) => vec![sess],
+        None => ctx
+            .ue_find_by_id(ue_id)
+            .map(|ue| {
+                ue.sess_ids
+                    .iter()
+                    .filter_map(|id| ctx.sess_find_by_id(*id))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    };
+    if sessions.is_empty() {
+        log::warn!("{because} (cause={cause}) for UE {ue_id}: no session to discard buffers on");
+        return;
+    }
+    for sess in sessions {
+        log::warn!(
+            "{because} carried cause={cause}: discarding the packets the SGW-U buffered for              session {} (TS 23.401 §5.3.4.2)",
+            sess.id
+        );
+        if let Err(e) = crate::pfcp_path::send_drop_buffered_packets(&sess) {
+            log::error!(
+                "Could not ask the SGW-U to discard session {}'s buffered packets: {e}. They                  stay buffered.",
+                sess.id
+            );
+        }
+    }
+}
+
+/// The Cause octet of a response body, without decoding the whole message.
+fn find_cause(body: &[u8]) -> Option<u8> {
+    let mut i = 0usize;
+    while i + 4 <= body.len() {
+        let ie_type = u16::from_be_bytes([body[i], body[i + 1]]);
+        let len = u16::from_be_bytes([body[i + 2], body[i + 3]]) as usize;
+        let value = &body[i + 4..(i + 4 + len).min(body.len())];
+        // TS 29.244 §8.2.1: Cause is IE type 19.
+        if ie_type == 19 && !value.is_empty() {
+            return Some(value[0]);
+        }
+        i += 4 + len;
+    }
+    None
+}
+
+fn answer(
+    peer: std::net::SocketAddr,
+    response_type: Gtp2MessageType,
+    teid: u32,
+    seq: u32,
+    cause: u8,
+) {
+    let Some(server) = gtp_path::s11_server() else {
+        log::error!("S11 server not open: cannot answer {peer}");
+        return;
+    };
+    let msg = s11_build::build_error_response(response_type as u8, teid, seq, cause, None);
+    if let Err(e) = server.send_response(peer, &msg) {
+        log::error!("Failed to answer {peer}: {e}");
+    }
+}


### PR DESCRIPTION
Closes #54. Spec: `specs/fix-sgwcd-gate-s11-on-sxa-and-drive-ddn.md`.

## The issue was right, and understated the problem twice

Every claim in #54 re-verified (table in the spec). But two things it did not know had to be fixed for its own criteria to mean anything — both hidden by the same fact, that `send_pfcp_message` discarded every buffer before it reached a socket:

**1. sgwcd's Sxa messages were not PFCP at all.** `sxa_build` emitted **no IE headers**: `build_create_pdr` pushed a bare PDR id, a bare interface octet and a bare TEID with nothing in front of them; the establishment body opened with eight raw bytes of SEID; the report response pushed the cause as a lone octet. One comment read *"Remote IP would be added here"*. Nothing ever parsed those bodies — including our own tests. With a real socket the SGW-U (decoding with the shared codec since #59) finds **zero IEs**, creates a session with no PDRs and no FARs, and answers `REQUEST_ACCEPTED`. Gating the S11 response on that answer would have been gating it on a lie. The builders are rebuilt on the library's message types, and the guard is a **decode of what the peer received**.

**2. Nothing ever allocated a PDR or FAR id.** `SgwcTunnel.pdr_id`/`far_id` had no writer anywhere in the daemon; every tunnel carried `None`, and the old builders omitted them under `if let Some(...)`. This surfaced as three new tests failing on `expect("pdr id")` before any reached an assertion about #54.

## What changed

- **A CP-side Sxa transport**, mirroring #59: bound UDP socket, transactions matched on sequence number with T1/N1, an association *initiated* toward the SGW-U (§6.2.6.2 makes the CP function the initiator), inbound heartbeats answered, inbound Session Report Requests dispatched. `main` is `#[tokio::main]` and its event loop `await`s rather than `thread::sleep`ing — blocking a worker for 100ms at a time would stall the receive loop and every gated procedure with it.
- **`S11Continuation`** carries `(peer, seq, teid)` with the PFCP transaction. It has to: the S11 response must echo the **sequence number** and only the request knew it. A transaction that times out answers `REMOTE_PEER_NOT_RESPONDING` instead of leaving the MME to its own timer.
- **A refusal keeps the local session.** Removing it while the SGW-U still holds one leaks the user plane with nothing left to address it by (TS 23.007 §17).
- **DLDR → DDN through a production caller.** The classifier returned `SendGtpToMme` to nobody (zero callers) and the sender was reachable only from `mod tests`, so downlink data for an idle UE produced no paging request at all.
- **A refused DDN Ack or a DDN Failure Indication discards the buffered packets** (Session Modification with DROBU), and the **Data Notification Delay throttles the next DDN** instead of being parsed into a struct field and dropped.

With no S5/S8 leg in the tree (#52: no PGW client, `pgw_addr` has no writer), the success arm answers the MME itself rather than contacting a PGW — stated in the spec so the handler's `SendGtpToPgw` return does not read as a forgotten step.

## Verification

`cargo test --workspace`: **6315 passed / 0 failed** over three consecutive runs (baseline 6306). sgwcd 75 → 81 plus 2 codec tests. clippy adds no warning; fmt clean.

**Eight reverts, eight bites** — including the two findings above: bare-value bodies fail the decode assertion, and un-allocated ids fail four tests.

Three test changes, each accounted for at the site rather than quietly:

- `test_create_session_request_accepted_over_socket` **deleted**: it asserted the immediate `REQUEST_ACCEPTED` that this issue removes. Its replacement asserts everything it did *plus* that nothing is sent until the SGW-U answers.
- Two tests **converted** to drive a stand-in SGW-U — their properties are unchanged, they simply cannot get a response without a peer. Checked against the spec first, per the recorded rule that twice the old test was right and the new code wrong; here the *expectation* is what #54 legitimately changes.
- `S11_SERVER` **became settable** (the gated answer goes through the process-global server, so a test has to install its own; an install-once `OnceLock` makes every test after the first answer through a closed socket — the same finding as #217). Its clear is folded into the existing Sxa test guard rather than given a second lock, so there is no lock order to get wrong.

Ceilings are in the spec — chiefly that **Modify Bearer and Release Access Bearers are deliberately not gated** (#54's criteria name Create and Delete; gating a modification means deciding what a partially-applied one answers, and the plumbing is now one enum variant away), that there is no CP-side heartbeat monitor, and that the association is attempted once at startup without retry.