### PR TITLE
fix(upfd): apply a Session Modification's rule operations instead of accepting them (#306)

### DIFF
--- a/specs/fix-upfd-modification-rule-operations.md
+++ b/specs/fix-upfd-modification-rule-operations.md
@@ -1,0 +1,183 @@
+# nextgcore #306 (upfd): a Session Modification's rule operations reach the rule store
+
+Verified against `main` @ `4f3af48`. TS 29.244 Table 7.5.4.1-1, §7.5.5, §8.2.36, §8.2.37, §8.2.50.
+
+#306 is accurate. Every claim in it still holds, and verifying it turned up one adjacent
+gap of the same kind that criterion 1 cannot honestly be met without.
+
+## Verified against current main
+
+| claim in the issue | site on `4f3af48` | still true? |
+|---|---|---|
+| the modification handler parses only Update FAR, Update QER, Create/Update BAR, SMReq-Flags | `pfcp_path.rs:1345-1508` | yes |
+| Create/Update/Remove URR, Remove QER, and every PDR/FAR operation are unparsed | grep: no reader for any | yes |
+| `UPDATE_URR` / `REMOVE_URR` / `REMOVE_QER` constants exist with no reader | `n4_build.rs:100-105` | yes |
+| the establishment path *does* parse Create PDR/FAR/QER/URR | `pfcp_path.rs:1115-1254` | yes |
+| the response is `RequestAccepted` regardless | it answers on the session lookup alone | yes |
+| the library models all of these after #304 | `message.rs:703-726` | yes |
+| upfd's session model differs from sgwud's (`AtomicU64` behind an `Arc`) | `data_plane.rs:1123` | yes |
+| **not in the issue:** the Measurement Period IE is parsed nowhere | `ParsedCreateUrr` has no such field | **new** |
+| **not in the issue:** QAURR is a constant with no reader | `pfcpsmreq_flags::QAURR` | **new** |
+
+The two new rows are the same defect as the issue's subject, and the first one makes criterion 1
+("Create URR provisions measurement") unmeetable as stated: `parse_create_urr` reads the PERIO
+reporting-trigger **flag** and never the period behind it, so `DataPlaneUrr::measurement_period_secs`
+— whose one reader is the data plane's periodic sweep — could never be anything but `None`. A URR
+"provisioned with measurement" that can never report periodically is the same half-truth one layer
+down, so it is fixed here rather than filed.
+
+## Decision 1: option 2 — extend upfd's own walk — and the drift risk is guarded, not accepted
+
+Criterion 6 asks for the choice and the reason.
+
+**Option 2.** The Update X IEs carry the same IE set as their Create X counterparts (Table 7.5.4.2-1
+against 7.5.2.2-1 and siblings), so `parse_create_pdr` / `_far` / `_qer` / `_urr` — already exercised
+by the establishment path on every session — are reused verbatim, and the four Remove IEs are one
+rule-id sub-IE each. Option 1 does not just swap a decoder: `PfcpSessionEvent::SessionModified` and
+`SessionEstablished` carry upfd's `ParsedCreate*` types, so moving to the library's would rewrite the
+event enum, both handlers and the data-plane consumer in `main.rs`. #304 sized that as needing its
+own revert pass and #306 repeats the sizing; that is still the right sizing.
+
+The argument for option 1 is drift — two decoders for one message. Rather than accept it, this PR
+**pins them together**: `the_library_decoder_and_upfds_walk_agree_on_one_modification` builds a
+Session Modification with the LIBRARY encoder, decodes it with both, and asserts the rule ids and
+thresholds match. Reverting upfd's Measurement Period lookup makes that test fail, so it is a real
+guard. If the library's wire format moves and upfd's walk does not follow, it fails here.
+
+## Decision 2: what an unapplicable rule operation is answered with
+
+Criterion 5. Four cases, three answers, and the split is the load-bearing part:
+
+- **A malformed rule body** (a Create URR with no URR ID) → cause 69 `MandatoryIeIncorrect` plus
+  §7.5.5's Offending IE naming the IE type. Skipping it silently is this issue's defect one level
+  down.
+- **An UPDATE naming a rule the session does not hold** → cause 73 `RuleCreationModificationFailure`
+  plus the Offending IE. The new threshold, gate or forwarding action has nowhere to land, so the CP
+  function's intent is not satisfied, and ignoring it is exactly "accepted a modification it did not
+  apply".
+- **A REMOVE naming a rule the session does not hold** → `RequestAccepted`, deliberately. The rule is
+  gone, which is what was asked. Answering 73 would fail a modification that achieved its intent.
+  Logged at debug, and guarded by its own test so the asymmetry with the update case is visible as a
+  decision rather than an oversight.
+- **An IE type upfd does not model at all** → ignored, because TS 29.244 §6.2 requires unknown IEs to
+  be ignored for forward compatibility. Not a change; stated so the boundary of the above is clear.
+
+§7.5.5 gives ONE Cause and ONE Offending IE per message, so with several failures the FIRST is
+reported — the earliest is the one whose rejection explains the rest. And a rejected modification
+emits **no** apply event: sending it anyway would leave the data plane holding rules the response
+just refused, which is the same divergence in the other direction.
+
+## Decision 3: the PFCP layer tracks rule IDs, because the response must be built before the apply
+
+To refuse an Update for an absent rule, the handler has to know which rules the session holds — and
+it cannot ask the data plane, because the response is built and sent **before** the data plane has
+consumed the event. Validating against the data-plane store would reject a rule created by a
+modification one round earlier that the consumer has not applied yet.
+
+So `PfcpSessionInfo` gains a `SessionRuleIds` set per kind, written synchronously inside the same
+critical section that updates the session, in §7.5.4's order — remove, then create, then update. That
+makes it the only race-free answer to "does this rule exist" at response-building time. It is a split
+of concerns, not duplication: the PFCP layer owns the ids (its contract with the CP function), the
+data plane owns the rules' behaviour.
+
+## Decision 4: a removed URR reports its residual volume in the Modification Response
+
+The issue's scope note says a removed URR whose counters keep running is "a leak as well as a wrong
+bill". Both halves are closed, and the volume is not discarded:
+
+- The residual is reported in the **response**, in IE 78 (`USAGE_REPORT_SMR`) with the TERMR trigger
+  — §8.2.36 defines TERMR as covering "removal of the URR" as well as session termination.
+- This was cheap because the pieces were already here with no caller: the `USAGE_REPORT_SMR` constant,
+  `add_usage_report`'s carrier parameter, and `PfcpServer`'s data-plane handle (added for the deletion
+  path's final reports). `collect_final_usage_reports` is generalised to `collect_usage_reports(seid,
+  only, reason)` and the deletion path now calls through it.
+- #215 had to settle for warn-and-drop on the SGW-U side because that daemon had no way to reach the
+  counters. upfd does, so it should not inherit the compromise.
+- The counters stop because dropping the `Arc` from `session.urrs` is the only route the data path has
+  to them, asserted with `Arc::strong_count`.
+
+QAURR (§8.2.50) is honoured on the same machinery: every URR reports immediately with IMMER, minus any
+URR this same message removed, which has already reported with TERMR — reporting both would
+double-count it.
+
+## Decision 5: Update URR re-thresholds in place, so the measured volume survives
+
+Criterion 2, and the reason `DataPlaneUrr`'s thresholds changed shape. They were plain `Option<u64>`
+behind the `Arc` the data plane holds, so the only way to change one was to rebuild the rule — which
+zeroes the `AtomicU64` counters. That is a wrong bill, not a lost setting.
+
+They are now atomics with documented sentinels (`u64::MAX` for volume, `0` for seconds) read through
+accessors. Atomics rather than a lock because `record` runs per packet; `u64::MAX` rather than `0` for
+volume because a zero-byte threshold is a threshold already met, and confusing the two would turn
+"measure without a threshold" into "report on the first packet".
+
+A threshold the update **omits** is withdrawn rather than silently retained — `set_reporting` writes
+all five slots — and that is asserted, because the opposite reading is equally defensible and a reader
+should not have to guess which was chosen.
+
+## Decision 6: one PDR builder, not two
+
+The modification path needed to install PDRs, which the establishment path already did inline. Rather
+than write a second builder, the establishment path's is extracted to
+`data_plane_pdr_from_parsed`. Two builders for one rule is how the SDF-filter compilation, or the
+QFI, or the precedence sort ends up present on one path and absent on the other — the drift argument
+of Decision 1, applied one layer in.
+
+Create FAR and Update FAR (likewise QER) install identical shapes, so they run through one loop
+rather than two.
+
+## Verification
+
+Every test drives a real datagram into the bound socket and then runs the emitted event through
+`crate::handle_pfcp_session_event` — the production apply path, not a copy. Asserting the parsed
+event alone would pass in exactly the broken state this issue describes, because the parse was the
+missing half and the apply did not exist.
+
+| claim | how it was made to fail | result |
+|---|---|---|
+| Create URR on a modification provisions measurement | disable the `created_urrs` apply | **fails** |
+| …including the Measurement Period | point the `MEASUREMENT_PERIOD` lookup at an unsent IE type | **fails** |
+| Update URR does not reset the measured volume | `reset_counters()` after `set_reporting`, as a rebuild would | **fails** |
+| a removed URR reports its residual volume | invert the `removed_urr_ids.is_empty()` guard | **fails** |
+| a removed URR stops measuring | drop the `dp_urrs.remove(id)` loop | **fails** |
+| Remove QER detaches the policing | drop the `dp_qers.remove(id)` loop | **fails** |
+| Remove PDR detaches the detection rule | make the `retain` predicate always true | **fails** |
+| Remove FAR detaches the forwarding rule | drop the `dp_fars.remove(id)` loop | **fails** |
+| an Update for an absent rule is refused with an Offending IE | short-circuit the `contains` check | **fails** |
+| QAURR is honoured | force `query_all_urrs` false | **fails** |
+| removals apply before creates | move the removal after the create | **fails** |
+| a malformed rule body is reported | drop the `note_first_failure` call | **fails** |
+| the two decoders agree | the Measurement Period revert above | **fails** |
+
+Thirteen reverts, thirteen bites. Two earlier attempts did **not** compile and the harness reported
+`DID-NOT-COMPILE` rather than a pass — the failure mode this repo has recorded as indistinguishable
+from a decorative test. A third revert reported `PASSED` because the patch did not actually invert the
+apply order (it moved the removal to the top of the create block, which is still remove-then-create);
+rewritten to move it *after* the inserts, it bites. That one is worth recording: a revert that reads
+like an inversion and is not is a false negative, and reading only the verdict would have called the
+ordering claim unverified.
+
+Workspace: 300 upfd tests (was 290), `cargo clippy --workspace` 0, `cargo fmt --check` clean.
+
+## Ceilings
+
+- **The establishment handler keeps its inline shape.** It parses the same IEs correctly and no
+  criterion asks about it, but its rule installation is still written inside a `match` arm in
+  `main.rs`, so only the modification path's application is reachable from a test today. The PDR
+  builder extraction is the one piece of it this PR shares.
+- **`updated_pdrs` / `created_pdrs` are applied but not asserted over the wire beyond the removal
+  case.** The PDR store is a precedence-sorted `Vec`, and the replace-then-sort behaviour on an Update
+  PDR has no test of its own; the criteria named Remove PDR, which is guarded.
+- **The Update QER path still rebuilds the QER from scratch** (`DataPlaneQer::new` then set fields),
+  so an Update QER omitting a member resets it and any token-bucket state is lost. That is
+  pre-existing, adjacent to Decision 5's reasoning, and NOT changed here: no criterion asks, and the
+  right answer depends on whether a QER's token bucket is state the CP function expects to survive a
+  re-authorisation — which is a decision, not a fix.
+- **No timer.** A Measurement Period is now provisioned and stored, and the data plane's existing
+  30-second sweep is what reads it; whether that sweep fires at the *provisioned* cadence rather than
+  its own is not tested here and is the same shape as the open sgwud lazy-reporting task.
+- **`Arc::strong_count` is the counters-stopped assertion**, which proves the data path can no longer
+  reach the URR rather than proving no packet is counted. A packet already inside `record` when the
+  removal lands is counted into a rule nobody will read — accepted, and it is what the pre-removal
+  report exists to bound.
+- **No E2E.** Loopback datagrams in one process; the Docker jobs are `workflow_dispatch`-only.

--- a/src/bins/nextgcore-upfd/src/data_plane.rs
+++ b/src/bins/nextgcore-upfd/src/data_plane.rs
@@ -1118,15 +1118,43 @@ impl DataPlaneQer {
     }
 }
 
+/// Sentinel for "no volume threshold provisioned" in [`DataPlaneUrr`]'s atomic
+/// threshold slots (#306).
+///
+/// The thresholds have to be mutable in place, because TS 29.244 Table 7.5.4.1-1's
+/// Update URR re-thresholds a LIVE rule and must not disturb the volume already
+/// measured against it — so they cannot stay plain `Option<u64>` behind the `Arc`
+/// the data plane holds. An atomic with a sentinel is preferred to a lock because
+/// `record` runs per packet.
+///
+/// `u64::MAX` and not `0`: a zero-byte volume threshold is a threshold that is
+/// already met, which is a meaningful (if useless) provisioning, whereas 16 exabytes
+/// is not reachable. Confusing the two would silently turn "measure without a
+/// threshold" into "report on the first packet".
+pub const NO_VOLUME_THRESHOLD: u64 = u64::MAX;
+
+/// Sentinel for "no time threshold / measurement period provisioned".
+///
+/// `0` is safe here where it is not for volume: TS 29.244 §8.2.32 states the Time
+/// Threshold as a duration after which the UP function shall report, and a zero
+/// duration has no reading that differs from "not provisioned".
+pub const NO_TIME_THRESHOLD: u32 = 0;
+
 /// Lightweight URR for usage reporting in the data plane
 #[derive(Debug)]
 pub struct DataPlaneUrr {
     pub urr_id: u32,
-    pub volume_threshold_total: Option<u64>,
-    pub volume_threshold_ul: Option<u64>,
-    pub volume_threshold_dl: Option<u64>,
-    pub time_threshold_secs: Option<u32>,
-    pub measurement_period_secs: Option<u32>,
+    /// Volume thresholds, in bytes. [`NO_VOLUME_THRESHOLD`] means unprovisioned.
+    /// Atomic so an Update URR can re-threshold without rebuilding the rule and
+    /// losing its counters — read through [`Self::volume_threshold_total`] and
+    /// friends rather than directly.
+    volume_threshold_total_raw: AtomicU64,
+    volume_threshold_ul_raw: AtomicU64,
+    volume_threshold_dl_raw: AtomicU64,
+    /// Time threshold and measurement period, in seconds. [`NO_TIME_THRESHOLD`]
+    /// means unprovisioned.
+    time_threshold_secs_raw: std::sync::atomic::AtomicU32,
+    measurement_period_secs_raw: std::sync::atomic::AtomicU32,
     /// Accumulated volume since last report
     pub acc_total_bytes: AtomicU64,
     pub acc_ul_bytes: AtomicU64,
@@ -1146,14 +1174,82 @@ pub struct DataPlaneUrr {
 }
 
 impl DataPlaneUrr {
+    /// The provisioned total-volume threshold, or `None` when unprovisioned.
+    pub fn volume_threshold_total(&self) -> Option<u64> {
+        Self::volume(&self.volume_threshold_total_raw)
+    }
+
+    /// The provisioned uplink-volume threshold, or `None`.
+    pub fn volume_threshold_ul(&self) -> Option<u64> {
+        Self::volume(&self.volume_threshold_ul_raw)
+    }
+
+    /// The provisioned downlink-volume threshold, or `None`.
+    pub fn volume_threshold_dl(&self) -> Option<u64> {
+        Self::volume(&self.volume_threshold_dl_raw)
+    }
+
+    /// The provisioned time threshold in seconds, or `None`.
+    pub fn time_threshold_secs(&self) -> Option<u32> {
+        Self::secs(&self.time_threshold_secs_raw)
+    }
+
+    /// The provisioned measurement period in seconds, or `None`.
+    pub fn measurement_period_secs(&self) -> Option<u32> {
+        Self::secs(&self.measurement_period_secs_raw)
+    }
+
+    fn volume(slot: &AtomicU64) -> Option<u64> {
+        match slot.load(Ordering::Relaxed) {
+            NO_VOLUME_THRESHOLD => None,
+            v => Some(v),
+        }
+    }
+
+    fn secs(slot: &std::sync::atomic::AtomicU32) -> Option<u32> {
+        match slot.load(Ordering::Relaxed) {
+            NO_TIME_THRESHOLD => None,
+            v => Some(v),
+        }
+    }
+
+    /// Install this URR's reporting triggers, replacing whatever was provisioned
+    /// before and **leaving every counter alone** (TS 29.244 Table 7.5.4.1-1, #306).
+    ///
+    /// That is the whole reason the thresholds are atomic: an Update URR re-thresholds
+    /// a rule that is already measuring, and the CP function's own accounting assumes
+    /// the volume measured so far survives. Rebuilding the rule would silently zero it,
+    /// which is a wrong bill rather than a lost setting.
+    pub fn set_reporting(
+        &self,
+        volume_total: Option<u64>,
+        volume_ul: Option<u64>,
+        volume_dl: Option<u64>,
+        time_threshold_secs: Option<u32>,
+        measurement_period_secs: Option<u32>,
+    ) {
+        let vol = |v: Option<u64>| v.unwrap_or(NO_VOLUME_THRESHOLD);
+        let sec = |v: Option<u32>| v.unwrap_or(NO_TIME_THRESHOLD);
+        self.volume_threshold_total_raw
+            .store(vol(volume_total), Ordering::Relaxed);
+        self.volume_threshold_ul_raw
+            .store(vol(volume_ul), Ordering::Relaxed);
+        self.volume_threshold_dl_raw
+            .store(vol(volume_dl), Ordering::Relaxed);
+        self.time_threshold_secs_raw
+            .store(sec(time_threshold_secs), Ordering::Relaxed);
+        self.measurement_period_secs_raw
+            .store(sec(measurement_period_secs), Ordering::Relaxed);
+    }
+
     pub fn new(urr_id: u32) -> Self {
         Self {
             urr_id,
-            volume_threshold_total: None,
-            volume_threshold_ul: None,
-            volume_threshold_dl: None,
-            time_threshold_secs: None,
-            measurement_period_secs: None,
+            volume_threshold_total_raw: AtomicU64::new(NO_VOLUME_THRESHOLD),
+            volume_threshold_ul_raw: AtomicU64::new(NO_VOLUME_THRESHOLD),
+            volume_threshold_dl_raw: AtomicU64::new(NO_VOLUME_THRESHOLD),
+            time_threshold_secs_raw: std::sync::atomic::AtomicU32::new(NO_TIME_THRESHOLD),
+            measurement_period_secs_raw: std::sync::atomic::AtomicU32::new(NO_TIME_THRESHOLD),
             acc_total_bytes: AtomicU64::new(0),
             acc_ul_bytes: AtomicU64::new(0),
             acc_dl_bytes: AtomicU64::new(0),
@@ -1180,7 +1276,7 @@ impl DataPlaneUrr {
         if is_uplink {
             let ul = self.acc_ul_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes;
             self.acc_ul_pkts.fetch_add(1, Ordering::Relaxed);
-            if let Some(thresh) = self.volume_threshold_ul {
+            if let Some(thresh) = self.volume_threshold_ul() {
                 if ul >= thresh {
                     self.threshold_exceeded.store(true, Ordering::Relaxed);
                     return true;
@@ -1189,7 +1285,7 @@ impl DataPlaneUrr {
         } else {
             let dl = self.acc_dl_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes;
             self.acc_dl_pkts.fetch_add(1, Ordering::Relaxed);
-            if let Some(thresh) = self.volume_threshold_dl {
+            if let Some(thresh) = self.volume_threshold_dl() {
                 if dl >= thresh {
                     self.threshold_exceeded.store(true, Ordering::Relaxed);
                     return true;
@@ -1206,7 +1302,7 @@ impl DataPlaneUrr {
         }
 
         // Check total volume threshold
-        if let Some(thresh) = self.volume_threshold_total {
+        if let Some(thresh) = self.volume_threshold_total() {
             if total >= thresh {
                 self.threshold_exceeded.store(true, Ordering::Relaxed);
                 return true;
@@ -1214,7 +1310,7 @@ impl DataPlaneUrr {
         }
 
         // Check time threshold
-        if let Some(time_thresh) = self.time_threshold_secs {
+        if let Some(time_thresh) = self.time_threshold_secs() {
             let report_time = self.last_report_time.read().unwrap();
             if let Some(last) = *report_time {
                 if last.elapsed().as_secs() >= time_thresh as u64 {
@@ -2855,7 +2951,7 @@ impl DataPlane {
             // Also check time-based thresholds (measurement period)
             for (urr_id, urr) in urrs.iter() {
                 if !urr.threshold_exceeded.load(Ordering::Relaxed) {
-                    if let Some(period) = urr.measurement_period_secs {
+                    if let Some(period) = urr.measurement_period_secs() {
                         let last_report = urr.last_report_time.read().unwrap();
                         if let Some(last) = *last_report {
                             if last.elapsed().as_secs() >= period as u64 {

--- a/src/bins/nextgcore-upfd/src/main.rs
+++ b/src/bins/nextgcore-upfd/src/main.rs
@@ -695,6 +695,36 @@ async fn update_session_stats() {
     // period checks as well.
 }
 
+/// Build a data-plane PDR from a wire-parsed Create/Update PDR.
+///
+/// Extracted by #306 so the establishment path and the modification path install
+/// PDRs through ONE builder. They were about to be two, and two builders for one
+/// rule is how the SDF-filter compilation (or the QFI, or the precedence) ends up
+/// present on one path and missing on the other.
+fn data_plane_pdr_from_parsed(p: &crate::n4_build::ParsedCreatePdr) -> data_plane::DataPlanePdr {
+    // Compile SDF filter's flow description into an IpfwRule
+    let sdf_rule = p.pdi.sdf_flow_description.as_ref().and_then(|desc| {
+        match nextgcore_ipfw::compile_rule(desc) {
+            Ok(rule) => Some(rule),
+            Err(e) => {
+                log::warn!("Failed to compile SDF filter '{desc}': {e}");
+                None
+            }
+        }
+    });
+    data_plane::DataPlanePdr {
+        pdr_id: p.pdr_id,
+        precedence: p.precedence,
+        source_interface: p.pdi.source_interface,
+        far_id: p.far_id,
+        qer_id: p.qer_id,
+        urr_ids: p.urr_ids.clone(),
+        outer_header_removal: p.outer_header_removal,
+        sdf_rule,
+        qfi: p.pdi.qfi,
+    }
+}
+
 /// Handle PFCP session events (connect PFCP to data plane)
 async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEvent) {
     use data_plane::{
@@ -742,35 +772,8 @@ async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEve
                 if let Some(session) = data_plane.sessions.find_by_seid(upf_seid) {
                     // Install PDRs from PFCP (replace defaults if provided)
                     if !pdrs.is_empty() {
-                        let mut dp_pdrs: Vec<DataPlanePdr> = pdrs
-                            .iter()
-                            .map(|p| {
-                                // Compile SDF filter's flow description into an IpfwRule
-                                let sdf_rule =
-                                    p.pdi.sdf_flow_description.as_ref().and_then(|desc| {
-                                        match nextgcore_ipfw::compile_rule(desc) {
-                                            Ok(rule) => Some(rule),
-                                            Err(e) => {
-                                                log::warn!(
-                                                    "Failed to compile SDF filter '{desc}': {e}"
-                                                );
-                                                None
-                                            }
-                                        }
-                                    });
-                                DataPlanePdr {
-                                    pdr_id: p.pdr_id,
-                                    precedence: p.precedence,
-                                    source_interface: p.pdi.source_interface,
-                                    far_id: p.far_id,
-                                    qer_id: p.qer_id,
-                                    urr_ids: p.urr_ids.clone(),
-                                    outer_header_removal: p.outer_header_removal,
-                                    sdf_rule,
-                                    qfi: p.pdi.qfi,
-                                }
-                            })
-                            .collect();
+                        let mut dp_pdrs: Vec<DataPlanePdr> =
+                            pdrs.iter().map(data_plane_pdr_from_parsed).collect();
                         dp_pdrs.sort_by_key(|p| p.precedence);
                         *session.pdrs.write().unwrap() = dp_pdrs;
                     }
@@ -854,11 +857,17 @@ async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEve
                     if !urrs.is_empty() {
                         let mut dp_urrs = std::collections::HashMap::new();
                         for u in &urrs {
-                            let mut urr = DataPlaneUrr::new(u.urr_id);
-                            urr.volume_threshold_total = u.volume_threshold_total;
-                            urr.volume_threshold_ul = u.volume_threshold_ul;
-                            urr.volume_threshold_dl = u.volume_threshold_dl;
-                            urr.time_threshold_secs = u.time_threshold_secs;
+                            let urr = DataPlaneUrr::new(u.urr_id);
+                            urr.set_reporting(
+                                u.volume_threshold_total,
+                                u.volume_threshold_ul,
+                                u.volume_threshold_dl,
+                                u.time_threshold_secs,
+                                // #306: parsed from the wire since the Measurement
+                                // Period IE is; before that the PERIO trigger flag
+                                // arrived with no cadence behind it.
+                                u.measurement_period_secs,
+                            );
                             dp_urrs.insert(u.urr_id, Arc::new(urr));
                         }
                         *session.urrs.write().unwrap() = dp_urrs;
@@ -878,8 +887,18 @@ async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEve
             upf_seid,
             dl_teid,
             gnb_addr,
+            removed_pdr_ids,
+            removed_far_ids,
+            removed_qer_ids,
+            removed_urr_ids,
+            created_pdrs,
+            created_fars,
+            created_qers,
+            created_urrs,
+            updated_pdrs,
             updated_fars,
             updated_qers,
+            updated_urrs,
             updated_bars,
             send_end_marker,
             drop_buffered,
@@ -908,9 +927,124 @@ async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEve
             // Update FAR rules in the data plane session
             let mut any_far_forwards = false;
             if let Some(session) = data_plane.sessions.find_by_seid(upf_seid) {
-                if !updated_fars.is_empty() {
+                // Removals first, in TS 29.244 §7.5.4's order, so a modification that
+                // removes and re-creates one rule id ends holding the NEW rule
+                // (#306). Every one of these was parsed nowhere before, so the UPF
+                // answered `RequestAccepted` and kept detecting, policing and
+                // measuring on rules the SMF believed were gone.
+                if !removed_pdr_ids.is_empty() {
+                    let mut dp_pdrs = session.pdrs.write().unwrap();
+                    let before = dp_pdrs.len();
+                    dp_pdrs.retain(|p| !removed_pdr_ids.contains(&p.pdr_id));
+                    log::info!(
+                        "Removed {} PDRs for SEID={upf_seid:#x}",
+                        before - dp_pdrs.len()
+                    );
+                }
+                if !removed_far_ids.is_empty() {
                     let mut dp_fars = session.fars.write().unwrap();
-                    for f in &updated_fars {
+                    for id in &removed_far_ids {
+                        dp_fars.remove(id);
+                    }
+                }
+                if !removed_qer_ids.is_empty() {
+                    let mut dp_qers = session.qers.write().unwrap();
+                    for id in &removed_qer_ids {
+                        dp_qers.remove(id);
+                    }
+                    log::info!(
+                        "Removed {} QERs for SEID={upf_seid:#x}: policing no longer applied",
+                        removed_qer_ids.len()
+                    );
+                }
+                if !removed_urr_ids.is_empty() {
+                    // The residual volume has already been reported in the Session
+                    // Modification Response (TERMR), so dropping the rule here loses
+                    // no measurement. Dropping the `Arc` is what stops the counters:
+                    // `urr_record`'s only route to them is this map.
+                    let mut dp_urrs = session.urrs.write().unwrap();
+                    for id in &removed_urr_ids {
+                        dp_urrs.remove(id);
+                    }
+                    log::info!(
+                        "Removed {} URRs for SEID={upf_seid:#x}: measurement stopped",
+                        removed_urr_ids.len()
+                    );
+                }
+
+                // Creates: rules added to a session that is already running.
+                // Provisioning charging mid-session is the normal way it is added.
+                if !created_pdrs.is_empty() {
+                    let mut dp_pdrs = session.pdrs.write().unwrap();
+                    for p in &created_pdrs {
+                        dp_pdrs.retain(|e| e.pdr_id != p.pdr_id);
+                        dp_pdrs.push(data_plane_pdr_from_parsed(p));
+                    }
+                    // The fast path takes the first match, so precedence order is
+                    // load-bearing rather than cosmetic (lower value wins).
+                    dp_pdrs.sort_by_key(|p| p.precedence);
+                }
+                if !created_urrs.is_empty() {
+                    let mut dp_urrs = session.urrs.write().unwrap();
+                    for u in &created_urrs {
+                        let urr = DataPlaneUrr::new(u.urr_id);
+                        urr.set_reporting(
+                            u.volume_threshold_total,
+                            u.volume_threshold_ul,
+                            u.volume_threshold_dl,
+                            u.time_threshold_secs,
+                            u.measurement_period_secs,
+                        );
+                        dp_urrs.insert(u.urr_id, Arc::new(urr));
+                    }
+                    log::info!(
+                        "Created {} URRs for SEID={upf_seid:#x}: measurement provisioned",
+                        created_urrs.len()
+                    );
+                }
+                if !updated_urrs.is_empty() {
+                    // Re-threshold IN PLACE. Rebuilding the rule would zero the
+                    // volume measured so far, which the CP function is accounting on
+                    // — a wrong bill rather than a lost setting.
+                    let dp_urrs = session.urrs.read().unwrap();
+                    for u in &updated_urrs {
+                        match dp_urrs.get(&u.urr_id) {
+                            Some(urr) => urr.set_reporting(
+                                u.volume_threshold_total,
+                                u.volume_threshold_ul,
+                                u.volume_threshold_dl,
+                                u.time_threshold_secs,
+                                u.measurement_period_secs,
+                            ),
+                            // Unreachable in practice: the handler refuses an Update
+                            // for a rule the session does not hold, so this arm means
+                            // the two stores have diverged. Logged rather than
+                            // silently created, because inventing the rule here would
+                            // hide that divergence.
+                            None => log::warn!(
+                                "Update URR {} applied to no rule on SEID {upf_seid:#x}: \
+                                 PFCP and data-plane rule sets have diverged",
+                                u.urr_id
+                            ),
+                        }
+                    }
+                }
+                if !updated_pdrs.is_empty() {
+                    let mut dp_pdrs = session.pdrs.write().unwrap();
+                    for p in &updated_pdrs {
+                        dp_pdrs.retain(|e| e.pdr_id != p.pdr_id);
+                        dp_pdrs.push(data_plane_pdr_from_parsed(p));
+                    }
+                    dp_pdrs.sort_by_key(|p| p.precedence);
+                }
+
+                // Create FAR and Update FAR install the same shape, so they run
+                // through one loop.
+                let far_writes: Vec<&crate::n4_build::ParsedCreateFar> =
+                    created_fars.iter().chain(updated_fars.iter()).collect();
+                if !far_writes.is_empty() {
+                    let mut dp_fars = session.fars.write().unwrap();
+                    for f in &far_writes {
                         let ohc_teid = f
                             .forwarding_parameters
                             .as_ref()
@@ -938,12 +1072,14 @@ async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEve
                             },
                         );
                     }
-                    log::info!("Updated {} FARs for SEID={upf_seid:#x}", updated_fars.len());
+                    log::info!("Installed {} FARs for SEID={upf_seid:#x}", far_writes.len());
                 }
 
-                if !updated_qers.is_empty() {
+                let qer_writes: Vec<&crate::n4_build::ParsedCreateQer> =
+                    created_qers.iter().chain(updated_qers.iter()).collect();
+                if !qer_writes.is_empty() {
                     let mut dp_qers = session.qers.write().unwrap();
-                    for q in &updated_qers {
+                    for q in &qer_writes {
                         let mut qer = DataPlaneQer::new(q.qer_id);
                         // Reflective QoS / paging policy the SMF asked for.
                         // Parsed since #81; previously decoded nowhere, so a
@@ -965,7 +1101,7 @@ async fn handle_pfcp_session_event(data_plane: &DataPlane, event: PfcpSessionEve
                         }
                         dp_qers.insert(q.qer_id, qer);
                     }
-                    log::info!("Updated {} QERs for SEID={upf_seid:#x}", updated_qers.len());
+                    log::info!("Installed {} QERs for SEID={upf_seid:#x}", qer_writes.len());
                 }
 
                 if !updated_bars.is_empty() {

--- a/src/bins/nextgcore-upfd/src/n4_build.rs
+++ b/src/bins/nextgcore-upfd/src/n4_build.rs
@@ -125,6 +125,11 @@ pub mod pfcp_ie {
     pub const NODE_ID: u16 = 60;
     pub const MEASUREMENT_METHOD: u16 = 62;
     pub const USAGE_REPORT_TRIGGER: u16 = 63;
+    /// TS 29.244 §8.2.37. Parsed since #306: the PERIO reporting-trigger FLAG was
+    /// parsed and the period itself was not, so a periodic URR was provisioned with
+    /// no cadence and `DataPlaneUrr::measurement_period_secs`'s only reader could
+    /// never fire.
+    pub const MEASUREMENT_PERIOD: u16 = 64;
     pub const VOLUME_MEASUREMENT: u16 = 66;
     pub const DURATION_MEASUREMENT: u16 = 67;
     pub const TIME_OF_FIRST_PACKET: u16 = 69;
@@ -749,6 +754,21 @@ pub fn build_session_establishment_response(
 /// Build Session Modification Response
 /// Port of upf_n4_build_session_modification_response
 pub fn build_session_modification_response(msg_type: u8, created_pdrs: &[CreatedPdr]) -> Vec<u8> {
+    build_session_modification_response_with_reports(msg_type, created_pdrs, &[])
+}
+
+/// Build Session Modification Response, optionally carrying Usage Reports.
+///
+/// The carrier is IE 78 (`USAGE_REPORT_SMR`) — the Session-Modification-Response
+/// spelling of the Usage Report, distinct from the 79/80 the Deletion Response and
+/// Report Request use. #306 needs it so a Remove URR can report the volume it
+/// measured before the rule is detached, and so QAURR can be honoured; the constant
+/// and `add_usage_report`'s carrier parameter were both already here, with no caller.
+pub fn build_session_modification_response_with_reports(
+    msg_type: u8,
+    created_pdrs: &[CreatedPdr],
+    usage_reports: &[UsageReport],
+) -> Vec<u8> {
     let mut builder = PfcpMessageBuilder::new();
 
     // Cause - Request Accepted
@@ -757,6 +777,10 @@ pub fn build_session_modification_response(msg_type: u8, created_pdrs: &[Created
     // Created PDRs
     for pdr in created_pdrs {
         builder.add_created_pdr(pdr);
+    }
+
+    for report in usage_reports {
+        builder.add_usage_report(report, pfcp_ie::USAGE_REPORT_SMR);
     }
 
     let _ = msg_type;
@@ -1649,6 +1673,18 @@ pub fn parse_create_urr(data: &[u8]) -> Result<ParsedCreateUrr, &'static str> {
         }
     }
 
+    // Measurement Period (IE type 64) - u32 seconds, the PERIO trigger's cadence
+    if let Some(ie) = ParsedIe::find_ie(&ies, pfcp_ie::MEASUREMENT_PERIOD) {
+        if ie.value.len() >= 4 {
+            urr.measurement_period_secs = Some(u32::from_be_bytes([
+                ie.value[0],
+                ie.value[1],
+                ie.value[2],
+                ie.value[3],
+            ]));
+        }
+    }
+
     Ok(urr)
 }
 
@@ -1665,6 +1701,8 @@ pub struct ParsedCreateUrr {
     pub volume_threshold_ul: Option<u64>,
     pub volume_threshold_dl: Option<u64>,
     pub time_threshold_secs: Option<u32>,
+    /// Measurement Period (IE type 64), the PERIO trigger's cadence.
+    pub measurement_period_secs: Option<u32>,
 }
 
 /// Parsed Node ID

--- a/src/bins/nextgcore-upfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-upfd/src/pfcp_path.rs
@@ -6,12 +6,12 @@ use crate::n4_build::{
     build_association_release_response, build_association_setup_response, build_failure_response,
     build_heartbeat_response, build_session_deletion_response,
     build_session_establishment_response, build_session_modification_response,
-    build_session_report_request, parse_create_bar, parse_create_far, parse_create_pdr,
-    parse_create_qer, parse_create_urr, parse_pfcpsmreq_flags, parse_recovery_time_stamp, pfcp_ie,
-    pfcp_type, pfcpsmreq_flags, CreatedPdr, DownlinkDataReport, DownlinkDataServiceInfo,
-    ErrorIndicationReport, FSeid, FTeid, NodeId, ParsedCreateBar, ParsedCreateFar, ParsedCreatePdr,
-    ParsedCreateQer, ParsedCreateUrr, ParsedFSeid, ParsedIe, ParsedPfcpHeader, PfcpCause,
-    ReportType, UserPlaneReport,
+    build_session_modification_response_with_reports, build_session_report_request,
+    parse_create_bar, parse_create_far, parse_create_pdr, parse_create_qer, parse_create_urr,
+    parse_pfcpsmreq_flags, parse_recovery_time_stamp, pfcp_ie, pfcp_type, pfcpsmreq_flags,
+    CreatedPdr, DownlinkDataReport, DownlinkDataServiceInfo, ErrorIndicationReport, FSeid, FTeid,
+    NodeId, ParsedCreateBar, ParsedCreateFar, ParsedCreatePdr, ParsedCreateQer, ParsedCreateUrr,
+    ParsedFSeid, ParsedIe, ParsedPfcpHeader, PfcpCause, ReportType, UserPlaneReport,
 };
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
@@ -398,16 +398,37 @@ pub enum PfcpSessionEvent {
         bars: Vec<ParsedCreateBar>,
     },
     /// Session modified - update forwarding rules
+    ///
+    /// Carries every rule operation TS 29.244 Table 7.5.4.1-1 defines. Before #306
+    /// it carried Update FAR, Update QER and BAR only, and the handler parsed only
+    /// those — so a Create/Update/Remove URR, a Remove QER and every PDR and FAR
+    /// operation were answered `RequestAccepted` and dropped.
     SessionModified {
         upf_seid: u64,
         /// Updated downlink TEID
         dl_teid: Option<u32>,
         /// Updated gNB address
         gnb_addr: Option<Ipv4Addr>,
+        /// Rule ids to detach, applied BEFORE the creates so a modification that
+        /// removes and re-creates the same id ends with the new rule (§7.5.4).
+        removed_pdr_ids: Vec<u16>,
+        removed_far_ids: Vec<u32>,
+        removed_qer_ids: Vec<u32>,
+        removed_urr_ids: Vec<u32>,
+        /// Rules created on this live session.
+        created_pdrs: Vec<ParsedCreatePdr>,
+        created_fars: Vec<ParsedCreateFar>,
+        created_qers: Vec<ParsedCreateQer>,
+        created_urrs: Vec<ParsedCreateUrr>,
+        /// Updated PDR rules
+        updated_pdrs: Vec<ParsedCreatePdr>,
         /// Updated FAR rules
         updated_fars: Vec<ParsedCreateFar>,
         /// Updated QERs
         updated_qers: Vec<ParsedCreateQer>,
+        /// Updated URRs. Re-threshold in place: the volume already measured against
+        /// the rule must survive (see `DataPlaneUrr::set_reporting`).
+        updated_urrs: Vec<ParsedCreateUrr>,
         /// Created/updated BARs
         updated_bars: Vec<ParsedCreateBar>,
         /// SMF requested End Marker packets on the old DL tunnel (SNDEM)
@@ -519,6 +540,76 @@ pub struct HeartbeatState {
 /// minutes.
 pub const HEARTBEAT_MAX_MISSES: u32 = 3;
 
+/// Why a Usage Report is being generated, which decides its Usage Report Trigger
+/// (TS 29.244 §8.2.36, #306).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageReportReason {
+    /// The URR is going away — the session is being deleted, or the URR removed.
+    Termination,
+    /// The CP function asked for a report now (QAURR).
+    Immediate,
+}
+
+/// Record the FIRST rule operation that could not be honoured (#306).
+///
+/// First and not last, because TS 29.244 §7.5.5 gives ONE Cause and ONE Offending IE
+/// for the whole message: with several failures the CP function can only act on one,
+/// and the earliest is the one whose rejection explains the rest.
+fn note_first_failure(slot: &mut Option<(PfcpCause, u16)>, cause: PfcpCause, ie_type: u16) {
+    if slot.is_none() {
+        *slot = Some((cause, ie_type));
+    }
+}
+
+/// Pull the `u32` rule id out of a Remove X IE body (TS 29.244 §7.5.4.6-§7.5.4.9).
+///
+/// `None` when the id sub-IE is absent or short — a malformed removal, which the
+/// caller reports rather than skipping.
+fn parse_rule_id_u32(body: &[u8], id_ie_type: u16) -> Option<u32> {
+    let ies = ParsedIe::parse_all(body);
+    let ie = ParsedIe::find_ie(&ies, id_ie_type)?;
+    if ie.value.len() < 4 {
+        return None;
+    }
+    Some(u32::from_be_bytes([
+        ie.value[0],
+        ie.value[1],
+        ie.value[2],
+        ie.value[3],
+    ]))
+}
+
+/// [`parse_rule_id_u32`] for the PDR ID, which TS 29.244 §8.2.36 makes 16-bit.
+fn parse_rule_id_u16(body: &[u8], id_ie_type: u16) -> Option<u16> {
+    let ies = ParsedIe::parse_all(body);
+    let ie = ParsedIe::find_ie(&ies, id_ie_type)?;
+    if ie.value.len() < 2 {
+        return None;
+    }
+    Some(u16::from_be_bytes([ie.value[0], ie.value[1]]))
+}
+
+/// Parse every IE of one type with the establishment path's parser, noting a
+/// malformed body as an Offending IE rather than dropping it silently (#306).
+fn parse_rule_list<T>(
+    ies: &[ParsedIe],
+    ie_type: u16,
+    parse: impl Fn(&[u8]) -> Result<T, &'static str>,
+    failure: &mut Option<(PfcpCause, u16)>,
+) -> Vec<T> {
+    let mut out = Vec::new();
+    for ie in ParsedIe::find_all_ies(ies, ie_type) {
+        match parse(&ie.value) {
+            Ok(rule) => out.push(rule),
+            Err(e) => {
+                log::warn!("Failed to parse rule in IE {ie_type}: {e}");
+                note_first_failure(failure, PfcpCause::MandatoryIeIncorrect, ie_type);
+            }
+        }
+    }
+    out
+}
+
 /// PFCP session information stored in server
 #[derive(Debug, Clone)]
 pub struct PfcpSessionInfo {
@@ -529,6 +620,26 @@ pub struct PfcpSessionInfo {
     pub ul_teid: u32,
     pub dl_teid: u32,
     pub gnb_addr: Option<Ipv4Addr>,
+    /// Which rule ids this session holds, by kind (#306).
+    ///
+    /// The PFCP layer tracks the ids; the data plane holds the rules' behaviour.
+    /// Both are needed, and the split is not redundancy: a Session Modification
+    /// Response has to be built and sent BEFORE the data plane has consumed the
+    /// event, so validating an Update against the data plane's store would reject
+    /// a rule created by a modification one round earlier that the consumer has
+    /// not applied yet. These sets are written synchronously in the handler, in
+    /// the same order the CP function sent the requests, so they are the only
+    /// race-free answer to "does this rule exist" at response-building time.
+    pub rules: SessionRuleIds,
+}
+
+/// The rule ids a session holds, by kind (TS 29.244 §7.5.4, #306).
+#[derive(Debug, Clone, Default)]
+pub struct SessionRuleIds {
+    pub pdr_ids: std::collections::HashSet<u16>,
+    pub far_ids: std::collections::HashSet<u32>,
+    pub qer_ids: std::collections::HashSet<u32>,
+    pub urr_ids: std::collections::HashSet<u32>,
 }
 
 impl PfcpServer {
@@ -1299,7 +1410,8 @@ impl PfcpServer {
             .await
             .map_err(|e| format!("Send error: {e}"))?;
 
-        // Store session info
+        // Store session info, including which rule ids the session now holds so a
+        // later modification's Update/Remove can be validated against them (#306).
         let session_info = PfcpSessionInfo {
             upf_seid,
             smf_seid,
@@ -1308,6 +1420,12 @@ impl PfcpServer {
             ul_teid,
             dl_teid,
             gnb_addr,
+            rules: SessionRuleIds {
+                pdr_ids: parsed_pdrs.iter().map(|p| p.pdr_id).collect(),
+                far_ids: parsed_fars.iter().map(|f| f.far_id).collect(),
+                qer_ids: parsed_qers.iter().map(|q| q.qer_id).collect(),
+                urr_ids: parsed_urrs.iter().map(|u| u.urr_id).collect(),
+            },
         };
 
         {
@@ -1353,50 +1471,121 @@ impl PfcpServer {
 
         let ies = ParsedIe::parse_all(payload);
 
-        // Parse Update FARs
+        // Every rule operation TS 29.244 Table 7.5.4.1-1 defines. Before #306 this
+        // parsed Update FAR, Update QER and BAR only; the rest were answered
+        // `RequestAccepted` and dropped on the floor.
+        //
+        // `offending` records the first IE type whose operation could not be honoured,
+        // so the response can carry a Cause plus an Offending IE (§7.5.5) rather than
+        // a bare acceptance. Collected while parsing and evaluated once, because
+        // §7.5.5 gives ONE Cause for the whole message: a partially-applied
+        // modification has no truthful per-rule answer on this message, and reporting
+        // the FIRST failure is the only thing the CP function can act on.
+        let mut failure: Option<(PfcpCause, u16)> = None;
+
         let mut updated_dl_teid: Option<u32> = None;
         let mut updated_gnb_addr: Option<Ipv4Addr> = None;
-        let mut mod_fars = Vec::new();
 
-        // Update FAR IE type = 10
-        for far_ie in ParsedIe::find_all_ies(&ies, pfcp_ie::UPDATE_FAR) {
-            match parse_create_far(&far_ie.value) {
-                Ok(far) => {
-                    log::debug!(
-                        "Update FAR {}: apply_action={:#x}",
-                        far.far_id,
-                        far.apply_action
-                    );
-                    if let Some(ref fp) = far.forwarding_parameters {
-                        if let Some(ref ohc) = fp.outer_header_creation {
-                            updated_dl_teid = Some(ohc.teid);
-                            updated_gnb_addr = ohc.ipv4;
-                            log::debug!(
-                                "Updated downlink: TEID={:#x}, gNB={:?}",
-                                ohc.teid,
-                                ohc.ipv4
-                            );
-                        }
-                    }
-                    mod_fars.push(far);
-                }
-                Err(e) => {
-                    log::warn!("Failed to parse Update FAR: {e}");
-                }
+        // ---- Removals: rule id only (TS 29.244 §7.5.4.6-7.5.4.9) ----
+        let removed_pdr_ids: Vec<u16> = ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_PDR)
+            .iter()
+            .filter_map(|ie| parse_rule_id_u16(&ie.value, pfcp_ie::PDR_ID))
+            .collect();
+        let removed_far_ids: Vec<u32> = ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_FAR)
+            .iter()
+            .filter_map(|ie| parse_rule_id_u32(&ie.value, pfcp_ie::FAR_ID))
+            .collect();
+        let removed_qer_ids: Vec<u32> = ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_QER)
+            .iter()
+            .filter_map(|ie| parse_rule_id_u32(&ie.value, pfcp_ie::QER_ID))
+            .collect();
+        let removed_urr_ids: Vec<u32> = ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_URR)
+            .iter()
+            .filter_map(|ie| parse_rule_id_u32(&ie.value, pfcp_ie::URR_ID))
+            .collect();
+
+        // A Remove IE whose rule-id sub-IE is missing or short is malformed, and is
+        // reported rather than skipped: silently dropping it is the defect #306 is
+        // about, one level down.
+        for (ie_type, parsed, total) in [
+            (
+                pfcp_ie::REMOVE_PDR,
+                removed_pdr_ids.len(),
+                ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_PDR).len(),
+            ),
+            (
+                pfcp_ie::REMOVE_FAR,
+                removed_far_ids.len(),
+                ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_FAR).len(),
+            ),
+            (
+                pfcp_ie::REMOVE_QER,
+                removed_qer_ids.len(),
+                ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_QER).len(),
+            ),
+            (
+                pfcp_ie::REMOVE_URR,
+                removed_urr_ids.len(),
+                ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_URR).len(),
+            ),
+        ] {
+            if parsed < total {
+                log::warn!(
+                    "{} of {total} Remove IE {ie_type} carried no rule id",
+                    total - parsed
+                );
+                note_first_failure(&mut failure, PfcpCause::MandatoryIeMissing, ie_type);
             }
         }
 
-        // Parse Update QERs (IE type 14)
-        let mut mod_qers = Vec::new();
-        for qer_ie in ParsedIe::find_all_ies(&ies, pfcp_ie::UPDATE_QER) {
-            match parse_create_qer(&qer_ie.value) {
-                Ok(qer) => {
-                    log::debug!("Update QER {}: qfi={:?}", qer.qer_id, qer.qfi);
-                    mod_qers.push(qer);
-                }
-                Err(e) => {
-                    log::warn!("Failed to parse Update QER: {e}");
-                }
+        // ---- Creates and updates ----
+        // Update X carries the same IE set as Create X (Table 7.5.4.2-1 vs
+        // 7.5.2.2-1 and siblings), so the establishment path's parsers are reused
+        // rather than duplicated.
+        let created_pdrs = parse_rule_list(
+            &ies,
+            pfcp_ie::CREATE_PDR,
+            crate::n4_build::parse_create_pdr,
+            &mut failure,
+        );
+        let updated_pdrs = parse_rule_list(
+            &ies,
+            pfcp_ie::UPDATE_PDR,
+            crate::n4_build::parse_create_pdr,
+            &mut failure,
+        );
+        let created_fars =
+            parse_rule_list(&ies, pfcp_ie::CREATE_FAR, parse_create_far, &mut failure);
+        let mod_fars = parse_rule_list(&ies, pfcp_ie::UPDATE_FAR, parse_create_far, &mut failure);
+        let created_qers =
+            parse_rule_list(&ies, pfcp_ie::CREATE_QER, parse_create_qer, &mut failure);
+        let mod_qers = parse_rule_list(&ies, pfcp_ie::UPDATE_QER, parse_create_qer, &mut failure);
+        let created_urrs = parse_rule_list(
+            &ies,
+            pfcp_ie::CREATE_URR,
+            crate::n4_build::parse_create_urr,
+            &mut failure,
+        );
+        let mod_urrs = parse_rule_list(
+            &ies,
+            pfcp_ie::UPDATE_URR,
+            crate::n4_build::parse_create_urr,
+            &mut failure,
+        );
+
+        // The DL tunnel this session forwards on is whatever the LAST Outer Header
+        // Creation on the message names, from a Create or an Update alike. Creates
+        // are considered first so an Update in the same message wins, which is the
+        // order §7.5.4 applies them in.
+        for far in created_fars.iter().chain(mod_fars.iter()) {
+            if let Some(ohc) = far
+                .forwarding_parameters
+                .as_ref()
+                .and_then(|fp| fp.outer_header_creation.as_ref())
+            {
+                updated_dl_teid = Some(ohc.teid);
+                updated_gnb_addr = ohc.ipv4;
+                log::debug!("Updated downlink: TEID={:#x}, gNB={:?}", ohc.teid, ohc.ipv4);
             }
         }
 
@@ -1413,13 +1602,23 @@ impl PfcpServer {
         }
 
         // PFCPSMReq-Flags (TS 29.244 8.2.50): SNDEM → emit End Marker on the
-        // old DL tunnel; DROBU → discard buffered DL packets
+        // old DL tunnel; DROBU → discard buffered DL packets; QAURR → report every
+        // URR immediately in this response. QAURR was declared as a constant and
+        // read nowhere until #306, so an SMF asking for all usage reports got a
+        // bare acceptance and no reports.
         let smreq_flags = parse_pfcpsmreq_flags(payload).unwrap_or(0);
         let send_end_marker = smreq_flags & pfcpsmreq_flags::SNDEM != 0;
         let drop_buffered = smreq_flags & pfcpsmreq_flags::DROBU != 0;
+        let query_all_urrs = smreq_flags & pfcpsmreq_flags::QAURR != 0;
 
         // Update session info; respond Session Context Not Found for an
         // unknown SEID (TS 29.244 7.5.5, cause 65)
+        //
+        // The rule-id bookkeeping is updated in the SAME critical section, in
+        // §7.5.4's application order — remove, then create, then update — so a
+        // modification that removes and re-creates one id ends holding it, and an
+        // Update naming a rule this session does not hold is caught HERE, before a
+        // response claiming acceptance has been sent.
         let lookup = {
             let mut sessions = self.sessions.write().await;
             if let Some(session) = sessions.get_mut(&upf_seid) {
@@ -1430,6 +1629,105 @@ impl PfcpServer {
                 if let Some(addr) = updated_gnb_addr {
                     session.gnb_addr = Some(addr);
                 }
+
+                // Removing a rule the session does not hold is IDEMPOTENT SUCCESS,
+                // deliberately: the CP function asked for the rule to be gone and it
+                // is gone, so answering §7.5.5's rule-failure cause would fail a
+                // modification that achieved exactly what was requested. Logged at
+                // debug so it is visible without being an error.
+                for id in &removed_pdr_ids {
+                    if !session.rules.pdr_ids.remove(id) {
+                        log::debug!("Remove PDR {id}: not held by SEID {upf_seid:#x}, idempotent");
+                    }
+                }
+                for id in &removed_far_ids {
+                    if !session.rules.far_ids.remove(id) {
+                        log::debug!("Remove FAR {id}: not held by SEID {upf_seid:#x}, idempotent");
+                    }
+                }
+                for id in &removed_qer_ids {
+                    if !session.rules.qer_ids.remove(id) {
+                        log::debug!("Remove QER {id}: not held by SEID {upf_seid:#x}, idempotent");
+                    }
+                }
+                for id in &removed_urr_ids {
+                    if !session.rules.urr_ids.remove(id) {
+                        log::debug!("Remove URR {id}: not held by SEID {upf_seid:#x}, idempotent");
+                    }
+                }
+
+                for p in &created_pdrs {
+                    session.rules.pdr_ids.insert(p.pdr_id);
+                }
+                for f in &created_fars {
+                    session.rules.far_ids.insert(f.far_id);
+                }
+                for q in &created_qers {
+                    session.rules.qer_ids.insert(q.qer_id);
+                }
+                for u in &created_urrs {
+                    session.rules.urr_ids.insert(u.urr_id);
+                }
+
+                // Updating a rule the session does NOT hold is a different case from
+                // removing one: the new threshold, gate or forwarding action has
+                // nowhere to land, so the CP function's intent is not satisfied and
+                // §7.5.5's Rule creation/modification Failure is the truthful answer.
+                // Ignoring it is precisely the "accepted a modification it did not
+                // apply" defect this issue is about.
+                for p in &updated_pdrs {
+                    if !session.rules.pdr_ids.contains(&p.pdr_id) {
+                        log::warn!(
+                            "Update PDR {}: no such rule on SEID {upf_seid:#x}",
+                            p.pdr_id
+                        );
+                        note_first_failure(
+                            &mut failure,
+                            PfcpCause::RuleCreationModificationFailure,
+                            pfcp_ie::UPDATE_PDR,
+                        );
+                    }
+                }
+                for f in &mod_fars {
+                    if !session.rules.far_ids.contains(&f.far_id) {
+                        log::warn!(
+                            "Update FAR {}: no such rule on SEID {upf_seid:#x}",
+                            f.far_id
+                        );
+                        note_first_failure(
+                            &mut failure,
+                            PfcpCause::RuleCreationModificationFailure,
+                            pfcp_ie::UPDATE_FAR,
+                        );
+                    }
+                }
+                for q in &mod_qers {
+                    if !session.rules.qer_ids.contains(&q.qer_id) {
+                        log::warn!(
+                            "Update QER {}: no such rule on SEID {upf_seid:#x}",
+                            q.qer_id
+                        );
+                        note_first_failure(
+                            &mut failure,
+                            PfcpCause::RuleCreationModificationFailure,
+                            pfcp_ie::UPDATE_QER,
+                        );
+                    }
+                }
+                for u in &mod_urrs {
+                    if !session.rules.urr_ids.contains(&u.urr_id) {
+                        log::warn!(
+                            "Update URR {}: no such rule on SEID {upf_seid:#x}",
+                            u.urr_id
+                        );
+                        note_first_failure(
+                            &mut failure,
+                            PfcpCause::RuleCreationModificationFailure,
+                            pfcp_ie::UPDATE_URR,
+                        );
+                    }
+                }
+
                 Some((session.smf_seid, old_tunnel))
             } else {
                 None
@@ -1455,11 +1753,56 @@ impl PfcpServer {
             }
         };
 
-        // Build response
-        let resp_payload = build_session_modification_response(
-            pfcp_type::SESSION_MODIFICATION_RESPONSE,
-            &[], // No created PDRs for modification
-        );
+        // Usage Reports the response owes the CP function, carried in IE 78
+        // (USAGE_REPORT_SMR — the Session-Modification-Response carrier).
+        //
+        // A removed URR must report before it is detached (TS 29.244 §8.2.36's TERMR
+        // covers "removal of the URR" as well as session termination). Dropping the
+        // residual instead would lose measured volume the CP function is billing on —
+        // the compromise #215 had to settle for on the SGW-U side, and it is
+        // avoidable here because this server already holds a data-plane handle for the
+        // deletion path's final reports.
+        //
+        // QAURR (§8.2.50) asks for every URR to report immediately; the flag was
+        // parsed nowhere before #306, so an SMF setting it got a bare acceptance and
+        // no reports at all.
+        let mut usage_reports = Vec::new();
+        if !removed_urr_ids.is_empty() {
+            usage_reports.extend(self.collect_usage_reports(
+                upf_seid,
+                Some(&removed_urr_ids),
+                UsageReportReason::Termination,
+            ));
+        }
+        if query_all_urrs {
+            let already: std::collections::HashSet<u32> =
+                usage_reports.iter().map(|r| r.urr_id).collect();
+            usage_reports.extend(
+                self.collect_usage_reports(upf_seid, None, UsageReportReason::Immediate)
+                    .into_iter()
+                    // A URR removed by this same message has already reported with
+                    // TERMR; reporting it twice would double-count it.
+                    .filter(|r| !already.contains(&r.urr_id)),
+            );
+        }
+
+        // Build response. A rule operation that could not be honoured answers with
+        // §7.5.5's Cause and Offending IE instead of a bare RequestAccepted — the
+        // whole point of #306.
+        let resp_payload = match failure {
+            Some((cause, offending_ie)) => {
+                log::warn!(
+                    "Session Modification for SEID {upf_seid:#x} rejected: cause {} offending IE {offending_ie}",
+                    cause as u8
+                );
+                build_failure_response(cause, Some(offending_ie))
+            }
+            None => build_session_modification_response_with_reports(
+                pfcp_type::SESSION_MODIFICATION_RESPONSE,
+                &[], // No created PDRs for modification
+                &usage_reports,
+            ),
+        };
 
         let response = self.build_response(
             pfcp_type::SESSION_MODIFICATION_RESPONSE,
@@ -1474,11 +1817,28 @@ impl PfcpServer {
             .await
             .map_err(|e| format!("Send error: {e}"))?;
 
+        // A rejected modification applies NOTHING. Sending the event anyway would
+        // leave the data plane holding rules the response just said were refused,
+        // which is the same divergence in the other direction.
+        if failure.is_some() {
+            return Ok(());
+        }
+
         // Notify data plane
         let has_changes = updated_dl_teid.is_some()
             || updated_gnb_addr.is_some()
+            || !removed_pdr_ids.is_empty()
+            || !removed_far_ids.is_empty()
+            || !removed_qer_ids.is_empty()
+            || !removed_urr_ids.is_empty()
+            || !created_pdrs.is_empty()
+            || !created_fars.is_empty()
+            || !created_qers.is_empty()
+            || !created_urrs.is_empty()
+            || !updated_pdrs.is_empty()
             || !mod_fars.is_empty()
             || !mod_qers.is_empty()
+            || !mod_urrs.is_empty()
             || !mod_bars.is_empty()
             || send_end_marker
             || drop_buffered;
@@ -1488,8 +1848,18 @@ impl PfcpServer {
                 upf_seid,
                 dl_teid: updated_dl_teid,
                 gnb_addr: updated_gnb_addr,
+                removed_pdr_ids,
+                removed_far_ids,
+                removed_qer_ids,
+                removed_urr_ids,
+                created_pdrs,
+                created_fars,
+                created_qers,
+                created_urrs,
+                updated_pdrs,
                 updated_fars: mod_fars,
                 updated_qers: mod_qers,
+                updated_urrs: mod_urrs,
                 updated_bars: mod_bars,
                 send_end_marker,
                 drop_buffered,
@@ -1584,6 +1954,24 @@ impl PfcpServer {
     /// Collect final usage reports (TERMR trigger) from the data-plane URRs
     /// of a session that is being deleted.
     fn collect_final_usage_reports(&self, upf_seid: u64) -> Vec<crate::n4_build::UsageReport> {
+        self.collect_usage_reports(upf_seid, None, UsageReportReason::Termination)
+    }
+
+    /// Read the current counters of a session's URRs and build Usage Reports.
+    ///
+    /// `only` restricts the set to named URR ids — which is what a Remove URR needs,
+    /// so a modification reports the residual volume of the rules it is detaching and
+    /// nothing else (#306). `None` means every URR on the session, for a deletion's
+    /// final reports or a QAURR query.
+    ///
+    /// Read-only on the counters: the caller decides whether the URR survives, and
+    /// resetting here would zero a rule that is merely being queried.
+    fn collect_usage_reports(
+        &self,
+        upf_seid: u64,
+        only: Option<&[u32]>,
+        reason: UsageReportReason,
+    ) -> Vec<crate::n4_build::UsageReport> {
         let dp = match self.data_plane.read().unwrap().clone() {
             Some(dp) => dp,
             None => return Vec::new(),
@@ -1594,9 +1982,15 @@ impl PfcpServer {
         };
         let urrs = session.urrs.read().unwrap();
         urrs.values()
+            .filter(|urr| only.is_none_or(|ids| ids.contains(&urr.urr_id)))
             .map(|urr| {
                 let mut trigger = crate::n4_build::UsageReportTrigger::default();
-                trigger.termination_report = true;
+                match reason {
+                    // TS 29.244 §8.2.36: TERMR covers the removal of the URR as well
+                    // as the termination of the session.
+                    UsageReportReason::Termination => trigger.termination_report = true,
+                    UsageReportReason::Immediate => trigger.immediate_report = true,
+                }
                 crate::n4_build::UsageReport {
                     urr_id: urr.urr_id,
                     ur_seqn: urr.next_ur_seqn(),
@@ -2125,6 +2519,542 @@ mod tests {
         );
     }
 
+    // ================================================================
+    // #306: a Session Modification's rule operations reach the rule store
+    //
+    // Every one of these drives a REAL datagram into the bound socket and then runs
+    // the event through `crate::handle_pfcp_session_event` -- the production apply
+    // path, not a copy of it. Asserting the parsed event alone would pass in exactly
+    // the broken state this issue describes, because before #306 the parse was the
+    // half that was missing and the apply was the half that did not exist.
+    // ================================================================
+
+    /// Body of a Create/Update URR IE. Update URR carries the same IE set as Create
+    /// URR (TS 29.244 Table 7.5.4.10-1 vs 7.5.2.4-1), which is why one helper serves.
+    fn urr_body(
+        id: u32,
+        vol_total: Option<u64>,
+        time_threshold: Option<u32>,
+        period: Option<u32>,
+    ) -> Vec<u8> {
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_u32(pfcp_ie::URR_ID, id);
+        // Measurement Method: VOLUM | DURAT
+        b.add_u8(pfcp_ie::MEASUREMENT_METHOD, 0x02 | 0x01);
+        // Reporting Triggers: PERIO | VOLTH | TIMTH
+        b.add_u8(pfcp_ie::REPORTING_TRIGGERS, 0x01 | 0x02 | 0x04);
+        if let Some(v) = vol_total {
+            // Volume Threshold (§8.2.13): flags byte then the selected u64s.
+            let mut value = vec![0x01u8];
+            value.extend_from_slice(&v.to_be_bytes());
+            b.add_tlv(pfcp_ie::VOLUME_THRESHOLD, &value);
+        }
+        if let Some(s) = time_threshold {
+            b.add_u32(pfcp_ie::TIME_THRESHOLD, s);
+        }
+        if let Some(s) = period {
+            b.add_u32(pfcp_ie::MEASUREMENT_PERIOD, s);
+        }
+        b.build()
+    }
+
+    /// Body of a Remove FAR / Remove QER / Remove URR IE: the rule id, nothing else.
+    fn remove_body_u32(id_ie: u16, id: u32) -> Vec<u8> {
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_u32(id_ie, id);
+        b.build()
+    }
+
+    /// Body of a Remove PDR IE (the PDR ID is 16-bit).
+    fn remove_body_u16(id: u16) -> Vec<u8> {
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_pdr_id(id);
+        b.build()
+    }
+
+    fn qer_body(id: u32, qfi: u8) -> Vec<u8> {
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_u32(pfcp_ie::QER_ID, id);
+        b.add_u8(pfcp_ie::QFI, qfi);
+        b.build()
+    }
+
+    fn far_body(id: u32, apply_action: u16) -> Vec<u8> {
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_u32(pfcp_ie::FAR_ID, id);
+        b.add_u16(pfcp_ie::APPLY_ACTION, apply_action);
+        b.build()
+    }
+
+    fn pdr_body(pdr_id: u16, precedence: u32, far_id: u32, qer_id: u32, urr_id: u32) -> Vec<u8> {
+        let mut pdi = crate::n4_build::PfcpMessageBuilder::new();
+        pdi.add_u8(pfcp_ie::SOURCE_INTERFACE, 0); // Access
+        pdi.add_f_teid(&crate::n4_build::FTeid {
+            teid: 0x1234,
+            ipv4: Some(Ipv4Addr::new(127, 0, 0, 4)),
+            ipv6: None,
+            choose: false,
+            choose_id: None,
+        });
+        pdi.add_ue_ip_address(
+            &crate::n4_build::UeIpAddress {
+                ipv4: Some(Ipv4Addr::new(10, 45, 0, 42)),
+                ipv6: None,
+                ipv6_prefix_len: 0,
+            },
+            false,
+        );
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_pdr_id(pdr_id);
+        b.add_u32(pfcp_ie::PRECEDENCE, precedence);
+        b.add_tlv(pfcp_ie::PDI, &pdi.build());
+        b.add_u32(pfcp_ie::FAR_ID, far_id);
+        b.add_u32(pfcp_ie::QER_ID, qer_id);
+        b.add_u32(pfcp_ie::URR_ID, urr_id);
+        b.build()
+    }
+
+    /// An associated server with ONE established session carrying PDR 1, FAR 1,
+    /// QER 1 and URR 1, applied to a real data plane.
+    ///
+    /// The data plane is attached to the server (`set_data_plane`), which is what
+    /// lets a Remove URR pull the residual counters for its Usage Report.
+    async fn established_session() -> (
+        Arc<PfcpServer>,
+        UdpSocket,
+        SocketAddr,
+        mpsc::Receiver<PfcpSessionEvent>,
+        Arc<crate::data_plane::DataPlane>,
+        u64,
+    ) {
+        let (server, smf, addr, mut rx) = spawn_test_server().await;
+        let dp = Arc::new(crate::data_plane::DataPlane::new(Arc::new(
+            AtomicBool::new(false),
+        )));
+        server.set_data_plane(dp.clone());
+
+        let assoc = build_association_setup_request_payload(Some(1));
+        let _ = exchange(&smf, addr, &encode_pfcp(5, None, 1, &assoc)).await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_node_id(&NodeId::Ipv4(Ipv4Addr::new(127, 0, 0, 9)));
+        b.add_f_seid(&crate::n4_build::FSeid {
+            seid: 0x4242,
+            ipv4: Some(Ipv4Addr::new(127, 0, 0, 9)),
+            ipv6: None,
+        });
+        b.add_tlv(pfcp_ie::CREATE_PDR, &pdr_body(1, 100, 1, 1, 1));
+        b.add_tlv(pfcp_ie::CREATE_FAR, &far_body(1, 0x02));
+        b.add_tlv(pfcp_ie::CREATE_QER, &qer_body(1, 5));
+        b.add_tlv(
+            pfcp_ie::CREATE_URR,
+            &urr_body(1, Some(1_000_000), Some(60), Some(30)),
+        );
+        let resp = exchange(&smf, addr, &encode_pfcp(50, Some(0), 2, &b.build())).await;
+        assert_eq!(
+            response_cause(&resp),
+            PfcpCause::RequestAccepted as u8,
+            "the establishment this fixture depends on must succeed"
+        );
+        let (hdr, _) = ParsedPfcpHeader::parse(&resp).unwrap();
+        let _ = hdr;
+        let upf_seid = server
+            .sessions
+            .read()
+            .await
+            .keys()
+            .copied()
+            .next()
+            .expect("the server must hold the session it just accepted");
+
+        let evt = rx.recv().await.expect("SessionEstablished");
+        crate::handle_pfcp_session_event(&dp, evt).await;
+        assert!(
+            dp.sessions.find_by_seid(upf_seid).is_some(),
+            "the data plane must hold the session before any modification"
+        );
+        (server, smf, addr, rx, dp, upf_seid)
+    }
+
+    /// Apply the next session event through the production handler.
+    async fn apply_next(
+        rx: &mut mpsc::Receiver<PfcpSessionEvent>,
+        dp: &crate::data_plane::DataPlane,
+    ) {
+        let evt = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("a session event must be emitted")
+            .expect("channel open");
+        crate::handle_pfcp_session_event(dp, evt).await;
+    }
+
+    fn usage_reports_in(resp: &[u8]) -> Vec<(u32, u64)> {
+        let (_, body) = ParsedPfcpHeader::parse(resp).unwrap();
+        let ies = ParsedIe::parse_all(body);
+        ParsedIe::find_all_ies(&ies, pfcp_ie::USAGE_REPORT_SMR)
+            .iter()
+            .filter_map(|ie| {
+                let inner = ParsedIe::parse_all(&ie.value);
+                let id = ParsedIe::find_ie(&inner, pfcp_ie::URR_ID)?;
+                let urr_id =
+                    u32::from_be_bytes([id.value[0], id.value[1], id.value[2], id.value[3]]);
+                // Volume Measurement (§8.2.14): flags byte then the selected u64s,
+                // total first.
+                let vm = ParsedIe::find_ie(&inner, pfcp_ie::VOLUME_MEASUREMENT)?;
+                let total = if vm.value.len() >= 9 && vm.value[0] & 0x01 != 0 {
+                    u64::from_be_bytes(vm.value[1..9].try_into().ok()?)
+                } else {
+                    0
+                };
+                Some((urr_id, total))
+            })
+            .collect()
+    }
+
+    /// Criterion 1: provisioning charging mid-session is the normal way it is added,
+    /// and before #306 the UPF answered `RequestAccepted` and measured nothing.
+    #[tokio::test]
+    async fn a_modification_creating_a_urr_provisions_measurement() {
+        let (_server, smf, addr, mut rx, dp, upf_seid) = established_session().await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(
+            pfcp_ie::CREATE_URR,
+            &urr_body(7, Some(555), Some(11), Some(9)),
+        );
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(resp[1], pfcp_type::SESSION_MODIFICATION_RESPONSE);
+        assert_eq!(response_cause(&resp), PfcpCause::RequestAccepted as u8);
+        apply_next(&mut rx, &dp).await;
+
+        let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+        let urrs = session.urrs.read().unwrap();
+        let urr = urrs.get(&7).expect("Create URR must install the rule");
+        assert_eq!(urr.volume_threshold_total(), Some(555));
+        assert_eq!(urr.time_threshold_secs(), Some(11));
+        assert_eq!(
+            urr.measurement_period_secs(),
+            Some(9),
+            "the Measurement Period must survive the wire: the PERIO trigger is \
+             useless without it"
+        );
+    }
+
+    /// Criterion 2, and the reason the thresholds are atomic: re-thresholding must
+    /// not zero the volume the CP function is accounting on.
+    #[tokio::test]
+    async fn an_update_urr_rethresholds_without_resetting_the_measured_volume() {
+        let (_server, smf, addr, mut rx, dp, upf_seid) = established_session().await;
+
+        // Measure something against URR 1 first.
+        {
+            let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+            let urrs = session.urrs.read().unwrap();
+            let urr = urrs.get(&1).expect("the fixture installs URR 1");
+            urr.record(4096, true);
+            urr.record(2048, false);
+            assert_eq!(urr.acc_total_bytes.load(Ordering::Relaxed), 6144);
+        }
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(pfcp_ie::UPDATE_URR, &urr_body(1, Some(99), Some(5), None));
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(response_cause(&resp), PfcpCause::RequestAccepted as u8);
+        apply_next(&mut rx, &dp).await;
+
+        let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+        let urrs = session.urrs.read().unwrap();
+        let urr = urrs.get(&1).expect("Update URR must not remove the rule");
+        assert_eq!(
+            urr.volume_threshold_total(),
+            Some(99),
+            "the new threshold must be in force"
+        );
+        assert_eq!(
+            urr.acc_total_bytes.load(Ordering::Relaxed),
+            6144,
+            "an Update URR must NOT reset the volume measured so far"
+        );
+        assert_eq!(urr.acc_ul_bytes.load(Ordering::Relaxed), 4096);
+        assert_eq!(
+            urr.measurement_period_secs(),
+            None,
+            "a period the update omits is withdrawn, not silently retained"
+        );
+    }
+
+    /// Criterion 3 plus the leak the issue names: a removed URR must report what it
+    /// measured and then stop measuring.
+    #[tokio::test]
+    async fn a_removed_urr_reports_its_residual_volume_then_stops_measuring() {
+        let (_server, smf, addr, mut rx, dp, upf_seid) = established_session().await;
+
+        let urr_arc = {
+            let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+            let urrs = session.urrs.read().unwrap();
+            let urr = urrs.get(&1).unwrap().clone();
+            urr.record(1500, true);
+            urr.record(500, false);
+            urr
+        };
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(pfcp_ie::REMOVE_URR, &remove_body_u32(pfcp_ie::URR_ID, 1));
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(response_cause(&resp), PfcpCause::RequestAccepted as u8);
+
+        // The residual volume leaves in the RESPONSE, in IE 78. Dropping it would
+        // lose measured traffic the CP function is billing on.
+        assert_eq!(
+            usage_reports_in(&resp),
+            vec![(1, 2000)],
+            "a removed URR must report its residual volume before being detached"
+        );
+
+        apply_next(&mut rx, &dp).await;
+        let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+        assert!(
+            !session.urrs.read().unwrap().contains_key(&1),
+            "Remove URR must detach the rule"
+        );
+        // And the counters are unreachable from the data path: `urr_record`'s only
+        // route to them is the map the rule was just removed from.
+        assert_eq!(Arc::strong_count(&urr_arc), 1);
+    }
+
+    /// Criterion 4: the other three removals.
+    #[tokio::test]
+    async fn removing_a_qer_a_pdr_and_a_far_detaches_each_of_them() {
+        let (_server, smf, addr, mut rx, dp, upf_seid) = established_session().await;
+        {
+            let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+            assert!(session.qers.read().unwrap().contains_key(&1));
+            assert!(session.fars.read().unwrap().contains_key(&1));
+            assert_eq!(session.pdrs.read().unwrap().len(), 1);
+        }
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(pfcp_ie::REMOVE_QER, &remove_body_u32(pfcp_ie::QER_ID, 1));
+        b.add_tlv(pfcp_ie::REMOVE_FAR, &remove_body_u32(pfcp_ie::FAR_ID, 1));
+        b.add_tlv(pfcp_ie::REMOVE_PDR, &remove_body_u16(1));
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(response_cause(&resp), PfcpCause::RequestAccepted as u8);
+        apply_next(&mut rx, &dp).await;
+
+        let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+        assert!(
+            session.qers.read().unwrap().is_empty(),
+            "Remove QER must remove the policing, not leave it installed"
+        );
+        assert!(session.fars.read().unwrap().is_empty());
+        assert!(
+            session.pdrs.read().unwrap().is_empty(),
+            "Remove PDR must remove the detection rule"
+        );
+    }
+
+    /// Criterion 5. An Update naming a rule the session does not hold has nowhere to
+    /// land, so §7.5.5's Cause and Offending IE are the truthful answer -- and
+    /// NOTHING is applied, because a response that refused must not be followed by
+    /// an event that applies.
+    #[tokio::test]
+    async fn an_update_for_an_absent_rule_is_refused_with_an_offending_ie() {
+        let (_server, smf, addr, mut rx, dp, upf_seid) = established_session().await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(pfcp_ie::UPDATE_URR, &urr_body(4242, Some(1), None, None));
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(
+            response_cause(&resp),
+            PfcpCause::RuleCreationModificationFailure as u8,
+            "an unapplicable rule operation must not be answered RequestAccepted"
+        );
+        let (_, body) = ParsedPfcpHeader::parse(&resp).unwrap();
+        let ies = ParsedIe::parse_all(body);
+        let off = ParsedIe::find_ie(&ies, pfcp_ie::OFFENDING_IE)
+            .expect("§7.5.5 pairs the cause with the offending IE");
+        assert_eq!(
+            u16::from_be_bytes([off.value[0], off.value[1]]),
+            pfcp_ie::UPDATE_URR
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(300), rx.recv())
+                .await
+                .is_err(),
+            "a refused modification must emit no apply event"
+        );
+        let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+        assert!(!session.urrs.read().unwrap().contains_key(&4242));
+    }
+
+    /// The other half of criterion 5's decision, stated so it is not mistaken for an
+    /// oversight: a REMOVAL of something absent is idempotent success, because the
+    /// end state is exactly what the CP function asked for.
+    #[tokio::test]
+    async fn a_removal_of_an_absent_rule_is_idempotent_success() {
+        let (_server, smf, addr, _rx, _dp, upf_seid) = established_session().await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(pfcp_ie::REMOVE_URR, &remove_body_u32(pfcp_ie::URR_ID, 999));
+        b.add_tlv(pfcp_ie::REMOVE_QER, &remove_body_u32(pfcp_ie::QER_ID, 999));
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(
+            response_cause(&resp),
+            PfcpCause::RequestAccepted as u8,
+            "the rule is gone, which is what was asked -- failing would refuse a \
+             modification that achieved its intent"
+        );
+    }
+
+    /// A malformed rule body is reported rather than skipped: dropping it silently is
+    /// this issue's defect one level down.
+    #[tokio::test]
+    async fn a_malformed_rule_body_is_reported_as_an_offending_ie() {
+        let (_server, smf, addr, _rx, _dp, upf_seid) = established_session().await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        // A Create URR with no URR ID at all.
+        let mut bad = crate::n4_build::PfcpMessageBuilder::new();
+        bad.add_u32(pfcp_ie::TIME_THRESHOLD, 10);
+        b.add_tlv(pfcp_ie::CREATE_URR, &bad.build());
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(response_cause(&resp), PfcpCause::MandatoryIeIncorrect as u8);
+        let (_, body) = ParsedPfcpHeader::parse(&resp).unwrap();
+        let ies = ParsedIe::parse_all(body);
+        let off = ParsedIe::find_ie(&ies, pfcp_ie::OFFENDING_IE).unwrap();
+        assert_eq!(
+            u16::from_be_bytes([off.value[0], off.value[1]]),
+            pfcp_ie::CREATE_URR
+        );
+    }
+
+    /// QAURR (§8.2.50) was a constant with no reader: an SMF asking for every URR to
+    /// report got a bare acceptance and no reports.
+    #[tokio::test]
+    async fn qaurr_reports_every_urr_in_the_response() {
+        let (_server, smf, addr, _rx, dp, upf_seid) = established_session().await;
+        {
+            let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+            let urrs = session.urrs.read().unwrap();
+            urrs.get(&1).unwrap().record(777, true);
+        }
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_u8(pfcp_ie::PFCPSMREQ_FLAGS, pfcpsmreq_flags::QAURR);
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(response_cause(&resp), PfcpCause::RequestAccepted as u8);
+        assert_eq!(
+            usage_reports_in(&resp),
+            vec![(1, 777)],
+            "QAURR must produce a Usage Report per URR"
+        );
+    }
+
+    /// A create and a remove of the SAME id in one message must end holding the NEW
+    /// rule: §7.5.4 applies removals before creates, and getting that order wrong
+    /// leaves the session with nothing.
+    #[tokio::test]
+    async fn a_remove_and_create_of_one_id_ends_with_the_new_rule() {
+        let (_server, smf, addr, mut rx, dp, upf_seid) = established_session().await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(pfcp_ie::REMOVE_URR, &remove_body_u32(pfcp_ie::URR_ID, 1));
+        b.add_tlv(pfcp_ie::CREATE_URR, &urr_body(1, Some(4242), None, None));
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 3, &b.build())).await;
+        assert_eq!(response_cause(&resp), PfcpCause::RequestAccepted as u8);
+        apply_next(&mut rx, &dp).await;
+
+        let session = dp.sessions.find_by_seid(upf_seid).unwrap();
+        let urrs = session.urrs.read().unwrap();
+        let urr = urrs
+            .get(&1)
+            .expect("the re-created rule must be the one that survives");
+        assert_eq!(urr.volume_threshold_total(), Some(4242));
+        assert_eq!(
+            urr.acc_total_bytes.load(Ordering::Relaxed),
+            0,
+            "it is a NEW rule, so its counters start at zero -- unlike an update"
+        );
+    }
+
+    /// #306 criterion 6's cost, guarded rather than accepted.
+    ///
+    /// This PR extends upfd's own `ParsedIe` walk instead of moving onto
+    /// `nextgcore_pfcp::message::SessionModificationRequest` (see the spec for why).
+    /// The argument against that choice is drift: two decoders for one message.
+    ///
+    /// So the two are pinned against each other. The message is built by the LIBRARY
+    /// encoder and decoded by BOTH, and the rule ids and thresholds must agree. If
+    /// the library's wire format moves and upfd's walk does not follow, this fails
+    /// here rather than in a deployment -- which is the guarantee moving onto the
+    /// library decoder would have given for free.
+    #[test]
+    fn the_library_decoder_and_upfds_walk_agree_on_one_modification() {
+        use bytes::{Bytes, BytesMut};
+        use nextgcore_pfcp::message::SessionModificationRequest;
+        use nextgcore_pfcp::types::{RemoveQer, RemoveUrr, UpdateUrr, VolumeThreshold};
+
+        let mut req = SessionModificationRequest::new();
+        req.remove_urrs.push(RemoveUrr::new(11));
+        req.remove_qers.push(RemoveQer::new(22));
+        let mut update = UpdateUrr {
+            urr_id: 33,
+            ..Default::default()
+        };
+        update.measurement_period = Some(77);
+        update.volume_threshold = Some(VolumeThreshold::new_total(8888));
+        req.update_urrs.push(update);
+
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let wire = buf.freeze();
+
+        // Round trip through the library, so a change in ITS decoder is visible too.
+        let via_library = SessionModificationRequest::decode(&mut wire.clone())
+            .expect("the library must decode what it encoded");
+        assert_eq!(
+            via_library
+                .remove_urrs
+                .iter()
+                .map(|r| r.urr_id)
+                .collect::<Vec<_>>(),
+            vec![11]
+        );
+
+        // And through upfd's walk, which is what the handler actually uses.
+        let ies = ParsedIe::parse_all(&wire);
+        let removed_urrs: Vec<u32> = ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_URR)
+            .iter()
+            .filter_map(|ie| super::parse_rule_id_u32(&ie.value, pfcp_ie::URR_ID))
+            .collect();
+        let removed_qers: Vec<u32> = ParsedIe::find_all_ies(&ies, pfcp_ie::REMOVE_QER)
+            .iter()
+            .filter_map(|ie| super::parse_rule_id_u32(&ie.value, pfcp_ie::QER_ID))
+            .collect();
+        let mut failure = None;
+        let updated_urrs = super::parse_rule_list(
+            &ies,
+            pfcp_ie::UPDATE_URR,
+            crate::n4_build::parse_create_urr,
+            &mut failure,
+        );
+
+        assert_eq!(removed_urrs, vec![11], "Remove URR must decode identically");
+        assert_eq!(removed_qers, vec![22], "Remove QER must decode identically");
+        assert!(
+            failure.is_none(),
+            "the library's Update URR must parse cleanly"
+        );
+        assert_eq!(updated_urrs.len(), 1);
+        assert_eq!(updated_urrs[0].urr_id, 33);
+        assert_eq!(
+            updated_urrs[0].measurement_period_secs,
+            Some(77),
+            "the Measurement Period the library encodes is the one upfd reads"
+        );
+        assert_eq!(updated_urrs[0].volume_threshold_total, Some(8888));
+    }
+
     #[tokio::test]
     async fn test_session_modification_unknown_seid_rejected() {
         let (_server, smf, addr, _rx) = spawn_test_server().await;
@@ -2551,6 +3481,7 @@ mod tests {
                 ul_teid: 0x100,
                 dl_teid: 0x200,
                 gnb_addr: Some(Ipv4Addr::new(127, 0, 0, 1)),
+                rules: SessionRuleIds::default(),
             })
             .await;
         (server, smf, upf_seid, smf_seid)


### PR DESCRIPTION
Closes #306. Spec: `specs/fix-upfd-modification-rule-operations.md`.

## The gap

`handle_session_modification_request` parsed Update FAR, Update QER and Create/Update BAR, then answered `RequestAccepted` on the **session lookup alone**. Everything else on TS 29.244 Table 7.5.4.1-1 was dropped: Create/Update/Remove URR, Remove QER, and every PDR and FAR operation. So an SMF that provisioned charging mid-session got an acceptance and no measurement; one that removed a URR kept being measured; a removed QER kept policing; a removed PDR kept detecting.

#306 is accurate — every claim in it verified against `4f3af48`. Verifying it turned up **two more of the same kind**, and the first makes criterion 1 unmeetable as written:

- **The Measurement Period IE was parsed nowhere.** `parse_create_urr` read the PERIO reporting-trigger *flag* and never the period behind it, so `DataPlaneUrr::measurement_period_secs` — whose one reader is the periodic sweep — could never be anything but `None`. A URR "provisioned with measurement" that can never report periodically is the same half-truth one layer down.
- **QAURR was a constant with no reader**, so an SMF asking for every URR to report got a bare acceptance and no reports.

## Criterion 6: option 2, with the drift risk guarded rather than accepted

Update X carries the same IE set as Create X (Table 7.5.4.2-1 vs 7.5.2.2-1 and siblings), so the establishment path's parsers — exercised on every session — are reused, and the four Remove IEs are one rule-id sub-IE each. Option 1 is not a decoder swap: `PfcpSessionEvent` carries upfd's `ParsedCreate*` types, so it would rewrite the event enum, both handlers and the data-plane consumer. #304 sized that as its own pass; that sizing still holds.

The argument for option 1 is drift, so the two decoders are **pinned to each other**: `the_library_decoder_and_upfds_walk_agree_on_one_modification` builds a Session Modification with the *library* encoder and asserts both decoders read the same ids and thresholds. Reverting upfd's Measurement Period lookup makes it fail, so it is a real guard, not a gesture.

## Criterion 5: four cases, three answers

| case | answer | why |
|---|---|---|
| malformed rule body | cause **69** + Offending IE | skipping it silently is this defect one level down |
| **Update** naming an absent rule | cause **73** + Offending IE | the new threshold/gate has nowhere to land — intent not satisfied |
| **Remove** naming an absent rule | **RequestAccepted** | the rule is gone, which is what was asked; failing would refuse a modification that achieved its intent |
| IE type upfd does not model | ignored | §6.2 requires unknown IEs to be ignored |

§7.5.5 gives one Cause per message, so the **first** failure is reported. A refused modification emits **no** apply event — otherwise the data plane holds rules the response just refused.

Answering that synchronously needs one design change: the response is built and sent **before** the data plane consumes the event, so validating against the data-plane store would reject a rule created one round earlier that the consumer has not applied yet. `PfcpSessionInfo` therefore tracks rule **IDs**, written in the same critical section in §7.5.4's order. The PFCP layer owns the ids; the data plane owns the rules' behaviour.

## A removed URR reports before it is detached

The issue calls a removed URR with running counters "a leak as well as a wrong bill". Both halves close, and the volume is not discarded: the residual leaves in the **response**, IE 78 (`USAGE_REPORT_SMR`) with TERMR — §8.2.36 defines TERMR as covering removal of the URR, not only session termination. This was cheap because the pieces were already present with no caller: the constant, `add_usage_report`'s carrier parameter, and the data-plane handle added for the deletion path. #215 had to settle for warn-and-drop on the SGW-U because it could not reach the counters; upfd can, so it should not inherit the compromise.

Update URR re-thresholds **in place**, which is why the thresholds became atomics: they were `Option<u64>` behind the `Arc` the data plane holds, so the only way to change one was to rebuild the rule and zero its `AtomicU64` counters — a wrong bill, not a lost setting. A threshold the update *omits* is withdrawn rather than retained, and that is asserted, because the opposite reading is equally defensible.

## Verification

Every test drives a real datagram into the bound socket and then runs the emitted event through `crate::handle_pfcp_session_event` — the production apply path, not a copy. Asserting the parsed event alone would pass in exactly the broken state this issue describes.

**13 reverts, 13 bites**: Create URR apply; Measurement Period parse; Update-URR-preserves-volume; the residual report; the URR detach; Remove QER / PDR / FAR applies; the update-absent refusal; QAURR; remove-before-create ordering; malformed-body reporting; the cross-decoder guard.

Three notes on the revert pass itself, because they are the difference between a verified claim and a written one:

- Two patches **did not compile** and the harness reported `DID-NOT-COMPILE` rather than a pass — the failure mode this repo records as indistinguishable from a decorative test.
- One reported **PASSED**: the patch read like an inversion of the apply order but moved the removal to the *top* of the create block, which is still remove-then-create. Rewritten to move it after the inserts, it bites. Reading only the verdict would have called the ordering claim unverified.

upfd 290 → 300 tests. Workspace 6325 passed / 0 failed, `clippy --workspace` 0, `fmt --check` clean.

## Ceilings

- The **establishment** handler keeps its inline-in-a-match-arm shape; only the modification path's application is reachable from a test. The shared PDR builder is the one piece extracted (one builder, not two — the same drift argument one layer in).
- **Update PDR** is applied but only Remove PDR is asserted over the wire; the replace-then-precedence-sort behaviour has no test of its own.
- The **Update QER** path still rebuilds the QER from scratch, so an omitted member resets it and token-bucket state is lost. Pre-existing, adjacent to the Update-URR reasoning, and deliberately unchanged: whether a QER's token bucket should survive a re-authorisation is a decision, not a fix.
- **No timer.** A Measurement Period is now provisioned and stored; whether the data plane's 30-second sweep fires at the *provisioned* cadence is untested and is the same shape as the open sgwud lazy-reporting task.
- `Arc::strong_count` proves the data path can no longer reach a removed URR, not that no packet is counted; a packet already inside `record` is counted into a rule nobody reads. Accepted, and bounded by the pre-removal report.
- **No E2E** — loopback datagrams in one process; the Docker jobs are `workflow_dispatch`-only.

## Note on CI

#308 removed the `cargo test` retry. **#313** (the cross-process `free_port` window) is now the residual, and it is more frequent than #308's spec estimated — roughly 2 in 29 workspace runs, measured while verifying this PR and [corrected on the issue](https://github.com/NextgCoreLab/nextgcore/issues/313). Both failures seen were `SbiServer::start` bind panics in `udrd` and `scpd`, neither of which this PR touches. If the Test gate reddens on one of those, it is #313 and a re-run is the right response.