### PR TITLE
fix(mmed): derive the attach and TAU accept content from negotiated state (#46)

### DIFF
--- a/specs/fix-mmed-attach-tau-accept-correctness.md
+++ b/specs/fix-mmed-attach-tau-accept-correctness.md
@@ -1,0 +1,160 @@
+# nextgcore #46 (mmed): attach/TAU accept correctness
+
+Verified against `main` @ `ce8a56a` (i.e. after #51). TS 24.301 §5.4.1, §5.5.1.3.4.3,
+§5.5.3.2.4, §9.9.2.1, §9.9.3.10, §9.9.3.11, §9.9.3.12, §9.9.3.16, §9.9.3.44, §9.9.3.45;
+TS 29.272 §7.3.1, §7.3.134; TS 23.401 §4.3.17.3, §5.3.2.1.
+
+**Two of the eight criteria were already done**, by work that landed after #46 was filed.
+The other six were exactly as described.
+
+## Verified against current main
+
+| criterion | site | still true? |
+|---|---|---|
+| 1. ULA APN configs persisted as `MmeSess` + `MmeBearer` | `materialise_subscribed_sessions` exists, is called from `fd_path.rs:1261`, and is tested | **already done** |
+| 2. `process_apn_configurations` uses the UE context, no `_mme_ue` | takes `mme_ue`, fills `mme_ue.session` | **already done** |
+| 3. `MmeUe` carries the subscribed RAU/TAU timer; T3412 from it | no such field; `nas_path.rs:260`/`:599` hardcode 3600; `s6a_handler.rs:160` is a comment saying the field "would need to be added" | yes |
+| 4. production GUTI/M-TMSI allocator | nothing writes `next.m_tmsi`; `nas_dispatch.rs:191` says so and names this issue | yes |
+| 5. `build_guti_reallocation_command` + a 0x51 handler | enum values only; 0x51 shared a match arm with TAU Complete and committed nothing | yes |
+| 6. attach result from the attach type; emergency branch | `emm_build.rs:413` writes the literal `AttachType::EpsAttach`; no emergency path | yes |
+| 7. TAU update result from the TAU type/SGs; bearer status populated | `0x00` hardcoded; the caller always passed `0` | yes |
+| 8. the four unit tests | criterion 1's persistence test exists but asserts only APN/EBI/QCI — not ARP or APN-AMBR | partly |
+
+## Decision 0: #46 was reordered to run AFTER #51, because of a dead function
+
+Criterion 4 asks for the GUTI IE to be emitted "in the normal (non-test) flow". While
+verifying, `nas_eps_send_attach_accept` turned out to have **no caller at all** — grep
+confirmed it, and `nas_dispatch.rs:801-803` explained why: bearers are established over
+S11, which did not exist. Implementing criterion 4's attach half against a dead function
+would have been a correct fix in an unreachable place.
+
+So this issue was parked, #51 was implemented first, and this spec is written against a
+tree where the S11 exchange is real. The attach accept still has no caller — that is
+#51's stated ceiling and is not #46's to close — so criterion 4 is satisfied **via the
+TAU path**, which is reachable (`nas_dispatch.rs` sends a TAU Accept today), and the
+attach path allocates the GUTI at Attach Request so it is staged whenever the accept
+becomes sendable. The spec says which is which rather than implying both.
+
+## Decision 1: the subscription wins, then configuration, then the old default
+
+`t3412_from(subscribed, configured)` is a **pure** function so the ordering is testable:
+`mme_self().time` is a plain field set at construction, so a test cannot vary the
+configured value, and the precedence is the part worth pinning.
+
+A deployment that configures nothing and a subscription that states nothing get 3600 —
+the value that used to be hardcoded — so nothing changes for anyone who was relying on
+it. A subscription with no timer leaves the field at `0` rather than overwriting a
+previous value, which is what keeps the configured fallback reachable.
+
+## Decision 2: a GUTI is STAGED, then committed when the UE acknowledges
+
+`allocate_guti` writes `next`; `commit_staged_guti` promotes it to `current`. The split
+matters in both directions:
+
+- Promoting early would make `mme_ue_find_by_s_tmsi` match a UE on an identity it has not
+  been told about.
+- Never promoting — which is what happened before, since nothing allocated *or* committed
+  — leaves that lookup permanently dormant, so every returning UE must re-identify by
+  IMSI. That is the confidentiality the GUTI exists to provide, lost at the first mobility
+  event.
+
+The M-TMSI comes from a **process-global** counter, checked against the pool: it is the
+key `mme_ue_find_by_s_tmsi` looks up by, so a duplicate makes one UE unreachable and
+resolves the other to the wrong context. `0` is never issued, because `TmsiInfo::m_tmsi`
+uses `None`/zero for "no GUTI allocated" and handing one out would produce a UE holding a
+GUTI the accept builder refuses to emit.
+
+With no served GUMMEI configured, allocation **refuses** rather than inventing an identity
+no eNB could route.
+
+## Decision 3: a combined attach without an SGs association is refused with a reason
+
+TS 24.301 §5.5.1.3.4.3 is explicit: answer "EPS only" **and** set EMM cause #18 "CS domain
+not available". A hardcoded EPS-only result told the UE the network declined without
+saying why, so it had no reason to attach to the CS domain over another access.
+
+Whether an SGs association exists is tested with `mme_ue.csmap_id` — the same test the
+Extended Service Request path already uses to refuse CS fallback, so this is the tree's
+existing notion of "is there a VLR" rather than a new one. The same test decides the EPS
+update result, where reporting "combined TA/LA updated" without a VLR would tell the UE it
+is reachable for CS services it cannot receive.
+
+ISR (update results 4 and 5) is deliberately never signalled: it needs an S3/S4 SGSN
+association this MME does not have.
+
+## Decision 4: the emergency branch recognises and records, and says what it does not do
+
+TS 24.301 §9.9.3.11 attach type 3 is now recognised and recorded on the context, and
+§9.9.3.10's result is correct for it (there are two results and three types, so an
+emergency attach is an EPS-only attach).
+
+**What it does not do, stated because the difference matters:** emergency bearer services
+are not implemented. §5.5.1.3 lets an emergency attach proceed for an unauthenticated or
+unsubscribed UE with EIA0/NIA0 and an emergency APN, and none of that exists here — so an
+emergency attach still follows the normal authentication and subscription path and will
+fail wherever that fails. The flag makes the case visible instead of silently
+indistinguishable, and it logs at `warn` saying exactly this. Claiming more would be the
+dishonest option; implementing §5.5.1.3 properly is a separate piece of work.
+
+## Decision 5: the 0x51 arm is split from TAU Complete
+
+They shared one match arm, and neither committed anything — sharing the arm is what hid
+that. Now each says what it does, and a GUTI Reallocation Complete with nothing staged is
+a `warn` naming the disagreement ("the UE acknowledged an identity this MME did not
+allocate") rather than a silent no-op.
+
+## Verification
+
+| claim | how it was made to fail | result |
+|---|---|---|
+| the subscribed RAU/TAU timer is recorded from the ULA | delete the assignment | **fails** |
+| the subscribed APN-AMBR reaches the session | drop `sess.ambr = …` | **fails** |
+| the subscribed ARP reaches the bearer | drop `bearer.qos = …` | **fails** |
+| T3412 is encoded from the value given | encode 3600 regardless | **fails** |
+| the subscription outranks configuration | drop the `subscribed > 0` branch | **fails** |
+| a combined attach with a VLR yields a combined result | return EPS-only | **fails** |
+| a combined attach without one carries EMM cause #18 | suppress the cause IE | **fails** |
+| the EPS update result follows the TAU type and the VLR | write `0x00` | **fails** |
+| the bearer-status bitmap sets a bit per active EBI | drop the `|=` | **fails** |
+| a GUTI is staged, not committed, until acknowledged | drop the promotion | **fails** |
+| M-TMSIs are unique | return a constant | **fails** |
+| the reallocation command carries the staged GUTI | write `0` for the M-TMSI | **fails** |
+| 0x51 commits the staged GUTI | short-circuit the commit | **fails** |
+
+Thirteen reverts, thirteen bites — after **one correction**: the "T3412 prefers the
+subscription" revert first reported PASSED because I pointed it at the S6a population test
+rather than at a test of the precedence, and no test of the precedence existed. That is
+what prompted splitting `t3412_from` out as a pure function; the claim had been written and
+not verified.
+
+One test failure was mine and not the code's: the GUTI-reallocation test read the M-TMSI at
+`msg[9]` when §9.9.3.12's content layout (0xf6, PLMN×3, group id×2, code, M-TMSI×4) puts it
+at `msg[10]`. The builder was right.
+
+mmed 320 → 338 tests. Workspace **6347 passed / 0 failed**, `clippy --workspace` 0,
+`fmt --check` clean.
+
+## Ceilings
+
+- **The attach accept still has no caller.** Criterion 4's "GUTI IE emitted in the normal
+  flow" is satisfied through the **TAU** path only; the attach path stages the GUTI at
+  Attach Request so it is ready, but the accept that would carry it is unreachable until
+  something drives Initial Context Setup from a Create Session Response. That is #51's
+  recorded ceiling.
+- **Emergency attach is recognised, not implemented** (Decision 4). This is the one
+  criterion where the letter is met and the spirit is bounded, and the code says so at
+  `warn` on every emergency attach.
+- **The configured-T3412 branch is untested against a real context**, because
+  `mme_self().time` is set at construction and cannot be varied from a test. The precedence
+  is tested purely; the wiring from `mme.time.t3412` into it is read, not exercised.
+- **The SGs outcome is "is there a CS map", not "did the location update succeed".**
+  `handle_location_update_accept` and `build_location_update_request` have only test
+  callers, so mmed never actually performs an SGs location update — there is no outcome to
+  consult. `csmap_id` is the strongest signal that exists today and is what the CSFB path
+  already uses; a real outcome needs the SGs procedure to be driven, which no criterion
+  here asks for.
+- **No GUTI reallocation is ever *initiated*.** The command builder and the 0x51 handler
+  exist and are tested, but nothing decides to rotate a GUTI outside an attach or a TAU —
+  §5.4.1's standalone procedure has the machinery and no trigger.
+- **`eps_bearer_context_status` reports what the caller passes.** The TAU path now passes
+  the UE's real bearers; the attach path has no caller to pass anything.

--- a/src/bins/nextgcore-mmed/src/context.rs
+++ b/src/bins/nextgcore-mmed/src/context.rs
@@ -1190,6 +1190,23 @@ pub struct MmeUe {
     pub csmap_id: u64,
     /// HSS map pool ID
     pub hssmap_id: u64,
+
+    /// Subscribed periodic RAU/TAU timer, in seconds, from the S6a ULA
+    /// (TS 29.272 §7.3.134). `0` means the subscription did not state one.
+    ///
+    /// #46: the shared S6a codec round-tripped this AVP all along and mmed dropped
+    /// it on the floor with the comment "would need to be added to MmeUe if needed",
+    /// so both accepts signalled a hardcoded 3600 s regardless of the subscriber's
+    /// profile. TS 23.401 §4.3.17.3 derives T3412 from this value, so a UE was told
+    /// to re-register on a cadence the HSS had not asked for.
+    pub subscribed_rau_tau_timer: u32,
+
+    /// Whether the UE asked for EMERGENCY attach (TS 24.301 §9.9.3.11 value 3).
+    ///
+    /// Recorded so the rest of the stack can distinguish an emergency attach from a
+    /// normal one. What it does NOT mean is that emergency bearer services are
+    /// implemented — see `emm_handler`'s emergency branch for the boundary.
+    pub emergency_attach: bool,
 }
 
 // ============================================================================
@@ -1446,6 +1463,11 @@ pub struct MmeContext {
 
     /// MME UE S1AP ID generator
     pub mme_ue_s1ap_id: AtomicU32,
+    /// M-TMSI allocation counter (#46).
+    ///
+    /// Starts at 1 because 0 is the "no GUTI allocated" encoding — see
+    /// [`MmeContext::allocate_m_tmsi`].
+    pub m_tmsi_counter: AtomicU32,
 
     /// MME UE list
     pub mme_ue_list: Vec<u64>,
@@ -1552,6 +1574,7 @@ impl MmeContext {
             sgsap_port: 29118,
             relative_capacity: 255,
             mme_ue_s1ap_id: AtomicU32::new(1),
+            m_tmsi_counter: AtomicU32::new(1),
             pool_id_counter: AtomicU64::new(NEXTGCORE_MIN_POOL_ID),
             initialized: AtomicBool::new(false),
             integrity_order: DEFAULT_INTEGRITY_ORDER.to_vec(),
@@ -1589,6 +1612,118 @@ impl MmeContext {
         } else {
             id
         }
+    }
+
+    /// Allocate an M-TMSI that no UE context currently holds (#46).
+    ///
+    /// From a process-global counter, not a per-UE one: the M-TMSI is the key
+    /// `mme_ue_find_by_s_tmsi` looks a UE up by, so two UEs minting the same value
+    /// would make one of them unreachable by S-TMSI and the other resolvable to the
+    /// wrong context. The counter is then checked against the pool, because a
+    /// wrapped counter can collide with a long-lived UE that is still attached.
+    ///
+    /// `0` is skipped: the encoding treats a zero M-TMSI as "no GUTI allocated"
+    /// (`TmsiInfo::m_tmsi` is `None` for exactly that state), so handing one out
+    /// would produce a UE that holds a GUTI the accept builder refuses to emit.
+    ///
+    /// Returns `None` only if 1024 consecutive candidates are all in use, which for
+    /// a 32-bit space means the pool is effectively full.
+    pub fn allocate_m_tmsi(&self) -> Option<u32> {
+        for _ in 0..1024 {
+            let candidate = self.m_tmsi_counter.fetch_add(1, Ordering::SeqCst);
+            if candidate == 0 {
+                continue;
+            }
+            let taken = self
+                .mme_ue_pool
+                .read()
+                .map(|pool| {
+                    pool.values().any(|ue| {
+                        ue.current.m_tmsi == Some(candidate) || ue.next.m_tmsi == Some(candidate)
+                    })
+                })
+                .unwrap_or(true);
+            if !taken {
+                return Some(candidate);
+            }
+        }
+        log::error!("no free M-TMSI after 1024 attempts: the S-TMSI space is exhausted");
+        None
+    }
+
+    /// Allocate a GUTI for this UE and stage it in `next` (TS 24.301 §5.4.1).
+    ///
+    /// Staged rather than applied, because the UE does not hold the new GUTI until it
+    /// acknowledges the message carrying it. `current` is promoted from `next` by
+    /// [`Self::commit_staged_guti`] when the Attach Complete / TAU Complete / GUTI
+    /// Reallocation Complete arrives — which is what makes the allocated GUTI
+    /// resolvable by `mme_ue_find_by_s_tmsi`. Before #46 nothing wrote either, so the
+    /// accept builders' `next.m_tmsi.is_some()` gate was never true outside tests and
+    /// the GUTI IE was dead code.
+    ///
+    /// The GUMMEI comes from the served GUMMEI this MME is configured with; with none
+    /// configured there is nothing to build a GUTI from and this returns `false`
+    /// rather than inventing an identity that no eNB would route.
+    pub fn allocate_guti(&self, mme_ue_id: u64) -> bool {
+        let Some(gummei) = self.served_gummei.first() else {
+            log::warn!("no served GUMMEI configured: cannot allocate a GUTI");
+            return false;
+        };
+        let (Some(plmn_id), Some(&mme_gid), Some(&mme_code)) = (
+            gummei.plmn_id.first().cloned(),
+            gummei.mme_gid.first(),
+            gummei.mme_code.first(),
+        ) else {
+            log::warn!("served GUMMEI is incomplete: cannot allocate a GUTI");
+            return false;
+        };
+        let Some(m_tmsi) = self.allocate_m_tmsi() else {
+            return false;
+        };
+        let Ok(mut pool) = self.mme_ue_pool.write() else {
+            return false;
+        };
+        let Some(ue) = pool.get_mut(&mme_ue_id) else {
+            return false;
+        };
+        ue.next.m_tmsi = Some(m_tmsi);
+        ue.next.guti = EpsGuti {
+            plmn_id,
+            mme_gid,
+            mme_code,
+            m_tmsi,
+        };
+        log::info!(
+            "[{}] GUTI allocated: mme_gid={mme_gid} mme_code={mme_code} m_tmsi=0x{m_tmsi:08x}",
+            ue.imsi_bcd
+        );
+        true
+    }
+
+    /// Promote a staged GUTI to `current` once the UE has acknowledged it.
+    ///
+    /// Without this the allocation is decorative: `mme_ue_find_by_s_tmsi` matches on
+    /// `current.m_tmsi`, so a UE that returns with only an S-TMSI would not be found
+    /// and would be made to re-identify itself with its IMSI — the confidentiality
+    /// the GUTI exists to provide, lost at the first mobility event.
+    pub fn commit_staged_guti(&self, mme_ue_id: u64) -> bool {
+        let Ok(mut pool) = self.mme_ue_pool.write() else {
+            return false;
+        };
+        let Some(ue) = pool.get_mut(&mme_ue_id) else {
+            return false;
+        };
+        if ue.next.m_tmsi.is_none() {
+            return false;
+        }
+        ue.current.m_tmsi = ue.next.m_tmsi;
+        ue.current.guti = ue.next.guti.clone();
+        log::debug!(
+            "[{}] GUTI committed: m_tmsi=0x{:08x}",
+            ue.imsi_bcd,
+            ue.current.guti.m_tmsi
+        );
+        true
     }
 }
 
@@ -2245,4 +2380,133 @@ pub fn mme_context_init_with_config(config_path: &str) -> bool {
 /// Finalize the global MME context
 pub fn mme_context_final() {
     mme_self().final_();
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A context with one served GUMMEI, built the way configuration builds it —
+    /// `served_gummei` is set at construction rather than mutated afterwards, which is
+    /// why this test owns its context instead of using `mme_self()`.
+    fn ctx_with_gummei() -> MmeContext {
+        let mut ctx = MmeContext::new();
+        ctx.init();
+        ctx.served_gummei = vec![ServedGummei {
+            num_of_plmn_id: 1,
+            plmn_id: vec![PlmnId::new("999", "70")],
+            num_of_mme_gid: 1,
+            mme_gid: vec![2],
+            num_of_mme_code: 1,
+            mme_code: vec![1],
+        }];
+        ctx.num_of_served_gummei = 1;
+        ctx
+    }
+
+    /// #46 criterion 4: the M-TMSI comes from a PROCESS-GLOBAL counter, so two UEs
+    /// never mint the same one.
+    ///
+    /// It is the key `mme_ue_find_by_s_tmsi` looks a UE up by: a duplicate makes one UE
+    /// unreachable by S-TMSI and resolves the other to the wrong context. Per-instance
+    /// numbering would be invisible in production, where there is one instance.
+    #[test]
+    fn allocated_m_tmsis_are_unique_and_never_zero() {
+        let ctx = ctx_with_gummei();
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..500 {
+            let m = ctx.allocate_m_tmsi().expect("the space is not exhausted");
+            assert_ne!(
+                m, 0,
+                "0 encodes \"no GUTI allocated\" and must never be issued"
+            );
+            assert!(seen.insert(m), "M-TMSI {m} was issued twice");
+        }
+    }
+
+    /// With no served GUMMEI there is nothing to build a GUTI from, and inventing one
+    /// would produce an identity no eNB could route.
+    #[test]
+    fn allocate_guti_refuses_without_a_served_gummei() {
+        let ctx = MmeContext::new();
+        ctx.init();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, 46);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        assert!(
+            !ctx.allocate_guti(mme_ue_id),
+            "it must refuse rather than invent a GUMMEI"
+        );
+        assert!(ctx
+            .mme_ue_find_by_id(mme_ue_id)
+            .unwrap()
+            .next
+            .m_tmsi
+            .is_none());
+    }
+
+    /// A GUTI is STAGED in `next` and only becomes `current` when the UE acknowledges.
+    ///
+    /// Promoting early would make `mme_ue_find_by_s_tmsi` match a UE on an identity it
+    /// has not been told about; never promoting at all — which is what happened before
+    /// #46, because nothing allocated or committed one — leaves that lookup permanently
+    /// dormant and forces every returning UE to re-identify by IMSI.
+    #[test]
+    fn a_guti_is_staged_then_committed_and_becomes_resolvable() {
+        let ctx = ctx_with_gummei();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, 46);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+
+        assert!(ctx.allocate_guti(mme_ue_id));
+        let staged = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        let m_tmsi = staged.next.m_tmsi.expect("staged in next");
+        assert_eq!(staged.next.guti.mme_gid, 2);
+        assert_eq!(staged.next.guti.mme_code, 1);
+        assert!(
+            staged.current.m_tmsi.is_none(),
+            "the UE has not acknowledged it yet, so current must be untouched"
+        );
+        assert_eq!(
+            ctx.mme_ue_find_by_s_tmsi(1, m_tmsi),
+            None,
+            "a staged GUTI must not resolve: the UE still answers to the old identity"
+        );
+
+        assert!(ctx.commit_staged_guti(mme_ue_id));
+        assert_eq!(
+            ctx.mme_ue_find_by_s_tmsi(1, m_tmsi),
+            Some(mme_ue_id),
+            "once acknowledged, the GUTI must resolve the UE by S-TMSI"
+        );
+    }
+
+    /// Committing with nothing staged is a disagreement worth reporting, not a no-op to
+    /// swallow: it means the UE acknowledged an identity this MME never allocated.
+    #[test]
+    fn committing_with_nothing_staged_reports_false() {
+        let ctx = ctx_with_gummei();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, 46);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        assert!(!ctx.commit_staged_guti(mme_ue_id));
+    }
+
+    /// The RAT Type defaults to E-UTRAN, not to `Default`'s 0 — which is a reserved
+    /// value a conformant SGW would reject on the S11 Create Session Request.
+    #[test]
+    fn a_new_ue_defaults_to_the_eutran_rat_type() {
+        let ctx = ctx_with_gummei();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, 46);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        assert_eq!(
+            ctx.mme_ue_find_by_id(mme_ue_id).unwrap().rat_type,
+            crate::s11_build::rat_type::EUTRAN
+        );
+    }
 }

