### PR TITLE
fix(tests): one ambient process-state lock per crate, covering readers not just writers (#308)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,23 @@ jobs:
         with:
           workspaces: src
       - name: cargo test
-        # Retry once: a few NF tests share process-global state (context /
-        # UDR_SBI_* env) and ephemeral ports (free_port TOCTOU), which can race
-        # under the runner's heavy parallel load. A single retry clears a flake
-        # while a deterministic failure still fails twice. TODO: proper deflake
-        # (bind-and-keep ports + one cross-crate serialize lock).
-        run: cd src && (cargo test --workspace || (echo '::warning::cargo test flaked, retrying once' && cargo test --workspace))
+        # No retry. There was one, for two named races: process-global state and
+        # the free_port TOCTOU. #308 fixed the first (one ambient test lock per
+        # crate, covering readers as well as writers) and measured what the retry
+        # had been hiding -- about 1 whole-workspace run in 5, in three smfd tests,
+        # for months, because a single retry passes ~96% of the time at that rate
+        # and the warning annotation went unread. A retry that can hide a 20% flake
+        # is not a flake mitigation, it is a detector for exactly the failures
+        # nobody investigates.
+        #
+        # What genuinely remains is #313: free_port hands out a port and unbinds it
+        # before the caller binds, and each test BINARY has its own issued-port set,
+        # so two crates can be given the same port. That fails as a bind panic, not
+        # as a wrong answer, and it did not occur once in ~60 whole-crate runs under
+        # synthetic 40-way load. Closing it needs SbiServer to accept a pre-bound
+        # listener, which is #313's subject; until then a rare red here is the
+        # honest signal and should be re-run, not retried automatically.
+        run: cd src && cargo test --workspace
 
       - name: cargo test (non-default features)
         # Feature-gated paths are invisible to the default build, so a gated

--- a/specs/fix-process-state-test-locks.md
+++ b/specs/fix-process-state-test-locks.md
@@ -1,0 +1,212 @@
+# nextgcore #308: one ambient process-state test lock per crate, covering readers as well as writers
+
+Filed as an smfd issue. It is a **workspace** issue: fixing smfd exposed the same defect in `lmfd`
+and `nextgcore-sbi`, both of which criterion 1 requires closing. Named for what it is rather than
+for where it was first seen.
+
+Verified against `main` @ `8c3321b`.
+
+#308's *symptom* is real and reproducible. **Its stated mechanism is stale**, and the two tests it
+names are not the whole set — a third test fails the same way, and the dominant race is not the one
+the issue describes. Everything below was measured on this machine (48 cores), not inferred.
+
+## Verified against current main
+
+| claim in the issue | site on `8c3321b` | still true? |
+|---|---|---|
+| `cargo test --workspace` fails ~1 run in 5 in smfd | 1 of 5 whole-workspace runs; 3 of 10 crate runs under load | **yes** |
+| `udm::tests::the_smf_registers_with_the_udm_and_fetches_sm_data` fails at `udm.rs:853` | reproduced, `left: "DELETE" right: "PUT"` | yes |
+| `tests::the_create_subscribes_to_sm_data_…` fails at `main.rs:7101` | reproduced, `left: None right: Some("sub-293")` | yes |
+| a third test also fails | `a_successful_create_registers_an_activated_session_and_its_binding`, `main.rs:8040` | **the issue does not name it** |
+| the mechanism is that `UDM_SBI_*` writers are unserialised | **NO** — every writer in smfd already held `UDM_ENV_TEST_LOCK` | **false** |
+| `N4_TEST_LOCK` is the existing lock to check against | it exists and is correct; it is not the one at fault | yes, but not the fix |
+| `ausfd`/`udmd`/`amfd` carry the same two-writer pattern | ausfd 7 writers **all locked**; udmd 3 writers **no lock at all**; amfd 1 writer | partly |
+| the `ci.yml` retry hides it at ~96% | arithmetic confirmed; the `TODO` is a CONSTITUTION violation | yes |
+| smfd is the only crate the workspace gate flakes in | **NO** — with smfd fixed, `lmfd` failed 2 of 20 runs and `nextgcore-sbi` 1 of 20 | **false, twice** |
+
+## What actually races
+
+Not one hazard but three, all the same family: **a locked writer and an unlocked reader disagreeing
+about a global that neither test names.**
+
+1. **The UDM leg's switch.** `handle_sm_context_create` consults `udm::enabled()`. A sibling with
+   the switch ON and `UDM_SBI_*` pointed at its own recording UDM makes an unrelated create fetch
+   *that sibling's* subscribed session-AMBR (40/80 Mbps), and the subscription outranks the config
+   default — so `a_successful_create_…` asserts `(100 Mbps, 100 Mbps)` and gets the sibling's values.
+2. **The `UDM_SBI_*` environment.** `main.rs:8415` uses the **same SUPI** as the `udm.rs` test.
+   Its release sends `DELETE /nudm-uecm/v1/imsi-001010000000079/registrations/smf-registrations/…`
+   to whatever the env names — landing on the `udm.rs` test's recording server, whose
+   `find(|uri| uri.contains("smf-registrations") && uri.contains(supi))` then matches the DELETE
+   before its own PUT. Hence `left: "DELETE"`.
+3. **The SMF context itself.** `smf_context_init` clears every pool for the whole process, and
+   **17 test sites called it with no lock of any kind**. One of them between a create and its
+   assertion is why `lookup_policy_binding(…).sdm_subscription_id` reads `None`.
+
+And the reason writer-locking was not enough is sharper than "readers were unguarded": there were
+**four** locks over one ambient state (`udm::SWITCH_LOCK`, `easdf::SWITCH_LOCK`,
+`eps_iwk::SWITCH_LOCK`, `main::UDM_ENV_TEST_LOCK`). Four locks are four disjoint agreements. A test
+holding the easdf lock ran concurrently with a test holding the udm locks, and the easdf test's
+create then fetched from the udm test's server *while both were correctly locked*.
+
+## Decision 1: one lock per crate, declared beside the largest global it guards
+
+`context::PROCESS_STATE_TEST_LOCK` replaces all four, and additionally covers the context wipe and
+the 25 ambient **readers** the audit found. It is declared beside `GLOBAL_SMF_CONTEXT` rather than
+inside any `mod tests`, so every module reaches the same static — the trap `#276` hit as a *hang*.
+
+`pfcp_path::N4_TEST_LOCK` is deliberately kept as a second, **inner** lock. It guards a different
+set (`PFCP_CLIENT`/`PFCP_POOL` `OnceLock`s and the installed client's association state), it is
+already correct, and `stand_in::associated_upf` takes it on the caller's behalf and holds it for the
+life of the returned value. Collapsing it in would mean either a reentrant acquisition (tokio
+mutexes are not reentrant → deadlock) or reworking the stand-in's ownership, which no part of #308
+asks for. The documented order — ambient first, N4 second — is unchanged and now stated in both
+places.
+
+Sync `#[test]` functions take the lock with `blocking_lock()`, which is sound precisely because they
+have no runtime to block.
+
+## Decision 2: udmd gets the same lock; ausfd's is relocated; amfd is named, not changed
+
+- **udmd** had 3 `UDR_SBI_*` writers and **no lock at all**, with 13 tests touching that env or a
+  UDR-backed path. `sbi_path::UDR_ENV_TEST_LOCK` is declared beside the fallback that reads it
+  (`udm_sbi_discover_and_send_nudr_dr`) and taken by all 13. It did not flake in 6 runs before the
+  change, which is not evidence of no race — a crate with no guard is not a crate with nothing to
+  guard.
+- **ausfd** was already correct: all 7 writers and its 3 readers took `TEST_MUTEX`, and the two
+  tests that matched an audit grep without it touch neither `env::` nor the fallback. But the lock
+  lived **inside `mod tests`**, which is the latent form of exactly this defect, so it moved to
+  module scope beside the fallback. Relocation only; no test changed.
+- **amfd** writes `SMF_SBI_*` from **one** test, and that same test is the only one in
+  `ngap_path.rs` that reaches either reader (`smf_sbi_target`, `handle_ue_context_release`). One
+  writer with no concurrent reader is not this defect. Named rather than fixed. Residual, stated
+  because it is not zero: those readers `unwrap_or_else(|_| "127.0.0.1")` and default the port, so
+  an unset env is not an error — if a future test reaches the release path it will silently dial
+  whatever the writer installed rather than fail. 0 failures in 8 runs under load.
+
+## Decision 3: lmfd is in scope, because criterion 1 is the deliverable
+
+#308's body is smfd-only. Its **criterion 1** is not: "`cargo test --workspace` is green over at
+least 20 consecutive runs". With smfd fixed, 20 runs produced 2 failures — both
+`lmfd::tests::test_capabilities_handler_serves_the_derived_body` at `main.rs:3816`, which is the
+second flake the #217 measurement recorded ("smfd's UDM_SBI_* env fallback **and lmfd's context
+TOCTOU**") and which the issue text drops. Removing the retry makes it a red gate rather than an
+annotation, so leaving it would ship a criterion this PR claims to meet and a CI that fails on it.
+
+lmfd is the same defect with **zero** locks. `lmf_context_init` clears the cell-coordinate registry
+process-wide (32 tests call it), `seed_scene_and_build_multi_rtt_lpp` writes coordinates into the
+global context and never removes them, and `capabilities_body` derives `nrppaSupported` /
+`nlsInterfaceSupported` from exactly that registry. The test reads the served body from the handler
+and then recomputes the expected body from the context — so a wipe in that gap makes them disagree.
+Its own doc comment claimed the comparison "holds whatever state a sibling test has left behind",
+which is true of state left behind and false of state changed in the gap.
+
+`context::PROCESS_STATE_TEST_LOCK`, declared beside `GLOBAL_LMF_CONTEXT`, taken by all 58 tests that
+touch the context. All 58 rather than just the 33 mutators-plus-reader, because the cheap version is
+the writer-only asymmetry this PR exists to remove, and lmfd's suite pays 1.0 s → 3.05 s for it.
+
+## Decision 4: nextgcore-sbi's path-mode guard moves out of `mod tests`, and gains two readers
+
+The third flake, and the clearest instance of the whole pattern. `OAUTH2_PATH_MODE` selects the
+bespoke or the TS 29.510 OAuth2 resource paths process-wide. Its writers were **already correctly
+serialised** — ten `oauth.rs` tests take `lock_path_mode()` — but the guard was declared inside
+`oauth.rs`'s `mod tests`, so no sibling module could reach it, and the selector has readers in two:
+
+- `security.rs`'s `production_profile_configures_tls_mtls_and_oauth2` asserts the derived JWKS URI
+  is `/nnrf-oauth2/v1/jwks`. `apply_sbi_security_policy` derives it through `JwksCache::for_nrf`,
+  which consults the selector. Concurrent with `test_flag_flips_default_to_standard`, it gets
+  `/oauth2/retrieve-key`. **1 of 20 whole-workspace runs.**
+- `client.rs`'s `test_oauth2_token_attached_when_enabled` stubs a token endpoint at the bespoke path
+  only, so a flipped selector makes its client dial `/oauth2/token` and receive nothing.
+
+The guard moves beside `OAUTH2_PATH_MODE` as `pub(crate)`, and both readers take it. It also becomes
+a `tokio::sync::Mutex` with a sync (`blocking_lock`) and an async entry point, because two of the
+guarded tests — and now `client.rs`'s reader, a third — await while holding it, and a `std` guard
+held across an await blocks the executor thread. That is this repo's own recorded reason for
+preferring a tokio mutex for a test switch (it was written in `easdf.rs`'s switch-lock comment).
+
+It is **not** a clippy fix, and the first draft of this spec claimed it was on the strength of a
+cached `-p` run. Measured properly: `clippy::await_holding_lock` fires 21 times workspace-wide on
+both main and this branch, in `nssfd` (13), `udmd/sbi_path.rs` (3), `tsctsf` (3) and `hssd` (2) —
+none in `nextgcore-sbi` on either side, so the conversion changes no count. It is justified by what
+the guard does, not by the lint.
+
+`client.rs`'s reader was found by **widening the writer's window during the revert pass**, not by a
+failing run. It is the same defect one window narrower, and it is the argument for covering readers
+structurally rather than only the ones a sample happens to catch.
+
+## Decision 5: the ci.yml retry is removed, not narrowed
+
+The retry existed for two named races. This closes the first. The second — `free_port` handing out a
+port and unbinding it before the caller binds, with a per-**binary** issued-port set so two crates
+can be given the same port — genuinely remains, and is now filed as **#313** (its own doc claimed it
+was "tracked separately" while no such issue existed).
+
+Removing rather than narrowing, because a retry that passes ~96% of the time against a 20% flake is
+not a mitigation but a detector for the failures nobody looks at — it hid this for months behind a
+warning annotation. The port half did not occur once in ~60 whole-crate runs under synthetic 40-way
+load or 5 whole-workspace runs, so a rare red is the honest signal.
+
+The CONSTITUTION's no-TODO rule is satisfied by the issue existing, not by the comment moving.
+
+## Verification
+
+Reproduction harness: the smfd test binary under 40 synthetic busy loops, which is the only thing
+the whole-workspace run adds (`cargo test -p nextgcore-smfd` alone is green, as the issue says).
+12 s per run against ~75 s for a whole-workspace run, so the rate is measurable rather than argued.
+
+| claim | how it was made to fail | result |
+|---|---|---|
+| the flake is real and this harness sees it | run the harness on `8c3321b` | **3 / 10 failed**, in 3 distinct tests |
+| the flake is real on the whole-workspace run too | 5 whole-workspace runs on `8c3321b` | **1 / 5 failed** (`main.rs:8040`) |
+| the locking scheme is load-bearing | delete every first-line lock acquisition (38 lines: the collapse **and** the additions) | **10 / 10 failed** — 3 named tests, with the sibling's 40/80 Mbps values in the diff |
+| the 25 reader locks are load-bearing **on their own** | delete exactly those 25, keep the collapse | **0 / 30 failed — the revert did NOT bite** |
+| the fixed branch is green under the same load | run the harness on the branch | **0 / 20 failed** |
+| smfd's fix holds on the whole-workspace gate | 20 consecutive runs, smfd fixed, lmfd not yet | **0 smfd failures**; 2 lmfd |
+| lmfd's flake is real (this is the lmfd revert baseline) | the same 20 runs, lmfd unlocked | **2 / 20 failed**, same test both times |
+| nextgcore-sbi's flake is real | the same 20 runs, guard still inside `mod tests` | **1 / 20 failed** |
+| the sbi reader locks are load-bearing | revert the `security.rs` lock, widen the writer's window to 800 ms | **fails**, `left: ".../oauth2/retrieve-key"` — the production message exactly, plus a SECOND reader in `client.rs` this exposed |
+| …and the locks close it | keep the widened window, restore both reader locks | **green** |
+| all three fixes hold together | 20 consecutive `cargo test --workspace` runs | **0 / 20 failed** |
+| the added clippy warnings are none | `cargo clippy --workspace --all-targets`, branch vs stashed main | 21 `MutexGuard`-across-await on **both**, same four files; CI's `cargo clippy --workspace` is **0** on both |
+
+**The fourth row is the honest result and it is not the one I expected.** What carries the weight is
+the *collapse* of four locks into one, not the reader additions. Two further experiments were run to
+try to make the reader locks fail on their own, and both were negative for a reason worth recording:
+widening a writer's switch-ON window to 2–3 s and unlocking one reader still produced green runs,
+because `N4_TEST_LOCK` **incidentally** serialises most reader/writer pairs — both tests take a UPF
+stand-in, so they could never have overlapped. The one racing writer that takes no stand-in
+(`a_sdm_notification_…`) does not overlap the reader either, because the reader waits on the heavily
+contended N4 lock and by then the switch is off again.
+
+So the reader locks are kept on a **structural** argument, not a measured one, and this spec says so
+rather than implying a revert proved them: 25 tests read ambient state that a sibling writes, one of
+the three failures reproduced on main (`main.rs:8040`) *was* an unlocked reader with no lock at all,
+and the protection those tests currently have is a side effect of a lock that guards something else.
+A side effect is not an agreement. If a future change gives `associated_upf` a cheaper lock, the
+incidental serialisation disappears and the hazard is live again.
+
+## Ceilings
+
+- **The 0/20 whole-workspace result bounds the rate, it does not prove zero.** At the measured
+  pre-fix rate (~20%), 20 clean runs put the residual state-flake rate under roughly 15% with 95%
+  confidence — enough to say the 1-in-5 failure is gone, not enough to certify the suite
+  deterministic. The reader-lock hazard specifically is below this floor by construction.
+- **The reader locks are unfalsified, not verified.** See above. This is the one claim in the PR
+  that rests on reading the code rather than on a revert.
+- **lmfd's fix is verified statistically, not deterministically.** Its revert baseline is the 2/20
+  whole-workspace measurement, not a forced failure: `-p nextgcore-lmfd` under 40-way load is 0/12
+  with the locks reverted, and widening the reader's own TOCTOU gap to 500 ms with the locks reverted
+  is still green. Both negatives have one explanation — the failure needs a specific ORDER (a sibling
+  seeds coordinates, the handler reads them, another sibling wipes), and a crate-alone run does not
+  produce it. So the lmfd claim is: the flake was measured at 2/20, the mechanism is read from the
+  code, and 20 runs after the fix are clean.
+- **`free_port`'s cross-process window is untouched** (#313), and removing the retry makes it
+  visible rather than fixing it. This PR deliberately trades a hidden 20% for an exposed rare one.
+- **The audit was per-crate, not workspace-wide.** `rg 'set_var\("[A-Z]+_SBI_' src/bins/` covers the
+  `*_SBI_*` fallbacks #308 names — smfd, ausfd, udmd, amfd, plus nrfd's OAuth2 switches. The nrfd
+  ones are a different shape (each test sets its own boolean and the tests are in one module) and
+  were not audited; other process-globals in other crates were not audited at all.
+- **The 15+ crate-local `fn free_port` duplicates have no in-process guard either**, which is worse
+  than the shared helper and is scoped into #313 rather than fixed here.
+- **No E2E.** Everything here is one process's test binary; the Docker jobs are
+  `workflow_dispatch`-only and untouched.

--- a/src/bins/nextgcore-ausfd/src/app.rs
+++ b/src/bins/nextgcore-ausfd/src/app.rs
@@ -1523,6 +1523,19 @@ enum UdmAuthData {
     },
 }
 
+/// The ONE agreement about the `UDM_SBI_ADDR` / `UDM_SBI_PORT` environment and the
+/// process-wide AUSF context, for tests.
+///
+/// Moved out of `mod tests` by #308. Every writer and every reader of that
+/// environment in this crate already took it, so this is a relocation and not a
+/// behaviour change — but a lock declared inside a test submodule is unreachable
+/// from a sibling module, and the next module that needs it declares a second one.
+/// That is exactly how `smfd` ended up with four locks over one ambient state and a
+/// suite that failed 1 whole-workspace run in 5. Declared beside the fallback below
+/// so there is one place to find it.
+#[cfg(test)]
+pub(crate) static TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Send NUDM-UEAU generate-auth-data request to UDM via SBI client
 async fn send_udm_generate_auth_data(
     supi_or_suci: &str,
@@ -2086,9 +2099,7 @@ async fn run_event_loop_async(
 mod tests {
     use super::*;
 
-    /// Serialise integration tests that share global env vars (UDM_SBI_ADDR/PORT)
-    /// and the process-wide AUSF context.
-    static TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    use super::TEST_MUTEX;
 
     /// Initiate a 5G-AKA authentication session and return the confirmation href
     /// and the RAND bytes needed to compute a valid RES*.

--- a/src/bins/nextgcore-lmfd/src/context.rs
+++ b/src/bins/nextgcore-lmfd/src/context.rs
@@ -1167,6 +1167,30 @@ pub fn lmf_context_init(max_measurements: usize) {
     };
 }
 
+/// The ONE agreement about the process-global LMF context, for tests (#308).
+///
+/// [`lmf_context_init`] calls `LmfContext::init`, which clears the measurement,
+/// session and **cell-coordinate** registries for the whole process — 32 tests call
+/// it — and `seed_scene_and_build_multi_rtt_lpp` writes coordinates INTO the global
+/// one via [`LmfContext::set_cell_coord`] and never removes them. `capabilities_body`
+/// derives `nrppaSupported` / `nlsInterfaceSupported` from exactly that registry.
+///
+/// So `test_capabilities_handler_serves_the_derived_body` had a genuine TOCTOU: it
+/// reads the served body from `handle_capabilities()` and then recomputes the
+/// expected body from the context, and a sibling wiping or seeding coordinates
+/// between the two reads makes them disagree. Its own doc comment said the equality
+/// "holds whatever state a sibling test has left behind" — true of state left
+/// behind, false of state changed in the gap, which is why it failed 2 of 20
+/// `cargo test --workspace` runs while `-p nextgcore-lmfd` alone was always green.
+///
+/// Declared beside the global rather than inside `mod tests` so a sibling module
+/// reaches this static instead of declaring a second one, and taken by every test
+/// that touches the context — readers included. #308 measured what guarding only the
+/// writers is worth: nothing, with a lock to look at.
+#[cfg(test)]
+pub(crate) static PROCESS_STATE_TEST_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 pub fn lmf_context_final() {
     let ctx = lmf_self();
     if let Ok(mut context) = ctx.write() {

--- a/src/bins/nextgcore-lmfd/src/main.rs
+++ b/src/bins/nextgcore-lmfd/src/main.rs
@@ -2885,6 +2885,7 @@ mod tests {
 
     #[test]
     fn test_parse_qos() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.blocking_lock();
         assert_eq!(parse_qos("EMERGENCY"), PositioningQos::Emergency);
         assert_eq!(parse_qos("HIGH_ACCURACY"), PositioningQos::HighAccuracy);
         assert_eq!(parse_qos("whatever"), PositioningQos::BestEffort);
@@ -2961,6 +2962,7 @@ mod tests {
     // single test so no other test observes a partially-toggled state.
     #[tokio::test]
     async fn test_debug_endpoints_flag_gates_bespoke_routes() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
 
         // The bespoke/debug routes, each with the method it normally handles.
@@ -3030,6 +3032,7 @@ mod tests {
     // registry match) returns 500 POSITIONING_FAILED — never 200 with lat 0.0.
     #[tokio::test]
     async fn test_determine_location_empty_registry_no_fabricated_zero_fix() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         // A decodable Multi-RTT measurement for an UN-seeded PCI: no registry hit.
         let lpp = build_multi_rtt_lpp(&[(303, 5000)], 62);
@@ -3049,6 +3052,7 @@ mod tests {
     // -- lmfd-02 + lmfd-04: 200 OK with a GAD LocationDataExt ----------------
     #[tokio::test]
     async fn test_determine_location_returns_200_location_data_ext() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Seed a real fix (h_accuracy 50 < requested 100 -> FULFILLED).
         seed_fix("imsi-001010000000001", 50.0);
         let body = r#"{
@@ -3088,6 +3092,7 @@ mod tests {
     /// emergency or regulatory one) could not tell.
     #[tokio::test]
     async fn test_assured_qos_class_refuses_an_unmet_accuracy() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // 200 m achieved accuracy against a 10 m request: not fulfillable.
         seed_fix("imsi-001010000000101", 200.0);
         let request = |qos: &str| {
@@ -3149,6 +3154,7 @@ mod tests {
     /// previous fix makes it derivable, and omits it when it does not.
     #[tokio::test]
     async fn test_velocity_requested_populates_the_estimate_when_derivable() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // TWO fixes for the same UE, 10 s and ~111 m apart. The first is displaced
         // into `previous_location` by the second, which is the two-fix history the
         // derivation needs — a single fix has no velocity.
@@ -3196,6 +3202,7 @@ mod tests {
     // -- lmfd-04: shape negotiation honors supportedGADShapes ----------------
     #[tokio::test]
     async fn test_determine_location_negotiates_ellipse_shape() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         seed_fix("imsi-001010000000002", 40.0);
         let body = r#"{
             "supi": "imsi-001010000000002",
@@ -3213,6 +3220,7 @@ mod tests {
     // -- lmfd-03 + lmfd-10: ecgi/ncgi exclusion -> 400 ProblemDetails --------
     #[tokio::test]
     async fn test_determine_location_ecgi_ncgi_exclusion_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body = r#"{
             "ecgi": { "plmnId": { "mcc": "001", "mnc": "01" }, "eutraCellId": "0000001" },
             "ncgi": { "plmnId": { "mcc": "001", "mnc": "01" }, "nrCellId": "000000001" }
@@ -3233,6 +3241,7 @@ mod tests {
     // -- lmfd-03 + lmfd-10: malformed body -> 400 ProblemDetails -------------
     #[tokio::test]
     async fn test_determine_location_malformed_body_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let req = SbiRequest::post("/nlmf-loc/v1/determine-location")
             .with_body("not json", "application/json");
         let resp = handle_determine_location(&req).await;
@@ -3247,6 +3256,7 @@ mod tests {
     // to perform positioning procedure").
     #[tokio::test]
     async fn test_determine_location_timeout_504() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body = r#"{ "supi": "imsi-001010000000003", "maxRespTime": 0 }"#;
         let req =
             SbiRequest::post("/nlmf-loc/v1/determine-location").with_body(body, "application/json");
@@ -3271,6 +3281,7 @@ mod tests {
     // (never the retired invented cause, never a fabricated 200).
     #[tokio::test]
     async fn test_determine_location_unreachable_amf_504_unreachable_user() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // A SUPI never seeded by any test: no per-SUPI stored fix exists, so
         // the handler runs the live procedure and fails at AMF discovery.
         let body = r#"{ "supi": "imsi-001010000000404" }"#;
@@ -3294,6 +3305,7 @@ mod tests {
     // received but the solver produced no fix.
     #[tokio::test]
     async fn test_positioning_outcome_solver_failed_maps_to_500() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let input: nlmf::InputData =
             serde_json::from_str(r#"{ "supi": "imsi-001010000000405" }"#).unwrap();
@@ -3315,6 +3327,7 @@ mod tests {
     // -- A2: a real fix on the session channel -> 200 LocationDataExt --------
     #[tokio::test]
     async fn test_positioning_outcome_fix_maps_to_200() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let input: nlmf::InputData = serde_json::from_str(
             r#"{ "supi": "imsi-001010000000406",
@@ -3358,6 +3371,7 @@ mod tests {
     // -- A2: timeout on the session channel -> 504 + session expired ---------
     #[tokio::test]
     async fn test_positioning_outcome_timeout_504_and_session_expired() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         // NO_DELAY -> zero wait budget -> immediate timeout (no real sleeps).
         let input: nlmf::InputData = serde_json::from_str(
@@ -3385,6 +3399,7 @@ mod tests {
     // -- A2: no target UE identity -> 400 MANDATORY_IE_MISSING ---------------
     #[tokio::test]
     async fn test_determine_location_no_target_identity_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body = r#"{ "locationQoS": { "hAccuracy": 50.0 } }"#;
         let req =
             SbiRequest::post("/nlmf-loc/v1/determine-location").with_body(body, "application/json");
@@ -3397,6 +3412,7 @@ mod tests {
     // -- A2: stored fix served with an HONEST age (not hardcoded 0) ----------
     #[tokio::test]
     async fn test_determine_location_stored_fix_reports_real_age() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Captured 5 minutes ago.
         seed_fix_at("imsi-001010000000408", 40.0, unix_now() - 300);
         let body = r#"{ "supi": "imsi-001010000000408" }"#;
@@ -3414,6 +3430,7 @@ mod tests {
     // -- A2: a stored fix with UNKNOWN capture instant is not short-circuited -
     #[tokio::test]
     async fn test_determine_location_ageless_stored_fix_not_served() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // timestamp 0 = capture instant unknown -> age cannot be honoured ->
         // the live procedure runs (and 504s here: no AMF discoverable).
         seed_fix_at("imsi-001010000000409", 40.0, 0);
@@ -3430,6 +3447,7 @@ mod tests {
     // the MT-LR path — another UE's completed report is never served. --------
     #[tokio::test]
     async fn test_determine_location_never_serves_another_ues_report() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         // Complete a measurement report (for some unrelated request) so a
         // "global newest report" exists — the retired latest_location fallback
@@ -3530,6 +3548,7 @@ mod tests {
     // -- lmfd-12: unknown positioning method on the debug route -> 400 -------
     #[tokio::test]
     async fn test_measurement_request_unknown_method_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let body = r#"{ "amfUeNgapId": 1, "positioningMethod": "BOGUS" }"#;
         let req = SbiRequest::post("/nlmf-loc/v1/measurements").with_body(body, "application/json");
@@ -3543,6 +3562,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_configure_up_204() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body = r#"{
             "upNotifyCallBackUri": "http://af/up-notify",
             "notifCorrelationId": "nc-001",
@@ -3555,6 +3575,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_configure_up_missing_ue_id_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body = r#"{
             "upNotifyCallBackUri": "http://af/up-notify",
             "notifCorrelationId": "nc-002"
@@ -3570,6 +3591,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_measure_location_unknown_403() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body = r#"{}"#;
         let req =
             SbiRequest::post("/nlmf-loc/v1/measure-location").with_body(body, "application/json");
@@ -3583,6 +3605,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_location_context_transfer_204() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body = r#"{
             "amfId": "amf-01",
             "ldrType": "PERIODIC",
@@ -3602,6 +3625,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_location_context_transfer_bad_event_class_403() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body = r#"{
             "amfId": "amf-01",
             "ldrType": "UE_AVAILABLE",
@@ -3621,6 +3645,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cancel_location_lifecycle() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Seed an LDR session directly.
         lmf_self().read().unwrap().register_ldr(LdrContext {
             ldr_reference: "bb01".to_string(),
@@ -3650,6 +3675,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_up_subscribe_201_and_unsubscribe_204() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let body = r#"{
             "upNotifyCallBackUri": "http://af/up",
@@ -3702,6 +3728,7 @@ mod tests {
     /// forgotten one.
     #[tokio::test]
     async fn test_configure_up_persists_the_configuration() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let body = r#"{
             "upNotifyCallBackUri": "http://af/up-cfg",
@@ -3804,6 +3831,7 @@ mod tests {
     /// against a literal, so it holds whatever state a sibling test has left behind.
     #[tokio::test]
     async fn test_capabilities_handler_serves_the_derived_body() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let resp = handle_capabilities().await;
         assert_eq!(resp.status, 200);
@@ -3828,6 +3856,7 @@ mod tests {
     /// key would make a UE decipher assistance data into noise.
     #[tokio::test]
     async fn test_nlmf_broadcast_cipher_key_data() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
 
         let req = SbiRequest::post("/nlmf-broadcast/v1/cipher-key-data").with_body(
@@ -3866,6 +3895,7 @@ mod tests {
     /// `TS29572_Nlmf_DataExposure.yaml`.
     #[tokio::test]
     async fn test_nlmf_dataexposure_subscription_crud() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
 
         let body = r#"{
@@ -3996,6 +4026,7 @@ mod tests {
     /// relocation, and the stored record made it look live.
     #[tokio::test]
     async fn test_context_transfer_rearms_periodic_reporting() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
 
         let body = serde_json::json!({
@@ -4052,6 +4083,7 @@ mod tests {
     /// The honest half of the same change.
     #[tokio::test]
     async fn test_context_transfer_without_periodic_info_does_not_invent_a_cadence() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
 
         let body = serde_json::json!({
@@ -4096,6 +4128,7 @@ mod tests {
     /// reader of the issue does not "fix" it.
     #[tokio::test]
     async fn test_dummy_event_class_is_accepted_because_the_yaml_defines_it() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
 
         let transfer = |event_class: &str, reference: &str| {
@@ -4189,6 +4222,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_determine_location_assistance_data_204() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let body =
             r#"{"supi":"imsi-001010000000012","ueLocationServiceInd":"LOCATION_ASSISTANCE_DATA"}"#;
         let req =
@@ -4201,6 +4235,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_determine_location_deferred_ldr_registers_and_cancellable() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         seed_fix("imsi-001010000000013", 40.0);
         let body = r#"{
             "supi": "imsi-001010000000013",
@@ -4354,6 +4389,7 @@ mod tests {
     // -- A5 acceptance: LPP bytes reach the decode adapter -> a real fix ------
     #[tokio::test]
     async fn test_determine_location_multipart_lpp_produces_fix_200() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let lpp = seed_scene_and_build_multi_rtt_lpp(55);
         let input = r#"{"supi":"imsi-001010000000501",
@@ -4384,6 +4420,7 @@ mod tests {
     // fallen through to the network path (504). 500-vs-504 is the discriminator.
     #[tokio::test]
     async fn test_determine_location_multipart_lpp_no_fix_500() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let lpp = build_multi_rtt_lpp(&[(301, 5000)], 60);
         let input = r#"{"supi":"imsi-001010000000502","lppMessage":{"contentId":"lpp-1"}}"#;
@@ -4397,6 +4434,7 @@ mod tests {
     // -- A5 acceptance: a dangling contentId fails 400 (never silently ignored) -
     #[tokio::test]
     async fn test_determine_location_lpp_dangling_content_id_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let lpp = build_multi_rtt_lpp(&[(301, 5000)], 61);
         // lppMessage references "lpp-missing"; the part carries a DIFFERENT id.
@@ -4415,6 +4453,7 @@ mod tests {
     // -- A5: a lppMessage IE with NO multipart parts at all -> 400 ------------
     #[tokio::test]
     async fn test_determine_location_lpp_ref_without_parts_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         // application/json body (no binary parts) carrying a lppMessage ref.
         let body = r#"{"supi":"imsi-001010000000504","lppMessage":{"contentId":"lpp-x"}}"#;
@@ -4429,6 +4468,7 @@ mod tests {
     // -- A5: content-type gate rejects unsupported media types with 415 -------
     #[tokio::test]
     async fn test_determine_location_unsupported_media_type_415() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let req = SbiRequest::post("/nlmf-loc/v1/determine-location")
             .with_body("not json or multipart", "text/plain");
         let resp = handle_determine_location(&req).await;
@@ -4447,6 +4487,7 @@ mod tests {
     // gate (application/json) or the multipart branch (no parts).
     #[tokio::test]
     async fn test_determine_location_plain_json_unaffected() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         seed_fix("imsi-001010000000505", 50.0);
         let body = r#"{
             "supi": "imsi-001010000000505",
@@ -4469,6 +4510,7 @@ mod tests {
     // handler round-trip (TS 29.500 boundary handling), yielding the same fix.
     #[tokio::test]
     async fn test_determine_location_multipart_roundtrip_via_sbi_codec() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         use bytes::Bytes;
         use nextgcore_sbi::message::SbiPart;
         use nextgcore_sbi::multipart;
@@ -4616,6 +4658,7 @@ mod tests {
     // callback handler completes a pending session with a measurement-derived fix.
     #[tokio::test]
     async fn test_n1_message_notify_strict_peer_completes_session_with_fix() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         use nextgcore_sbi::multipart;
         lmf_context_init(1024);
         let supi = "imsi-001010000000601";
@@ -4702,6 +4745,7 @@ mod tests {
     // -- A4: an unknown lcsCorrelationId / LPP transaction → 404, no ingestion.
     #[tokio::test]
     async fn test_n1_message_notify_unknown_correlation_404() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         // txn 249 + a fresh UUID correlation: neither matches any session.
         let lpp = build_ecid_lpp(42, 60, 800, 249);
@@ -4731,6 +4775,7 @@ mod tests {
     // -- A4: jsonData references a contentId with no matching part → 400.
     #[tokio::test]
     async fn test_n1_message_notify_missing_binary_part_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let json = "{\"n1MessageContainer\":{\"n1MessageClass\":\"LPP\",\
              \"n1MessageContent\":{\"contentId\":\"n1-lpp\"}},\
@@ -4748,6 +4793,7 @@ mod tests {
     // the session; the report is attached to the session's request_id.
     #[tokio::test]
     async fn test_n2_info_notify_completes_session() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let supi = "imsi-001010000000602";
         let ctx = lmf_self();
@@ -4798,6 +4844,7 @@ mod tests {
     // -- A4: N2InfoNotify with an unknown lcsCorrelationId → 404.
     #[tokio::test]
     async fn test_n2_info_notify_unknown_correlation_404() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let nrppa = build_nrppa_ecid_report();
         let json = format!(
@@ -5109,6 +5156,7 @@ mod a8_event_notify_tests {
     // -- A8 acceptance: exactly reportingAmount callbacks, then the task stops.
     #[tokio::test]
     async fn test_periodic_ldr_emits_exact_amount_then_stops() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let (server, port) = start_sink().await;
         let path = "/sink/a8-exact/cb";
@@ -5166,6 +5214,7 @@ mod a8_event_notify_tests {
     // -- A8 acceptance: cancel-location mid-stream stops emission.
     #[tokio::test]
     async fn test_periodic_ldr_cancel_stops_emission() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let (server, port) = start_sink().await;
         let path = "/sink/a8-cancel/cb";
@@ -5204,6 +5253,7 @@ mod a8_event_notify_tests {
     // retried forever (one report + one retry, then the session is dropped).
     #[tokio::test]
     async fn test_periodic_ldr_failing_gmlc_auto_cancels() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         lmf_context_init(1024);
         let (server, port) = start_sink().await;
         let path = "/sink/a8-fail/cb";
@@ -5323,6 +5373,7 @@ mod a8_event_notify_tests {
     // -- A8 unit: callback-URI splitter (host/port/path + scheme defaults). ---
     #[test]
     fn test_split_callback_uri() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.blocking_lock();
         assert_eq!(
             split_callback_uri("http://10.0.0.5:8080/gmlc/cb"),
             Some(("10.0.0.5".to_string(), 8080, "/gmlc/cb".to_string()))
@@ -5620,6 +5671,7 @@ mod positioning_chain_strict_peer {
     /// returns a measurement-derived fix, driven end-to-end across BOTH real NFs.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_positioning_chain_returns_200_computed_fix_via_real_amfd() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Drives REAL amfd peer-call code against a loopback PLAINTEXT stub, i.e.
         // describes a dev-profile deployment (issue #63). Declared, not inherited.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
@@ -5717,6 +5769,7 @@ mod positioning_chain_strict_peer {
     /// the real harness (proving the A2 leg), then fail-closes.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_positioning_chain_silent_ue_times_out_504() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let _serial = chain_lock().lock().await;
         let supi = "imsi-001010000000702".to_string();
 
@@ -5741,6 +5794,7 @@ mod positioning_chain_strict_peer {
     /// POSITIONING_FAILED (TS 29.572 Table 6.1.7.3-1), never a fabricated fix.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_positioning_chain_corrupt_lpp_reply_maps_to_500() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Drives REAL amfd peer-call code against a loopback PLAINTEXT stub, i.e.
         // describes a dev-profile deployment (issue #63). Declared, not inherited.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
@@ -5799,6 +5853,7 @@ mod positioning_chain_strict_peer {
     /// pending. Driven through lmfd's REAL notify handler + amfd's REAL producer.
     #[tokio::test]
     async fn test_positioning_chain_correlation_isolation() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let _serial = chain_lock().lock().await;
         lmf_context_init(1024);
         let supi_a = "imsi-001010000000704";
@@ -5893,6 +5948,7 @@ mod positioning_chain_strict_peer {
     /// killing the "prepared and logged" (log-only) non-delivery.
     #[tokio::test]
     async fn test_h4_lmfd_transfer_strict_peer_amfd_extracts_exact_lpp() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let _serial = chain_lock().lock().await;
         let supi = "imsi-001010000000731";
         seed_amf_connected_ue(supi);
@@ -5934,6 +5990,7 @@ mod positioning_chain_strict_peer {
     /// real handler (TS 29.518 Table 6.1.7.3-1) — not a fake 200.
     #[tokio::test]
     async fn test_h4_lmfd_transfer_idle_ue_504_ue_not_reachable() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let _serial = chain_lock().lock().await;
         let supi = "imsi-001010000000732";
         seed_amf_idle_ue(supi);
@@ -5950,6 +6007,7 @@ mod positioning_chain_strict_peer {
     /// amfd's real handler (the transfer can never land for an absent UE).
     #[tokio::test]
     async fn test_h4_lmfd_transfer_unknown_ue_404() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let _serial = chain_lock().lock().await;
         nextgcore_amfd::test_support::init_context();
         let supi = "imsi-001019999999999"; // never seeded

--- a/src/bins/nextgcore-smfd/src/context.rs
+++ b/src/bins/nextgcore-smfd/src/context.rs
@@ -3083,6 +3083,52 @@ pub fn smf_context_init(max_ue: usize, max_sess: usize, max_bearer: usize) {
     };
 }
 
+/// The ONE agreement about this process's ambient SMF state, for tests (#308).
+///
+/// Four globals are involved and they cannot be guarded separately, because the
+/// production paths under test read all four together:
+/// - [`GLOBAL_SMF_CONTEXT`] — [`smf_context_init`] calls `SmfContext::init`, which
+///   clears the UE, session, bearer, policy-binding and PFCP-session maps for the
+///   WHOLE process rather than for the test that asked;
+/// - `udm::UDM_ENABLED`, `easdf`'s config slot and `eps_iwk::EPS_IWK_ENABLED` — the
+///   feature switches `handle_sm_context_create` / `_release` consult, so a sibling
+///   that turns one ON changes what a create does in a test that never mentions it;
+/// - the `UDM_SBI_ADDR` / `UDM_SBI_PORT` / `NRF_URI` environment — the fallback
+///   `discover_udm_service_endpoint` resolves, which names one UDM for every `nudm`
+///   service, so whoever wrote it last owns every sibling's UDM traffic.
+///
+/// Before #308 the writers of the last two were locked (three per-module
+/// `SWITCH_LOCK`s plus a crate-root `UDM_ENV_TEST_LOCK`) and the READERS were not,
+/// and the context wipe was not guarded at all. That asymmetry is not a smaller
+/// version of the same protection, it is none: `cargo test --workspace` failed
+/// about 1 run in 5 in three different tests, each one a locked writer and an
+/// unlocked reader disagreeing about a global neither test names —
+/// - a create-path test read a sibling's subscribed session-AMBR (40/80 Mbps) in
+///   place of the config default, because the sibling's UDM switch was still on;
+/// - a release-path test's `DELETE` landed on another test's recording UDM, which
+///   then found it instead of its own `PUT`;
+/// - a sibling `smf_context_init` cleared the policy bindings between a create and
+///   the assertion that the create had stored one.
+///
+/// Four locks over one ambient state were four disjoint agreements: each
+/// serialised its own writers and none could order a test that did not know about
+/// it. This is deliberately ONE lock, declared beside the largest of the globals
+/// it guards rather than inside any `mod tests`, so every module reaches the same
+/// static (`pub(crate)`) instead of declaring its own — #276 showed that a second
+/// lock over shared state HANGS the suite rather than merely flaking it.
+///
+/// Lock order, for a test that needs a UPF as well: take THIS one first, then
+/// [`crate::pfcp_path::N4_TEST_LOCK`] (which
+/// [`crate::pfcp_path::stand_in::associated_upf`] takes on the test's behalf and
+/// holds for the life of the returned value). Every call site in the crate follows
+/// that order; reversing it anywhere reintroduces a deadlock.
+///
+/// Sync `#[test]` functions take it with `blocking_lock()`, which is sound
+/// precisely because they have no runtime to block.
+#[cfg(test)]
+pub(crate) static PROCESS_STATE_TEST_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 /// Finalize the global SMF context
 pub fn smf_context_final() {
     let ctx = smf_self();
@@ -3253,6 +3299,7 @@ mod tests {
 
     #[test]
     fn test_cascade_removal() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.blocking_lock();
         let mut ctx = SmfContext::new();
         ctx.init(100, 200, 400);
 

--- a/src/bins/nextgcore-smfd/src/easdf.rs
+++ b/src/bins/nextgcore-smfd/src/easdf.rs
@@ -84,22 +84,15 @@ pub fn enabled() -> bool {
     EASDF_ENABLED.load(Ordering::SeqCst)
 }
 
-/// Serialises every test that touches the process-global switch (#114).
-///
-/// `EASDF_ENABLED` is a static and `EASDF_CONFIG` a `OnceLock`, so a test that
-/// toggles either while a sibling is mid-flight changes the sibling's answer —
-/// which is exactly how the two tests in this module failed on their first run.
-/// Public within the crate because `main.rs`'s tests toggle the same switch: a
-/// lock private to this module's test submodule would be two disjoint agreements
-/// about one variable.
-///
-/// A `tokio::sync::Mutex`, not a `std` one: every holder awaits while holding it
-/// (they drive loopback servers), and a `std` guard held across an await blocks
-/// the executor thread — `clippy::await_holding_lock`.
-#[cfg(test)]
-pub static SWITCH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
 /// Test-only: enable/disable without going through startup.
+///
+/// `EASDF_ENABLED` is a static and `EASDF_CONFIG` a `RwLock`, so a test that toggles
+/// either while a sibling is mid-flight changes the sibling's answer — which is
+/// exactly how the two tests in this module failed on their first run (#114).
+///
+/// The caller must therefore hold [`crate::context::PROCESS_STATE_TEST_LOCK`]. This
+/// module kept a switch lock of its own until #308, which showed that one lock per
+/// switch cannot order a test that names no switch at all.
 #[cfg(test)]
 pub fn set_for_test(config: Option<EasdfConfig>) {
     let enabled = config.is_some();
@@ -378,8 +371,6 @@ pub(crate) mod tests {
         assert_eq!(dnscontext_endpoint(&profile), None);
     }
 
-    use super::SWITCH_LOCK;
-
     /// The create decision, as a pure function: no config, or a config naming no
     /// edge pattern, means no DNS context.
     ///
@@ -412,7 +403,7 @@ pub(crate) mod tests {
     /// produced — the guard on the default posture.
     #[tokio::test]
     async fn the_leg_is_off_by_default() {
-        let _g = SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         set_for_test(None);
         assert!(!enabled());
         assert_eq!(
@@ -523,7 +514,7 @@ pub(crate) mod tests {
     /// happened.
     #[tokio::test]
     async fn the_dns_context_is_created_and_deleted_over_the_wire() {
-        let _g = SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let (nrf, easdf, seen) = spawn_nrf_and_easdf().await;
 
         let ctx_id = create_dns_context(

--- a/src/bins/nextgcore-smfd/src/eps_iwk.rs
+++ b/src/bins/nextgcore-smfd/src/eps_iwk.rs
@@ -58,16 +58,12 @@ pub fn enabled() -> bool {
     EPS_IWK_ENABLED.load(Ordering::SeqCst)
 }
 
-/// Serialises every test that touches the process-global switch.
-///
-/// Public within the crate because `main.rs`'s tests toggle the same variable; a
-/// lock private to this module would be a second disjoint agreement about one
-/// variable, which is the collision shape this repo keeps recording (and which
-/// #276 hit as a hang rather than a flake).
-#[cfg(test)]
-pub static SWITCH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
 /// Test-only: set the switch without going through startup.
+///
+/// The caller must hold [`crate::context::PROCESS_STATE_TEST_LOCK`]. This module kept
+/// a switch lock of its own until #308: one lock per switch serialises that switch's
+/// writers and orders nothing else, and the release path reads this switch from tests
+/// that never mention interworking.
 #[cfg(test)]
 pub fn set_for_test(on: bool) {
     EPS_IWK_ENABLED.store(on, Ordering::SeqCst);
@@ -343,7 +339,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_disabled_leg_dials_nothing() {
-        let _g = SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         set_for_test(false);
         // A URI that would fail loudly if it were dialled at all.
         assert_eq!(
@@ -428,7 +424,7 @@ mod tests {
         // would make this test fail for a reason unrelated to what it asserts.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
 
-        let _g = SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         set_for_test(true);
 
         let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>> =
@@ -517,6 +513,7 @@ mod tests {
     /// in the context and no GTPv2 message is involved anywhere.
     #[test]
     fn the_assigned_ebi_reaches_smf_bearer_without_the_gtpv2_path() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.blocking_lock();
         use crate::context::{smf_context_init, smf_self};
 
         smf_context_init(64, 256, 512);

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -1158,20 +1158,6 @@ impl DefaultDnnError {
     }
 }
 
-/// The ONE agreement about the `UDM_SBI_ADDR` / `UDM_SBI_PORT` / `NRF_URI`
-/// environment, for tests.
-///
-/// Declared at the crate root rather than inside `mod tests` because `udm.rs`'s
-/// tests set the same variables (#79) and a sibling module cannot reach a static
-/// inside this file's test submodule. It was in `mod tests` first, and the result
-/// was a flaky `the_smf_registers_with_the_udm_and_fetches_sm_data`: another test
-/// re-pointed `UDM_SBI_PORT` at its own loopback UDM between the registration and
-/// the `sm-data` fetch, so the fetch reached a server that answers 201 to
-/// everything and returned no subscription. Env is per-process; two locks over it
-/// are two disjoint agreements.
-#[cfg(test)]
-pub(crate) static UDM_ENV_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
 /// Resolve a UDM `nudm-sdm` endpoint.
 ///
 /// NRF discovery first (TS 29.510 §5.3.2), because that is the mechanism a real
@@ -5972,6 +5958,7 @@ mod tests {
     /// a source-grepping guard would match its own justification.
     #[tokio::test]
     async fn create_sm_context_without_supi_is_rejected() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         smf_context_init(64, 256, 512);
         let body = serde_json::json!({
             "pduSessionId": 5,
@@ -6255,11 +6242,6 @@ mod tests {
         }
     }
 
-    /// The lock over the `UDM_SBI_*` / `NRF_URI` environment now lives at the crate
-    /// root, because `udm.rs`'s tests take the SAME one (#79). Re-exported under the
-    /// local name so the call sites below are unchanged.
-    use super::UDM_ENV_TEST_LOCK;
-
     /// **Issue #204, end to end.** `fetch_subscribed_default_dnn` really reaches a
     /// UDM, sends a conformant `Nudm_SDM_Get smf-select-data` with a
     /// percent-encoded `single-nssai`, and returns the flagged DNN.
@@ -6268,7 +6250,7 @@ mod tests {
     /// and the plumbing around it, which is the half a unit test cannot see.
     #[tokio::test]
     async fn fetch_subscribed_default_dnn_queries_the_udm_and_returns_the_flagged_dnn() {
-        let _guard = UDM_ENV_TEST_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // The stub UDM is a loopback PLAINTEXT peer, which describes a dev-profile
         // deployment; the default profile is Production and would require client
         // TLS material this test has no business inventing.
@@ -6366,7 +6348,7 @@ mod tests {
     /// REFUSED with a cause that says so — never a silent `"internet"`.
     #[tokio::test]
     async fn dnn_less_create_with_no_udm_is_refused_not_defaulted() {
-        let _guard = UDM_ENV_TEST_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         std::env::remove_var("UDM_SBI_ADDR");
         std::env::remove_var("UDM_SBI_PORT");
         std::env::remove_var("NRF_URI");
@@ -6419,6 +6401,7 @@ mod tests {
     /// The path portion is extracted from an absolute AMF callback URI.
     #[test]
     fn uri_path_extraction() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.blocking_lock();
         assert_eq!(
             uri_path("http://amf.example:7777/namf-comm/v1/ue-contexts/imsi-1/sm-context-status/7"),
             "/namf-comm/v1/ue-contexts/imsi-1/sm-context-status/7"
@@ -6481,6 +6464,7 @@ mod tests {
     /// handler that parsed nothing.
     #[tokio::test]
     async fn easdf_dns_report_is_attributed_to_its_session() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         seed_binding("easdf-report-ref", 7);
         // Give that session a DNS context id to be matched against.
         if let Ok(ctx) = smf_self().read() {
@@ -6569,8 +6553,9 @@ mod tests {
     /// green (#276).
     #[tokio::test]
     async fn a_failed_establishment_creates_no_easdf_dns_context() {
-        // Lock order (see `pfcp_path::N4_TEST_LOCK`): switch lock first, N4 second.
-        let _g = easdf::SWITCH_LOCK.lock().await;
+        // Lock order (see `context::PROCESS_STATE_TEST_LOCK`): ambient state first,
+        // N4 second — `stand_in` takes the N4 lock on this test's behalf.
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let _upf = pfcp_path::stand_in::unassociated_upf().await;
         let (nrf, easdf_srv, seen) = easdf::tests::spawn_nrf_and_easdf().await;
         smf_context_init(64, 256, 512);
@@ -6634,8 +6619,9 @@ mod tests {
     /// context that can never match a query.
     #[tokio::test]
     async fn an_established_session_creates_its_easdf_dns_context() {
-        // Lock order (see `pfcp_path::N4_TEST_LOCK`): switch lock first, N4 second.
-        let _g = easdf::SWITCH_LOCK.lock().await;
+        // Lock order (see `context::PROCESS_STATE_TEST_LOCK`): ambient state first,
+        // N4 second — `stand_in` takes the N4 lock on this test's behalf.
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let upf = pfcp_path::stand_in::associated_upf().await;
         let (nrf, easdf_srv, seen) = easdf::tests::spawn_nrf_and_easdf().await;
         smf_context_init(64, 256, 512);
@@ -6690,7 +6676,7 @@ mod tests {
     /// wiring is not", for the third time in this session.
     #[tokio::test]
     async fn releasing_a_session_deletes_its_easdf_dns_context() {
-        let _g = easdf::SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let (nrf, easdf_srv, seen) = easdf::tests::spawn_nrf_and_easdf().await;
 
         seed_binding("easdf-release-ref", 9);
@@ -6735,7 +6721,7 @@ mod tests {
     /// deletes (204). Returns the recorded `(method, uri, body)` list (#293).
     ///
     /// Points `UDM_SBI_*` at itself, which is how both discovery paths find a UDM in
-    /// tests; the caller must hold `crate::UDM_ENV_TEST_LOCK`.
+    /// tests; the caller must hold [`crate::context::PROCESS_STATE_TEST_LOCK`].
     async fn spawn_recording_udm(
         sm_data: serde_json::Value,
     ) -> (
@@ -6897,7 +6883,7 @@ mod tests {
     /// asserted is a recorded HTTP request with the identity in it.
     #[tokio::test]
     async fn releasing_a_session_returns_its_ebi_to_the_amf() {
-        let _g = eps_iwk::SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         eps_iwk::set_for_test(true);
         let (amf, amf_uri, seen) = spawn_recording_amf().await;
@@ -6966,7 +6952,7 @@ mod tests {
     /// even for a binding that carries an EBI from an earlier enabled run.
     #[tokio::test]
     async fn a_disabled_interworking_leg_releases_no_ebi() {
-        let _g = eps_iwk::SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         eps_iwk::set_for_test(false);
         let (amf, amf_uri, seen) = spawn_recording_amf().await;
@@ -6999,7 +6985,7 @@ mod tests {
     /// fails at connect.
     #[tokio::test]
     async fn a_failed_ebi_release_does_not_fail_the_session_release() {
-        let _g = eps_iwk::SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         eps_iwk::set_for_test(true);
 
@@ -7029,8 +7015,7 @@ mod tests {
     /// Lock order (see `pfcp_path::N4_TEST_LOCK`): switch locks first, N4 last.
     #[tokio::test]
     async fn the_create_subscribes_to_sm_data_and_the_release_deregisters_and_unsubscribes() {
-        let _g = udm::SWITCH_LOCK.lock().await;
-        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let upf = pfcp_path::stand_in::associated_upf().await;
         let (udm_srv, seen) = spawn_recording_udm(sm_data_with("100 Mbps", "500 Mbps", 7)).await;
@@ -7139,8 +7124,7 @@ mod tests {
     /// PCF the authority and the subscription is one of its inputs.
     #[tokio::test]
     async fn a_sdm_notification_applies_the_changed_ambr_to_a_live_session() {
-        let _g = udm::SWITCH_LOCK.lock().await;
-        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         // The UDM now answers with DIFFERENT values from the ones the session holds.
         let (udm_srv, seen) = spawn_recording_udm(sm_data_with("40 Mbps", "80 Mbps", 6)).await;
@@ -7271,8 +7255,7 @@ mod tests {
     /// cannot release during a UDM outage.
     #[tokio::test]
     async fn a_failed_udm_teardown_does_not_fail_the_session_release() {
-        let _g = udm::SWITCH_LOCK.lock().await;
-        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         udm::set_for_test(true);
         std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
@@ -7308,8 +7291,7 @@ mod tests {
     /// for a binding that carries a subscription id from an earlier enabled run.
     #[tokio::test]
     async fn a_disabled_udm_leg_neither_deregisters_nor_unsubscribes() {
-        let _g = udm::SWITCH_LOCK.lock().await;
-        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let (udm_srv, seen) = spawn_recording_udm(sm_data_with("100 Mbps", "500 Mbps", 7)).await;
         udm::set_for_test(false);
@@ -7423,6 +7405,7 @@ mod tests {
     /// container must run the 5GSM procedure, not fall through to `upCnxState`.
     #[tokio::test]
     async fn modify_with_only_an_n1_container_runs_the_release_procedure() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let reference = "n77-release";
         seed_binding(reference, 5);
 
@@ -7567,6 +7550,7 @@ mod tests {
 
     #[tokio::test]
     async fn n1_message_for_an_unknown_context_is_404_and_a_malformed_one_400() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         smf_context_init(64, 256, 512);
         let resp = handle_n1_sm_message(
             "n77-absent",
@@ -7866,6 +7850,7 @@ mod tests {
 
     #[test]
     fn smf_yaml_dns_and_mtu_are_parsed() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.blocking_lock();
         // The shipped docker config has declared these all along; nothing read
         // them, so the UE received no DNS configuration.
         let dir = std::env::temp_dir();
@@ -7940,6 +7925,7 @@ mod tests {
     /// `a_successful_create_registers_an_activated_session_and_its_binding` below.
     #[tokio::test]
     async fn a_failed_create_leaves_no_registered_sm_context() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let _upf = pfcp_path::stand_in::unassociated_upf().await;
         smf_context_init(64, 256, 512);
         let supi = "imsi-001010000000086";
@@ -7994,6 +7980,7 @@ mod tests {
     /// executing the step it names, so no early return can satisfy them.
     #[tokio::test]
     async fn a_successful_create_registers_an_activated_session_and_its_binding() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let upf = pfcp_path::stand_in::associated_upf().await;
         smf_context_init(64, 256, 512);
         let supi = "imsi-001010000000290";
@@ -8071,6 +8058,7 @@ mod tests {
     /// separately from the same counter would have left it one behind.
     #[test]
     fn register_sm_context_returns_the_reference_that_resolves_to_it() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.blocking_lock();
         smf_context_init(64, 256, 512);
         let ctx = smf_self();
         let context = ctx.read().expect("context");
@@ -8118,6 +8106,7 @@ mod tests {
     /// registration yields is the one that resolves.
     #[test]
     fn a_registered_session_resolves_by_the_reference_it_minted() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.blocking_lock();
         smf_context_init(64, 256, 512);
         let ctx = smf_self();
         let context = ctx.read().expect("context");
@@ -8154,6 +8143,7 @@ mod tests {
     /// identity — and the unchanged-when-absent half is criterion 5.
     #[tokio::test]
     async fn the_retrieved_ue_eps_pdn_connection_names_the_assigned_ebi() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         use base64::Engine as _;
 
         let without = seed_registered_session("imsi-001010000000123", 7, "internet");
@@ -8384,6 +8374,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn a_released_session_notifies_its_event_subscriber() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
 
         let _g = event_exposure::lock_store();
@@ -8581,6 +8572,7 @@ mod tests {
     /// `404 CONTEXT_NOT_FOUND` for a session that had just been created.
     #[tokio::test]
     async fn retrieve_answers_200_with_ue_eps_pdn_connection() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let reference = seed_registered_session("imsi-001010000000078", 7, "internet");
 
         let resp = handle_sm_context_retrieve(&reference).await;
@@ -8614,6 +8606,7 @@ mod tests {
     /// `application/json` it used to send.
     #[tokio::test]
     async fn retrieve_of_an_unknown_ref_is_404_problem_details() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         smf_context_init(64, 256, 512);
         let resp = handle_sm_context_retrieve("no-such-ref-78").await;
         assert_eq!(resp.status, 404);
@@ -8632,6 +8625,7 @@ mod tests {
     /// everything would satisfy the first alone.
     #[tokio::test]
     async fn update_rejects_an_unknown_ref_and_still_serves_a_known_one() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let reference = seed_registered_session("imsi-001010000000079", 9, "internet");
 
         let unknown = SbiRequest::post("/nsmf-pdusession/v1/sm-contexts/nope-78/modify").with_body(
@@ -8659,6 +8653,7 @@ mod tests {
     /// known one parses `SmContextReleaseData` and answers 204.
     #[tokio::test]
     async fn release_rejects_an_unknown_ref_and_parses_release_data() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let reference = seed_registered_session("imsi-001010000000080", 3, "internet");
 
         let unknown = SbiRequest::post("/nsmf-pdusession/v1/sm-contexts/gone-78/release")
@@ -8727,6 +8722,7 @@ mod tests {
     /// "rejected".
     #[tokio::test]
     async fn n2_handover_states_are_processed_not_refused() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let reference = seed_registered_session("imsi-001010000000081", 5, "internet");
 
         for (info_type, requested, expected) in [
@@ -8766,6 +8762,7 @@ mod tests {
     /// operator unable to tell a switched tunnel from an unswitched one.
     #[tokio::test]
     async fn handover_complete_without_a_target_endpoint_still_completes() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         let reference = seed_registered_session("imsi-001010000000082", 6, "internet");
         let req = SbiRequest::post("/nsmf-pdusession/v1/sm-contexts/x/modify").with_body(
             serde_json::json!({
@@ -8872,6 +8869,7 @@ mod tests {
     /// `trigger_service_request` flag, both of which the issue explicitly rules out.
     #[tokio::test]
     async fn a_downlink_data_report_pages_the_ue_via_the_amf() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
         // dev-profile deployment. Declared rather than inherited: the default
         // `SbiProfile` is Production, which would refuse the plaintext connection and
@@ -8974,6 +8972,7 @@ mod tests {
     /// pages" would be satisfied by a version that pages unconditionally.
     #[tokio::test]
     async fn a_downlink_data_report_for_an_active_connection_does_not_page() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
         // dev-profile deployment. Declared rather than inherited: the default
         // `SbiProfile` is Production, which would refuse the plaintext connection and

--- a/src/bins/nextgcore-smfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-smfd/src/pfcp_path.rs
@@ -915,9 +915,12 @@ pub fn clear_pfcp_sessions() -> usize {
 /// (`pub(crate)`) instead of being re-declared there.
 ///
 /// Lock order, where a test needs more than one process-global: take
-/// `easdf::SWITCH_LOCK` (or any other module's switch lock) FIRST, then this
+/// [`crate::context::PROCESS_STATE_TEST_LOCK`] — the one agreement about the SMF
+/// context, the feature switches and the `UDM_SBI_*` environment — FIRST, then this
 /// one. Every call site in the crate follows that order; reversing it anywhere
-/// reintroduces the deadlock this comment exists to prevent.
+/// reintroduces the deadlock this comment exists to prevent. Note that
+/// [`stand_in::associated_upf`] takes THIS lock on the caller's behalf, so a test
+/// that wants both must take the ambient one itself and let the stand-in take this.
 #[cfg(test)]
 pub(crate) static N4_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
@@ -1557,6 +1560,7 @@ mod tests {
     /// instead of establishing. There is one installer in the test build.
     #[tokio::test]
     async fn test_select_upf_defaults_to_global_client_and_bindings_resolve() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Association state is irrelevant to a single-peer pool: `select_upf`
         // returns the default client without consulting it (the load-aware path
         // needs the feature AND more than one peer).
@@ -1689,6 +1693,7 @@ mod tests {
     /// and the restored sessions are never questioned.
     #[tokio::test]
     async fn a_seeded_recovery_time_stamp_makes_a_peer_restart_detectable() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Serialised: this test can reach a teardown, which flushes the
         // process-global session map (see N4_TEST_LOCK).
         let _map_guard = N4_TEST_LOCK.lock().await;
@@ -1735,6 +1740,7 @@ mod tests {
     /// pointless.
     #[tokio::test]
     async fn an_unchanged_recovery_time_stamp_leaves_restored_sessions_alone() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         // Serialised: this test can reach a teardown, which flushes the
         // process-global session map (see N4_TEST_LOCK).
         let _map_guard = N4_TEST_LOCK.lock().await;

--- a/src/bins/nextgcore-smfd/src/udm.rs
+++ b/src/bins/nextgcore-smfd/src/udm.rs
@@ -80,11 +80,11 @@ pub fn smf_instance_id() -> &'static str {
     SMF_INSTANCE_ID.get_or_init(|| uuid::Uuid::new_v4().to_string())
 }
 
-/// Serialises tests that touch the process-global switch. `pub` within the crate
-/// because `main.rs`'s tests toggle the same variable — one agreement, not two.
-#[cfg(test)]
-pub static SWITCH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
+/// Test-only: set the switch without going through startup.
+///
+/// The caller must hold [`crate::context::PROCESS_STATE_TEST_LOCK`]: this switch is
+/// one of the four ambient globals that lock covers, and #308 showed that guarding
+/// the writers while leaving the readers free is not weaker protection but none.
 #[cfg(test)]
 pub fn set_for_test(on: bool) {
     UDM_ENABLED.store(on, Ordering::SeqCst);
@@ -757,7 +757,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_disabled_leg_neither_fetches_nor_registers() {
-        let _g = SWITCH_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         set_for_test(false);
         assert!(fetch_sm_data("imsi-1", "internet", 1, None).await.is_none());
         assert!(
@@ -786,8 +786,7 @@ mod tests {
         // the crate-root one `main.rs`'s #204 tests also take — a lock of this
         // module's own would be a second disjoint agreement about one variable, and
         // that is exactly how this test first flaked.
-        let _g = SWITCH_LOCK.lock().await;
-        let _env = crate::UDM_ENV_TEST_LOCK.lock().await;
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
         set_for_test(true);
 
         // `(method, path, body, dnn-query-param)`. The fourth field exists because

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -3833,6 +3833,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state (current-thread test)
     async fn test_http_generate_auth_data_flows() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
         // dev-profile deployment (issue #63). Declared rather than inherited.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
@@ -4249,6 +4250,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state (current-thread test)
     async fn test_sdm_subscribe_persists_and_unsubscribe_is_idempotent() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         // Serialize on udmd's global-context/UDR-env guard: this test re-inits
         // the process-global UDM context and/or sets UDR_SBI_* env vars, which
         // races any other udmd test doing the same (the CI-flaky AUTS-resync).
@@ -4349,6 +4351,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state (current-thread test)
     async fn test_auth_event_returns_201_with_location_header() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         // Serialize on udmd's global-context/UDR-env guard: this test re-inits
         // the process-global UDM context and/or sets UDR_SBI_* env vars, which
         // races any other udmd test doing the same (the CI-flaky AUTS-resync).
@@ -4407,6 +4410,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state (current-thread test)
     async fn test_ee_subscribe_persists_and_unsubscribe_404_then_204() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         // Serialize on udmd's global-context/UDR-env guard: this test re-inits
         // the process-global UDM context and/or sets UDR_SBI_* env vars, which
         // races any other udmd test doing the same (the CI-flaky AUTS-resync).
@@ -4922,6 +4926,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
     async fn sdm_subscribe_refuses_a_subscription_missing_a_mandatory_ie() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         let _guard = crate::test_support::CONTEXT_GUARD
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -4996,6 +5001,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize process-global UDM state (context, UDM_NOTIFY_DISABLE, SBI profile)
     async fn ee_modify_applies_the_patch_and_the_change_is_readable_back() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         let _guard = crate::test_support::CONTEXT_GUARD
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -5158,6 +5164,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)]
     async fn sdm_multi_data_set_get_is_routed_and_fans_out() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _guard = crate::test_support::CONTEXT_GUARD
             .lock()
@@ -5252,6 +5259,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)]
     async fn ue_context_in_amf_data_reads_the_stored_registration() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _guard = crate::test_support::CONTEXT_GUARD
             .lock()
@@ -5333,6 +5341,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)]
     async fn every_routed_sdm_data_set_answers_a_derived_status() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _guard = crate::test_support::CONTEXT_GUARD
             .lock()
@@ -5550,6 +5559,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
     async fn test_http_uecm_registration_surface() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _guard = crate::test_support::CONTEXT_GUARD
             .lock()
@@ -5817,6 +5827,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
     async fn test_http_ueau_ausf_pinning_delete_auth_and_sqn_withholding() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _guard = crate::test_support::CONTEXT_GUARD
             .lock()
@@ -6254,6 +6265,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
     async fn test_http_id_translation_result_both_directions() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let _guard = crate::test_support::CONTEXT_GUARD
             .lock()
@@ -6329,6 +6341,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::await_holding_lock)] // std guard held across .await to serialize global UDM state
     async fn test_http_nudm_pp_and_mt_are_served() {
+        let _udr_env = crate::sbi_path::UDR_ENV_TEST_LOCK.lock().await;
         use nextgcore_sbi::context::{global_context, NfInstance, NfService};
         use nextgcore_sbi::types::{NfType, SbiServiceType};
 

--- a/src/bins/nextgcore-udmd/src/sbi_path.rs
+++ b/src/bins/nextgcore-udmd/src/sbi_path.rs
@@ -400,6 +400,21 @@ pub async fn udm_sbi_send_request(
     }
 }
 
+/// The ONE agreement about the `UDR_SBI_ADDR` / `UDR_SBI_PORT` environment, for
+/// tests (#308).
+///
+/// Declared beside the fallback below rather than inside `mod tests`, so a sibling
+/// module that starts writing these variables reaches the same static instead of
+/// declaring a second one. `app.rs` had three writers and no lock at all: each
+/// pointed the fallback at its own mock UDR, and the fallback names ONE UDR for
+/// every `nudr` query, so whoever wrote last owned every sibling's UDR traffic.
+///
+/// It covers readers as well as writers. `smfd`'s equivalent flake (#308's subject)
+/// was a locked writer and an unlocked reader disagreeing about one variable, which
+/// is not weaker protection than none — it is none, with a lock to look at.
+#[cfg(test)]
+pub(crate) static UDR_ENV_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Discover UDR and send a NUDR-DR request
 ///
 /// Port of udm_sbi_discover_and_send() for UDR queries.

--- a/src/libs/nextgcore-sbi/src/client.rs
+++ b/src/libs/nextgcore-sbi/src/client.rs
@@ -1434,6 +1434,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_oauth2_token_attached_when_enabled() {
+        // The stub below answers the BESPOKE token path only, so this test reads the
+        // process-wide OAuth2 path selector through `OAuth2Client::new` and must take
+        // the same guard `oauth.rs`'s writers take (#308).
+        let _paths = crate::oauth::lock_path_mode_async().await;
         let addr = serve_token_and_echo("test-access-token").await;
         let nrf_uri = format!("http://{addr}");
 

--- a/src/libs/nextgcore-sbi/src/oauth.rs
+++ b/src/libs/nextgcore-sbi/src/oauth.rs
@@ -70,6 +70,52 @@ pub fn reset_oauth2_standard_paths_default() {
     OAUTH2_PATH_MODE.store(0, std::sync::atomic::Ordering::Relaxed);
 }
 
+/// Serializes every test that reads or mutates [`OAUTH2_PATH_MODE`], the
+/// process-wide default OAuth2 path selector (I4).
+///
+/// Declared here beside the global rather than inside this module's `mod tests`,
+/// where it lived until #308. The move is the whole fix: a lock inside a test
+/// submodule is unreachable from a sibling module, and this selector has readers
+/// in TWO sibling modules —
+/// - `security.rs`'s `production_profile_configures_tls_mtls_and_oauth2` asserts the
+///   derived JWKS URI is the BESPOKE `/nnrf-oauth2/v1/jwks`, which
+///   `apply_sbi_security_policy` obtains through [`JwksCache::for_nrf`] and therefore
+///   through this selector. With `test_flag_flips_default_to_standard` in flight it
+///   gets `/oauth2/retrieve-key`, and it failed 1 of 20 `cargo test --workspace` runs.
+/// - `client.rs`'s `test_oauth2_token_attached_when_enabled` stubs a token endpoint at
+///   the bespoke `/nnrf-oauth2/v1/access-token` only, so a flipped selector makes its
+///   client dial `/oauth2/token` and get nothing. That one was found by WIDENING the
+///   writer's window during #308's revert pass, not by a failing CI run — it is the
+///   same defect, one window narrower.
+///
+/// A `tokio::sync::Mutex` rather than a `std` one: two of the guarded tests await
+/// while holding it (they drive loopback token endpoints), and a `std` guard held
+/// across an await blocks the executor thread — `clippy::await_holding_lock`, which
+/// those two were already tripping before #308. Tokio mutexes do not poison, so the
+/// poison tolerance the `std` version needed is gone rather than lost.
+#[cfg(test)]
+pub(crate) static PATH_MODE_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Take [`PATH_MODE_GUARD`] from a **sync** test and pin the shipped (env-driven)
+/// baseline, clearing any override leaked by a previously-panicked guarded test.
+///
+/// `blocking_lock` is sound here precisely because a sync `#[test]` has no runtime
+/// to block; async tests must use [`lock_path_mode_async`].
+#[cfg(test)]
+pub(crate) fn lock_path_mode() -> tokio::sync::MutexGuard<'static, ()> {
+    let g = PATH_MODE_GUARD.blocking_lock();
+    reset_oauth2_standard_paths_default();
+    g
+}
+
+/// [`lock_path_mode`] for an `async` test.
+#[cfg(test)]
+pub(crate) async fn lock_path_mode_async() -> tokio::sync::MutexGuard<'static, ()> {
+    let g = PATH_MODE_GUARD.lock().await;
+    reset_oauth2_standard_paths_default();
+    g
+}
+
 /// Whether newly-constructed OAuth2 clients / JWKS caches default to the
 /// standard TS 29.510 paths. Resolves the programmatic override first, then
 /// [`OAUTH2_STANDARD_PATHS_ENV`], defaulting to `false` (bespoke).
@@ -1542,19 +1588,10 @@ pub async fn fetch_jwks(jwks_uri: &str) -> SbiResult<serde_json::Value> {
 mod tests {
     use super::*;
 
-    /// Serializes every test that reads or mutates the process-wide default
-    /// OAuth2 path selector (I4) so a parallel flip cannot perturb a
-    /// default-asserting test. Poison-tolerant so one panicking test does not
-    /// cascade-fail the rest.
-    static PATH_MODE_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn lock_path_mode() -> std::sync::MutexGuard<'static, ()> {
-        let g = PATH_MODE_GUARD.lock().unwrap_or_else(|e| e.into_inner());
-        // Clear any override leaked by a previously-panicked guarded test so we
-        // start from the shipped (env-driven) baseline.
-        reset_oauth2_standard_paths_default();
-        g
-    }
+    /// The selector's guard now lives beside the global it guards, because
+    /// `security.rs`'s tests take the SAME one (#308) and a sibling module cannot
+    /// reach a static inside this file's test submodule.
+    use super::{lock_path_mode, lock_path_mode_async};
 
     /// Same treatment for the process-wide CCA signing key (issue #64): tests
     /// that flip it must not perturb one asserting the default.
@@ -2505,7 +2542,7 @@ mod tests {
         // The I4 selector is read at construction; hold the guard only over the
         // (synchronous) build to pin the bespoke baseline, then release before I/O.
         let client = {
-            let _g = lock_path_mode();
+            let _g = lock_path_mode_async().await;
             OAuth2Client::new(format!("http://{addr}"), "amf-1", NfType::Amf)
         };
         let resp = client
@@ -2626,7 +2663,7 @@ mod tests {
         // The selector is read at construction; flip → build → reset all under
         // the guard, then release before the network I/O (no lock across await).
         let client = {
-            let _g = lock_path_mode();
+            let _g = lock_path_mode_async().await;
             set_oauth2_standard_paths_default(true);
             let c = OAuth2Client::new(format!("http://{addr}"), "amf-1", NfType::Amf);
             reset_oauth2_standard_paths_default();

--- a/src/libs/nextgcore-sbi/src/security.rs
+++ b/src/libs/nextgcore-sbi/src/security.rs
@@ -822,6 +822,17 @@ mod profile_tests {
     /// bound to this NF's own audience.
     #[test]
     fn production_profile_configures_tls_mtls_and_oauth2() {
+        // The JWKS URI asserted below is DERIVED, through `JwksCache::for_nrf`, from
+        // the process-wide OAuth2 path selector — so this test is a reader of that
+        // global and must take the same guard its writers in `oauth.rs` take (#308).
+        // Without it, `test_flag_flips_default_to_standard` running concurrently
+        // yields `/oauth2/retrieve-key` here.
+        let _paths = crate::oauth::lock_path_mode();
+        // The JWKS URI asserted below is DERIVED, through `JwksCache::for_nrf`, from
+        // the process-wide OAuth2 path selector — so this test is a reader of that
+        // global and must take the same guard its writers in `oauth.rs` take (#308).
+        // Without it, `test_flag_flips_default_to_standard` running concurrently
+        // yields `/oauth2/retrieve-key` here.
         let dir = std::env::temp_dir().join(format!("sbi-profile-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("temp dir");
         let cert = dir.join("server.crt");

--- a/src/libs/nextgcore-sbi/src/test_support.rs
+++ b/src/libs/nextgcore-sbi/src/test_support.rs
@@ -29,9 +29,15 @@ use std::sync::{Mutex, OnceLock};
 /// claim the port in that gap. Eliminating that requires handing callers a
 /// PRE-BOUND `TcpListener` — the port is then never unbound — which in turn
 /// requires [`crate::server::SbiServer`] to accept a listener instead of only a
-/// `SocketAddr` (it binds internally today). That API change is tracked
-/// separately; when it lands, every caller of this helper inherits it, which is
-/// the point of having one implementation rather than 21.
+/// `SocketAddr` (it binds internally today). That API change is tracked as #313;
+/// when it lands, every caller of this helper inherits it, which is the point of
+/// having one implementation rather than 21. (It said "tracked separately" for
+/// months while no such issue existed — #308 filed it.)
+///
+/// Note that each test BINARY has its own `ISSUED` set, so the cross-process case
+/// this cannot close is precisely `cargo test --workspace`, where one binary per
+/// crate runs concurrently. That is why #313 matters more than the low rate
+/// suggests, and why `ci.yml` names it where the blanket retry used to be.
 ///
 /// # Panics
 ///


### PR DESCRIPTION
Closes #308. Spec: `specs/fix-process-state-test-locks.md`.

## The issue is right about the symptom and wrong about the mechanism

`cargo test --workspace` failed ~1 run in 5. Reproduced on `main` @ `8c3321b` with a cheap harness — the smfd test binary under 40 synthetic busy loops, which is the only thing the whole-workspace run adds — at **3 of 10 runs**, in **three** distinct tests (#308 names two).

Everything else in the issue's mechanism is stale:

| claim | reality on `8c3321b` |
|---|---|
| `UDM_SBI_*` writers are unserialised | **every writer already held `UDM_ENV_TEST_LOCK`** |
| smfd is the only affected crate | with smfd fixed, `lmfd` failed 2/20 and `nextgcore-sbi` 1/20 |
| two tests fail | a third does: `a_successful_create_registers_an_activated_session_and_its_binding` |

## One defect, four crates

**A locked writer and an unlocked reader disagreeing about a global neither test names.**

- **smfd** had **four** locks over one ambient state (`udm`/`easdf`/`eps_iwk` switch locks plus a crate-root env lock). Four locks are four disjoint agreements: a test holding the easdf lock ran concurrently with one holding the udm locks, and its create fetched *the other test's* subscribed session-AMBR — while both were correctly locked. Separately, `smf_context_init` clears every pool process-wide and **17 test sites called it with no lock at all**, and **25 tests read ambient state** unguarded. Collapsed to one `context::PROCESS_STATE_TEST_LOCK` declared beside `GLOBAL_SMF_CONTEXT`. `pfcp_path::N4_TEST_LOCK` is deliberately kept as the documented **inner** lock — it guards a different set, it is already correct, and `stand_in::associated_upf` takes it on the caller's behalf, so collapsing it in would mean a reentrant acquisition (deadlock) or reworking the stand-in's ownership.
- **lmfd** had **no lock**. `lmf_context_init` clears the cell-coordinate registry `capabilities_body` derives `nrppaSupported` from, so a sibling wiping it between the handler read and the expected-body read made them disagree. Its own doc claimed the comparison "holds whatever state a sibling test has left behind" — true of state left behind, false of state changed in the gap.
- **nextgcore-sbi**'s path-mode guard was correct and its ten writers took it, but it was declared inside `oauth.rs`'s `mod tests`, unreachable from the **two** sibling modules that read the selector. Moved beside `OAUTH2_PATH_MODE`; now a tokio mutex with sync and async entry points, because three holders await while holding it.
- **udmd** had three `UDR_SBI_*` writers and **no lock**; 13 tests touch that env or a UDR path. New `sbi_path::UDR_ENV_TEST_LOCK` beside the fallback that reads it.
- **ausfd** was already correct — all 7 writers and its readers took `TEST_MUTEX` — but the lock lived inside `mod tests`, the latent form of this defect. Relocated; no test changed.
- **amfd** is audited and **named, not changed**: one writer, and that same test is the only one reaching either reader. Residual stated in the spec.

## ci.yml: the retry is removed, not narrowed

A retry that passes ~96% of the time against a 20% flake is not a mitigation, it is a detector for the failures nobody investigates — it hid this for months, and its `TODO` violated the CONSTITUTION. What genuinely remains is the cross-process `free_port` window, now filed as **#313**; `test_support`'s own doc claimed that was "tracked separately" while no such issue existed.

## Verification

Every row measured, not argued.

| claim | how it was made to fail | result |
|---|---|---|
| the flake is real | harness on `8c3321b` | **3 / 10** |
| …on the workspace gate too | 5 whole-workspace runs on `8c3321b` | **1 / 5** |
| the smfd scheme is load-bearing | delete all 38 first-line lock acquisitions | **10 / 10 fail**, with the sibling's 40/80 Mbps in the diff |
| the 25 smfd **reader** locks alone | delete exactly those 25, keep the collapse | **0 / 30 — the revert did NOT bite** |
| lmfd's flake is real | 20 workspace runs, lmfd unfixed | **2 / 20**, same test both times |
| sbi's flake is real | the same 20 runs | **1 / 20** |
| the sbi reader locks are load-bearing | revert them under a widened writer window | **fails** with `left: ".../oauth2/retrieve-key"` — the production message exactly |
| …and close it | widened window, locks restored | **green** |
| **criterion 1** | 20 consecutive `cargo test --workspace` | **0 / 20** |
| no new lint | `clippy --workspace --all-targets`, branch vs stashed main | 21 `await_holding_lock` on **both**, same four files; CI's `clippy --workspace` **0** on both |

### Two things this PR does not claim

1. **The 25 smfd reader locks are unfalsified, not verified.** What carries the weight is the *collapse*. Two attempts to make the readers fail alone — widening a writer's switch-ON window to 2–3 s with one reader unlocked — stayed green, because `N4_TEST_LOCK` **incidentally** serialises most reader/writer pairs. They are kept on a structural argument: 25 tests read state a sibling writes, one of the three reproduced failures *was* an unlocked reader, and protection that is a side effect of a lock guarding something else is not an agreement.
2. **lmfd's fix is statistical.** Its baseline is the 2/20 measurement; `-p nextgcore-lmfd` under load is 0/12 reverted, and widening the reader's own gap to 500 ms is still green, because the failure needs a specific *order* (seed → handler → wipe) a crate-alone run does not produce.

A third sbi reader (`client.rs`) was found **by** the widened-window revert rather than by a failing run — the same defect one window narrower, and the reason for covering readers structurally.

## Ceilings

0/20 bounds the residual rate under ~15% at 95% confidence; it does not certify determinism. The `free_port` cross-process window is untouched (#313) and removing the retry makes it visible rather than fixed. The audit covered the `*_SBI_*` fallbacks #308 names; nrfd's OAuth2 switches (different shape, one module) and other crates' process-globals were not audited. No E2E — the Docker jobs are `workflow_dispatch`-only and untouched.