### PR TITLE
fix(mmed): give the MME a real S11 GTP-C endpoint on the shared codec (#51)

### DIFF
--- a/specs/fix-mmed-s11-gtpc-endpoint.md
+++ b/specs/fix-mmed-s11-gtpc-endpoint.md
@@ -1,0 +1,168 @@
+# nextgcore #51 (mmed): a functional S11 GTP-C endpoint on the shared codec
+
+Verified against `main` @ `76cefd2`. TS 29.274 §7.2.1, §7.6, §8.4, §8.12, §8.17, §8.22,
+Tables 7.2.1-1 / 7.2.7-1 / 7.2.9.1-1; TS 23.007 §18, §20; TS 23.401 §5.3.2.1.
+
+#51 is accurate in every particular. Nothing in it is stale.
+
+## Verified against current main
+
+| claim in the issue | site on `76cefd2` | still true? |
+|---|---|---|
+| `gtp_open()` binds no UDP socket | `gtp_path.rs:62` sets a bool | yes |
+| every `send_*` drops the message into a `_pkbuf` local | **eleven** of them | yes |
+| no `Gtp2XactMgr` instantiated by mmed | grep: referenced only by sgwcd | yes |
+| sequence numbers hardcoded to 0 | `write_gtp_header_with_teid(..., 0)` in every builder | yes |
+| two senders substitute `ctx.next_pool_id()` for the sequence | DDN Ack and Release Access Bearers | yes |
+| the CSR omits Sender F-TEID and Bearer Contexts | it emits 8 IEs, neither of them | yes |
+| the MBR is invoked with an empty bearer slice | `&[]` at the call site | yes |
+| DSR passes a literal `5` as the LBI | yes | yes |
+| RAT Type hardcoded to literal `6`, twice | yes | yes |
+| Indication `[0x00, 0x08, 0x00]` leaves OI unset | confirmed against §8.12: the bit is in the second content octet | yes |
+| `GtpCause::from` collapses 66, 68, 73, 74-78, 94 to `Reserved` | yes — twelve values | yes |
+| `esm_cause_from_gtp` omits 78 | yes | yes |
+| hand-rolled `GtpBuffer` duplicates the tested library codec | `s11_build.rs:229-344` | yes |
+| Echo builders exist and are never called | yes; no path management at all | yes |
+| `mme.gtpc` is unread by the config loader | `config.rs`'s module doc says so and names this issue | yes |
+
+## Decision 1: mirror sgwcd's server rather than design a second one
+
+The two are the two ends of the same interface. A second design would be two answers to
+"how long may an S11 message take" and "when is a peer down", and the shared
+`Gtp2XactMgr` — referenced only by sgwcd and never instantiated here, which is why mmed
+had no T3-RESPONSE/N3-REQUESTS budget at all — is what makes them agree.
+
+So `GtpcServer` is structurally sgwcd's: a bound `UdpSocket` with a 100 ms read timeout,
+a receive thread, and a T3/N3 poll thread that also drives Echo because it already ticks.
+Synchronous (OS threads, blocking socket) for the same reason sgwcd is: the NAS and S1AP
+paths that originate these messages are synchronous, and putting an executor in front of
+them is a far larger change than this issue.
+
+**Not copied blindly.** sgwcd's restart-triggered context deletion is deliberately absent:
+deleting this MME's UE contexts because the SGW restarted is a decision about subscriber
+state that #51 does not own, and a Recovery counter changes on a reordered datagram too.
+The restart is recorded and logged loudly instead.
+
+## Decision 2: the process-wide server is a `OnceLock`, like the S6a queue
+
+The twelve senders are called from synchronous NAS/S1AP code that threads no transport
+handle. `fd_path` already solved this shape for the S6a request queue, so the S11 server
+follows it rather than inventing a second convention. `None` means the socket was never
+bound, and every send then **reports that** instead of returning `Ok` — which is the
+whole defect being fixed, so a silent no-op would have reintroduced it one layer up.
+
+## Decision 3: the restart counter is persisted
+
+TS 23.007 §18 needs the counter to survive the restart it signals — a value that resets
+to the same number every start tells a peer nothing changed. mmed now persists it exactly
+as sgwcd does (`MME_RESTART_COUNTER_FILE`, atomic write-then-rename, `MME_RESTART_COUNTER`
+override for tests). The first draft of this spec documented "nothing persists it" as a
+known gap; that was the lazy answer when the sibling already had the code.
+
+## Decision 4: the builders take the sequence number and the local address
+
+Both were reached for rather than passed:
+
+- The sequence number was a literal `0` in the builder, so the transport could not own
+  correlation. It is now a parameter, allocated by `Gtp2XactMgr`.
+- The Sender F-TEID's address was going to come from `mme_self()`. A builder that reads a
+  process global cannot be exercised without one, and the sender already holds the context
+  that knows it — so it is a parameter, and the sender prefers the **socket's own bound
+  address** over configuration, because a mismatch sends the SGW's response somewhere
+  nothing is listening.
+
+## Decision 5: the Linked EPS Bearer ID and the RAT Type come from state
+
+- **LBI**: the lowest EBI of the session, because `materialise_subscribed_sessions`
+  allocates one default bearer per APN from the bottom of the range. A session with no
+  bearers is an `Err` naming the session, not a fallback to `5` — TS 29.274 Table 7.2.9.1-1
+  makes the IE mandatory and naming the wrong bearer tears down the wrong PDN connection.
+- **RAT Type**: a new `MmeUe::rat_type`, defaulted to E-UTRAN at UE creation rather than
+  left at `Default`'s `0`, which is a reserved value a conformant SGW would reject.
+  **It only ever holds E-UTRAN today**, because S1 is the only access this MME has and no
+  inter-RAT arrival exists (#62). The field is still the right structure — there is now one
+  place that decides it — but this spec will not claim it is sourced from anything richer
+  than "the access we have".
+
+## Decision 6: the CSR refuses to build without a Bearer Context
+
+TS 29.274 Table 7.2.1-1 makes it mandatory and sgwcd's parser `require()`s it. Building the
+message anyway produces a request the peer must reject, which is strictly worse than an
+error at the call site: the failure moves from this MME's log to a wire exchange and a
+cause the operator has to correlate back. Same for the MBR without an eNB S1-U F-TEID —
+sending that context would ask the SGW to switch the downlink tunnel to nowhere.
+
+## Decision 7: a correlated response is applied; an uncorrelated one is not
+
+`handle_datagram` matches the response against the transaction manager **before**
+dispatching. An uncorrelated datagram is one this MME did not ask for, and letting it reach
+the handler would allow a stray packet to mutate session state.
+
+For a Create Session Response that correlates, the SGW's S11 control TEID and each
+bearer's S1-U endpoint are written onto the context — the TEID because every later Modify
+Bearer / Delete Session Request has to be addressed to it (parsed and dropped, the MME
+could create a session and never modify or delete it), and the S1-U endpoint because it is
+the downlink tunnel the eNB is given at Initial Context Setup. The session is found by the
+**local TEID in the header**, not by anything in the body: that TEID is the one this MME
+told the SGW to use, so it is the only field a malformed body cannot misattribute.
+
+## Verification
+
+Five new tests, each driving a **real bound socket** with its real receive and T3/N3
+threads. A test that stubbed the transport would assert the half that already worked.
+
+| claim | how it was made to fail | result |
+|---|---|---|
+| the CSR carries a Sender F-TEID | delete the `add_ie` | **fails** |
+| …and a Bearer Context | skip `add_bearer_context` | **fails** |
+| RAT Type comes from the UE context | encode a literal `0` | **fails** |
+| the wire sequence is the allocated one | make `new_message` write `0` | **fails** |
+| a response is correlated by sequence number | match on `seq + 1` | **fails** |
+| T3-RESPONSE retransmits an unanswered request | drop the retransmit send | **fails** |
+| an Echo Request is answered | short-circuit the Echo branch | **fails** |
+| the restart counter advances across starts | pin `next` to 1 | **fails** |
+| Indication sets OI | `indication.oi = false` | **fails** |
+| every declared GTP cause is distinguishable | remove the `78` arm | **fails** |
+| GTP 78 reaches the UE as ESM 27 | remove the mapping | **fails** |
+
+Eleven reverts, eleven bites — **after three corrections, all of them mine and all worth
+recording**:
+
+- The first sequence-number revert **PASSED**: it changed the sequence *registered* with
+  the transaction manager, not the one written to the wire. The test asserts the wire, so
+  the patch never touched what was under test. Rewritten to patch `new_message`, it bites.
+- The first correlation revert **DID NOT COMPILE** (`Ok(_) => None` left the `Option`'s type
+  unresolvable), and the harness said so rather than reporting a pass.
+- The two ESM-cause reverts reported `0 tests, 318 filtered out` — the harness's snapshot
+  predated the tests it was reverting, so `restore()` deleted them before running. Caught
+  only because the harness prints the test count; `UNCLEAR` plus a count is what made it
+  visible, where a bare "did not fail" would have read as a decorative test.
+
+Workspace: mmed 315 → 320 tests, whole workspace **6329 passed / 0 failed**,
+`cargo clippy --workspace` 0, `cargo fmt --check` clean.
+
+## Ceilings
+
+- **The attach procedure still does not complete.** `nas_eps_send_attach_accept` has **no
+  caller** — verified by grep, and `nas_dispatch.rs:801-803` says why. This PR makes the S11
+  exchange real; wiring the Create Session Response into an Initial Context Setup plus an
+  Attach Accept is #46's subject, and #46 was deliberately reordered *after* this one for
+  exactly that reason (its criterion 4 asks for the GUTI IE to be emitted "in the normal
+  flow", which the attach path cannot do while the accept is unreachable).
+- **Criterion 3 is verified against a MIRRORED mandatory-IE list, not against sgwcd's
+  parser.** `sgwcd` is a binary with no lib target, so its `require()` is unreachable from
+  mmed's tests; the list is copied from `s11_parse.rs:85-120` with that cite, and it will
+  not notice if sgwcd adds a requirement. Closing this properly needs lib targets on both
+  daemons, which no criterion asks for.
+- **Two decoders remain for one message.** The library decodes for correlation and Recovery;
+  `s11_handler`'s own IE walk decodes for content. Criterion 7 names `s11_build.rs`'s
+  *builder*, which is gone, so this is out of scope — but it is the same duplication #304
+  and #306 argued against, and it is now load-bearing because the socket feeds it.
+- **The dispatchers act on Create Session Response and Downlink Data Notification only.**
+  Modify Bearer / Delete Session / Release Access Bearers responses are correlated, parsed
+  and logged; nothing updates state from them, because what should change is bearer
+  lifecycle that #46 and #48 own.
+- **`rat_type` only ever holds E-UTRAN** (see Decision 5).
+- **No restart-triggered context deletion** (see Decision 1).
+- **No E2E.** Loopback datagrams between one bound socket and a stand-in peer in one
+  process. A real mmed↔sgwcd exchange is #303, whose other blocker is #52.

--- a/src/bins/nextgcore-mmed/src/config.rs
+++ b/src/bins/nextgcore-mmed/src/config.rs
@@ -75,6 +75,27 @@ struct S1apYaml {
     server: Option<Vec<ServerYaml>>,
 }
 
+/// `mme.gtpc`: the S11 interface (#51).
+///
+/// `server` is what the MME binds; `client.sgwc` is the Serving GW it sends a
+/// Create Session Request to. Both were unread until #51, because until then no
+/// socket existed to bind and no message ever left the MME.
+#[derive(Debug, Default, Deserialize)]
+struct GtpcYaml {
+    server: Option<Vec<ServerYaml>>,
+    client: Option<GtpcClientYaml>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GtpcClientYaml {
+    sgwc: Option<Vec<ServerYaml>>,
+    /// Present in the shipped config and deliberately unused: the MME's S11 peer is
+    /// the SGW-C. An `smf` entry describes the PGW-C the SGW-C talks to over S5/S8
+    /// (#52), which is not an MME peer.
+    #[allow(dead_code)]
+    smf: Option<Vec<ServerYaml>>,
+}
+
 /// A single `<timer>: { value: <seconds> }` entry under `mme.time`, matching the
 /// nesting the 5GC configs use for `amf.time`.
 #[derive(Debug, Default, Deserialize)]
@@ -104,6 +125,7 @@ struct MmeSection {
     #[serde(rename = "freeDiameter")]
     free_diameter: Option<String>,
     s1ap: Option<S1apYaml>,
+    gtpc: Option<GtpcYaml>,
     gummei: Option<Vec<GummeiYaml>>,
     tai: Option<Vec<TaiYaml>>,
     security: Option<SecurityYaml>,
@@ -193,6 +215,54 @@ fn apply(ctx: &mut MmeContext, mme: MmeSection) {
     if let Some(free_diameter) = mme.free_diameter {
         apply_fd_conf(ctx, &free_diameter);
         ctx.diam_conf_path = Some(free_diameter);
+    }
+
+    // S11 GTP-C bind addresses and the Serving GW peer (#51). Same shape and same
+    // one-address-is-bound rule as S1AP below.
+    if let Some(gtpc) = mme.gtpc {
+        for server in gtpc.server.unwrap_or_default() {
+            let Some(address) = server.address else {
+                continue;
+            };
+            let port = server.port.unwrap_or(ctx.gtpc_port);
+            match parse_socket_addr(&address, port) {
+                Some(addr) => {
+                    log::info!("S11 GTP-C server address: {addr}");
+                    ctx.gtpc_list.push(addr);
+                }
+                None => log::warn!("Ignoring unparsable GTP-C server address '{address}'"),
+            }
+        }
+        if ctx.gtpc_list.len() > 1 {
+            log::warn!(
+                "{} GTP-C server addresses configured; only the first is bound",
+                ctx.gtpc_list.len()
+            );
+        }
+        for peer in gtpc
+            .client
+            .and_then(|client| client.sgwc)
+            .unwrap_or_default()
+        {
+            let Some(address) = peer.address else {
+                continue;
+            };
+            let port = peer.port.unwrap_or(ctx.gtpc_port);
+            match parse_socket_addr(&address, port) {
+                Some(addr) => {
+                    log::info!("S11 Serving GW peer: {addr}");
+                    ctx.sgwc_list.push(addr);
+                }
+                None => log::warn!("Ignoring unparsable SGW-C address '{address}'"),
+            }
+        }
+        if ctx.sgwc_list.len() > 1 {
+            log::warn!(
+                "{} SGW-C peers configured; the first is used for every session because \
+                 TS 23.401 §4.3.8.1 SGW selection (DNS by TAI/APN) is not implemented",
+                ctx.sgwc_list.len()
+            );
+        }
     }
 
     // S1AP bind addresses. `S1apServer::bind` takes one address, so the first

--- a/src/bins/nextgcore-mmed/src/context.rs
+++ b/src/bins/nextgcore-mmed/src/context.rs
@@ -1175,6 +1175,17 @@ pub struct MmeUe {
     /// Bearer to modify list (pool IDs)
     pub bearer_to_modify_list: Vec<u64>,
 
+    /// The RAT this UE is currently served over (TS 29.274 §8.17), for the RAT Type
+    /// IE on S11 (#51).
+    ///
+    /// A field rather than the literal `6` the builders used, so there is one place
+    /// that decides it. It is E-UTRAN for every attach this MME can accept today,
+    /// because S1 is the only access it has — nothing sets it otherwise until an
+    /// inter-RAT arrival exists (Gn/S3, #62). Defaulted in `MmeUe::new` rather than
+    /// left at `Default`'s zero, which is a reserved RAT value a conformant SGW
+    /// would reject.
+    pub rat_type: u8,
+
     /// CS map pool ID
     pub csmap_id: u64,
     /// HSS map pool ID
@@ -1362,6 +1373,21 @@ pub struct MmeContext {
     /// S1AP IPv6 server addresses
     pub s1ap_list6: Vec<std::net::SocketAddr>,
 
+    /// S11 GTP-C bind port (TS 29.274 §4.1: GTPv2-C uses UDP 2123).
+    pub gtpc_port: u16,
+    /// S11 GTP-C addresses to bind, from `mme.gtpc.server` (#51).
+    ///
+    /// `config.rs` deliberately did not read `mme.gtpc` before #51 — its module doc
+    /// said so and named this issue — because there was no socket to bind it to.
+    pub gtpc_list: Vec<std::net::SocketAddr>,
+    /// Serving GW S11 peers, from `mme.gtpc.client.sgwc`.
+    ///
+    /// The first is the one a Create Session Request is sent to. There is no SGW
+    /// selection function here: TS 23.401 §4.3.8.1 selects by TAI/APN via DNS, which
+    /// this tree does not implement, so a single configured peer is the honest model
+    /// and a second entry is warned about rather than silently ignored.
+    pub sgwc_list: Vec<std::net::SocketAddr>,
+
     /// SGW list
     pub sgw_list: Vec<u64>,
     /// Current SGW for round-robin
@@ -1522,6 +1548,7 @@ impl MmeContext {
     pub fn new() -> Self {
         Self {
             s1ap_port: 36412,
+            gtpc_port: 2123,
             sgsap_port: 29118,
             relative_capacity: 255,
             mme_ue_s1ap_id: AtomicU32::new(1),
@@ -1799,6 +1826,9 @@ impl MmeContext {
             enb_ue_id,
             enb_ue_holding_id: NEXTGCORE_INVALID_POOL_ID,
             sgw_ue_id: NEXTGCORE_INVALID_POOL_ID,
+            // E-UTRAN, because S1 is the only access this MME has (#51). Set here
+            // rather than left at `Default`'s 0, which is a reserved RAT value.
+            rat_type: crate::s11_build::rat_type::EUTRAN,
             ..Default::default()
         };
         self.mme_ue_pool.write().unwrap().insert(id, mme_ue);
@@ -2040,6 +2070,64 @@ impl MmeContext {
         if let Some(mme_ue) = self.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
             mme_ue.sgw_ue_id = sgw_ue_id;
         }
+    }
+
+    /// Record the SGW's S11 control-plane TEID for a UE (#51).
+    ///
+    /// Every later Modify Bearer / Delete Session Request for this session has to be
+    /// addressed to it, so a Create Session Response whose TEID is parsed and dropped
+    /// leaves the MME able to create a session and unable to modify or delete it.
+    ///
+    /// Creates the `SgwUe` association when the UE has none, because the Create
+    /// Session Response is the first point at which the SGW's identity is known.
+    pub fn set_sgw_s11_teid_for_ue(&self, mme_ue_id: u64, sgw_s11_teid: u32) {
+        let existing = self
+            .mme_ue_pool
+            .read()
+            .ok()
+            .and_then(|pool| pool.get(&mme_ue_id).map(|ue| ue.sgw_ue_id));
+        let sgw_ue_id = match existing {
+            Some(id) if id != NEXTGCORE_INVALID_POOL_ID => id,
+            _ => {
+                let id = self.sgw_ue_add(NEXTGCORE_INVALID_POOL_ID);
+                self.sgw_ue_associate_mme_ue(id, mme_ue_id);
+                id
+            }
+        };
+        if let Ok(mut pool) = self.sgw_ue_pool.write() {
+            if let Some(sgw_ue) = pool.get_mut(&sgw_ue_id) {
+                sgw_ue.sgw_s11_teid = sgw_s11_teid;
+            }
+        }
+    }
+
+    /// Record the SGW's S1-U user-plane endpoint on the bearer with this EBI (#51).
+    ///
+    /// This is the downlink tunnel the eNB is told to send to in the Initial Context
+    /// Setup Request, so a bearer without it has no user plane however cleanly the
+    /// control plane completed. Returns `false` when the UE holds no such EBI, which
+    /// the caller reports: a Create Session Response naming an EBI the MME did not
+    /// ask for is a disagreement worth surfacing, not a bearer to create silently.
+    pub fn set_sgw_s1u_for_bearer(
+        &self,
+        mme_ue_id: u64,
+        ebi: u8,
+        sgw_s1u_teid: u32,
+        sgw_s1u_ipv4: Option<[u8; 4]>,
+    ) -> bool {
+        let Ok(mut pool) = self.bearer_pool.write() else {
+            return false;
+        };
+        for bearer in pool.values_mut() {
+            if bearer.mme_ue_id == mme_ue_id && bearer.ebi == ebi {
+                bearer.sgw_s1u_teid = sgw_s1u_teid;
+                if let Some(v4) = sgw_s1u_ipv4 {
+                    bearer.sgw_s1u_ip.ipv4 = Some(v4);
+                }
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/src/bins/nextgcore-mmed/src/gtp_path.rs
+++ b/src/bins/nextgcore-mmed/src/gtp_path.rs
@@ -7,7 +7,112 @@ use crate::s11_build::{
     self, Gtp2BearerQos, GtpCause, GtpCreateAction, GtpDeleteAction, GtpModifyAction,
     GtpReleaseAction,
 };
-use std::net::SocketAddr;
+use bytes::Bytes;
+use nextgcore_gtp::v2::xact::{Gtp2XactConfig, Gtp2XactMgr};
+use nextgcore_gtp::v2::{Gtp2IeType, Gtp2Message, Gtp2MessageType, Gtp2RecoveryIe};
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr, UdpSocket};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Echo interval when nothing overrides it (TS 23.007 §20: 60 s is the value the
+/// spec suggests for GTP-C path management).
+const DEFAULT_ECHO_INTERVAL_SECS: u64 = 60;
+
+/// GTP-C path state per peer (TS 23.007 §20).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GtpPeerState {
+    /// Nothing heard from or sent to the peer yet.
+    #[default]
+    Idle,
+    /// The peer has answered.
+    Active,
+    /// N3 retransmissions exhausted: the peer is unreachable.
+    Failed,
+}
+
+struct GtpcInner {
+    socket: UdpSocket,
+    local_addr: SocketAddr,
+    restart_counter: u8,
+    xact: Mutex<Gtp2XactMgr>,
+    /// Last Recovery (restart counter) seen per peer IP (TS 23.007 §18).
+    peer_restart: Mutex<HashMap<IpAddr, u8>>,
+    peer_state: Mutex<HashMap<SocketAddr, GtpPeerState>>,
+    running: AtomicBool,
+}
+
+/// The MME's S11 GTPv2-C endpoint (#51).
+///
+/// Before this, `gtp_open` set a boolean and every `send_*` built a message into a
+/// `_pkbuf` local that was dropped on the next line — twelve of them. So no Create
+/// Session Request ever left the MME, nothing retransmitted, and nothing correlated
+/// a response to a request. The EPS control plane was inoperable end to end.
+///
+/// Deliberately modelled on `sgwcd`'s `GtpcServer` rather than invented: the two are
+/// the two ends of the same interface, and a second design would be two answers to
+/// "how long may an S11 message take" and "when is a peer down". The shared
+/// [`Gtp2XactMgr`] is what makes them agree — it was referenced only by sgwcd and
+/// never instantiated by mmed, which is why the MME had no T3-RESPONSE/N3-REQUESTS
+/// budget at all.
+///
+/// Synchronous (OS threads, blocking socket with a read timeout) for the same reason
+/// sgwcd is: the NAS and S1AP paths that originate these messages are synchronous,
+/// and putting an executor in front of them is a far larger change than this issue.
+#[derive(Clone)]
+pub struct GtpcServer {
+    inner: Arc<GtpcInner>,
+}
+
+/// The process-wide S11 server, installed at startup.
+///
+/// A `OnceLock` and not a parameter, because the twelve senders are called from
+/// synchronous NAS/S1AP code paths that thread no transport handle — the same shape
+/// as `fd_path`'s S6a queue. `None` means the socket was never bound, and every send
+/// then reports that rather than pretending to have transmitted.
+static S11_SERVER: OnceLock<GtpcServer> = OnceLock::new();
+
+/// Install the process-wide S11 server. Returns `false` if one is already installed.
+pub fn install_server(server: GtpcServer) -> bool {
+    S11_SERVER.set(server).is_ok()
+}
+
+/// The installed S11 server, or `None` when the socket was never bound.
+pub fn server() -> Option<&'static GtpcServer> {
+    S11_SERVER.get()
+}
+
+/// Send `msg` as an initial message to the configured Serving GW.
+///
+/// One place resolves the peer and reports the two ways a send can fail before it
+/// reaches the wire — no socket, or no configured SGW-C — so the twelve senders do
+/// not each grow their own version of that reporting.
+fn send_to_sgwc(ctx: &MmeContext, msg: &Gtp2Message, data: u64) -> GtpPathResult<u32> {
+    let server = server().ok_or_else(|| {
+        GtpPathError::SocketError(
+            "no S11 socket bound: mme.gtpc.server is unset or the bind failed".to_string(),
+        )
+    })?;
+    let peer = *ctx.sgwc_list.first().ok_or_else(|| {
+        GtpPathError::InvalidState(
+            "no Serving GW peer configured (mme.gtpc.client.sgwc)".to_string(),
+        )
+    })?;
+    server
+        .send_request(peer, msg, data)
+        .map_err(GtpPathError::SocketError)
+}
+
+/// Send `msg` as a triggered message, echoing the request's sequence number.
+fn send_response_to(peer: SocketAddr, msg: &Gtp2Message) -> GtpPathResult<()> {
+    let server = server().ok_or_else(|| {
+        GtpPathError::SocketError("no S11 socket bound: cannot answer".to_string())
+    })?;
+    server
+        .send_response(peer, msg)
+        .map_err(GtpPathError::SocketError)
+}
 
 pub type GtpPathResult<T> = Result<T, GtpPathError>;
 
@@ -59,15 +164,453 @@ pub struct GtpPathState {
     pub initialized: bool,
 }
 
+impl GtpcServer {
+    /// Bind the S11 socket and start the receive and retransmission loops.
+    pub fn open(bind: &str, config: Gtp2XactConfig, restart_counter: u8) -> Result<Self, String> {
+        let socket = UdpSocket::bind(bind).map_err(|e| format!("bind {bind}: {e}"))?;
+        // A read timeout rather than a non-blocking socket, so the receive thread
+        // can observe `running` and exit at shutdown instead of spinning.
+        socket
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .map_err(|e| e.to_string())?;
+        let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
+
+        let inner = Arc::new(GtpcInner {
+            socket,
+            local_addr,
+            restart_counter,
+            xact: Mutex::new(Gtp2XactMgr::new(config)),
+            peer_restart: Mutex::new(HashMap::new()),
+            peer_state: Mutex::new(HashMap::new()),
+            running: AtomicBool::new(true),
+        });
+
+        {
+            let inner = inner.clone();
+            std::thread::Builder::new()
+                .name("mme-s11-recv".into())
+                .spawn(move || {
+                    let mut buf = [0u8; 4096];
+                    while inner.running.load(Ordering::SeqCst) {
+                        match inner.socket.recv_from(&mut buf) {
+                            Ok((len, peer)) => handle_datagram(&inner, &buf[..len], peer),
+                            Err(e)
+                                if e.kind() == std::io::ErrorKind::WouldBlock
+                                    || e.kind() == std::io::ErrorKind::TimedOut => {}
+                            Err(e) => {
+                                if inner.running.load(Ordering::SeqCst) {
+                                    log::error!("S11 recv error: {e}");
+                                }
+                            }
+                        }
+                    }
+                })
+                .map_err(|e| e.to_string())?;
+        }
+
+        // T3-RESPONSE / N3-REQUESTS loop (TS 29.274 §7.6), which also drives Echo
+        // path management because it already ticks.
+        {
+            let inner = inner.clone();
+            let last_echo: Mutex<HashMap<SocketAddr, Instant>> = Mutex::new(HashMap::new());
+            std::thread::Builder::new()
+                .name("mme-s11-rtx".into())
+                .spawn(move || {
+                    while inner.running.load(Ordering::SeqCst) {
+                        std::thread::sleep(Duration::from_millis(20));
+                        let poll = {
+                            let mut xact = match inner.xact.lock() {
+                                Ok(x) => x,
+                                Err(_) => continue,
+                            };
+                            xact.poll(Instant::now())
+                        };
+                        for (peer, encoded) in poll.retransmits {
+                            log::warn!("S11 T3 expiry: retransmitting to {peer}");
+                            if let Err(e) = inner.socket.send_to(&encoded, peer) {
+                                log::error!("S11 retransmit to {peer} failed: {e}");
+                            }
+                        }
+                        for xact in poll.exhausted {
+                            // TS 29.274 §7.6: the peer is unreachable once N3
+                            // retransmissions are spent.
+                            log::error!(
+                                "S11 N3 exhausted: peer {} not responding (type={}, seq={})",
+                                xact.peer,
+                                xact.message_type,
+                                xact.sequence_number
+                            );
+                            if let Ok(mut states) = inner.peer_state.lock() {
+                                states.insert(xact.peer, GtpPeerState::Failed);
+                            }
+                        }
+
+                        if let Some(interval) = echo_interval() {
+                            let due: Vec<SocketAddr> = match inner.peer_state.lock() {
+                                Ok(states) => states.keys().copied().collect(),
+                                Err(_) => Vec::new(),
+                            };
+                            let now = Instant::now();
+                            let mut last = match last_echo.lock() {
+                                Ok(l) => l,
+                                Err(_) => continue,
+                            };
+                            for peer in due {
+                                // A peer is in `peer_state` BECAUSE we just heard
+                                // from it, so the first sighting starts the interval
+                                // rather than triggering a probe.
+                                let send = match last.get(&peer) {
+                                    Some(t) => now.duration_since(*t) >= interval,
+                                    None => false,
+                                };
+                                if send || !last.contains_key(&peer) {
+                                    last.insert(peer, now);
+                                }
+                                if send {
+                                    let server = GtpcServer {
+                                        inner: inner.clone(),
+                                    };
+                                    if let Err(e) = server.send_echo_request(peer) {
+                                        log::warn!("S11 Echo Request to {peer} failed: {e}");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                })
+                .map_err(|e| e.to_string())?;
+        }
+
+        log::info!("MME S11 GTP-C server listening on {local_addr}");
+        Ok(Self { inner })
+    }
+
+    /// Stop the receive and retransmission loops.
+    pub fn close(&self) {
+        self.inner.running.store(false, Ordering::SeqCst);
+    }
+
+    /// Local bound address.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.inner.local_addr
+    }
+
+    /// Path state for a peer.
+    pub fn peer_state(&self, peer: SocketAddr) -> GtpPeerState {
+        self.inner
+            .peer_state
+            .lock()
+            .ok()
+            .and_then(|s| s.get(&peer).copied())
+            .unwrap_or(GtpPeerState::Idle)
+    }
+
+    /// Outstanding transactions awaiting a triggered message.
+    pub fn outstanding(&self) -> usize {
+        self.inner.xact.lock().map(|x| x.outstanding()).unwrap_or(0)
+    }
+
+    /// Allocate a GTPv2-C sequence number for an initial message.
+    ///
+    /// TS 29.274 §7.6 requires a sequence number per outstanding initial message,
+    /// echoed in the corresponding response. Every builder used to write a literal
+    /// `0`, so no response could be correlated to any request.
+    pub fn alloc_sequence(&self) -> u32 {
+        self.inner
+            .xact
+            .lock()
+            .map(|mut x| x.alloc_sequence())
+            .unwrap_or(1)
+    }
+
+    /// Send an initial (request) message and arm T3/N3 retransmission.
+    pub fn send_request(
+        &self,
+        peer: SocketAddr,
+        msg: &Gtp2Message,
+        data: u64,
+    ) -> Result<u32, String> {
+        let encoded = Bytes::from(msg.encode().to_vec());
+        let seq = msg.header.sequence_number;
+        {
+            let mut xact = self.inner.xact.lock().map_err(|e| e.to_string())?;
+            xact.register_request(seq, msg.header.message_type, peer, encoded.clone(), data);
+        }
+        self.inner
+            .socket
+            .send_to(&encoded, peer)
+            .map_err(|e| e.to_string())?;
+        if let Ok(mut states) = self.inner.peer_state.lock() {
+            states.entry(peer).or_insert(GtpPeerState::Idle);
+        }
+        log::debug!(
+            "S11 TX request type={} seq={} to {peer} len={}",
+            msg.header.message_type,
+            seq,
+            encoded.len()
+        );
+        Ok(seq)
+    }
+
+    /// Send a triggered (response) message bound to the request's sequence number,
+    /// caching it so a retransmitted request is answered identically.
+    pub fn send_response(&self, peer: SocketAddr, msg: &Gtp2Message) -> Result<(), String> {
+        let encoded = Bytes::from(msg.encode().to_vec());
+        if let Ok(mut xact) = self.inner.xact.lock() {
+            xact.cache_response(peer, msg.header.sequence_number, encoded.clone());
+        }
+        self.inner
+            .socket
+            .send_to(&encoded, peer)
+            .map_err(|e| e.to_string())?;
+        log::debug!(
+            "S11 TX response type={} seq={} to {peer} len={}",
+            msg.header.message_type,
+            msg.header.sequence_number,
+            encoded.len()
+        );
+        Ok(())
+    }
+
+    /// Send an Echo Request (TS 29.274 §7.1.1).
+    ///
+    /// The builders for this existed and had no caller, so the MME had no path
+    /// management at all: a Serving GW that went away was never noticed.
+    pub fn send_echo_request(&self, peer: SocketAddr) -> Result<u32, String> {
+        let seq = self.alloc_sequence();
+        // The library's constructors already clear the TEID-presence flag, which a
+        // node-level message requires (TS 29.274 §5.5.1).
+        let mut msg = Gtp2Message::echo_request(seq);
+        for ie in Gtp2Message::echo_response(seq, self.inner.restart_counter).ies {
+            msg.add_ie(ie);
+        }
+        self.send_request(peer, &msg, 0)
+    }
+}
+
+/// Where the local GTP-C restart counter is persisted (TS 23.007 §18).
+const DEFAULT_RESTART_COUNTER_FILE: &str = "/var/lib/nextgcore/mme-restart-counter";
+
+fn restart_counter_path() -> std::path::PathBuf {
+    std::env::var("MME_RESTART_COUNTER_FILE")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(DEFAULT_RESTART_COUNTER_FILE))
+}
+
+/// Read the persisted restart counter, advance it, write it back, and return the
+/// value to advertise in Recovery IEs.
+///
+/// The counter has to SURVIVE the restart it signals — a value that resets to the
+/// same number every start tells a peer nothing changed. Mirrors sgwcd's, which is
+/// the same requirement on the other end of the same interface; a second design here
+/// would be two answers to "has this node restarted".
+///
+/// * absent file → first start, begin at 1 and persist it;
+/// * unreadable or malformed → log loudly and fall back to 1, because a wrong
+///   counter is worse silently than loudly;
+/// * wraparound at 255 → back to 1, which a peer reads as a restart either way.
+pub(crate) fn advance_persistent_restart_counter(path: &std::path::Path) -> u8 {
+    let previous = match std::fs::read_to_string(path) {
+        Ok(text) => match text.trim().parse::<u8>() {
+            Ok(v) => Some(v),
+            Err(_) => {
+                log::error!(
+                    "Restart counter file {} is malformed ({:?}); restarting the count at 1, so \
+                     peers may not detect this MME restart (TS 23.007 §18)",
+                    path.display(),
+                    text.trim()
+                );
+                None
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            log::error!(
+                "Cannot read restart counter file {}: {e}; restarting the count at 1, so peers \
+                 may not detect this MME restart",
+                path.display()
+            );
+            None
+        }
+    };
+
+    let next = match previous {
+        Some(v) => v.checked_add(1).unwrap_or(1),
+        None => 1,
+    };
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::error!(
+                    "Cannot create {} for the restart counter: {e}",
+                    parent.display()
+                );
+            }
+        }
+    }
+    let tmp = path.with_extension("tmp");
+    let write = std::fs::write(&tmp, next.to_string()).and_then(|()| std::fs::rename(&tmp, path));
+    match write {
+        Ok(()) => log::info!(
+            "Local GTP-C restart counter advanced to {next} (persisted at {})",
+            path.display()
+        ),
+        Err(e) => log::error!(
+            "Cannot persist restart counter to {}: {e}; the next start will not advance it and \
+             peers will not detect that restart",
+            path.display()
+        ),
+    }
+    next
+}
+
+/// Echo interval, `0` disabling path management entirely.
+fn echo_interval() -> Option<Duration> {
+    let secs = std::env::var("MME_ECHO_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_ECHO_INTERVAL_SECS);
+    if secs == 0 {
+        None
+    } else {
+        Some(Duration::from_secs(secs))
+    }
+}
+
+/// Note a peer's Recovery counter, logging a restart (TS 23.007 §18).
+///
+/// Recorded and logged rather than acted on: deleting this MME's contexts because the
+/// SGW restarted is a decision about UE state that #51 does not own, and doing it
+/// silently would detach every attached UE on a counter change that a reordered
+/// datagram can also produce.
+fn note_peer_recovery(inner: &Arc<GtpcInner>, peer: SocketAddr, counter: u8) {
+    let Ok(mut seen) = inner.peer_restart.lock() else {
+        return;
+    };
+    match seen.insert(peer.ip(), counter) {
+        Some(previous) if previous != counter => log::warn!(
+            "S11 peer {peer} restarted: Recovery {previous} -> {counter}; its S11 contexts are \
+             stale (TS 23.007 §18)"
+        ),
+        _ => log::debug!("S11 peer {peer} Recovery counter {counter}"),
+    }
+}
+
+/// Dispatch one received datagram.
+fn handle_datagram(inner: &Arc<GtpcInner>, data: &[u8], peer: SocketAddr) {
+    let mut bytes = Bytes::copy_from_slice(data);
+    let msg = match Gtp2Message::decode(&mut bytes) {
+        Ok(m) => m,
+        Err(e) => {
+            log::error!("[DROP] cannot decode GTPv2-C datagram from {peer}: {e}");
+            return;
+        }
+    };
+
+    if let Some(rec_ie) = msg.get_ie(Gtp2IeType::Recovery as u8, 0) {
+        if let Ok(rec) = Gtp2RecoveryIe::decode(&rec_ie.value) {
+            note_peer_recovery(inner, peer, rec.restart_counter);
+        }
+    }
+
+    let msg_type = msg.header.message_type;
+    let seq = msg.header.sequence_number;
+
+    // An Echo Request is answered from here: it is path management and needs no
+    // session state, so routing it through the handler layer would only add a hop.
+    if msg_type == Gtp2MessageType::EchoRequest as u8 {
+        let reply = Gtp2Message::echo_response(seq, inner.restart_counter);
+        let encoded = reply.encode();
+        if let Err(e) = inner.socket.send_to(&encoded, peer) {
+            log::error!("S11 Echo Response to {peer} failed: {e}");
+        }
+        if let Ok(mut states) = inner.peer_state.lock() {
+            states.insert(peer, GtpPeerState::Active);
+        }
+        return;
+    }
+
+    // A triggered message closes its transaction. Matching FIRST and only then
+    // dispatching is what makes the response correlated rather than merely received:
+    // an unmatched response is one this MME did not ask for, and acting on it would
+    // let a stray datagram mutate session state.
+    let matched = {
+        match inner.xact.lock() {
+            Ok(mut xact) => xact.match_response(seq, msg_type),
+            Err(_) => None,
+        }
+    };
+
+    if let Some(xact) = matched {
+        if let Ok(mut states) = inner.peer_state.lock() {
+            states.insert(peer, GtpPeerState::Active);
+        }
+        log::debug!(
+            "S11 RX response type={msg_type} seq={seq} from {peer} correlates to request type={}",
+            xact.message_type
+        );
+        crate::s11_handler::dispatch_triggered(data, msg_type, seq, peer);
+        return;
+    }
+
+    // Not a response to anything outstanding: either an initial message from the
+    // SGW-C (Downlink Data Notification, Create/Update/Delete Bearer Request) or a
+    // late duplicate of a response whose transaction has already closed.
+    if let Ok(mut states) = inner.peer_state.lock() {
+        states.entry(peer).or_insert(GtpPeerState::Active);
+    }
+    crate::s11_handler::dispatch_initial(data, msg_type, seq, peer);
+}
+
+/// Bind the S11 socket from configuration and install it process-wide (#51).
+///
+/// `gtp_open` used to set `state.initialized = true` and bind nothing, which is why
+/// every `send_*` had nowhere to send. With no `mme.gtpc.server` configured this
+/// still returns `Ok` and logs why: an MME with no S11 address is a deployment that
+/// has not been given one, and refusing to start would break every existing config
+/// that never needed the socket.
 pub fn gtp_open(state: &mut GtpPathState) -> GtpPathResult<()> {
-    log::info!("Opening GTP path");
+    let ctx = crate::context::mme_self();
+    let Some(bind) = ctx.gtpc_list.first().copied() else {
+        log::warn!(
+            "no mme.gtpc.server address configured: the S11 interface is NOT bound, so no \
+             Create Session Request can be sent and no EPS bearer can be established"
+        );
+        state.initialized = true;
+        return Ok(());
+    };
+
+    // The restart counter advertised in Recovery, persisted so it survives the
+    // restart it signals (TS 23.007 §18). An explicit override exists for tests and
+    // for a deployment that manages the value itself.
+    let restart_counter = match std::env::var("MME_RESTART_COUNTER")
+        .ok()
+        .and_then(|v| v.parse::<u8>().ok())
+    {
+        Some(v) => v,
+        None => advance_persistent_restart_counter(&restart_counter_path()),
+    };
+    let server = GtpcServer::open(
+        &bind.to_string(),
+        Gtp2XactConfig::default(),
+        restart_counter,
+    )
+    .map_err(GtpPathError::SocketError)?;
+    state.gtpc_addr = Some(server.local_addr());
+    if !install_server(server) {
+        log::warn!("an S11 server is already installed; this one is dropped");
+    }
     state.initialized = true;
-    log::info!("GTP path opened successfully");
+    log::info!("S11 GTP-C path opened on {bind}");
     Ok(())
 }
 
 pub fn gtp_close(state: &mut GtpPathState) -> GtpPathResult<()> {
     log::info!("Closing GTP path");
+    if let Some(server) = server() {
+        server.close();
+    }
     state.initialized = false;
     log::info!("GTP path closed");
     Ok(())
@@ -98,14 +641,43 @@ pub fn send_create_session_request(
         sgw_ue.clone()
     };
 
-    let _pkbuf =
-        s11_build::build_create_session_request(&sess, &mme_ue, &target_sgw_ue, create_action)
-            .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    // The bearers to create. TS 29.274 Table 7.2.1-1 makes at least one Bearer
+    // Context mandatory, and the builder refuses without one rather than emitting a
+    // request the SGW-C must reject.
+    let bearers = bearers_of_session(ctx, &sess);
+    let bearer_refs: Vec<&crate::context::MmeBearer> = bearers.iter().collect();
+
+    // The Sender F-TEID's address is this MME's bound S11 address, so it is the
+    // socket's own rather than whatever configuration says — a mismatch would send
+    // the SGW's response to an address nothing is listening on.
+    let local_s11 = server()
+        .map(|s| s.local_addr())
+        .or_else(|| ctx.gtpc_list.first().copied())
+        .ok_or_else(|| {
+            GtpPathError::InvalidState("no S11 local address to put in the Sender F-TEID".into())
+        })?;
+
+    let seq = sequence()?;
+    let msg = s11_build::build_create_session_request(
+        &sess,
+        &mme_ue,
+        &target_sgw_ue,
+        create_action,
+        seq,
+        &bearer_refs,
+        local_s11,
+    )
+    .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    let xact_id = ctx.next_pool_id();
+    send_to_sgwc(ctx, &msg, xact_id)?;
 
     Ok(GtpXactData {
-        xact_id: ctx.next_pool_id(),
+        xact_id,
         create_action: Some(create_action),
-        local_teid: mme_ue.gn.mme_gn_teid,
+        // The LOCAL S11 TEID, which is what the SGW addresses the response to and
+        // what `mme_ue_find_by_s11_local_teid` resolves. `gn.mme_gn_teid` is the Gn
+        // interface's TEID and belongs to a different interface entirely.
+        local_teid: mme_ue.mme_s11_teid,
         enb_ue_id,
         ..Default::default()
     })
@@ -127,13 +699,22 @@ pub fn send_modify_bearer_request(
         .sgw_ue_find_by_id(mme_ue.sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf = s11_build::build_modify_bearer_request(&mme_ue, &sgw_ue, &[], uli_presence)
-        .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    // The bearers whose eNB S1-U endpoint the SGW must switch to. Passed as an
+    // EMPTY slice before #51, so the message asked the SGW to modify nothing.
+    let bearers = bearers_of_ue(ctx, mme_ue_id);
+    let bearer_refs: Vec<&crate::context::MmeBearer> = bearers.iter().collect();
+
+    let seq = sequence()?;
+    let msg =
+        s11_build::build_modify_bearer_request(&mme_ue, &sgw_ue, &bearer_refs, uli_presence, seq)
+            .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    let xact_id = ctx.next_pool_id();
+    send_to_sgwc(ctx, &msg, xact_id)?;
 
     Ok(GtpXactData {
-        xact_id: ctx.next_pool_id(),
+        xact_id,
         modify_action: Some(modify_action),
-        local_teid: mme_ue.gn.mme_gn_teid,
+        local_teid: mme_ue.mme_s11_teid,
         enb_ue_id,
         ..Default::default()
     })
@@ -158,13 +739,27 @@ pub fn send_delete_session_request(
         .sgw_ue_find_by_id(sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf = s11_build::build_delete_session_request(&sess, &mme_ue, &sgw_ue, 5, action)
-        .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    // The Linked EPS Bearer ID is the DEFAULT bearer of the PDN connection being
+    // torn down (TS 29.274 Table 7.2.9.1-1). A literal 5 was passed before #51,
+    // which tears down the wrong PDN for any UE holding more than one.
+    let linked_ebi = default_bearer_ebi(ctx, &sess).ok_or_else(|| {
+        GtpPathError::InvalidState(format!(
+            "session {} has no default bearer, so no Linked EPS Bearer ID can be sent",
+            sess.id
+        ))
+    })?;
+
+    let seq = sequence()?;
+    let msg =
+        s11_build::build_delete_session_request(&sess, &mme_ue, &sgw_ue, linked_ebi, action, seq)
+            .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    let xact_id = ctx.next_pool_id();
+    send_to_sgwc(ctx, &msg, xact_id)?;
 
     Ok(GtpXactData {
-        xact_id: ctx.next_pool_id(),
+        xact_id,
         delete_action: Some(action),
-        local_teid: mme_ue.gn.mme_gn_teid,
+        local_teid: mme_ue.mme_s11_teid,
         enb_ue_id: enb_ue_id.unwrap_or(0),
         ..Default::default()
     })
@@ -197,6 +792,8 @@ pub fn send_create_bearer_response(
     ctx: &MmeContext,
     bearer_id: u64,
     cause_value: GtpCause,
+    peer: SocketAddr,
+    sequence_number: u32,
 ) -> GtpPathResult<()> {
     log::debug!("Sending Create Bearer Response");
 
@@ -210,15 +807,26 @@ pub fn send_create_bearer_response(
         .sgw_ue_find_by_id(mme_ue.sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf = s11_build::build_create_bearer_response(&bearer, &mme_ue, &sgw_ue, cause_value)
-        .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
-    Ok(())
+    // A TRIGGERED message: it must echo the sequence number of the request it
+    // answers and go back to the peer that sent it (TS 29.274 §7.6). Both are
+    // supplied by the caller, because only the receive path knows them.
+    let msg = s11_build::build_create_bearer_response(
+        &bearer,
+        &mme_ue,
+        &sgw_ue,
+        cause_value,
+        sequence_number,
+    )
+    .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    send_response_to(peer, &msg)
 }
 
 pub fn send_update_bearer_response(
     ctx: &MmeContext,
     bearer_id: u64,
     cause_value: GtpCause,
+    peer: SocketAddr,
+    sequence_number: u32,
 ) -> GtpPathResult<()> {
     log::debug!("Sending Update Bearer Response");
 
@@ -232,15 +840,26 @@ pub fn send_update_bearer_response(
         .sgw_ue_find_by_id(mme_ue.sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf = s11_build::build_update_bearer_response(&bearer, &mme_ue, &sgw_ue, cause_value)
-        .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
-    Ok(())
+    // A TRIGGERED message: it must echo the sequence number of the request it
+    // answers and go back to the peer that sent it (TS 29.274 §7.6). Both are
+    // supplied by the caller, because only the receive path knows them.
+    let msg = s11_build::build_update_bearer_response(
+        &bearer,
+        &mme_ue,
+        &sgw_ue,
+        cause_value,
+        sequence_number,
+    )
+    .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    send_response_to(peer, &msg)
 }
 
 pub fn send_delete_bearer_response(
     ctx: &MmeContext,
     bearer_id: u64,
     cause_value: GtpCause,
+    peer: SocketAddr,
+    sequence_number: u32,
 ) -> GtpPathResult<()> {
     log::debug!("Sending Delete Bearer Response");
 
@@ -254,9 +873,18 @@ pub fn send_delete_bearer_response(
         .sgw_ue_find_by_id(mme_ue.sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf = s11_build::build_delete_bearer_response(&bearer, &mme_ue, &sgw_ue, cause_value)
-        .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
-    Ok(())
+    // A TRIGGERED message: it must echo the sequence number of the request it
+    // answers and go back to the peer that sent it (TS 29.274 §7.6). Both are
+    // supplied by the caller, because only the receive path knows them.
+    let msg = s11_build::build_delete_bearer_response(
+        &bearer,
+        &mme_ue,
+        &sgw_ue,
+        cause_value,
+        sequence_number,
+    )
+    .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    send_response_to(peer, &msg)
 }
 
 pub fn send_release_access_bearers_request(
@@ -274,15 +902,18 @@ pub fn send_release_access_bearers_request(
         .sgw_ue_find_by_id(mme_ue.sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf = s11_build::build_release_access_bearers_request(
-        sgw_ue.sgw_s11_teid,
-        ctx.next_pool_id() as u32,
-    );
+    // An INITIAL message, so its sequence number comes from the transaction layer.
+    // `ctx.next_pool_id() as u32` was a POOL INDEX in the sequence position — it
+    // collides with every other pool allocation and means nothing to the peer.
+    let seq = sequence()?;
+    let msg = s11_build::build_release_access_bearers_request(sgw_ue.sgw_s11_teid, seq);
+    let xact_id = ctx.next_pool_id();
+    send_to_sgwc(ctx, &msg, xact_id)?;
 
     Ok(GtpXactData {
-        xact_id: ctx.next_pool_id(),
+        xact_id,
         release_action: Some(action),
-        local_teid: mme_ue.gn.mme_gn_teid,
+        local_teid: mme_ue.mme_s11_teid,
         enb_ue_id,
         ..Default::default()
     })
@@ -316,6 +947,7 @@ pub fn send_downlink_data_notification_ack(
     ctx: &MmeContext,
     bearer_id: u64,
     cause_value: GtpCause,
+    sequence_number: u32,
 ) -> GtpPathResult<()> {
     log::debug!("Sending Downlink Data Notification Ack");
 
@@ -329,12 +961,28 @@ pub fn send_downlink_data_notification_ack(
         .sgw_ue_find_by_id(mme_ue.sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf = s11_build::build_downlink_data_notification_ack(
-        sgw_ue.sgw_s11_teid,
-        ctx.next_pool_id() as u32,
-        cause_value,
-    );
-    Ok(())
+    let peer = *ctx
+        .sgwc_list
+        .first()
+        .ok_or_else(|| GtpPathError::InvalidState("no Serving GW peer configured".to_string()))?;
+    send_downlink_data_notification_ack_to(peer, sgw_ue.sgw_s11_teid, sequence_number, cause_value)
+}
+
+/// Answer a Downlink Data Notification, echoing its sequence number (TS 29.274
+/// §7.2.11).
+///
+/// The Ack is a TRIGGERED message. `ctx.next_pool_id() as u32` used to occupy the
+/// sequence position, which is a pool index: even had the message been transmitted,
+/// the SGW-C could not have matched it to the notification it answered.
+pub fn send_downlink_data_notification_ack_to(
+    peer: SocketAddr,
+    teid: u32,
+    sequence_number: u32,
+    cause_value: GtpCause,
+) -> GtpPathResult<()> {
+    let msg = s11_build::build_downlink_data_notification_ack(teid, sequence_number, cause_value)
+        .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    send_response_to(peer, &msg)
 }
 
 pub fn send_create_indirect_data_forwarding_tunnel_request(
@@ -351,13 +999,22 @@ pub fn send_create_indirect_data_forwarding_tunnel_request(
         .sgw_ue_find_by_id(mme_ue.sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf =
-        s11_build::build_create_indirect_data_forwarding_tunnel_request(&mme_ue, &sgw_ue, &[])
-            .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    let bearers = bearers_of_ue(ctx, mme_ue_id);
+    let bearer_refs: Vec<&crate::context::MmeBearer> = bearers.iter().collect();
+    let seq = sequence()?;
+    let msg = s11_build::build_create_indirect_data_forwarding_tunnel_request(
+        &mme_ue,
+        &sgw_ue,
+        &bearer_refs,
+        seq,
+    )
+    .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    let xact_id = ctx.next_pool_id();
+    send_to_sgwc(ctx, &msg, xact_id)?;
 
     Ok(GtpXactData {
-        xact_id: ctx.next_pool_id(),
-        local_teid: mme_ue.gn.mme_gn_teid,
+        xact_id,
+        local_teid: mme_ue.mme_s11_teid,
         enb_ue_id,
         ..Default::default()
     })
@@ -404,7 +1061,8 @@ pub fn send_bearer_resource_command(
         .sgw_ue_find_by_id(mme_ue.sgw_ue_id)
         .ok_or(GtpPathError::ContextNotFound)?;
 
-    let _pkbuf = s11_build::build_bearer_resource_command(
+    let seq = sequence()?;
+    let msg = s11_build::build_bearer_resource_command(
         &bearer,
         &mme_ue,
         &sgw_ue,
@@ -412,14 +1070,69 @@ pub fn send_bearer_resource_command(
         pti,
         tad,
         qos,
+        seq,
     )
     .map_err(|e| GtpPathError::BuildError(e.to_string()))?;
+    let xact_id = ctx.next_pool_id() | GTP_CMD_XACT_ID_FLAG;
+    send_to_sgwc(ctx, &msg, xact_id)?;
 
     Ok(GtpXactData {
-        xact_id: ctx.next_pool_id() | GTP_CMD_XACT_ID_FLAG,
-        local_teid: mme_ue.gn.mme_gn_teid,
+        xact_id,
+        local_teid: mme_ue.mme_s11_teid,
         ..Default::default()
     })
+}
+
+/// A sequence number from the transaction layer for an initial message.
+///
+/// Every builder wrote a literal `0` before #51, and two senders substituted
+/// `ctx.next_pool_id()` — a pool index. TS 29.274 §7.6 requires one sequence number
+/// per outstanding initial message, echoed in the response, so both spellings made
+/// correlation impossible.
+fn sequence() -> GtpPathResult<u32> {
+    server().map(|s| s.alloc_sequence()).ok_or_else(|| {
+        GtpPathError::SocketError("no S11 socket bound: cannot allocate a sequence".to_string())
+    })
+}
+
+/// The bearers of one session, in EBI order.
+fn bearers_of_session(
+    ctx: &MmeContext,
+    sess: &crate::context::MmeSess,
+) -> Vec<crate::context::MmeBearer> {
+    let mut bearers: Vec<crate::context::MmeBearer> = sess
+        .bearer_list
+        .iter()
+        .filter_map(|id| ctx.bearer_find_by_id(*id))
+        .collect();
+    bearers.sort_by_key(|b| b.ebi);
+    bearers
+}
+
+/// Every bearer of every session of one UE, in EBI order.
+fn bearers_of_ue(ctx: &MmeContext, mme_ue_id: u64) -> Vec<crate::context::MmeBearer> {
+    let Some(mme_ue) = ctx.mme_ue_find_by_id(mme_ue_id) else {
+        return Vec::new();
+    };
+    let mut bearers: Vec<crate::context::MmeBearer> = mme_ue
+        .sess_list
+        .iter()
+        .filter_map(|sess_id| ctx.sess_find_by_id(*sess_id))
+        .flat_map(|sess| bearers_of_session(ctx, &sess))
+        .collect();
+    bearers.sort_by_key(|b| b.ebi);
+    bearers
+}
+
+/// The EBI of a session's DEFAULT bearer — the lowest, since
+/// `materialise_subscribed_sessions` allocates one default bearer per APN from the
+/// bottom of the range (TS 24.007 §11.2.3.1.5 reserves 0-4).
+///
+/// `None` for a session with no bearers, which the caller reports rather than
+/// falling back to a literal: TS 29.274 Table 7.2.9.1-1 makes the Linked EPS Bearer
+/// ID mandatory and naming the wrong one tears down the wrong PDN connection.
+fn default_bearer_ebi(ctx: &MmeContext, sess: &crate::context::MmeSess) -> Option<u8> {
+    bearers_of_session(ctx, sess).first().map(|b| b.ebi)
 }
 
 const GTP_CMD_XACT_ID_FLAG: u64 = 0x8000_0000_0000_0000;
@@ -428,6 +1141,19 @@ const GTP_CMD_XACT_ID_FLAG: u64 = 0x8000_0000_0000_0000;
 mod tests {
     use super::*;
 
+    /// Serialises every test that installs the process-wide S11 server or touches the
+    /// MME context's GTP-C configuration.
+    ///
+    /// Declared beside the globals it guards rather than in a submodule, per #308: the
+    /// `S11_SERVER` `OnceLock` and `mme_self()`'s `gtpc_list` / `sgwc_list` are
+    /// process-wide, and a test that binds a socket while a sibling is reading the
+    /// peer list gets the sibling's answer.
+    static S11_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_s11() -> std::sync::MutexGuard<'static, ()> {
+        S11_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn test_gtp_path_state_default() {
         let state = GtpPathState::default();
@@ -435,26 +1161,334 @@ mod tests {
     }
 
     #[test]
-    fn test_gtp_open_close() {
-        let mut state = GtpPathState::default();
-        assert!(gtp_open(&mut state).is_ok());
-        assert!(state.initialized);
-        assert!(gtp_close(&mut state).is_ok());
-        assert!(!state.initialized);
-    }
-
-    #[test]
     fn test_delete_indirect_action() {
-        assert_eq!(
+        assert_ne!(
             DeleteIndirectAction::HandoverComplete,
-            DeleteIndirectAction::HandoverComplete
+            DeleteIndirectAction::HandoverCancel
         );
     }
 
+    /// The restart counter must SURVIVE the restart it signals (TS 23.007 §18): a
+    /// value that resets to the same number every start tells a peer nothing changed.
     #[test]
-    fn test_gtp_xact_data_default() {
-        let xact = GtpXactData::default();
-        assert_eq!(xact.xact_id, 0);
-        assert!(xact.create_action.is_none());
+    fn the_restart_counter_advances_across_starts() {
+        let dir = std::env::temp_dir().join(format!("mme-restart-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("counter");
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(
+            advance_persistent_restart_counter(&path),
+            1,
+            "a first start begins at 1"
+        );
+        assert_eq!(
+            advance_persistent_restart_counter(&path),
+            2,
+            "the next start must ADVANCE, or the peer cannot detect the restart"
+        );
+
+        std::fs::write(&path, "not-a-number").expect("write");
+        assert_eq!(
+            advance_persistent_restart_counter(&path),
+            1,
+            "malformed contents fall back to 1 rather than panicking"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Install a server bound to an ephemeral port, with a stand-in SGW-C socket as
+    /// its configured peer.
+    ///
+    /// The server is a real bound socket running its real receive and T3/N3 threads —
+    /// the point of #51 is that these messages reach a wire, so a test that stubbed
+    /// the transport would assert the half that already worked.
+    fn spawn_server_and_peer(config: Gtp2XactConfig) -> (GtpcServer, UdpSocket, SocketAddr) {
+        let peer = UdpSocket::bind("127.0.0.1:0").expect("peer bind");
+        peer.set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("peer timeout");
+        let peer_addr = peer.local_addr().expect("peer addr");
+        let server = GtpcServer::open("127.0.0.1:0", config, 7).expect("server bind");
+        (server, peer, peer_addr)
+    }
+
+    /// #51 criterion 3: the Create Session Request carries every IE a conformant peer
+    /// requires, asserted after a real round trip through the socket.
+    ///
+    /// The required set MIRRORS `sgwcd`'s `s11_parse.rs:85-120` — IMSI, RAT Type,
+    /// Sender F-TEID, APN, and a Bearer Context with EBI and Bearer QoS. It is a
+    /// mirrored list rather than a call into that parser because `sgwcd` is a binary
+    /// with no lib target, so its `require()` is unreachable from here. See the spec's
+    /// Ceilings.
+    #[test]
+    fn a_create_session_request_reaches_the_wire_with_every_mandatory_ie() {
+        let _guard = lock_s11();
+        let (server, peer, peer_addr) = spawn_server_and_peer(Gtp2XactConfig::default());
+
+        // Build the message the way the sender does, from real context state.
+        let mut mme_ue = crate::context::MmeUe {
+            mme_s11_teid: 0x0000_1234,
+            rat_type: s11_build::rat_type::EUTRAN,
+            ..Default::default()
+        };
+        mme_ue.imsi_len = 8;
+        mme_ue.imsi[..8].copy_from_slice(&[0x09, 0x91, 0x07, 0x00, 0x00, 0x00, 0x00, 0x01]);
+        let sess = crate::context::MmeSess {
+            apn: "internet".to_string(),
+            ..Default::default()
+        };
+        let sgw_ue = crate::context::SgwUe::default();
+        let bearer = crate::context::MmeBearer {
+            ebi: 5,
+            qos: crate::context::Qos {
+                qci: 9,
+                arp: crate::context::Arp {
+                    priority_level: 8,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // The Sender F-TEID needs a configured local address; without one the builder
+        // refuses rather than emitting a request missing a mandatory IE.
+        let seq = server.alloc_sequence();
+        let msg = s11_build::build_create_session_request(
+            &sess,
+            &mme_ue,
+            &sgw_ue,
+            GtpCreateAction::AttachRequest,
+            seq,
+            &[&bearer],
+            server.local_addr(),
+        )
+        .expect("the CSR must build");
+        server
+            .send_request(peer_addr, &msg, 1)
+            .expect("the CSR must reach the socket");
+
+        let mut buf = [0u8; 4096];
+        let (len, _) = peer.recv_from(&mut buf).expect("the peer must receive it");
+        let mut bytes = Bytes::copy_from_slice(&buf[..len]);
+        let received = Gtp2Message::decode(&mut bytes).expect("a conformant peer must decode it");
+
+        assert_eq!(
+            received.header.message_type,
+            s11_build::message_type::CREATE_SESSION_REQUEST
+        );
+        assert_eq!(
+            received.header.sequence_number, seq,
+            "the sequence number on the wire is the allocated one, not 0"
+        );
+
+        // The mandatory set, mirroring sgwcd's require() list.
+        for (ie_type, name) in [
+            (Gtp2IeType::Imsi as u8, "IMSI"),
+            (Gtp2IeType::RatType as u8, "RAT Type"),
+            (Gtp2IeType::FTeid as u8, "Sender F-TEID"),
+            (Gtp2IeType::Apn as u8, "APN"),
+            (
+                Gtp2IeType::BearerContext as u8,
+                "Bearer Contexts to be created",
+            ),
+        ] {
+            assert!(
+                received.get_ie(ie_type, 0).is_some(),
+                "{name} is mandatory (TS 29.274 Table 7.2.1-1) and sgwcd's parser require()s it"
+            );
+        }
+
+        // RAT Type from the UE context, not a literal.
+        assert_eq!(
+            received
+                .get_ie(Gtp2IeType::RatType as u8, 0)
+                .and_then(|ie| ie.value.first().copied()),
+            Some(s11_build::rat_type::EUTRAN)
+        );
+
+        // The Sender F-TEID names the S11 MME control-plane interface and this UE's
+        // own local TEID, which is what the response has to be addressed to.
+        let fteid = nextgcore_gtp::v2::Gtp2FTeidIe::decode(
+            &received.get_ie(Gtp2IeType::FTeid as u8, 0).unwrap().value,
+        )
+        .expect("the F-TEID must decode");
+        assert_eq!(
+            fteid.interface_type,
+            s11_build::f_teid_interface::S11_MME_GTP_C
+        );
+        assert_eq!(fteid.teid, 0x0000_1234);
+
+        // The Bearer Context carries both sub-IEs sgwcd require()s.
+        let bc = nextgcore_gtp::v2::Gtp2BearerContextIe::decode(
+            &received
+                .get_ie(Gtp2IeType::BearerContext as u8, 0)
+                .unwrap()
+                .value,
+        )
+        .expect("the Bearer Context must decode");
+        assert_eq!(bc.ebi().expect("EBI is mandatory"), 5);
+        let qos = bc
+            .bearer_qos()
+            .expect("Bearer QoS must decode")
+            .expect("Bearer QoS is mandatory");
+        assert_eq!(qos.qci, 9);
+
+        server.close();
+    }
+
+    /// #51 criterion 8(b): a response is correlated back to its request by sequence
+    /// number, and an UNSOLICITED one is not.
+    #[test]
+    fn a_response_is_correlated_to_its_request_by_sequence_number() {
+        let _guard = lock_s11();
+        let (server, peer, peer_addr) = spawn_server_and_peer(Gtp2XactConfig::default());
+
+        let seq = server.alloc_sequence();
+        let request = s11_build::build_release_access_bearers_request(0x99, seq);
+        server
+            .send_request(peer_addr, &request, 4242)
+            .expect("send");
+        assert_eq!(server.outstanding(), 1, "the transaction must be armed");
+
+        let mut buf = [0u8; 4096];
+        let (_, from) = peer.recv_from(&mut buf).expect("peer receives");
+
+        // Answer with the SAME sequence number: the transaction closes.
+        let response = Gtp2Message::new(nextgcore_gtp::v2::Gtp2Header::new(
+            s11_build::message_type::RELEASE_ACCESS_BEARERS_RESPONSE,
+            0x99,
+            seq,
+        ));
+        peer.send_to(&response.encode(), from)
+            .expect("peer answers");
+        for _ in 0..200 {
+            if server.outstanding() == 0 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(
+            server.outstanding(),
+            0,
+            "a matching sequence number must close the transaction"
+        );
+
+        // And a response for a sequence nobody asked about must NOT close anything,
+        // because acting on an uncorrelated datagram lets a stray packet mutate state.
+        let seq2 = server.alloc_sequence();
+        let request2 = s11_build::build_release_access_bearers_request(0x99, seq2);
+        server.send_request(peer_addr, &request2, 1).expect("send");
+        let (_, from2) = peer.recv_from(&mut buf).expect("peer receives");
+        let stray = Gtp2Message::new(nextgcore_gtp::v2::Gtp2Header::new(
+            s11_build::message_type::RELEASE_ACCESS_BEARERS_RESPONSE,
+            0x99,
+            seq2.wrapping_add(1000),
+        ));
+        peer.send_to(&stray.encode(), from2).expect("peer answers");
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            server.outstanding(),
+            1,
+            "a response for an unknown sequence number must leave the transaction open"
+        );
+
+        server.close();
+    }
+
+    /// #51 criterion 8(c): a dropped response triggers T3-RESPONSE retransmission, and
+    /// N3-REQUESTS bounds it.
+    ///
+    /// The peer deliberately never answers. Before #51 there was no transaction layer
+    /// at all, so a lost response stalled the procedure silently and forever.
+    #[test]
+    fn a_dropped_response_is_retransmitted_and_then_exhausts_n3() {
+        let _guard = lock_s11();
+        let (server, peer, peer_addr) = spawn_server_and_peer(Gtp2XactConfig {
+            t3_response: Duration::from_millis(120),
+            n3_requests: 2,
+            response_hold: Duration::from_secs(1),
+        });
+
+        let seq = server.alloc_sequence();
+        let request = s11_build::build_release_access_bearers_request(0x99, seq);
+        server.send_request(peer_addr, &request, 1).expect("send");
+
+        // The original plus n3_requests retransmissions, all with the same sequence
+        // number — a retransmission that renumbered would be a new transaction.
+        let mut seen = 0;
+        let mut buf = [0u8; 4096];
+        for _ in 0..3 {
+            let (len, _) = match peer.recv_from(&mut buf) {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let mut bytes = Bytes::copy_from_slice(&buf[..len]);
+            let decoded = Gtp2Message::decode(&mut bytes).expect("decode");
+            assert_eq!(
+                decoded.header.sequence_number, seq,
+                "a retransmission repeats the sequence number, it does not allocate a new one"
+            );
+            seen += 1;
+        }
+        assert!(
+            seen >= 2,
+            "T3-RESPONSE must retransmit an unanswered request; saw {seen} sends"
+        );
+
+        // Once N3 is spent the peer is declared unreachable rather than waited on.
+        for _ in 0..200 {
+            if server.peer_state(peer_addr) == GtpPeerState::Failed {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(
+            server.peer_state(peer_addr),
+            GtpPeerState::Failed,
+            "N3 exhaustion must mark the path failed (TS 29.274 §7.6)"
+        );
+        assert_eq!(
+            server.outstanding(),
+            0,
+            "an exhausted transaction must not stay outstanding forever"
+        );
+
+        server.close();
+    }
+
+    /// An Echo Request is answered with a Recovery-bearing Echo Response, which is the
+    /// path management the MME had none of: the Echo builders existed and were never
+    /// called, so a Serving GW that went away was never noticed.
+    #[test]
+    fn an_echo_request_is_answered_with_this_nodes_recovery() {
+        let _guard = lock_s11();
+        let (server, peer, _) = spawn_server_and_peer(Gtp2XactConfig::default());
+
+        let echo = Gtp2Message::echo_request(11);
+        peer.send_to(&echo.encode(), server.local_addr())
+            .expect("send echo");
+
+        let mut buf = [0u8; 4096];
+        let (len, _) = peer
+            .recv_from(&mut buf)
+            .expect("the MME must answer an Echo");
+        let mut bytes = Bytes::copy_from_slice(&buf[..len]);
+        let reply = Gtp2Message::decode(&mut bytes).expect("decode");
+        assert_eq!(
+            reply.header.message_type,
+            Gtp2MessageType::EchoResponse as u8
+        );
+        assert_eq!(
+            reply.header.sequence_number, 11,
+            "the Echo Response echoes the request's sequence number"
+        );
+        let recovery = reply
+            .get_ie(Gtp2IeType::Recovery as u8, 0)
+            .expect("Recovery is mandatory in an Echo Response");
+        assert_eq!(recovery.value.first().copied(), Some(7));
+
+        server.close();
     }
 }

--- a/src/bins/nextgcore-mmed/src/s11_build.rs
+++ b/src/bins/nextgcore-mmed/src/s11_build.rs
@@ -105,6 +105,14 @@ pub enum GtpCause {
 }
 
 impl From<u8> for GtpCause {
+    /// TS 29.274 §8.4. Every variant this enum declares is now reachable (#51).
+    ///
+    /// The previous mapping listed nine values and collapsed the rest — including 66,
+    /// 68, 73, 74-78 and 94 — to `Reserved`. Cause 78 mattered most: an SGW rejecting
+    /// a session for "Missing or unknown APN" was indistinguishable from a reserved
+    /// value, so the UE was told `NETWORK_FAILURE` instead of the ESM cause that names
+    /// its own misconfiguration. A cause the receiver cannot distinguish is a cause
+    /// the operator cannot debug.
     fn from(value: u8) -> Self {
         match value {
             16 => GtpCause::RequestAccepted,
@@ -113,12 +121,31 @@ impl From<u8> for GtpCause {
             19 => GtpCause::NewPdnTypeDueToSingleAddressBearerOnly,
             64 => GtpCause::ContextNotFound,
             65 => GtpCause::InvalidMessageFormat,
+            66 => GtpCause::VersionNotSupported,
+            67 => GtpCause::InvalidLength,
+            68 => GtpCause::ServiceNotSupported,
+            69 => GtpCause::MandatoryIeIncorrect,
             70 => GtpCause::MandatoryIeMissing,
             72 => GtpCause::SystemFailure,
+            73 => GtpCause::NoResourcesAvailable,
+            74 => GtpCause::SemanticErrorInTftOperation,
+            75 => GtpCause::SyntacticErrorInTftOperation,
+            76 => GtpCause::SemanticErrorsInPacketFilter,
+            77 => GtpCause::SyntacticErrorsInPacketFilter,
+            78 => GtpCause::MissingOrUnknownApn,
+            94 => GtpCause::RequestRejected,
             103 => GtpCause::ConditionalIeMissing,
+            // Anything else really is unmapped. `Reserved` is honest for a value
+            // TS 29.274 does not define; it was not honest for the twelve above.
             _ => GtpCause::Reserved,
         }
     }
+}
+
+/// RAT Type values (TS 29.274 §8.17).
+pub mod rat_type {
+    /// E-UTRAN — the only access this MME serves.
+    pub const EUTRAN: u8 = 6;
 }
 
 // ============================================================================
@@ -221,417 +248,453 @@ impl std::error::Error for S11BuildError {}
 pub type S11BuildResult<T> = Result<T, S11BuildError>;
 
 // ============================================================================
-// GTP Buffer Helper
+// Message builders (TS 29.274), on the shared nextgcore-gtp v2 codec
 // ============================================================================
+//
+// #51 deleted the hand-rolled `GtpBuffer` these were written against. It duplicated
+// the round-trip-tested library codec and mis-encoded protocol semantics on its own:
+// the sequence number was a literal 0 in every initial message, the Indication IE put
+// the OI flag in the wrong content octet, and there was no mandatory-IE validation at
+// all — so the messages it built would have been rejected by sgwcd's own conformant
+// parser, if any of them had ever been transmitted.
+//
+// Every builder now returns a `Gtp2Message` and takes the sequence number the
+// transaction layer allocated, so the transport owns correlation rather than each
+// builder guessing at it.
 
-/// Buffer for building GTP-C messages
-#[derive(Debug, Clone)]
-pub struct GtpBuffer {
-    data: Vec<u8>,
+use bytes::BytesMut;
+use nextgcore_gtp::v2::{
+    Gtp2AmbrIe, Gtp2ApnIe, Gtp2BearerContextIe, Gtp2BearerQosIe, Gtp2CauseIe, Gtp2FTeidIe,
+    Gtp2Header, Gtp2Ie, Gtp2IeType, Gtp2IndicationIe, Gtp2Message, Gtp2PdnTypeIe, Gtp2RatTypeIe,
+    Gtp2SelectionModeIe,
+};
+
+/// F-TEID interface types (TS 29.274 §8.22 Table 8.22-1).
+pub mod f_teid_interface {
+    /// S1-U eNodeB GTP-U
+    pub const S1U_ENB_GTP_U: u8 = 0;
+    /// S1-U eNodeB GTP-U for downlink data forwarding
+    pub const S1U_ENB_GTP_U_DL_FORWARDING: u8 = 4;
+    /// S11 MME GTP-C
+    pub const S11_MME_GTP_C: u8 = 10;
 }
 
-impl GtpBuffer {
-    pub fn new() -> Self {
-        Self {
-            data: Vec::with_capacity(1024),
-        }
-    }
+/// A message with a TEID-bearing header.
+fn new_message(message_type: u8, teid: u32, sequence_number: u32) -> Gtp2Message {
+    Gtp2Message::new(Gtp2Header::new(message_type, teid, sequence_number))
+}
 
-    pub fn data(&self) -> &[u8] {
-        &self.data
-    }
+/// Encode one library IE type into a `Gtp2Ie` at the given instance.
+///
+/// The library's IE types encode themselves into a buffer including their own TLV
+/// header, so the round trip back through `Gtp2Ie::decode` is how a typed value
+/// becomes something `Gtp2Message::add_ie` accepts. Same idiom sgwcd uses.
+fn typed_ie<F>(encode: F) -> S11BuildResult<Gtp2Ie>
+where
+    F: FnOnce(&mut BytesMut),
+{
+    let mut buf = BytesMut::new();
+    encode(&mut buf);
+    let mut frozen = buf.freeze();
+    Gtp2Ie::decode(&mut frozen).map_err(|e| S11BuildError::BuildFailed(e.to_string()))
+}
 
-    pub fn into_vec(self) -> Vec<u8> {
-        self.data
-    }
-
-    pub fn len(&self) -> usize {
-        self.data.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-
-    pub fn write_u8(&mut self, value: u8) {
-        self.data.push(value);
-    }
-
-    pub fn write_u16(&mut self, value: u16) {
-        self.data.extend_from_slice(&value.to_be_bytes());
-    }
-
-    pub fn write_u32(&mut self, value: u32) {
-        self.data.extend_from_slice(&value.to_be_bytes());
-    }
-
-    pub fn write_bytes(&mut self, bytes: &[u8]) {
-        self.data.extend_from_slice(bytes);
-    }
-
-    /// Write GTP-C header with TEID
-    pub fn write_gtp_header_with_teid(&mut self, msg_type: u8, teid: u32, seq_num: u32) {
-        self.write_u8(0x48); // Version 2, T=1
-        self.write_u8(msg_type);
-        self.write_u16(0); // Length placeholder
-        self.write_u32(teid);
-        self.write_u8(((seq_num >> 16) & 0xff) as u8);
-        self.write_u8(((seq_num >> 8) & 0xff) as u8);
-        self.write_u8((seq_num & 0xff) as u8);
-        self.write_u8(0); // Spare
-    }
-
-    /// Write GTP-C header without TEID
-    pub fn write_gtp_header_no_teid(&mut self, msg_type: u8, seq_num: u32) {
-        self.write_u8(0x40); // Version 2, T=0
-        self.write_u8(msg_type);
-        self.write_u16(0); // Length placeholder
-        self.write_u8(((seq_num >> 16) & 0xff) as u8);
-        self.write_u8(((seq_num >> 8) & 0xff) as u8);
-        self.write_u8((seq_num & 0xff) as u8);
-        self.write_u8(0); // Spare
-    }
-
-    /// Update message length in header
-    pub fn update_length(&mut self) {
-        let len = (self.data.len() - 4) as u16;
-        self.data[2] = (len >> 8) as u8;
-        self.data[3] = (len & 0xff) as u8;
-    }
-
-    /// Write IE header
-    pub fn write_ie_header(&mut self, ie_type: u8, length: u16, instance: u8) {
-        self.write_u8(ie_type);
-        self.write_u16(length);
-        self.write_u8(instance & 0x0f);
-    }
-
-    /// Write Recovery IE
-    pub fn write_recovery(&mut self, recovery: u8, instance: u8) {
-        self.write_ie_header(ie_type::RECOVERY, 1, instance);
-        self.write_u8(recovery);
-    }
-
-    /// Write Cause IE
-    pub fn write_cause(&mut self, cause: GtpCause, instance: u8) {
-        self.write_ie_header(ie_type::CAUSE, 2, instance);
-        self.write_u8(cause as u8);
-        self.write_u8(0); // Spare
-    }
-
-    /// Write EBI IE
-    pub fn write_ebi(&mut self, ebi: u8, instance: u8) {
-        self.write_ie_header(ie_type::EBI, 1, instance);
-        self.write_u8(ebi & 0x0f);
-    }
-
-    /// Write a complete IE (header + data)
-    pub fn write_ie(&mut self, ie_type: u8, instance: u8, data: &[u8]) {
-        self.write_ie_header(ie_type, data.len() as u16, instance);
-        self.write_bytes(data);
-    }
-
-    /// Finalize message length in the GTP header
-    pub fn finalize_length(&mut self) {
-        self.update_length();
+/// The MME's own S11 control-plane F-TEID (TS 29.274 Table 7.2.1-1, M).
+///
+/// Absent from every Create Session Request this daemon built before #51, which
+/// sgwcd's parser `require()`s — so the SGW-C would have answered
+/// "Mandatory IE missing" to every one of them.
+///
+/// The local address is a PARAMETER rather than read from `mme_self()`: a builder that
+/// reaches for a process global cannot be exercised without one, and the sender
+/// already holds the context that knows it.
+fn sender_fteid(mme_ue: &MmeUe, local: std::net::SocketAddr) -> S11BuildResult<Gtp2FTeidIe> {
+    match local.ip() {
+        std::net::IpAddr::V4(v4) => Ok(Gtp2FTeidIe::new_ipv4(
+            f_teid_interface::S11_MME_GTP_C,
+            mme_ue.mme_s11_teid,
+            v4.octets(),
+        )),
+        std::net::IpAddr::V6(v6) => Ok(Gtp2FTeidIe::new_ipv6(
+            f_teid_interface::S11_MME_GTP_C,
+            mme_ue.mme_s11_teid,
+            v6.octets(),
+        )),
     }
 }
 
-impl Default for GtpBuffer {
-    fn default() -> Self {
-        Self::new()
-    }
+/// The Bearer QoS IE for a bearer's subscribed QoS (TS 29.274 §8.15).
+fn bearer_qos(bearer: &MmeBearer) -> Gtp2BearerQosIe {
+    let mut qos = Gtp2BearerQosIe::new(
+        bearer.qos.qci,
+        bearer.qos.mbr.uplink,
+        bearer.qos.mbr.downlink,
+        bearer.qos.gbr.uplink,
+        bearer.qos.gbr.downlink,
+    );
+    qos.pl = bearer.qos.arp.priority_level;
+    // The context stores the NAS/GTP spelling (0 = enabled), and the library IE takes
+    // booleans, so the conversion happens here rather than being assumed either way.
+    qos.pci = bearer.qos.arp.pre_emption_capability == 0;
+    qos.pvi = bearer.qos.arp.pre_emption_vulnerability == 0;
+    qos
 }
 
-// ============================================================================
-// Build Functions
-// ============================================================================
-
-/// Build Echo Request
-pub fn build_echo_request(seq_num: u32, recovery: u8) -> Vec<u8> {
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_no_teid(message_type::ECHO_REQUEST, seq_num);
-    buf.write_recovery(recovery, 0);
-    buf.update_length();
-    buf.into_vec()
+/// The eNB's S1-U F-TEID for a bearer, or `None` when none has been saved yet.
+fn enb_s1u_fteid(bearer: &MmeBearer, interface_type: u8) -> Option<Gtp2FTeidIe> {
+    let ipv4 = bearer.enb_s1u_ip.ipv4?;
+    Some(Gtp2FTeidIe::new_ipv4(
+        interface_type,
+        bearer.enb_s1u_teid,
+        ipv4,
+    ))
 }
 
-/// Build Echo Response
-pub fn build_echo_response(seq_num: u32, recovery: u8) -> Vec<u8> {
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_no_teid(message_type::ECHO_RESPONSE, seq_num);
-    buf.write_recovery(recovery, 0);
-    buf.update_length();
-    buf.into_vec()
-}
-
-/// Build Create Session Request
+/// Build Create Session Request (TS 29.274 §7.2.1)
 pub fn build_create_session_request(
     sess: &MmeSess,
     mme_ue: &MmeUe,
     sgw_ue: &SgwUe,
     _create_action: GtpCreateAction,
-) -> S11BuildResult<Vec<u8>> {
+    sequence_number: u32,
+    bearers: &[&MmeBearer],
+    local_s11_addr: std::net::SocketAddr,
+) -> S11BuildResult<Gtp2Message> {
     log::debug!("Build Create Session Request for APN={}", sess.apn);
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(message_type::CREATE_SESSION_REQUEST, sgw_ue.sgw_s11_teid, 0);
+    let mut msg = new_message(
+        message_type::CREATE_SESSION_REQUEST,
+        sgw_ue.sgw_s11_teid,
+        sequence_number,
+    );
 
-    // IE: IMSI (1) - mandatory
-    buf.write_ie(ie_type::IMSI, 0, &mme_ue.imsi[..mme_ue.imsi_len]);
+    // IMSI (M)
+    if mme_ue.imsi_len > 0 {
+        msg.add_ie(Gtp2Ie::from_slice(
+            Gtp2IeType::Imsi as u8,
+            0,
+            &mme_ue.imsi[..mme_ue.imsi_len],
+        ));
+    }
 
-    // IE: MSISDN (76) - conditional
+    // MSISDN (C)
     if mme_ue.msisdn_len > 0 {
-        buf.write_ie(ie_type::MSISDN, 0, &mme_ue.msisdn[..mme_ue.msisdn_len]);
+        msg.add_ie(Gtp2Ie::from_slice(
+            Gtp2IeType::Msisdn as u8,
+            0,
+            &mme_ue.msisdn[..mme_ue.msisdn_len],
+        ));
     }
 
-    // IE: MEI (75) - conditional
+    // MEI (C)
     if mme_ue.imeisv_len > 0 {
-        buf.write_ie(ie_type::MEI, 0, &mme_ue.imeisv[..mme_ue.imeisv_len]);
+        msg.add_ie(Gtp2Ie::from_slice(
+            Gtp2IeType::Mei as u8,
+            0,
+            &mme_ue.imeisv[..mme_ue.imeisv_len],
+        ));
     }
 
-    // IE: RAT Type (82) - mandatory (E-UTRAN = 6)
-    buf.write_ie(ie_type::RAT_TYPE, 0, &[6]);
+    // RAT Type (M) — from the UE context, not a literal (#51 criterion 5)
+    msg.add_ie(typed_ie(|buf| {
+        Gtp2RatTypeIe::new(mme_ue.rat_type).encode(buf, 0)
+    })?);
 
-    // IE: APN (71) - mandatory (DNS format)
-    let apn_bytes = encode_apn_dns(&sess.apn);
-    buf.write_ie(ie_type::APN, 0, &apn_bytes);
+    // Sender F-TEID for Control Plane (M)
+    msg.add_ie(sender_fteid(mme_ue, local_s11_addr)?.to_ie(0));
 
-    // IE: Selection Mode (80)
-    buf.write_ie(ie_type::SELECTION_MODE, 0, &[0]);
+    // APN (M)
+    msg.add_ie(typed_ie(|buf| {
+        Gtp2ApnIe::from_string(&sess.apn).encode(buf, 0)
+    })?);
 
-    // IE: PDN Type (99) - mandatory
-    buf.write_ie(ie_type::PDN_TYPE, 0, &[sess.ue_request_pdn_type as u8]);
+    // Selection Mode (C)
+    msg.add_ie(typed_ie(|buf| Gtp2SelectionModeIe::new(0).encode(buf, 0))?);
 
-    // IE: APN-AMBR (72) - mandatory
-    let mut ambr_data = Vec::new();
-    ambr_data.extend_from_slice(&(sess.ambr.uplink as u32).to_be_bytes());
-    ambr_data.extend_from_slice(&(sess.ambr.downlink as u32).to_be_bytes());
-    buf.write_ie(ie_type::AMBR, 0, &ambr_data);
+    // PDN Type (C)
+    msg.add_ie(typed_ie(|buf| {
+        Gtp2PdnTypeIe::new(sess.ue_request_pdn_type as u8).encode(buf, 0)
+    })?);
 
-    buf.finalize_length();
-    Ok(buf.into_vec())
+    // APN-AMBR (C)
+    msg.add_ie(typed_ie(|buf| {
+        // TS 29.274 §8.7 states APN-AMBR in kbps as two u32s.
+        Gtp2AmbrIe::new(
+            (sess.ambr.uplink / 1000) as u32,
+            (sess.ambr.downlink / 1000) as u32,
+        )
+        .encode(buf, 0)
+    })?);
+
+    // Bearer Contexts to be created (M), each with EBI (M) and Bearer QoS (M)
+    let mut created = 0;
+    for bearer in bearers {
+        let mut bc = Gtp2BearerContextIe::new();
+        bc.set_ebi(bearer.ebi);
+        bc.set_bearer_qos(&bearer_qos(bearer));
+        msg.add_bearer_context(0, &bc);
+        created += 1;
+    }
+    if created == 0 {
+        // TS 29.274 Table 7.2.1-1 makes this mandatory, and sgwcd's parser
+        // `require()`s it: building the message without one produces a request the
+        // peer must reject, which is worse than refusing to build it.
+        return Err(S11BuildError::MissingRequiredField(
+            "Create Session Request requires at least one bearer context".to_string(),
+        ));
+    }
+
+    Ok(msg)
 }
 
-/// Build Modify Bearer Request
+/// Build Modify Bearer Request (TS 29.274 §7.2.7)
 pub fn build_modify_bearer_request(
-    _mme_ue: &MmeUe,
+    mme_ue: &MmeUe,
     sgw_ue: &SgwUe,
     bearers: &[&MmeBearer],
     _uli_presence: bool,
-) -> S11BuildResult<Vec<u8>> {
+    sequence_number: u32,
+) -> S11BuildResult<Gtp2Message> {
     log::debug!("Build Modify Bearer Request with {} bearers", bearers.len());
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(message_type::MODIFY_BEARER_REQUEST, sgw_ue.sgw_s11_teid, 0);
+    let mut msg = new_message(
+        message_type::MODIFY_BEARER_REQUEST,
+        sgw_ue.sgw_s11_teid,
+        sequence_number,
+    );
 
-    // IE: Bearer Context to be modified (93, instance 0) for each bearer
+    // Bearer Contexts to be modified, each carrying the eNB's S1-U F-TEID — which
+    // is the whole point of the message (Table 7.2.7-1). The previous caller passed
+    // an empty slice, so the SGW was asked to modify nothing.
+    let mut modified = 0;
     for bearer in bearers {
-        let mut bearer_ctx = GtpBuffer::new();
-        // Sub-IE: EBI
-        bearer_ctx.write_ie(ie_type::EBI, 0, &[bearer.ebi]);
-        // Sub-IE: S1-U eNB F-TEID (interface type 0 = S1-U eNB)
-        let mut fteid = Vec::new();
-        fteid.push(0x80); // V4 flag | interface type 0
-        fteid.extend_from_slice(&bearer.enb_s1u_teid.to_be_bytes());
-        if let Some(ipv4) = bearer.enb_s1u_ip.ipv4 {
-            fteid.extend_from_slice(&ipv4);
+        let mut bc = Gtp2BearerContextIe::new();
+        bc.set_ebi(bearer.ebi);
+        match enb_s1u_fteid(bearer, f_teid_interface::S1U_ENB_GTP_U) {
+            Some(ft) => bc.set_fteid(0, &ft),
+            None => {
+                // No eNB S1-U endpoint saved yet means Initial Context Setup has not
+                // completed for this bearer. Sending the context without it would ask
+                // the SGW to switch the downlink tunnel to nowhere.
+                log::warn!(
+                    "Modify Bearer Request: EBI {} has no eNB S1-U F-TEID saved; omitting it",
+                    bearer.ebi
+                );
+                continue;
+            }
         }
-        bearer_ctx.write_ie(ie_type::F_TEID, 0, &fteid);
-
-        buf.write_ie(ie_type::BEARER_CONTEXT, 0, bearer_ctx.data());
+        msg.add_bearer_context(0, &bc);
+        modified += 1;
+    }
+    if modified == 0 {
+        return Err(S11BuildError::MissingRequiredField(
+            "Modify Bearer Request requires at least one bearer context with an eNB S1-U F-TEID"
+                .to_string(),
+        ));
     }
 
-    // IE: RAT Type (82) - E-UTRAN = 6
-    buf.write_ie(ie_type::RAT_TYPE, 0, &[6]);
+    // RAT Type (C)
+    msg.add_ie(typed_ie(|buf| {
+        Gtp2RatTypeIe::new(mme_ue.rat_type).encode(buf, 0)
+    })?);
 
-    buf.finalize_length();
-    Ok(buf.into_vec())
+    Ok(msg)
 }
 
-/// Build Delete Session Request
+/// Build Delete Session Request (TS 29.274 §7.2.9)
 pub fn build_delete_session_request(
     _sess: &MmeSess,
     _mme_ue: &MmeUe,
     sgw_ue: &SgwUe,
-    default_bearer_ebi: u8,
+    linked_bearer_ebi: u8,
     _action: GtpDeleteAction,
-) -> S11BuildResult<Vec<u8>> {
-    log::debug!("Build Delete Session Request for EBI={default_bearer_ebi}");
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(message_type::DELETE_SESSION_REQUEST, sgw_ue.sgw_s11_teid, 0);
+    sequence_number: u32,
+) -> S11BuildResult<Gtp2Message> {
+    log::debug!("Build Delete Session Request for LBI={linked_bearer_ebi}");
+    let mut msg = new_message(
+        message_type::DELETE_SESSION_REQUEST,
+        sgw_ue.sgw_s11_teid,
+        sequence_number,
+    );
 
-    // IE: EBI (73) - mandatory (Linked EPS Bearer ID)
-    buf.write_ie(ie_type::EBI, 0, &[default_bearer_ebi]);
+    // Linked EPS Bearer ID (M, Table 7.2.9.1-1): the DEFAULT bearer of the PDN
+    // connection being torn down. The caller used to pass a literal 5, which tears
+    // down the wrong PDN for any UE with more than one.
+    msg.add_ie(Gtp2Ie::from_slice(
+        Gtp2IeType::Ebi as u8,
+        0,
+        &[linked_bearer_ebi],
+    ));
 
-    // IE: Indication Flags (77)
-    buf.write_ie(ie_type::INDICATION, 0, &[0x00, 0x08, 0x00]); // OI flag
+    // Indication (C, §8.12): Operation Indication. Hand-encoded as
+    // `[0x00, 0x08, 0x00]` before #51, which puts the bit in the SECOND content
+    // octet and therefore left OI unset; the library IE puts it where §8.12 does.
+    let mut indication = Gtp2IndicationIe::default();
+    indication.oi = true;
+    msg.add_ie(typed_ie(|buf| indication.encode(buf, 0))?);
 
-    buf.finalize_length();
-    Ok(buf.into_vec())
+    Ok(msg)
 }
 
-/// Build Create Bearer Response
+/// Build Create Bearer Response (TS 29.274 §7.2.4)
 pub fn build_create_bearer_response(
     bearer: &MmeBearer,
     mme_ue: &MmeUe,
     sgw_ue: &SgwUe,
     cause_value: GtpCause,
-) -> S11BuildResult<Vec<u8>> {
+    sequence_number: u32,
+) -> S11BuildResult<Gtp2Message> {
     log::debug!("Build Create Bearer Response for EBI={}", bearer.ebi);
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(message_type::CREATE_BEARER_RESPONSE, sgw_ue.sgw_s11_teid, 0);
+    let mut msg = new_message(
+        message_type::CREATE_BEARER_RESPONSE,
+        sgw_ue.sgw_s11_teid,
+        sequence_number,
+    );
+    msg.add_ie(typed_ie(|buf| {
+        Gtp2CauseIe::new(cause_value as u8).encode(buf, 0)
+    })?);
 
-    // IE: Cause (2)
-    buf.write_cause(cause_value, 0);
-
-    // Bearer Context (93, instance 0)
-    let mut bearer_ctx = GtpBuffer::new();
-    // Sub-IE: EBI
-    bearer_ctx.write_ie(ie_type::EBI, 0, &[bearer.ebi]);
-    // Sub-IE: Cause
-    bearer_ctx.write_ie(ie_type::CAUSE, 0, &[cause_value as u8, 0]);
-    // Sub-IE: S1-U eNB F-TEID (if accepted)
+    let mut bc = Gtp2BearerContextIe::new();
+    bc.set_ebi(bearer.ebi);
+    bc.set_cause(&Gtp2CauseIe::new(cause_value as u8));
     if cause_value as u8 == GtpCause::RequestAccepted as u8 {
-        let mut fteid = Vec::new();
-        fteid.push(0x80); // V4 flag | interface type 0 (S1-U eNB)
-        fteid.extend_from_slice(&bearer.enb_s1u_teid.to_be_bytes());
-        if let Some(ipv4) = bearer.enb_s1u_ip.ipv4 {
-            fteid.extend_from_slice(&ipv4);
+        if let Some(ft) = enb_s1u_fteid(bearer, f_teid_interface::S1U_ENB_GTP_U) {
+            bc.set_fteid(0, &ft);
         }
-        bearer_ctx.write_ie(ie_type::F_TEID, 0, &fteid);
     }
-    buf.write_ie(ie_type::BEARER_CONTEXT, 0, bearer_ctx.data());
+    msg.add_bearer_context(0, &bc);
 
-    // IE: ULI (86) - User Location Information
-    {
-        let mut uli = Vec::new();
-        // Flags: TAI=0x08, ECGI=0x10
-        uli.push(0x08 | 0x10);
-        // TAI: PLMN (3 bytes BCD) + TAC (2 bytes)
-        let tai_plmn = &mme_ue.tai.plmn_id;
-        uli.push((tai_plmn.mcc2 << 4) | tai_plmn.mcc1);
-        uli.push((tai_plmn.mnc3 << 4) | tai_plmn.mcc3);
-        uli.push((tai_plmn.mnc2 << 4) | tai_plmn.mnc1);
-        uli.extend_from_slice(&mme_ue.tai.tac.to_be_bytes());
-        // ECGI: PLMN (3 bytes BCD) + Cell ID (4 bytes, 28-bit)
-        let ecgi_plmn = &mme_ue.e_cgi.plmn_id;
-        uli.push((ecgi_plmn.mcc2 << 4) | ecgi_plmn.mcc1);
-        uli.push((ecgi_plmn.mnc3 << 4) | ecgi_plmn.mcc3);
-        uli.push((ecgi_plmn.mnc2 << 4) | ecgi_plmn.mnc1);
-        uli.extend_from_slice(&mme_ue.e_cgi.cell_id.to_be_bytes());
-        buf.write_ie(ie_type::ULI, 0, &uli);
-    }
+    // ULI (C): where the UE is. Encoded by the library rather than by hand — the
+    // previous version built the TAI/ECGI BCD nibbles inline in the builder.
+    msg.add_ie(uli_ie(mme_ue)?);
 
-    buf.finalize_length();
-    Ok(buf.into_vec())
+    Ok(msg)
 }
 
-/// Build Update Bearer Response
+/// User Location Information carrying TAI and ECGI (TS 29.274 §8.21).
+fn uli_ie(mme_ue: &MmeUe) -> S11BuildResult<Gtp2Ie> {
+    let mut value = Vec::with_capacity(1 + 5 + 7);
+    // Flags: TAI (bit 3) | ECGI (bit 4)
+    value.push(0x08 | 0x10);
+    value.extend_from_slice(&encode_plmn_bcd(&mme_ue.tai.plmn_id));
+    value.extend_from_slice(&mme_ue.tai.tac.to_be_bytes());
+    value.extend_from_slice(&encode_plmn_bcd(&mme_ue.e_cgi.plmn_id));
+    value.extend_from_slice(&mme_ue.e_cgi.cell_id.to_be_bytes());
+    Ok(Gtp2Ie::from_slice(Gtp2IeType::Uli as u8, 0, &value))
+}
+
+/// PLMN ID in the 3-octet BCD form GTP-C uses (TS 29.274 §8.21.1).
+fn encode_plmn_bcd(plmn: &crate::context::PlmnId) -> [u8; 3] {
+    [
+        (plmn.mcc2 << 4) | plmn.mcc1,
+        (plmn.mnc3 << 4) | plmn.mcc3,
+        (plmn.mnc2 << 4) | plmn.mnc1,
+    ]
+}
+
+/// Build Update Bearer Response (TS 29.274 §7.2.16)
 pub fn build_update_bearer_response(
     bearer: &MmeBearer,
     _mme_ue: &MmeUe,
     sgw_ue: &SgwUe,
     cause_value: GtpCause,
-) -> S11BuildResult<Vec<u8>> {
+    sequence_number: u32,
+) -> S11BuildResult<Gtp2Message> {
     log::debug!("Build Update Bearer Response for EBI={}", bearer.ebi);
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(message_type::UPDATE_BEARER_RESPONSE, sgw_ue.sgw_s11_teid, 0);
-
-    // IE: Cause (2)
-    buf.write_cause(cause_value, 0);
-
-    // Bearer Context (93, instance 0)
-    let mut bearer_ctx = GtpBuffer::new();
-    bearer_ctx.write_ie(ie_type::EBI, 0, &[bearer.ebi]);
-    bearer_ctx.write_ie(ie_type::CAUSE, 0, &[cause_value as u8, 0]);
-    buf.write_ie(ie_type::BEARER_CONTEXT, 0, bearer_ctx.data());
-
-    buf.finalize_length();
-    Ok(buf.into_vec())
+    let mut msg = new_message(
+        message_type::UPDATE_BEARER_RESPONSE,
+        sgw_ue.sgw_s11_teid,
+        sequence_number,
+    );
+    msg.add_ie(typed_ie(|buf| {
+        Gtp2CauseIe::new(cause_value as u8).encode(buf, 0)
+    })?);
+    let mut bc = Gtp2BearerContextIe::new();
+    bc.set_ebi(bearer.ebi);
+    bc.set_cause(&Gtp2CauseIe::new(cause_value as u8));
+    msg.add_bearer_context(0, &bc);
+    Ok(msg)
 }
 
-/// Build Delete Bearer Response
+/// Build Delete Bearer Response (TS 29.274 §7.2.10)
 pub fn build_delete_bearer_response(
     bearer: &MmeBearer,
     _mme_ue: &MmeUe,
     sgw_ue: &SgwUe,
     cause_value: GtpCause,
-) -> S11BuildResult<Vec<u8>> {
+    sequence_number: u32,
+) -> S11BuildResult<Gtp2Message> {
     log::debug!("Build Delete Bearer Response for EBI={}", bearer.ebi);
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(message_type::DELETE_BEARER_RESPONSE, sgw_ue.sgw_s11_teid, 0);
-
-    // IE: Cause (2)
-    buf.write_cause(cause_value, 0);
-
-    // Bearer Context (93, instance 0)
-    let mut bearer_ctx = GtpBuffer::new();
-    bearer_ctx.write_ie(ie_type::EBI, 0, &[bearer.ebi]);
-    bearer_ctx.write_ie(ie_type::CAUSE, 0, &[cause_value as u8, 0]);
-    buf.write_ie(ie_type::BEARER_CONTEXT, 0, bearer_ctx.data());
-
-    buf.finalize_length();
-    Ok(buf.into_vec())
+    let mut msg = new_message(
+        message_type::DELETE_BEARER_RESPONSE,
+        sgw_ue.sgw_s11_teid,
+        sequence_number,
+    );
+    msg.add_ie(typed_ie(|buf| {
+        Gtp2CauseIe::new(cause_value as u8).encode(buf, 0)
+    })?);
+    let mut bc = Gtp2BearerContextIe::new();
+    bc.set_ebi(bearer.ebi);
+    bc.set_cause(&Gtp2CauseIe::new(cause_value as u8));
+    msg.add_bearer_context(0, &bc);
+    Ok(msg)
 }
 
-/// Build Release Access Bearers Request
-pub fn build_release_access_bearers_request(teid: u32, seq_num: u32) -> Vec<u8> {
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(message_type::RELEASE_ACCESS_BEARERS_REQUEST, teid, seq_num);
-    buf.update_length();
-    buf.into_vec()
+/// Build Release Access Bearers Request (TS 29.274 §7.2.21)
+pub fn build_release_access_bearers_request(teid: u32, sequence_number: u32) -> Gtp2Message {
+    new_message(
+        message_type::RELEASE_ACCESS_BEARERS_REQUEST,
+        teid,
+        sequence_number,
+    )
 }
 
-/// Build Downlink Data Notification Ack
-pub fn build_downlink_data_notification_ack(teid: u32, seq_num: u32, cause: GtpCause) -> Vec<u8> {
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(message_type::DOWNLINK_DATA_NOTIFICATION_ACK, teid, seq_num);
-    buf.write_cause(cause, 0);
-    buf.update_length();
-    buf.into_vec()
+/// Build Downlink Data Notification Acknowledge (TS 29.274 §7.2.11)
+pub fn build_downlink_data_notification_ack(
+    teid: u32,
+    sequence_number: u32,
+    cause: GtpCause,
+) -> S11BuildResult<Gtp2Message> {
+    let mut msg = new_message(
+        message_type::DOWNLINK_DATA_NOTIFICATION_ACK,
+        teid,
+        sequence_number,
+    );
+    msg.add_ie(typed_ie(|buf| {
+        Gtp2CauseIe::new(cause as u8).encode(buf, 0)
+    })?);
+    Ok(msg)
 }
 
-/// Build Create Indirect Data Forwarding Tunnel Request
+/// Build Create Indirect Data Forwarding Tunnel Request (TS 29.274 §7.2.18)
 pub fn build_create_indirect_data_forwarding_tunnel_request(
     _mme_ue: &MmeUe,
     sgw_ue: &SgwUe,
     bearers: &[&MmeBearer],
-) -> S11BuildResult<Vec<u8>> {
+    sequence_number: u32,
+) -> S11BuildResult<Gtp2Message> {
     log::debug!(
         "Build Create Indirect Data Forwarding Tunnel Request with {} bearers",
         bearers.len()
     );
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(
+    let mut msg = new_message(
         message_type::CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST,
         sgw_ue.sgw_s11_teid,
-        0,
+        sequence_number,
     );
-
-    // Bearer Contexts for each bearer
     for bearer in bearers {
-        let mut bearer_ctx = GtpBuffer::new();
-        // Sub-IE: EBI
-        bearer_ctx.write_ie(ie_type::EBI, 0, &[bearer.ebi]);
-
-        // Sub-IE: S1-U eNB F-TEID for DL data forwarding
+        let mut bc = Gtp2BearerContextIe::new();
+        bc.set_ebi(bearer.ebi);
         if bearer.enb_s1u_teid != 0 {
-            let mut fteid = Vec::new();
-            fteid.push(0x80 | 4); // V4 | interface type 4 (S1-U eNB for DL data forwarding)
-            fteid.extend_from_slice(&bearer.enb_s1u_teid.to_be_bytes());
-            if let Some(ipv4) = bearer.enb_s1u_ip.ipv4 {
-                fteid.extend_from_slice(&ipv4);
+            if let Some(ft) = enb_s1u_fteid(bearer, f_teid_interface::S1U_ENB_GTP_U_DL_FORWARDING) {
+                bc.set_fteid(0, &ft);
             }
-            bearer_ctx.write_ie(ie_type::F_TEID, 0, &fteid);
         }
-
-        buf.write_ie(ie_type::BEARER_CONTEXT, 0, bearer_ctx.data());
+        msg.add_bearer_context(0, &bc);
     }
-
-    buf.finalize_length();
-    Ok(buf.into_vec())
+    Ok(msg)
 }
 
-/// Build Bearer Resource Command
+/// Build Bearer Resource Command (TS 29.274 §7.2.5)
+#[allow(clippy::too_many_arguments)]
 pub fn build_bearer_resource_command(
     _bearer: &MmeBearer,
     _mme_ue: &MmeUe,
@@ -640,75 +703,44 @@ pub fn build_bearer_resource_command(
     pti: u8,
     tad: &[u8],
     qos: Option<&Gtp2BearerQos>,
-) -> S11BuildResult<Vec<u8>> {
+    sequence_number: u32,
+) -> S11BuildResult<Gtp2Message> {
     log::debug!("Build Bearer Resource Command, linked EBI={linked_bearer_ebi}");
-    let mut buf = GtpBuffer::new();
-    buf.write_gtp_header_with_teid(
+    let mut msg = new_message(
         message_type::BEARER_RESOURCE_COMMAND,
         sgw_ue.sgw_s11_teid,
-        0,
+        sequence_number,
     );
 
-    // IE: Linked EPS Bearer ID (73, instance 0)
-    buf.write_ie(ie_type::EBI, 0, &[linked_bearer_ebi]);
-
-    // IE: Procedure Transaction Id (100)
-    buf.write_ie(ie_type::PTI, 0, &[pti]);
-
-    // IE: TAD (85) - Traffic Aggregate Description
+    // Linked EPS Bearer ID (M)
+    msg.add_ie(Gtp2Ie::from_slice(
+        Gtp2IeType::Ebi as u8,
+        0,
+        &[linked_bearer_ebi],
+    ));
+    // Procedure Transaction Id (M)
+    msg.add_ie(Gtp2Ie::from_slice(Gtp2IeType::Pti as u8, 0, &[pti]));
+    // Traffic Aggregate Description (C)
     if !tad.is_empty() {
-        buf.write_ie(ie_type::TAD, 0, tad);
+        msg.add_ie(Gtp2Ie::from_slice(Gtp2IeType::Tad as u8, 0, tad));
     }
-
-    // IE: Flow QoS (81) - optional
+    // Flow QoS (C). The library's Bearer QoS IE has the same 22-octet layout as
+    // Flow QoS minus the leading ARP octet's position, so it is encoded here and
+    // re-tagged rather than hand-built a second time.
     if let Some(q) = qos {
-        let mut qos_data = Vec::with_capacity(22);
-        // ARP: PEC(2bits) | PL(4bits) | PEV(1bit) | spare(1bit)
-        let arp_byte =
-            (q.pre_emption_capability << 6) | (q.priority_level << 2) | q.pre_emption_vulnerability;
-        qos_data.push(arp_byte);
-        qos_data.push(q.qci);
-        // MBR UL (5 bytes)
-        let mbr_ul_kbps = q.ul_mbr / 1000;
-        qos_data.extend_from_slice(&[
-            ((mbr_ul_kbps >> 32) & 0xff) as u8,
-            ((mbr_ul_kbps >> 24) & 0xff) as u8,
-            ((mbr_ul_kbps >> 16) & 0xff) as u8,
-            ((mbr_ul_kbps >> 8) & 0xff) as u8,
-            (mbr_ul_kbps & 0xff) as u8,
-        ]);
-        // MBR DL (5 bytes)
-        let mbr_dl_kbps = q.dl_mbr / 1000;
-        qos_data.extend_from_slice(&[
-            ((mbr_dl_kbps >> 32) & 0xff) as u8,
-            ((mbr_dl_kbps >> 24) & 0xff) as u8,
-            ((mbr_dl_kbps >> 16) & 0xff) as u8,
-            ((mbr_dl_kbps >> 8) & 0xff) as u8,
-            (mbr_dl_kbps & 0xff) as u8,
-        ]);
-        // GBR UL (5 bytes)
-        let gbr_ul_kbps = q.ul_gbr / 1000;
-        qos_data.extend_from_slice(&[
-            ((gbr_ul_kbps >> 32) & 0xff) as u8,
-            ((gbr_ul_kbps >> 24) & 0xff) as u8,
-            ((gbr_ul_kbps >> 16) & 0xff) as u8,
-            ((gbr_ul_kbps >> 8) & 0xff) as u8,
-            (gbr_ul_kbps & 0xff) as u8,
-        ]);
-        // GBR DL (5 bytes)
-        let gbr_dl_kbps = q.dl_gbr / 1000;
-        qos_data.extend_from_slice(&[
-            ((gbr_dl_kbps >> 32) & 0xff) as u8,
-            ((gbr_dl_kbps >> 24) & 0xff) as u8,
-            ((gbr_dl_kbps >> 16) & 0xff) as u8,
-            ((gbr_dl_kbps >> 8) & 0xff) as u8,
-            (gbr_dl_kbps & 0xff) as u8,
-        ]);
-        buf.write_ie(ie_type::FLOW_QOS, 0, &qos_data);
+        let mut flow = Gtp2BearerQosIe::new(q.qci, q.ul_mbr, q.dl_mbr, q.ul_gbr, q.dl_gbr);
+        flow.pl = q.priority_level;
+        flow.pci = q.pre_emption_capability == 0;
+        flow.pvi = q.pre_emption_vulnerability == 0;
+        let encoded = typed_ie(|buf| flow.encode(buf, 0))?;
+        msg.add_ie(Gtp2Ie::from_slice(
+            Gtp2IeType::FlowQos as u8,
+            0,
+            &encoded.value,
+        ));
     }
 
-    buf.finalize_length();
-    Ok(buf.into_vec())
+    Ok(msg)
 }
 
 // ============================================================================
@@ -736,40 +768,99 @@ mod tests {
         assert_eq!(GtpCause::from(0), GtpCause::Reserved);
     }
 
+    /// #51 criterion 6: every value this enum declares must round-trip, because a
+    /// cause collapsed to `Reserved` is a rejection reason the operator cannot see.
+    ///
+    /// 78 is called out separately below; this covers the twelve the old mapping
+    /// dropped as a set, so adding a variant without a mapping fails here.
     #[test]
-    fn test_build_echo_request() {
-        let msg = build_echo_request(100, 5);
-        assert!(!msg.is_empty());
-        assert_eq!(msg[1], message_type::ECHO_REQUEST);
+    fn every_declared_gtp_cause_is_distinguishable() {
+        for value in [
+            16u8, 17, 18, 19, 64, 65, 66, 67, 68, 69, 70, 72, 73, 74, 75, 76, 77, 78, 94, 103,
+        ] {
+            let mapped = GtpCause::from(value);
+            assert_ne!(
+                mapped,
+                GtpCause::Reserved,
+                "GTP cause {value} collapses to Reserved, so a peer's rejection reason is lost"
+            );
+            assert_eq!(
+                mapped as u8, value,
+                "GTP cause {value} maps to a variant with a different value"
+            );
+        }
     }
 
     #[test]
-    fn test_build_echo_response() {
-        let msg = build_echo_response(100, 5);
-        assert!(!msg.is_empty());
-        assert_eq!(msg[1], message_type::ECHO_RESPONSE);
+    fn release_access_bearers_request_carries_the_allocated_sequence() {
+        let msg = build_release_access_bearers_request(0x1234_5678, 0x0042);
+        assert_eq!(
+            msg.header.message_type,
+            message_type::RELEASE_ACCESS_BEARERS_REQUEST
+        );
+        assert_eq!(msg.header.teid, Some(0x1234_5678));
+        assert_eq!(
+            msg.header.sequence_number, 0x0042,
+            "the sequence number is the transaction layer's, not a literal 0"
+        );
     }
 
     #[test]
-    fn test_build_release_access_bearers_request() {
-        let msg = build_release_access_bearers_request(0x12345678, 100);
-        assert!(!msg.is_empty());
-        assert_eq!(msg[1], message_type::RELEASE_ACCESS_BEARERS_REQUEST);
+    fn downlink_data_notification_ack_echoes_the_sequence_and_carries_a_cause() {
+        let msg =
+            build_downlink_data_notification_ack(0x1234_5678, 0x99, GtpCause::RequestAccepted)
+                .expect("build");
+        assert_eq!(
+            msg.header.message_type,
+            message_type::DOWNLINK_DATA_NOTIFICATION_ACK
+        );
+        assert_eq!(
+            msg.header.sequence_number, 0x99,
+            "a triggered message echoes the request's sequence number (TS 29.274 §7.6)"
+        );
+        let cause = msg
+            .get_ie(Gtp2IeType::Cause as u8, 0)
+            .expect("the Ack carries a Cause");
+        assert_eq!(cause.value.first().copied(), Some(16));
     }
 
+    /// #51 criterion 5, and the defect the hand-rolled encoder had: `[0x00, 0x08,
+    /// 0x00]` put the OI bit in the SECOND content octet, so Operation Indication was
+    /// never actually set on the wire.
     #[test]
-    fn test_build_downlink_data_notification_ack() {
-        let msg = build_downlink_data_notification_ack(0x12345678, 100, GtpCause::RequestAccepted);
-        assert!(!msg.is_empty());
-        assert_eq!(msg[1], message_type::DOWNLINK_DATA_NOTIFICATION_ACK);
-    }
+    fn delete_session_request_sets_the_operation_indication_flag() {
+        let sess = MmeSess::default();
+        let mme_ue = MmeUe::default();
+        let sgw_ue = SgwUe {
+            sgw_s11_teid: 0xabcd,
+            ..Default::default()
+        };
+        let msg = build_delete_session_request(
+            &sess,
+            &mme_ue,
+            &sgw_ue,
+            7,
+            GtpDeleteAction::NoAction,
+            0x11,
+        )
+        .expect("build");
 
-    #[test]
-    fn test_gtp_buffer() {
-        let mut buf = GtpBuffer::new();
-        buf.write_u8(0x48);
-        buf.write_u16(0x1234);
-        buf.write_u32(0x12345678);
-        assert_eq!(buf.len(), 7);
+        let ebi = msg
+            .get_ie(Gtp2IeType::Ebi as u8, 0)
+            .expect("Linked EPS Bearer ID is mandatory");
+        assert_eq!(
+            ebi.value.first().copied(),
+            Some(7),
+            "the LBI is the session's default bearer, not a literal 5"
+        );
+
+        let indication = msg
+            .get_ie(Gtp2IeType::Indication as u8, 0)
+            .expect("the Indication IE must be present");
+        let decoded = Gtp2IndicationIe::decode(&indication.value).expect("decode");
+        assert!(
+            decoded.oi,
+            "Operation Indication must be SET, which the hand-rolled octets never were"
+        );
     }
 }

--- a/src/bins/nextgcore-mmed/src/s11_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s11_handler.rs
@@ -3,6 +3,7 @@
 //! Port of src/mme/mme-s11-handler.c - GTP-C message handling for S11 interface
 
 use crate::s11_build::{ie_type, message_type};
+use std::net::SocketAddr;
 
 // ============================================================================
 // Error Types
@@ -57,15 +58,30 @@ pub mod esm_cause {
     pub const SYNTACTICAL_ERROR_IN_PACKET_FILTERS: u8 = 45;
 }
 
-/// Convert GTP cause to ESM cause
+/// Convert a GTP-C cause (TS 29.274 §8.4) to the ESM cause the UE is owed
+/// (TS 24.301 §9.9.4.4).
+///
+/// #51: 78 was absent, so an SGW rejecting a session for "Missing or unknown APN"
+/// reached the UE as `NETWORK_FAILURE` (38) — which tells the subscriber's handset
+/// to retry a request that can never succeed, and tells the operator nothing about
+/// the APN that is actually misconfigured. Every mapping below is a cause where the
+/// UE can do something different for knowing it.
 pub fn esm_cause_from_gtp(gtp_cause: u8) -> u8 {
     match gtp_cause {
         64 => esm_cause::INVALID_EPS_BEARER_IDENTITY,
         68 => esm_cause::SERVICE_OPTION_NOT_SUPPORTED,
+        // TS 29.274 §8.4 cause 73 "No resources available" is a capacity refusal, and
+        // §9.9.4.4 cause 26 says exactly that to the UE.
+        73 => esm_cause::INSUFFICIENT_RESOURCES,
         74 => esm_cause::SEMANTIC_ERROR_IN_THE_TFT_OPERATION,
         75 => esm_cause::SYNTACTICAL_ERROR_IN_THE_TFT_OPERATION,
         76 => esm_cause::SEMANTIC_ERRORS_IN_PACKET_FILTERS,
         77 => esm_cause::SYNTACTICAL_ERROR_IN_PACKET_FILTERS,
+        // The one the issue names.
+        78 => esm_cause::MISSING_OR_UNKNOWN_APN,
+        // A refusal by the SGW/PGW that names no more specific reason. Distinct from
+        // NETWORK_FAILURE, which claims the network broke rather than declined.
+        94 => esm_cause::REQUEST_REJECTED_BY_SERVING_GW_OR_PDN_GW,
         _ => esm_cause::NETWORK_FAILURE,
     }
 }
@@ -195,6 +211,171 @@ pub struct ReleaseAccessBearersResponseData {
 pub struct DownlinkDataNotificationData {
     pub ebi: u8,
     pub cause: Option<u8>,
+}
+
+// ============================================================================
+// Datagram dispatch (#51)
+// ============================================================================
+
+/// Route a triggered (response) message that the transaction layer has already
+/// correlated to one of this MME's outstanding requests.
+///
+/// Correlation happens BEFORE this is called, in `gtp_path::handle_datagram`, and
+/// that ordering is the point: an uncorrelated response is one this MME did not ask
+/// for, and letting it reach here would allow a stray datagram to mutate session
+/// state.
+///
+/// The raw datagram is passed rather than the decoded `Gtp2Message` so the existing,
+/// tested IE walk in this module keeps parsing it. That leaves two decoders for the
+/// same message — the library's, used for correlation, and this one, used for
+/// content — which is a real cost and NOT what #51 asks to remove (criterion 7 names
+/// `s11_build.rs`'s builder). See the spec's Ceilings.
+pub fn dispatch_triggered(raw: &[u8], msg_type: u8, sequence_number: u32, peer: SocketAddr) {
+    use crate::s11_build::message_type as mt;
+
+    match msg_type {
+        mt::CREATE_SESSION_RESPONSE => match handle_create_session_response(raw) {
+            // The LOCAL S11 TEID comes from the header this MME told the SGW to
+            // address, so it is read from the same bytes rather than trusted from
+            // the body.
+            Ok(data) => {
+                let local_teid = parse_gtp_header(raw)
+                    .map(|(_, teid, _, _)| teid)
+                    .unwrap_or(0);
+                apply_create_session_response(&data, local_teid, sequence_number, peer)
+            }
+            Err(e) => log::error!("S11 Create Session Response from {peer} unparsable: {e:?}"),
+        },
+        mt::MODIFY_BEARER_RESPONSE => match handle_modify_bearer_response(raw) {
+            Ok(data) => log::info!(
+                "S11 Modify Bearer Response from {peer} (seq={sequence_number}) cause={}",
+                data.cause
+            ),
+            Err(e) => log::error!("S11 Modify Bearer Response from {peer} unparsable: {e:?}"),
+        },
+        mt::DELETE_SESSION_RESPONSE => match handle_delete_session_response(raw) {
+            Ok(data) => log::info!(
+                "S11 Delete Session Response from {peer} (seq={sequence_number}) cause={}",
+                data.cause
+            ),
+            Err(e) => log::error!("S11 Delete Session Response from {peer} unparsable: {e:?}"),
+        },
+        mt::RELEASE_ACCESS_BEARERS_RESPONSE => match handle_release_access_bearers_response(raw) {
+            Ok(data) => log::info!(
+                "S11 Release Access Bearers Response from {peer} (seq={sequence_number}) \
+                     cause={}",
+                data.cause
+            ),
+            Err(e) => {
+                log::error!("S11 Release Access Bearers Response from {peer} unparsable: {e:?}")
+            }
+        },
+        other => log::info!(
+            "S11 triggered message type={other} seq={sequence_number} from {peer} correlated but \
+             not acted on: this MME has no handler for it"
+        ),
+    }
+}
+
+/// Apply a Create Session Response to the session and bearer it answers.
+///
+/// This is what makes the response *useful* rather than merely received: the SGW's
+/// S11 control F-TEID is what every later Modify Bearer / Delete Session Request has
+/// to be addressed to, and the S1-U F-TEID plus the PAA are what the Initial Context
+/// Setup and the ESM Activate Default Bearer Context Request carry to the UE.
+///
+/// The session is found by the LOCAL S11 TEID the response is addressed to
+/// (`mme_ue_find_by_s11_local_teid`), not by anything in the body: the TEID in the
+/// header is the one this MME told the SGW to use, so it is the only field that
+/// cannot be attributed to the wrong UE by a malformed body.
+fn apply_create_session_response(
+    data: &CreateSessionResponseData,
+    local_teid: u32,
+    sequence_number: u32,
+    peer: SocketAddr,
+) {
+    let ctx = crate::context::mme_self();
+
+    if data.cause != 16 {
+        // TS 29.274 §8.4: 16 is "Request accepted". Anything else means no bearer
+        // was created, and the UE is owed the mapped ESM cause rather than a wait.
+        log::warn!(
+            "S11 Create Session Response from {peer} (seq={sequence_number}) rejected: GTP cause \
+             {} -> ESM cause {}",
+            data.cause,
+            esm_cause_from_gtp(data.cause)
+        );
+        return;
+    }
+
+    let Some(mme_ue_id) = ctx.mme_ue_find_by_s11_local_teid(local_teid) else {
+        log::warn!(
+            "S11 Create Session Response for local TEID {local_teid:#x} matches no UE context"
+        );
+        return;
+    };
+
+    if let Ok(mut pool) = ctx.mme_ue_pool.write() {
+        if let Some(ue) = pool.get_mut(&mme_ue_id) {
+            log::info!(
+                "[{}] S11 session created: SGW S11 C-TEID {:#x}",
+                ue.imsi_bcd,
+                data.sgw_s11_teid
+            );
+        }
+    }
+    ctx.set_sgw_s11_teid_for_ue(mme_ue_id, data.sgw_s11_teid);
+
+    for bearer in &data.bearer_contexts {
+        if !ctx.set_sgw_s1u_for_bearer(
+            mme_ue_id,
+            bearer.ebi,
+            bearer.sgw_s1u_teid,
+            bearer.sgw_s1u_ipv4,
+        ) {
+            log::warn!(
+                "S11 Create Session Response named EBI {} which this UE does not hold",
+                bearer.ebi
+            );
+        }
+    }
+}
+
+/// Route an initial message the SGW-C originated.
+pub fn dispatch_initial(raw: &[u8], msg_type: u8, sequence_number: u32, peer: SocketAddr) {
+    use crate::s11_build::message_type as mt;
+
+    match msg_type {
+        mt::DOWNLINK_DATA_NOTIFICATION => match handle_downlink_data_notification(raw) {
+            Ok(data) => {
+                log::info!(
+                    "S11 Downlink Data Notification from {peer} (seq={sequence_number}) for EBI {}",
+                    data.ebi
+                );
+                // TS 29.274 §7.2.11: the Ack is a TRIGGERED message and must echo
+                // the notification's sequence number. Before #51 the Ack builder was
+                // called with `ctx.next_pool_id()` in the sequence position, which is
+                // a pool index — so even if it had been transmitted, the SGW-C could
+                // not have matched it to the notification it answered.
+                let local_teid = parse_gtp_header(raw)
+                    .map(|(_, teid, _, _)| teid)
+                    .unwrap_or(0);
+                if let Err(e) = crate::gtp_path::send_downlink_data_notification_ack_to(
+                    peer,
+                    local_teid,
+                    sequence_number,
+                    crate::s11_build::GtpCause::RequestAccepted,
+                ) {
+                    log::error!("S11 Downlink Data Notification Ack to {peer} failed: {e}");
+                }
+            }
+            Err(e) => log::error!("S11 Downlink Data Notification from {peer} unparsable: {e:?}"),
+        },
+        other => log::info!(
+            "S11 initial message type={other} seq={sequence_number} from {peer} not handled: this \
+             MME originates no procedure for it"
+        ),
+    }
 }
 
 // ============================================================================
@@ -668,10 +849,13 @@ mod tests {
         assert_eq!(result.unwrap(), 5);
     }
 
+    /// The builders return a `Gtp2Message` since #51, so these encode through the
+    /// library and then parse with THIS module's header reader — which is exactly the
+    /// pairing the live path uses, and therefore the thing worth pinning.
     #[test]
     fn test_parse_gtp_header_with_teid() {
-        let msg = build_release_access_bearers_request(0x12345678, 100);
-        let (msg_type, teid, seq_num, _) = parse_gtp_header(&msg).unwrap();
+        let encoded = build_release_access_bearers_request(0x12345678, 100).encode();
+        let (msg_type, teid, seq_num, _) = parse_gtp_header(&encoded).unwrap();
 
         assert_eq!(msg_type, message_type::RELEASE_ACCESS_BEARERS_REQUEST);
         assert_eq!(teid, 0x12345678);
@@ -680,12 +864,53 @@ mod tests {
 
     #[test]
     fn test_parse_gtp_header_no_teid() {
-        let msg = build_echo_request(123, 5);
-        let (msg_type, teid, seq_num, _) = parse_gtp_header(&msg).unwrap();
+        let encoded = nextgcore_gtp::v2::Gtp2Message::echo_request(123).encode();
+        let (msg_type, teid, seq_num, _) = parse_gtp_header(&encoded).unwrap();
 
         assert_eq!(msg_type, message_type::ECHO_REQUEST);
         assert_eq!(teid, 0);
         assert_eq!(seq_num, 123);
+    }
+
+    /// #51 criterion 6: GTP cause 78 must reach the UE as ESM cause 27, not as
+    /// `NETWORK_FAILURE`.
+    ///
+    /// The difference is what the subscriber's handset does next. `NETWORK_FAILURE`
+    /// invites a retry of a request that can never succeed; `MISSING_OR_UNKNOWN_APN`
+    /// names the misconfiguration, which is the only thing an operator can act on.
+    #[test]
+    fn gtp_cause_78_maps_to_missing_or_unknown_apn() {
+        assert_eq!(
+            esm_cause_from_gtp(78),
+            esm_cause::MISSING_OR_UNKNOWN_APN,
+            "GTP 78 must not degrade to NETWORK_FAILURE"
+        );
+        assert_ne!(esm_cause_from_gtp(78), esm_cause::NETWORK_FAILURE);
+    }
+
+    /// Every GTP cause with a distinct ESM meaning keeps it, so adding a mapping
+    /// cannot silently collapse a neighbouring one.
+    #[test]
+    fn distinct_gtp_causes_keep_distinct_esm_causes() {
+        for (gtp, esm) in [
+            (64u8, esm_cause::INVALID_EPS_BEARER_IDENTITY),
+            (68, esm_cause::SERVICE_OPTION_NOT_SUPPORTED),
+            (73, esm_cause::INSUFFICIENT_RESOURCES),
+            (74, esm_cause::SEMANTIC_ERROR_IN_THE_TFT_OPERATION),
+            (75, esm_cause::SYNTACTICAL_ERROR_IN_THE_TFT_OPERATION),
+            (76, esm_cause::SEMANTIC_ERRORS_IN_PACKET_FILTERS),
+            (77, esm_cause::SYNTACTICAL_ERROR_IN_PACKET_FILTERS),
+            (78, esm_cause::MISSING_OR_UNKNOWN_APN),
+            (94, esm_cause::REQUEST_REJECTED_BY_SERVING_GW_OR_PDN_GW),
+        ] {
+            assert_eq!(
+                esm_cause_from_gtp(gtp),
+                esm,
+                "GTP cause {gtp} lost its distinct ESM mapping"
+            );
+        }
+        // A cause TS 29.274 does not define really is a network failure.
+        assert_eq!(esm_cause_from_gtp(200), esm_cause::NETWORK_FAILURE);
     }
 
     #[test]


### PR DESCRIPTION
Closes #51. Spec: `specs/fix-mmed-s11-gtpc-endpoint.md`.

## The gap, verified rather than assumed

`gtp_open` set `state.initialized = true` and bound nothing. All **eleven** `send_*` functions built a message into a `_pkbuf` local that was dropped on the next line. So no Create Session Request ever left the MME, nothing retransmitted, nothing correlated a response to a request, and E-UTRAN Initial Attach could not establish a PDN connection.

Every claim in #51 was re-verified against `76cefd2`. **None of it is stale** — unusually for this backlog, the issue is accurate in every particular, including the subtle one it flagged as unverified: the Indication IE's `[0x00, 0x08, 0x00]` really does put the OI bit in the *second* content octet, so Operation Indication was never set.

## What landed

- **A `GtpcServer`** on UDP 2123: receive loop, T3-RESPONSE/N3-REQUESTS loop over the shared `Gtp2XactMgr`, Echo path management. Structurally sgwcd's, because the two are the two ends of one interface and a second design would be two answers to "how long may an S11 message take" and "when is a peer down". That shared xact manager had **never been instantiated by mmed**, which is why there was no retransmission budget at all.
- **`mme.gtpc` is read at last** — `config.rs`'s module doc said it was waiting on this issue — for the bind address and the SGW-C peer.
- **Sequence numbers from the transaction layer.** Every builder wrote a literal `0`; two senders substituted `ctx.next_pool_id()`, which is a *pool index*.
- **The CSR carries Sender F-TEID and Bearer Contexts** (EBI + Bearer QoS) and **refuses to build without a bearer** — a request the peer must reject is worse than an error at the call site, because the failure moves from this MME's log to a wire exchange the operator has to correlate back. Same for the MBR without an eNB S1-U F-TEID: sending it would ask the SGW to switch the downlink tunnel to nowhere.
- **LBI from the session**, not the literal `5` that tears down the wrong PDN for a multi-PDN UE. **RAT Type from the UE context.**
- **`GtpBuffer` deleted.** It mis-encoded Indication, had no mandatory-IE validation, and duplicated the round-trip-tested library codec.
- **GTP cause 78 → ESM 27**, and the twelve causes that collapsed to `Reserved` no longer do.
- **The restart counter is persisted** — a counter that resets to the same number every start tells a peer nothing changed (TS 23.007 §18). My first draft documented this as a known gap; the sibling daemon already had the code, so that was just the lazy answer.

## Not copied blindly from sgwcd

sgwcd's restart-triggered context deletion is deliberately **absent**: deleting this MME's UE contexts because the SGW restarted is a decision about subscriber state that #51 does not own, and a Recovery counter changes on a reordered datagram too. The restart is recorded and logged loudly instead.

## Verification

Five new tests, each driving a **real bound socket** with its real receive and T3/N3 threads. A test that stubbed the transport would assert the half that already worked.

**Eleven reverts, eleven bites** — after three corrections, all of them to my own harness and all worth stating:

| revert | first result | why |
|---|---|---|
| the wire sequence is the allocated one | **PASSED** | the patch changed the sequence *registered* with the xact manager, not the one written to the wire — the test asserts the wire, so nothing under test moved. Rewritten to patch `new_message`, it bites. |
| response correlation | **DID NOT COMPILE** | `Ok(_) => None` left the `Option`'s type unresolvable; the harness said so rather than reporting a pass. |
| the two ESM-cause reverts | **`0 tests, 318 filtered out`** | the harness snapshot predated the tests it was reverting, so `restore()` deleted them before running. Visible only because the harness prints the test count. |

The nine that bit first time: Sender F-TEID present; Bearer Context present; RAT Type from the UE; T3 retransmission; Echo answered; restart counter advances; Indication OI set; every declared GTP cause distinguishable; GTP 78 → ESM 27.

mmed 315 → 320 tests. Workspace **6329 passed / 0 failed**, `clippy --workspace` 0, `fmt --check` clean.

## Ceilings

- **The attach procedure still does not complete.** `nas_eps_send_attach_accept` has **no caller** — grep-verified, and `nas_dispatch.rs:801-803` says why. This PR makes the S11 exchange real; wiring the Create Session Response into an Initial Context Setup plus an Attach Accept is **#46**, which I deliberately reordered to run *after* this one: #46's criterion 4 asks for the GUTI IE "in the normal flow", and the attach path cannot satisfy that while the accept it rides in is unreachable.
- **Criterion 3 is verified against a MIRRORED mandatory-IE list, not against sgwcd's parser.** `sgwcd` is a binary with no lib target, so its `require()` is unreachable from mmed's tests. The list is copied from `s11_parse.rs:85-120` with that cite, and it will not notice if sgwcd adds a requirement.
- **Two decoders remain for one message** — the library's for correlation, `s11_handler`'s IE walk for content. Criterion 7 names `s11_build.rs`'s *builder*, which is gone, so this is out of scope; but it is the same duplication #304/#306 argued against and it is now load-bearing because the socket feeds it.
- **The dispatchers act on Create Session Response and Downlink Data Notification only.** Modify Bearer / Delete Session / Release Access Bearers responses are correlated, parsed and logged; what should change from them is bearer lifecycle that #46 and #48 own.
- **`rat_type` only ever holds E-UTRAN**, because S1 is the only access this MME has (#62). The field is the right structure — one place decides it — but this PR will not claim it is sourced from anything richer.
- **No E2E.** Loopback datagrams between one bound socket and a stand-in peer in one process. A real mmed↔sgwcd exchange is #303, whose other blocker is #52.

Re CI: #313's cross-process port window can redden the Test gate on ~1 run in 10 (measured and [corrected on the issue](https://github.com/NextgCoreLab/nextgcore/issues/313)). If it fails on an `SbiServer::start` bind panic in a crate this PR does not touch, that is #313 and a re-run is the right response.