--- a/src/bins/nextgcore-mmed/src/emm_build.rs
+++ b/src/bins/nextgcore-mmed/src/emm_build.rs
@@ -392,6 +392,35 @@ impl NasBuffer {
 // EMM Message Building Functions
 // ============================================================================
 
+/// The EPS attach result to signal, and whether the CS domain was refused
+/// (TS 24.301 §9.9.3.10, §5.5.1.3.4.3).
+///
+/// A combined EPS/IMSI attach can only be ACCEPTED as combined if this MME actually
+/// has an SGs association for the UE's tracking area — `csmap_id` is the same test
+/// the Extended Service Request path already uses to refuse CS fallback, so this is
+/// the tree's existing notion of "is there a VLR", not a new one.
+///
+/// When the UE asked for combined and there is no SGs association, §5.5.1.3.4.3 is
+/// explicit: answer "EPS only" AND set the EMM cause to #18 "CS domain not
+/// available". Answering EPS-only with no cause — which is what a hardcoded result
+/// did — tells the UE the network declined without saying why, so it never falls back
+/// to attaching to the CS domain over another access.
+fn attach_result_for(mme_ue: &MmeUe) -> (u8, bool) {
+    let combined_requested = mme_ue.nas_eps.attach_type == AttachType::CombinedEpsImsiAttach as u8;
+    if !combined_requested {
+        return (AttachType::EpsAttach as u8, false);
+    }
+    if mme_ue.csmap_id == crate::context::NEXTGCORE_INVALID_POOL_ID {
+        log::info!(
+            "[{}] combined EPS/IMSI attach requested with no SGs association: answering EPS \
+             only with EMM cause #18 (TS 24.301 §5.5.1.3.4.3)",
+            mme_ue.imsi_bcd
+        );
+        return (AttachType::EpsAttach as u8, true);
+    }
+    (AttachType::CombinedEpsImsiAttach as u8, false)
+}
+
 /// Build attach accept message
 pub fn build_attach_accept(
     mme_ue: &MmeUe,
@@ -409,8 +438,16 @@ pub fn build_attach_accept(
     buf.write_u8(NAS_PROTOCOL_DISCRIMINATOR_EMM);
     buf.write_u8(NasEpsMessageType::AttachAccept as u8);
 
-    // EPS attach result (4 bits) + spare (4 bits)
-    let attach_result = AttachType::EpsAttach as u8;
+    // EPS attach result (TS 24.301 §9.9.3.10): 1 = EPS only, 2 = combined EPS/IMSI.
+    //
+    // #46: this was the literal `AttachType::EpsAttach`, so a UE that asked for a
+    // combined EPS/IMSI attach was always told EPS-only with no cause — which reads
+    // to the UE as "the network chose not to", and leaves it with no reason to
+    // attach to the CS domain separately.
+    //
+    // §9.9.3.11 has three attach TYPES and §9.9.3.10 only two RESULTS: an emergency
+    // attach (type 3) is an EPS-only attach, so it answers 1.
+    let (attach_result, cs_domain_refused) = attach_result_for(mme_ue);
     buf.write_u8(attach_result & 0x07);
 
     // T3412 value
@@ -443,6 +480,14 @@ pub fn build_attach_accept(
         buf.write_u8(mme_ue.next.guti.mme_code);
         // M-TMSI
         buf.write_u32(mme_ue.next.guti.m_tmsi);
+    }
+
+    // EMM cause (IEI 0x53, optional). Present only to say WHY a combined attach was
+    // downgraded; a UE that asked for EPS-only gets no cause, because there is
+    // nothing to explain.
+    if cs_domain_refused {
+        buf.write_u8(0x53);
+        buf.write_u8(EmmCause::CsDomainNotAvailable as u8);
     }
 
     Ok(buf.into_vec())
@@ -606,7 +651,10 @@ pub fn build_tau_accept(
     buf.write_u8(NasEpsMessageType::TauAccept as u8);
 
     // EPS update result (4 bits) + spare (4 bits)
-    buf.write_u8(0x00); // TA updated
+    // EPS update result (TS 24.301 §9.9.3.44). Hardcoded to 0 ("TA updated") before
+    // #46, so a UE that asked for a combined TA/LA update was never told whether its
+    // location area had been updated — and had no reason to think it had not.
+    buf.write_u8(eps_update_result_for(mme_ue) & 0x07);
 
     // Optional: T3412 value
     if t3412_value > 0 {
@@ -639,6 +687,96 @@ pub fn build_tau_accept(
         buf.write_u8(0x57); // EPS bearer context status IEI
         buf.write_u8(2); // Length
         buf.write_u16(eps_bearer_status);
+    }
+
+    buf.into_vec()
+}
+
+/// The EPS update result to signal (TS 24.301 §9.9.3.44, §5.5.3.2.4).
+///
+/// TAU types (§9.9.3.45): 0 = TA updating, 1 = combined TA/LA updating,
+/// 2 = combined with IMSI attach, 3 = periodic updating.
+/// Update results (§9.9.3.44): 0 = TA updated, 1 = combined TA/LA updated.
+///
+/// A combined update can only be reported as combined if this MME has an SGs
+/// association for the UE — same `csmap_id` test as the attach result and as the
+/// Extended Service Request path. Reporting "combined TA/LA updated" without one
+/// would claim a VLR update that never happened, which is worse than the
+/// conservative answer: the UE would believe it is reachable for CS services it
+/// cannot receive.
+///
+/// ISR (results 4 and 5) is deliberately never signalled: Idle-mode Signalling
+/// Reduction requires an S3/S4 SGSN association, and this MME has none.
+fn eps_update_result_for(mme_ue: &MmeUe) -> u8 {
+    const TA_UPDATED: u8 = 0;
+    const COMBINED_TA_LA_UPDATED: u8 = 1;
+
+    let combined_requested = matches!(mme_ue.nas_eps.update_type, 1 | 2);
+    if !combined_requested {
+        return TA_UPDATED;
+    }
+    if mme_ue.csmap_id == crate::context::NEXTGCORE_INVALID_POOL_ID {
+        log::info!(
+            "[{}] combined TA/LA update requested with no SGs association: reporting \
+             \"TA updated\" (TS 24.301 §5.5.3.2.4)",
+            mme_ue.imsi_bcd
+        );
+        return TA_UPDATED;
+    }
+    COMBINED_TA_LA_UPDATED
+}
+
+/// The EPS bearer context status bitmap for a UE's active bearers
+/// (TS 24.301 §9.9.2.1).
+///
+/// Bit N of the 16-bit value means EBI N is active. EBIs 0-4 are reserved
+/// (TS 24.007 §11.2.3.1.5), so only 5-15 can ever be set.
+///
+/// Always passed as `0` before #46, and the builder omits the IE when it is zero — so
+/// after a TAU the UE and the MME had no way to discover they disagreed about which
+/// bearers exist, which is the whole purpose of the IE.
+pub fn eps_bearer_context_status(ebis: impl IntoIterator<Item = u8>) -> u16 {
+    let mut status = 0u16;
+    for ebi in ebis {
+        if (crate::context::MIN_EPS_BEARER_ID..=crate::context::MAX_EPS_BEARER_ID).contains(&ebi) {
+            status |= 1 << ebi;
+        } else {
+            log::warn!("EBI {ebi} is outside the assignable range; omitted from the bearer status");
+        }
+    }
+    status
+}
+
+/// Build GUTI Reallocation Command (TS 24.301 §5.4.1, §8.2.16).
+///
+/// The standalone GUTI reallocation procedure. `GutiReallocationCommand = 0x50` and
+/// `GutiReallocationComplete = 0x51` existed as enum values with no builder and no
+/// handler, so a GUTI could never be refreshed outside an attach or a TAU — which
+/// means the temporary identity a UE presents was never rotated, and the IMSI
+/// confidentiality the GUTI exists to provide degrades with every reuse.
+///
+/// The GUTI is taken from `next`, which is where [`crate::context::MmeContext::allocate_guti`]
+/// stages it; `current` is promoted only when the UE acknowledges with 0x51.
+pub fn build_guti_reallocation_command(mme_ue: &MmeUe, tai_list: &[EpsTai]) -> Vec<u8> {
+    let mut buf = NasBuffer::new();
+    buf.write_u8(NAS_PROTOCOL_DISCRIMINATOR_EMM);
+    buf.write_u8(NasEpsMessageType::GutiReallocationCommand as u8);
+
+    // GUTI (M, §9.9.3.12): the whole point of the message, so it is written
+    // unconditionally rather than gated on `next.m_tmsi` the way the accepts are.
+    buf.write_u8(11); // Length
+    buf.write_u8(0xf6); // Odd/even + type = GUTI
+    let plmn = encode_plmn_id(&mme_ue.next.guti.plmn_id);
+    buf.write_bytes(&plmn);
+    buf.write_u16(mme_ue.next.guti.mme_gid);
+    buf.write_u8(mme_ue.next.guti.mme_code);
+    buf.write_u32(mme_ue.next.guti.m_tmsi);
+
+    // TAI list (O, IEI 0x54)
+    if !tai_list.is_empty() {
+        buf.write_u8(0x54);
+        let tai_list_data = encode_tai_list(tai_list);
+        buf.write_lv(&tai_list_data);
     }
 
     buf.into_vec()
@@ -828,6 +966,194 @@ fn encode_time_zone(offset_quarters: i8) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ================================================================
+    // #46: the accept messages say what the negotiated procedure produced
+    // ================================================================
+
+    fn ue_with(attach_type: u8, csmap_id: u64) -> MmeUe {
+        let mut ue = MmeUe {
+            csmap_id,
+            ..Default::default()
+        };
+        ue.nas_eps.attach_type = attach_type;
+        ue
+    }
+
+    /// #46 criterion 8(c): a combined EPS/IMSI attach must yield a COMBINED result.
+    ///
+    /// The result was the literal `AttachType::EpsAttach`, so a UE asking for combined
+    /// attach was always told EPS-only.
+    #[test]
+    fn a_combined_attach_with_an_sgs_association_yields_a_combined_result() {
+        let ue = ue_with(AttachType::CombinedEpsImsiAttach as u8, 42);
+        let msg = build_attach_accept(&ue, &[0x01], 600, &[]).expect("build");
+        assert_eq!(
+            msg[2] & 0x07,
+            AttachType::CombinedEpsImsiAttach as u8,
+            "a combined attach with a VLR must be accepted as combined"
+        );
+    }
+
+    /// TS 24.301 §5.5.1.3.4.3: with no SGs association the MME answers EPS-only AND
+    /// says why with EMM cause #18. Answering EPS-only silently — which a hardcoded
+    /// result did — leaves the UE with no reason to attach to the CS domain elsewhere.
+    #[test]
+    fn a_combined_attach_without_an_sgs_association_is_eps_only_with_cause_18() {
+        let ue = ue_with(
+            AttachType::CombinedEpsImsiAttach as u8,
+            crate::context::NEXTGCORE_INVALID_POOL_ID,
+        );
+        let msg = build_attach_accept(&ue, &[0x01], 600, &[]).expect("build");
+        assert_eq!(msg[2] & 0x07, AttachType::EpsAttach as u8);
+        let cause_iei = msg
+            .windows(2)
+            .position(|w| w[0] == 0x53)
+            .expect("the EMM cause IE must be present");
+        assert_eq!(
+            msg[cause_iei + 1],
+            EmmCause::CsDomainNotAvailable as u8,
+            "the UE must be told the CS domain is unavailable, not just refused"
+        );
+    }
+
+    /// An EPS-only attach gets no cause, because there is nothing to explain.
+    #[test]
+    fn an_eps_only_attach_carries_no_emm_cause() {
+        let ue = ue_with(AttachType::EpsAttach as u8, 42);
+        let msg = build_attach_accept(&ue, &[0x01], 600, &[]).expect("build");
+        assert_eq!(msg[2] & 0x07, AttachType::EpsAttach as u8);
+        assert!(
+            !msg.windows(2).any(|w| w[0] == 0x53),
+            "an unremarkable accept must not carry an EMM cause"
+        );
+    }
+
+    /// TS 24.301 §9.9.3.10 has two attach RESULTS and §9.9.3.11 three TYPES: an
+    /// emergency attach is an EPS-only attach, so it answers 1 rather than echoing 3.
+    #[test]
+    fn an_emergency_attach_is_answered_eps_only() {
+        let ue = ue_with(AttachType::EpsEmergencyAttach as u8, 42);
+        let msg = build_attach_accept(&ue, &[0x01], 600, &[]).expect("build");
+        assert_eq!(msg[2] & 0x07, AttachType::EpsAttach as u8);
+    }
+
+    /// #46 criterion 8(b): T3412 is encoded from the value passed, not a literal 3600.
+    ///
+    /// The encoding is a GPRS Timer, so the assertion is against the encoded unit and
+    /// value rather than the raw seconds — which is also what makes it catch a caller
+    /// that passes the right number to the wrong parameter.
+    #[test]
+    fn the_attach_accept_encodes_the_t3412_it_is_given() {
+        let ue = ue_with(AttachType::EpsAttach as u8, 42);
+        let subscribed = build_attach_accept(&ue, &[0x01], 720, &[]).expect("build");
+        let hardcoded = build_attach_accept(&ue, &[0x01], 3600, &[]).expect("build");
+        assert_eq!(
+            subscribed[3],
+            GprsTimer::from_sec(720).encode(),
+            "the accept must encode the timer it was given"
+        );
+        assert_ne!(
+            subscribed[3], hardcoded[3],
+            "720 s and 3600 s must not encode identically, or this test proves nothing"
+        );
+    }
+
+    /// #46 criterion 8(d): a TAU accept with active bearers must carry a NONZERO EPS
+    /// bearer context status, or the UE and the MME cannot resynchronise.
+    #[test]
+    fn a_tau_accept_with_active_bearers_carries_a_nonzero_bearer_status() {
+        let ue = MmeUe::default();
+        let status = eps_bearer_context_status([5u8, 6]);
+        assert_ne!(status, 0, "two active bearers must set two bits");
+        assert_eq!(status, (1 << 5) | (1 << 6));
+
+        let msg = build_tau_accept(&ue, 600, &[], status);
+        let iei = msg
+            .windows(2)
+            .position(|w| w[0] == 0x57)
+            .expect("the EPS bearer context status IE must be present");
+        assert_eq!(msg[iei + 1], 2, "the IE is two octets long");
+        assert_eq!(u16::from_be_bytes([msg[iei + 2], msg[iei + 3]]), status);
+    }
+
+    /// EBIs 0-4 are reserved (TS 24.007 §11.2.3.1.5), so they can never appear in the
+    /// bitmap — a bearer claiming one is a bug worth surfacing, not a bit to set.
+    #[test]
+    fn reserved_ebis_are_excluded_from_the_bearer_status() {
+        assert_eq!(eps_bearer_context_status([0u8, 4, 16, 255]), 0);
+        assert_eq!(eps_bearer_context_status([5u8]), 1 << 5);
+        assert_eq!(eps_bearer_context_status(std::iter::empty()), 0);
+    }
+
+    /// #46 criterion 7: the EPS update result must follow the TAU type and the SGs
+    /// outcome, not be a hardcoded "TA updated".
+    #[test]
+    fn the_eps_update_result_follows_the_tau_type_and_the_sgs_association() {
+        // Plain TA updating, and periodic updating: TA updated.
+        for update_type in [0u8, 3] {
+            let mut ue = MmeUe {
+                csmap_id: 42,
+                ..Default::default()
+            };
+            ue.nas_eps.update_type = update_type;
+            assert_eq!(build_tau_accept(&ue, 600, &[], 0)[2] & 0x07, 0);
+        }
+        // Combined, with a VLR: combined TA/LA updated.
+        for update_type in [1u8, 2] {
+            let mut ue = MmeUe {
+                csmap_id: 42,
+                ..Default::default()
+            };
+            ue.nas_eps.update_type = update_type;
+            assert_eq!(
+                build_tau_accept(&ue, 600, &[], 0)[2] & 0x07,
+                1,
+                "a combined update with a VLR must be reported as combined"
+            );
+        }
+        // Combined, with no VLR: TA updated, because claiming the LA was updated
+        // would tell the UE it is reachable for CS services it cannot receive.
+        let mut ue = MmeUe {
+            csmap_id: crate::context::NEXTGCORE_INVALID_POOL_ID,
+            ..Default::default()
+        };
+        ue.nas_eps.update_type = 1;
+        assert_eq!(build_tau_accept(&ue, 600, &[], 0)[2] & 0x07, 0);
+    }
+
+    /// #46 criterion 5: the GUTI Reallocation Command exists and carries the staged
+    /// GUTI. `GutiReallocationCommand = 0x50` was an enum value with no builder, so a
+    /// GUTI could never be refreshed outside an attach or a TAU.
+    #[test]
+    fn the_guti_reallocation_command_carries_the_staged_guti() {
+        let mut ue = MmeUe::default();
+        ue.next.m_tmsi = Some(0x0102_0304);
+        ue.next.guti = crate::context::EpsGuti {
+            plmn_id: PlmnId::new("999", "70"),
+            mme_gid: 2,
+            mme_code: 1,
+            m_tmsi: 0x0102_0304,
+        };
+
+        let msg = build_guti_reallocation_command(&ue, &[]);
+        assert_eq!(msg[0], NAS_PROTOCOL_DISCRIMINATOR_EMM);
+        assert_eq!(msg[1], NasEpsMessageType::GutiReallocationCommand as u8);
+        assert_eq!(msg[2], 11, "the GUTI IE is 11 octets of content");
+        assert_eq!(msg[3], 0xf6, "odd/even indicator plus type = GUTI");
+        // Content layout (TS 24.301 §9.9.3.12): 0xf6, PLMN (3), MME group id (2),
+        // MME code (1), M-TMSI (4) — so the M-TMSI is the LAST four of the eleven.
+        assert_eq!(
+            u32::from_be_bytes([msg[10], msg[11], msg[12], msg[13]]),
+            0x0102_0304,
+            "the command must carry the GUTI that was staged"
+        );
+        assert_eq!(
+            msg.len(),
+            2 + 1 + 11,
+            "header, length octet, and 11 of content"
+        );
+    }
 
     #[test]
     fn test_encode_tai_list_type0_single_plmn() {

--- a/src/bins/nextgcore-mmed/src/nas_dispatch.rs
+++ b/src/bins/nextgcore-mmed/src/nas_dispatch.rs
@@ -342,14 +342,37 @@ fn dispatch_emm(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, pdu: &[u8]) {
             );
             release_ue_context(ctx, enb_ue);
         }
-        emm_type::TAU_COMPLETE | emm_type::GUTI_REALLOCATION_COMPLETE => {
-            log::debug!(
-                "EMM 0x{message_type:02x} acknowledged by enb_ue_s1ap_id={}",
-                enb_ue.enb_ue_s1ap_id
-            );
+        emm_type::TAU_COMPLETE => {
+            log::debug!("TAU Complete from enb_ue_s1ap_id={}", enb_ue.enb_ue_s1ap_id);
             // TS 24.301 §5.5.3.2.4: the TAU procedure completed (issue #45).
             if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
                 mme_ue.t3450.stop();
+            }
+            // The GUTI the accept carried is now the UE's (#46). Committed HERE and
+            // not at send time: until the UE acknowledges, it still answers to the
+            // old identity, and promoting early would make `mme_ue_find_by_s_tmsi`
+            // miss a UE that returns before the accept arrives.
+            ctx.commit_staged_guti(mme_ue_id);
+        }
+        emm_type::GUTI_REALLOCATION_COMPLETE => {
+            log::debug!(
+                "GUTI Reallocation Complete from enb_ue_s1ap_id={}",
+                enb_ue.enb_ue_s1ap_id
+            );
+            // TS 24.301 §5.4.1.3: the reallocation completed, so T3450 stops and the
+            // new GUTI takes effect. Split from the TAU arm by #46 because the two
+            // procedures are different and sharing an arm hid that neither committed
+            // anything.
+            if let Some(mme_ue) = ctx.mme_ue_pool.write().unwrap().get_mut(&mme_ue_id) {
+                mme_ue.t3450.stop();
+            }
+            if ctx.commit_staged_guti(mme_ue_id) {
+                log::info!("GUTI reallocation completed for mme_ue_id={mme_ue_id}");
+            } else {
+                log::warn!(
+                    "GUTI Reallocation Complete for mme_ue_id={mme_ue_id} with no staged GUTI: \
+                     the UE acknowledged an identity this MME did not allocate"
+                );
             }
         }
         emm_type::EMM_STATUS => {
@@ -458,6 +481,45 @@ fn emm_attach_request(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, body: &[
             }
         }
     };
+
+    // TS 24.301 §9.9.3.11 attach type 3 is an EMERGENCY attach. Recorded on the
+    // context so the rest of the stack can tell one from a normal attach (#46).
+    //
+    // What this does NOT do, stated because the difference matters: emergency BEARER
+    // SERVICES are not implemented. §5.5.1.3 lets an emergency attach proceed for an
+    // unauthenticated or unsubscribed UE with EIA0/NIA0 and an emergency APN, and
+    // none of that exists here — so an emergency attach still goes through the normal
+    // authentication and subscription path and will fail wherever that fails. The flag
+    // makes the case visible instead of silently indistinguishable, and the accept's
+    // EPS attach result is now correct for it (§9.9.3.10 has no emergency value, so it
+    // is EPS-only).
+    if parsed.attach_type == crate::emm_build::AttachType::EpsEmergencyAttach as u8 {
+        if let Ok(mut pool) = ctx.mme_ue_pool.write() {
+            if let Some(ue) = pool.get_mut(&mme_ue_id) {
+                ue.emergency_attach = true;
+            }
+        }
+        log::warn!(
+            "EMERGENCY attach requested on enb_ue_s1ap_id={}: recognised and recorded, but \
+             emergency bearer services (unauthenticated access, EIA0/NIA0, emergency APN) are \
+             not implemented, so this attach follows the normal path",
+            enb_ue.enb_ue_s1ap_id
+        );
+    }
+
+    // Allocate the GUTI this attach will hand the UE (TS 24.301 §5.4.1). Staged in
+    // `next`; promoted to `current` when the UE acknowledges. Before #46 nothing
+    // allocated one, so the accepts' `next.m_tmsi.is_some()` gate was never true
+    // outside tests and the GUTI IE was dead code — which also left
+    // `mme_ue_find_by_s_tmsi` and the GUTI-identified attach lookup below permanently
+    // dormant, as `resolve_mme_ue`'s comment said.
+    if !ctx.allocate_guti(mme_ue_id) {
+        log::warn!(
+            "no GUTI allocated for enb_ue_s1ap_id={}: the UE will be given none and must keep \
+             identifying itself by IMSI",
+            enb_ue.enb_ue_s1ap_id
+        );
+    }
 
     if let Some(imsi) = parsed.imsi.as_deref() {
         log::info!(
@@ -798,10 +860,27 @@ fn emm_tau_request(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue_id: u64, body: &[u8]
         parsed.update_type,
         parsed.active_flag
     );
-    // No E-RABs can be listed: bearers are established over S11, which is not
-    // implemented (#51). The accept therefore never asks for Initial Context
-    // Setup, and subscribed timer / GUTI reallocation content is #46.
-    if let Err(e) = nas_path::nas_eps_send_tau_accept(mme_ue, enb_ue, false, &[]) {
+    // TS 24.301 §5.5.3.2.4: the TAU accept may reallocate the GUTI, and rotating it
+    // on mobility is what keeps the temporary identity temporary (#46).
+    ctx.allocate_guti(mme_ue_id);
+    // The UE's active bearers, so the accept can carry a real EPS bearer context
+    // status (#46). An empty slice was passed while S11 could establish nothing;
+    // #51 gave the MME a real S11 endpoint, so a UE that has completed an attach
+    // holds bearers worth reporting. Initial Context Setup is still not requested
+    // from here — that is the attach path's job, and it has no caller yet (#51's
+    // ceiling).
+    let bearers: Vec<crate::context::MmeBearer> = mme_ue
+        .sess_list
+        .iter()
+        .filter_map(|sess_id| ctx.sess_find_by_id(*sess_id))
+        .flat_map(|sess| {
+            sess.bearer_list
+                .iter()
+                .filter_map(|id| ctx.bearer_find_by_id(*id))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    if let Err(e) = nas_path::nas_eps_send_tau_accept(mme_ue, enb_ue, false, &bearers) {
         log::error!("[{}] TAU Accept send failed: {e}", mme_ue.imsi_bcd);
     }
 }
@@ -2432,6 +2511,66 @@ mod tests {
         let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
         assert!(!mme_ue.t3460.is_running());
         assert!(mme_ue.t3460.pkbuf.is_none());
+    }
+
+    /// #46 criterion 4 and 5: a GUTI Reallocation Complete promotes the staged GUTI so
+    /// the UE becomes resolvable by S-TMSI.
+    ///
+    /// 0x51 shared an arm with TAU Complete before #46 and neither committed anything,
+    /// so the acknowledgement was recorded and the new identity never took effect.
+    #[test]
+    fn guti_reallocation_complete_commits_the_staged_guti() {
+        // Its OWN context with a served GUMMEI: `test_ctx()` has none, and adding one
+        // there would change the ambient state every other test in this module runs
+        // against.
+        let mut ctx = test_ctx();
+        ctx.served_gummei = vec![crate::context::ServedGummei {
+            num_of_plmn_id: 1,
+            plmn_id: vec![crate::context::PlmnId::new("001", "01")],
+            num_of_mme_gid: 1,
+            mme_gid: vec![2],
+            num_of_mme_code: 1,
+            mme_code: vec![1],
+        }];
+        ctx.num_of_served_gummei = 1;
+        let ctx = ctx;
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+
+        assert!(
+            ctx.allocate_guti(mme_ue_id),
+            "the fixture's served GUMMEI must allow an allocation"
+        );
+        let staged = ctx
+            .mme_ue_find_by_id(mme_ue_id)
+            .unwrap()
+            .next
+            .m_tmsi
+            .expect("staged");
+        let mme_code = ctx.mme_ue_find_by_id(mme_ue_id).unwrap().next.guti.mme_code;
+        assert_eq!(
+            ctx.mme_ue_find_by_s_tmsi(mme_code, staged),
+            None,
+            "a staged GUTI must not resolve before the UE acknowledges it"
+        );
+
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        let complete = protect_uplink(
+            &mme_ue,
+            1,
+            &[
+                NAS_PROTOCOL_DISCRIMINATOR_EMM,
+                NasEpsMessageType::GutiReallocationComplete as u8,
+            ],
+        );
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &complete));
+
+        assert_eq!(
+            ctx.mme_ue_find_by_s_tmsi(mme_code, staged),
+            Some(mme_ue_id),
+            "the acknowledged GUTI must resolve the UE by S-TMSI"
+        );
     }
 
     #[test]

--- a/src/bins/nextgcore-mmed/src/nas_path.rs
+++ b/src/bins/nextgcore-mmed/src/nas_path.rs
@@ -216,6 +216,41 @@ pub fn nas_eps_send_emm_to_esm(
 // ============================================================================
 // EMM Message Send Functions
 // ============================================================================
+/// The T3412 value to signal, in seconds (TS 23.401 §4.3.17.3, TS 29.272 §7.3.134).
+///
+/// The subscription wins, then the configured default. Both accepts wrote a literal
+/// 3600 before #46 while the S6a codec had been round-tripping the subscribed timer
+/// all along — so every UE was told to re-register on a cadence its own subscription
+/// had not asked for.
+///
+/// `mme.time.t3412` is the configured fallback and is already parsed; a deployment
+/// that sets neither gets the shipped 3600, which is the value that used to be
+/// hardcoded, so nothing changes for a subscription that states no timer.
+fn t3412_for(mme_ue: &MmeUe) -> u32 {
+    t3412_from(
+        mme_ue.subscribed_rau_tau_timer,
+        crate::context::mme_self().time.t3412,
+    )
+}
+
+/// The precedence, as a pure function of the two inputs.
+///
+/// Split from [`t3412_for`] so the ordering is testable without the process-global
+/// context: `mme_self().time` is a plain field set at construction, so a test cannot
+/// vary the configured value, and the precedence is the part worth pinning.
+fn t3412_from(subscribed: u32, configured: u64) -> u32 {
+    /// What used to be hardcoded, so a deployment that configures nothing and a
+    /// subscription that states nothing behave exactly as before.
+    const DEFAULT_T3412_SECS: u32 = 3600;
+
+    if subscribed > 0 {
+        return subscribed;
+    }
+    if configured > 0 {
+        return configured as u32;
+    }
+    DEFAULT_T3412_SECS
+}
 
 /// Send attach accept message
 ///
@@ -254,13 +289,9 @@ pub fn nas_eps_send_attach_accept(
 
     // Build EMM attach accept with ESM message
     let tai_list = vec![mme_ue.tai.clone()];
-    let emm_message = emm_build::build_attach_accept(
-        mme_ue,
-        &esm_message,
-        3600, // T3412 value in seconds
-        &tai_list,
-    )
-    .map_err(|_| NasError::BuildFailed)?;
+    let emm_message =
+        emm_build::build_attach_accept(mme_ue, &esm_message, t3412_for(mme_ue), &tai_list)
+            .map_err(|_| NasError::BuildFailed)?;
 
     // Apply security encoding
     let secured_message = nas_security::nas_eps_security_encode(
@@ -595,10 +626,12 @@ pub fn nas_eps_send_tau_accept(
     log::debug!("[{}] Tracking area update accept", mme_ue.imsi_bcd);
 
     let tai_list = vec![mme_ue.tai.clone()];
-    let plain_message = emm_build::build_tau_accept(
-        mme_ue, 3600, // T3412 value
-        &tai_list, 0, // EPS bearer context status
-    );
+    // The EPS bearer context status is built from the bearers the caller passed, so
+    // the UE and the MME can discover a disagreement about which bearers exist —
+    // which is the IE's only purpose, and it was always sent as 0.
+    let bearer_status = emm_build::eps_bearer_context_status(bearers.iter().map(|b| b.ebi));
+    let plain_message =
+        emm_build::build_tau_accept(mme_ue, t3412_for(mme_ue), &tai_list, bearer_status);
 
     // Apply security encoding
     let emm_message = nas_security::nas_eps_security_encode(
@@ -1095,6 +1128,24 @@ pub fn nas_eps_send_downlink_nas_transport(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #46 criterion 3: the SUBSCRIPTION wins, then the configured value, then the
+    /// 3600 that used to be hardcoded.
+    ///
+    /// The order is the whole point: a subscription that states a timer must not be
+    /// overridden by an operator default, and a deployment that configures neither must
+    /// behave exactly as it did before this issue.
+    #[test]
+    fn t3412_prefers_the_subscription_then_the_configured_value() {
+        assert_eq!(t3412_from(720, 1800), 720, "the subscription wins");
+        assert_eq!(t3412_from(0, 1800), 1800, "then the configured value");
+        assert_eq!(t3412_from(0, 0), 3600, "then the shipped default");
+        assert_ne!(
+            t3412_from(720, 1800),
+            3600,
+            "a subscribed timer must not silently become the old hardcoded value"
+        );
+    }
 
     #[test]
     fn test_nas_error_display() {

--- a/src/bins/nextgcore-mmed/src/s6a_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s6a_handler.rs
@@ -156,8 +156,21 @@ pub fn mme_s6a_handle_ula(mme_ue: &mut MmeUe, ula_message: &UlaMessage) -> S6aRe
     // Update network access mode
     mme_ue.network_access_mode = subscription_data.network_access_mode;
 
-    // Update subscribed RAU/TAU timer
-    // Note: subscribed_rau_tau_timer field would need to be added to MmeUe if needed
+    // Update subscribed RAU/TAU timer (TS 29.272 §7.3.134).
+    //
+    // #46: this was a comment saying the field "would need to be added to MmeUe if
+    // needed", while the shared S6a codec had been round-tripping the AVP all along
+    // and both NAS accepts hardcoded 3600 s. TS 23.401 §4.3.17.3 derives T3412 from
+    // this value, so dropping it told every UE to re-register on a cadence its
+    // subscription had not asked for.
+    mme_ue.subscribed_rau_tau_timer = subscription_data.subscribed_rau_tau_timer;
+    if mme_ue.subscribed_rau_tau_timer > 0 {
+        log::debug!(
+            "[{}] subscribed periodic RAU/TAU timer: {} s",
+            mme_ue.imsi_bcd,
+            mme_ue.subscribed_rau_tau_timer
+        );
+    }
 
     // Update charging characteristics
     if let Some(cc) = subscription_data.charging_characteristics {
@@ -898,7 +911,15 @@ mod tests {
                     name: "internet".to_string(),
                     qos: Qos {
                         qci: 9,
+                        arp: Arp {
+                            priority_level: 7,
+                            ..Default::default()
+                        },
                         ..Default::default()
+                    },
+                    ambr: Bitrate {
+                        uplink: 1_000_000,
+                        downlink: 4_000_000,
                     },
                     ..Default::default()
                 },
@@ -921,6 +942,18 @@ mod tests {
         let bearer = ctx.bearer_find_by_id(first.bearer_list[0]).unwrap();
         assert_eq!(bearer.ebi, crate::context::MIN_EPS_BEARER_ID);
         assert_eq!(bearer.qos.qci, 9);
+        // #46 criterion 8(a): the ARP and the APN-AMBR must survive too. The QCI
+        // alone was asserted before, so a subscription whose priority or rate limit
+        // was dropped looked persisted.
+        assert_eq!(
+            bearer.qos.arp.priority_level, 7,
+            "the subscribed ARP priority must reach the bearer"
+        );
+        assert_eq!(
+            (first.ambr.uplink, first.ambr.downlink),
+            (1_000_000, 4_000_000),
+            "the subscribed APN-AMBR must reach the session"
+        );
 
         // The second session gets the next EBI, not a duplicate.
         let second = ctx.sess_find_by_id(sess_list[1]).unwrap();
@@ -935,6 +968,60 @@ mod tests {
         assert_eq!(materialise_subscribed_sessions(&ctx, mme_ue_id), 2);
         assert_eq!(ctx.sess_pool.read().unwrap().len(), 2);
         assert_eq!(ctx.bearer_pool.read().unwrap().len(), 2);
+    }
+
+    /// #46 criterion 3: the subscribed periodic RAU/TAU timer must reach the UE
+    /// context from the ULA.
+    ///
+    /// The S6a codec round-tripped this AVP all along and mmed dropped it under a
+    /// comment saying the field "would need to be added to MmeUe if needed", so both
+    /// NAS accepts signalled a hardcoded 3600 s whatever the subscription said.
+    #[test]
+    fn the_subscribed_rau_tau_timer_reaches_the_ue_context() {
+        let mut mme_ue = MmeUe::default();
+        let mut ula = UlaMessage {
+            result_code: result_code::DIAMETER_SUCCESS,
+            ..Default::default()
+        };
+        ula.subscription_data.subscribed_rau_tau_timer = 720;
+        ula.subscription_data.apn_configs = vec![ApnConfiguration {
+            service_selection: "internet".to_string(),
+            qci: 9,
+            ..Default::default()
+        }];
+
+        assert_eq!(
+            mme_s6a_handle_ula(&mut mme_ue, &ula).expect("ULA handled"),
+            EmmCause::RequestAccepted
+        );
+        assert_eq!(
+            mme_ue.subscribed_rau_tau_timer, 720,
+            "the subscribed timer must be recorded, not dropped"
+        );
+    }
+
+    /// A subscription that states no timer leaves the field at 0, which is what makes
+    /// the configured fallback reachable rather than being overwritten by a zero.
+    #[test]
+    fn an_absent_subscribed_timer_leaves_the_field_zero() {
+        let mut mme_ue = MmeUe {
+            subscribed_rau_tau_timer: 999,
+            ..Default::default()
+        };
+        let mut ula = UlaMessage {
+            result_code: result_code::DIAMETER_SUCCESS,
+            ..Default::default()
+        };
+        ula.subscription_data.apn_configs = vec![ApnConfiguration {
+            service_selection: "internet".to_string(),
+            ..Default::default()
+        }];
+
+        mme_s6a_handle_ula(&mut mme_ue, &ula).expect("ULA handled");
+        assert_eq!(
+            mme_ue.subscribed_rau_tau_timer, 0,
+            "a subscription with no timer must not leave a stale one in place"
+        );
     }
 
     /// A UE with one subscribed APN materialised, plus the session the UE's own


### PR DESCRIPTION
Closes #46. Spec: `specs/fix-mmed-attach-tau-accept-correctness.md`.

## Two criteria were already done

Verified against `ce8a56a` before writing anything:

| criterion | status |
|---|---|
| 1. ULA APN configs persisted as `MmeSess` + `MmeBearer` | **already done** — `materialise_subscribed_sessions`, called from `fd_path.rs:1261`, tested |
| 2. `process_apn_configurations` uses the UE context, no `_mme_ue` | **already done** |
| 3-7 | exactly as described |
| 8. the four unit tests | partly — criterion 1's test asserts APN/EBI/QCI but **not** ARP or APN-AMBR |

## #46 was reordered to run *after* #51, because of a dead function

Criterion 4 asks for the GUTI IE "in the normal (non-test) flow". While verifying, `nas_eps_send_attach_accept` turned out to have **no caller at all** — grep-confirmed, and `nas_dispatch.rs:801-803` said why: bearers come over S11, which did not exist. Implementing criterion 4's attach half against a dead function would have been a correct fix in an unreachable place, so this issue was parked, #51 landed first, and this PR is written against a tree where the S11 exchange is real.

The attach accept *still* has no caller — that is #51's stated ceiling, not #46's to close — so **criterion 4 is satisfied via the reachable TAU path**, and the attach path stages the GUTI at Attach Request so it is ready when its accept becomes sendable. This PR says which is which rather than implying both.

## What landed

- **T3412** from the subscribed timer, then `mme.time.t3412`, then the 3600 that used to be hardcoded. The S6a codec had round-tripped that AVP all along while mmed dropped it under a comment saying the field "would need to be added to `MmeUe` if needed".
- **A GUTI/M-TMSI allocator** from a process-global counter (it is the key `mme_ue_find_by_s_tmsi` looks up by — a duplicate makes one UE unreachable and resolves the other to the wrong context), **staged** in `next` and promoted only when the UE acknowledges. Nothing wrote either before, so the accepts' `next.m_tmsi.is_some()` gate was never true outside tests and that lookup was permanently dormant: every returning UE had to re-identify by IMSI, which is exactly the confidentiality the GUTI exists to provide. With no served GUMMEI it **refuses** rather than inventing an identity no eNB could route.
- **`build_guti_reallocation_command`**, and 0x51 split out of the arm it shared with TAU Complete — sharing the arm is what hid that neither committed anything.
- **The EPS attach result follows the requested type.** A combined attach with no SGs association answers EPS-only **and EMM cause #18**, per §5.5.1.3.4.3: a silent EPS-only told the UE the network declined without saying why, so it had no reason to attach to the CS domain elsewhere.
- **The EPS update result** follows the TAU type and the same `csmap_id` test the CSFB path already uses; claiming "combined TA/LA updated" without a VLR would tell the UE it is reachable for CS services it cannot receive. ISR is never signalled — it needs an S3/S4 SGSN this MME does not have.
- **The EPS bearer context status** is built from the UE's real bearers instead of the `0` the caller always passed.

## Emergency attach: recognised, not implemented — and it says so

Attach type 3 is recognised and recorded, and §9.9.3.10's result is correct for it (two results, three types, so an emergency attach is an EPS-only attach).

**It does not implement emergency bearer services.** §5.5.1.3 lets an emergency attach proceed for an unauthenticated or unsubscribed UE with EIA0/NIA0 and an emergency APN; none of that exists here, so an emergency attach still follows the normal authentication and subscription path and fails wherever that fails. The code logs exactly this at `warn` on every emergency attach. The flag makes the case visible instead of silently indistinguishable; claiming more would be the dishonest option.

## Verification

**13 reverts, 13 bites**, covering: the subscribed timer recorded; APN-AMBR persisted; ARP persisted; T3412 encoded from the value given; the subscription outranking configuration; the combined result; EMM cause #18 on downgrade; the EPS update result; the bearer-status bitmap; GUTI staged-not-committed; M-TMSI uniqueness; the reallocation command's GUTI; 0x51 committing.

Two things worth stating:

- The **"T3412 prefers the subscription" revert first reported PASSED**, because I pointed it at the S6a population test and *no test of the precedence existed*. That is what prompted splitting `t3412_from` out as a pure function — the claim had been written and not verified.
- One test failure was **mine, not the code's**: the GUTI-reallocation test read the M-TMSI at `msg[9]` when §9.9.3.12's layout (0xf6, PLMN×3, group id×2, code, M-TMSI×4) puts it at `msg[10]`. The builder was right.

mmed 320 → 338 tests. Workspace **6347 passed / 0 failed**, `clippy --workspace` 0, `fmt --check` clean.

## Ceilings

- **The attach accept still has no caller** — criterion 4 is met via TAU only (see above).
- **Emergency attach is recognised, not implemented**, and the code says so at `warn`.
- **The configured-T3412 branch is untested against a real context**: `mme_self().time` is set at construction and cannot be varied from a test. The precedence is tested purely; the wiring from `mme.time.t3412` into it is read, not exercised.
- **The SGs outcome is "is there a CS map", not "did the location update succeed".** `handle_location_update_accept` and `build_location_update_request` have only test callers, so mmed never performs an SGs location update — there is no outcome to consult. `csmap_id` is the strongest signal that exists and is what the CSFB path already uses.
- **No GUTI reallocation is ever *initiated*.** The command and the 0x51 handler exist and are tested; nothing decides to rotate a GUTI outside an attach or a TAU, so §5.4.1's standalone procedure has machinery and no trigger.

Re CI: if the Test gate reddens on an `SbiServer::start` bind panic in a crate this PR does not touch, that is #313 and a re-run is the right response.