### PR TITLE
fix(sgwcd,smfd): stand up the S5/S8 interface on both legs (#52)

### DIFF
--- a/specs/fix-s5s8-interface-bringup.md
+++ b/specs/fix-s5s8-interface-bringup.md
@@ -1,0 +1,163 @@
+# nextgcore #52 (sgwcd + smfd): stand up the S5/S8 interface
+
+Verified against `main` @ `b1797d8`. TS 29.274 §7.2.1, §7.2.2, §7.2.5, §8.18, §8.21, §8.34,
+Tables 7.2.1-1 / 7.2.2-1; TS 23.401 §5.3.2.1, §4.3.8.1; TS 23.501 §4.3.1 NOTE 2.
+
+#52 is accurate in every particular. Standing the interface up then exposed **three
+further layers**, each invisible from either side alone — the same shape #54 found.
+
+## Verified against current main
+
+| claim in the issue | site on `b1797d8` | still true? |
+|---|---|---|
+| sgwcd answers the S11 CSR locally; no S5/S8 leaves | `gtp_path.rs` sent the Sxa request and answered from the Sxa reply | yes |
+| the PAA is merely echoed from the MME | `parsed.paa` copied into `sess.paa` | yes |
+| the S5-C builder set exists with `#[cfg(test)]` callers only | `s11_build.rs:449+` | yes |
+| `build_s5c_create_session_request` reuses `ctx.s11_address()` | yes, with its own comment saying so | yes |
+| `SgwcFsm::handle_s5c_message` is a log-only stub; `s5c_handler` has no production caller | `sm.rs:109` | yes |
+| Bearer Resource Command answers `SERVICE_NOT_SUPPORTED` | yes, with a comment naming this issue | yes |
+| smfd binds no GTP-C socket | no `UdpSocket` in `gtp_path.rs` | yes |
+| smfd's `gtp_handler` is blanket-suppressed and has test-only callers | `#![allow(dead_code)]` etc. | yes |
+
+## The three layers underneath
+
+**Layer 1 — the SGW-C never kept what the anchor needs.** A conformant PGW requires
+Serving Network (§8.18) and ULI (§8.21) for an E-UTRAN session; this tree's own smfd
+answers `ConditionalIeMissing` without them. sgwcd's `s11_parse` **did not parse either**
+— it kept a `uli_presence` boolean and nothing else — because nothing relayed anything.
+So the first working relay was refused by the anchor it was built to reach.
+
+**Layer 2 — the MME never sent them either.** #51 gave mmed a conformant CSR, and its
+criteria named the Sender F-TEID and the Bearer Contexts. Serving Network and ULI were in
+that issue's *prose* and not in its criteria, so they were correctly reported as met and
+the chain still could not complete. Both are added to mmed's CSR here, because #52's
+criterion 9 is unachievable without them.
+
+**Layer 3 — two PDN-type numberings compared directly.** `build_create_session_response`
+chooses between cause 16 and cause 18 ("New PDN type due to network preference") on
+`ue_session_type != session_type as u8`. `PduSessionType` is the NAS/5G enum where
+`Ipv4 == 0`; the GTP PDN Type IE is 1-based (§8.34). `handle_create_session_request` stored
+the raw GTP value, so **every IPv4 session answered 18** — a spurious "the network chose
+differently" on a request the network honoured exactly. Latent until #52 because neither
+function had a production caller. Fixed at the source, in the handler.
+
+Each layer was found by building the layer above it, not by reading. That is the argument
+for the cross-daemon parity test below.
+
+## Decision 1: relay first, then provision — and the S11 answer stays where #54 put it
+
+TS 23.401 §5.3.2.1's order is MME → SGW → **PGW** → SGW → MME, and the PGW's response
+carries the PAA and the PGW-U F-TEID that the SGW-U's Sxa session needs. So the S5-C stage
+is **inserted before** the Sxa stage rather than replacing it: `S11Continuation` rides
+through untouched, and the MME's answer is still produced by #54's `sxa_response` from a
+session that now holds the PGW's values.
+
+Keyed by the S5-C sequence number, which is what correlates the PGW's answer. An
+uncorrelated Create Session Response is dropped with a warning rather than acted on.
+
+## Decision 2: with no PGW configured, the SGW-C REFUSES
+
+Answering locally is the defect. `SGWC_PGW_S5C` unset means the S11 Create Session Request
+is answered `REMOTE_PEER_NOT_RESPONDING` with **no PAA**, and that is asserted. A
+fabricated success is worse than a visible refusal, and there is no PGW *selection*
+function here — §4.3.8.1 selects by APN via DNS, which this tree does not implement, so
+one configured peer is the honest model.
+
+## Decision 3: smfd's server is async; mmed's and sgwcd's are not
+
+Those two are synchronous because the NAS and S1AP paths that originate their messages
+are. smfd is the **terminating** end, and answering a Create Session Request requires
+awaiting an N4 exchange — so an async receive loop lets the handler await it directly, and
+smfd needs none of the deferred-continuation machinery #54 had to build for sgwcd. Each
+datagram is handled in its own task, because handling inline would stop the socket
+receiving for the duration of an N4 round trip — including the SGW-C's retransmission of
+the request being served.
+
+The T3/N3 budget still comes from the shared `Gtp2XactMgr`, so all three GTP-C endpoints
+in this tree agree about how long a message may take.
+
+## Decision 4: `has_gx_peer` is passed `true`, and why
+
+smfd has Gx *state* (`gsm_sm.rs`'s CCR/CCA fields) and no Gx transport. The handler rejects
+with `RemotePeerNotResponding` when told there is no Gx peer, which would make this
+endpoint refuse every Create Session Request — a socket that binds and serves nothing.
+
+TS 23.401 does not require a PCRF for a PGW to serve a session, and
+`policy::PolicyDecision::config_default_for_dnn` is a policy source — the same one the 5G
+path falls back to when no PCF is configured (recorded precedence: PCF, then subscription,
+then config default). So the parameter is passed `true` on the grounds that a policy source
+exists. Recorded rather than silently done, because it reinterprets what that argument
+means.
+
+## Decision 5: the allocated address is released on every failure path
+
+A leaked address per refused request exhausts a /16 silently, and the UE never received it.
+`release_and_reject` is the single exit for every rejection after allocation.
+
+## Verification
+
+| claim | how it was made to fail | result |
+|---|---|---|
+| the SGW-C relays a CSR to the PGW | suppress the `send_request` | **fails** |
+| the PAA comes from the PGW's response | write `None` instead | **fails** |
+| no configured PGW is refused, not answered | fall back to a bogus peer | **fails** |
+| mmed's CSR carries Serving Network | delete the `add_ie` | **fails** |
+| sgwcd relays Serving Network | short-circuit the relay | **fails** |
+| sgwcd retains the MME's ULI | store `None` | **fails** |
+| smfd allocates the PAA rather than echoing | use the request's PAA | **fails** |
+| smfd echoes the request's sequence number | drop the assignment | **fails** |
+
+Eight reverts, eight bites.
+
+**Three of my own mistakes are worth recording**, because each was caught by a different
+instrument:
+
+- The first `with_sequence_number` patched three octets at a fixed offset that is only
+  right when the TEID-present flag is set. The response went out with sequence 0 and the
+  test caught it; it now decodes, sets the header, and re-encodes.
+- I set the process-global PGW peer **before** taking the guard that serialises sgwcd's
+  ambient configuration, which broke three existing tests — the unlocked-writer race #308
+  was about, reintroduced by me two issues later.
+- The smfd wire test was failing for several steps while I worked on sgwcd, and I lost
+  track of it. The **whole-workspace run** is what surfaced it again. A per-crate run I had
+  stopped reading would not have.
+
+Three existing sgwcd tests failed once the relay landed, because they asserted the old
+"answer from Sxa alone" behaviour — the defect pinned as the requirement, which this repo
+has recorded as systematic. They were given a stand-in anchor rather than reverted.
+
+Workspace **6352 passed / 0 failed** (was 6347), `clippy --workspace` 0, `fmt --check`
+clean. sgwcd 81 → 84 tests, smfd 464 → 466, mmed unchanged at 338.
+
+## Ceilings
+
+- **Criterion 9 is verified in two halves, not as one process.** sgwcd's chain is driven end
+  to end over real sockets against a **stand-in** anchor; smfd's PGW-C role is driven over
+  a real socket by its own test. The two are **not** run against each other, because both
+  are binaries with no lib target — the same ceiling #51 recorded for its criterion 3.
+  What bridges them is `the_relayed_s5c_request_carries_what_the_anchor_requires`, which
+  asserts sgwcd's relayed request carries the IE set smfd's handler requires. That guard is
+  load-bearing, not decorative: the first version of this change relayed neither Serving
+  Network nor ULI and the real anchor refused it.
+- **The EPC compose file is untouched.** `docker-compose-epc.yml` has no PGW-C service (its
+  own header comment says bridging EPC↔5GC via SMF+PGW-C is future work), so there is
+  nothing to point `SGWC_PGW_S5C` at. Adding that service is #303's stage, and a
+  half-wired compose would be worse than none.
+- **smfd's restart counter is not persisted.** mmed and sgwcd each persist theirs; smfd's is
+  a constant `1`, so a peer cannot detect an smfd restart. Inventing a third answer to the
+  same question inside this issue was the wrong place for it.
+- **Only Create Session is terminated by smfd.** Delete Session, Modify Bearer and the
+  PGW-initiated procedures answer `ServiceNotSupported` with a cause rather than being
+  dropped, so the SGW-C's transaction completes instead of expiring on T3 — but they are
+  not implemented. The handlers for them exist and remain unreached.
+- **The PGW-initiated relay toward the MME is written and not exercised.** Nothing in this
+  tree originates a Create/Update/Delete Bearer Request from the PGW, so
+  `forward_pgw_bearer_procedure_to_mme` has no test driving it. It is a correct
+  implementation in a place nothing reaches yet, and this spec says so rather than implying
+  coverage.
+- **`sess_find_by_teid` resolves the S5-C TEID only because `sess_add` derives it from the
+  SEID** (`context.rs:791-792`). True by construction, not by intent, and commented at the
+  call site.
+- **smfd serves IPv4 only**, because `ipv4_pool` is its only pool. An IPv6 or IPv4v6 request
+  now legitimately gets cause 18.
+- **No E2E.** The Docker jobs are `workflow_dispatch`-only and untouched.

--- a/src/bins/nextgcore-mmed/src/gtp_path.rs
+++ b/src/bins/nextgcore-mmed/src/gtp_path.rs
@@ -1293,6 +1293,11 @@ mod tests {
                 Gtp2IeType::BearerContext as u8,
                 "Bearer Contexts to be created",
             ),
+            // Added by #52: a conformant PGW answers ConditionalIeMissing for an E-UTRAN
+            // session without these, so the MME -> SGW-C -> PGW chain cannot complete
+            // while they are absent. Found by building the anchor, not by inspection.
+            (Gtp2IeType::ServingNetwork as u8, "Serving Network"),
+            (Gtp2IeType::Uli as u8, "User Location Information"),
         ] {
             assert!(
                 received.get_ie(ie_type, 0).is_some(),

--- a/src/bins/nextgcore-mmed/src/s11_build.rs
+++ b/src/bins/nextgcore-mmed/src/s11_build.rs
@@ -407,6 +407,21 @@ pub fn build_create_session_request(
         Gtp2ApnIe::from_string(&sess.apn).encode(buf, 0)
     })?);
 
+    // Serving Network (C, TS 29.274 §8.18) and ULI (C, §8.21).
+    //
+    // Added by #52, not #51: #51's criteria named only the Sender F-TEID and the Bearer
+    // Contexts, and these two were listed in that issue's PROSE. Building the anchor
+    // (smfd's PGW-C role) is what showed they are load-bearing — a conformant PGW
+    // answers `ConditionalIeMissing` for an E-UTRAN session without them, so the
+    // MME→SGW-C→PGW chain cannot complete while they are absent, however conformant the
+    // first hop looks on its own.
+    msg.add_ie(Gtp2Ie::from_slice(
+        Gtp2IeType::ServingNetwork as u8,
+        0,
+        &encode_plmn_bcd(&mme_ue.tai.plmn_id),
+    ));
+    msg.add_ie(uli_ie(mme_ue)?);
+
     // Selection Mode (C)
     msg.add_ie(typed_ie(|buf| Gtp2SelectionModeIe::new(0).encode(buf, 0))?);
 

--- a/src/bins/nextgcore-sgwcd/src/context.rs
+++ b/src/bins/nextgcore-sgwcd/src/context.rs
@@ -237,6 +237,11 @@ pub struct SgwcSess {
     pub pfcp_node_id: Option<u64>,
     /// Parent UE ID
     pub sgwc_ue_id: u64,
+    /// Serving Network (TS 29.274 §8.18) from the MME's Create Session Request, held so
+    /// the S5/S8 leg can relay it (#52). A conformant PGW requires it for E-UTRAN.
+    pub serving_network: Option<Vec<u8>>,
+    /// User Location Information (§8.21), likewise relayed rather than re-derived.
+    pub uli: Option<Vec<u8>>,
 }
 
 impl SgwcSess {
@@ -256,6 +261,8 @@ impl SgwcSess {
             gnode_id: None,
             pfcp_node_id: None,
             sgwc_ue_id,
+            serving_network: None,
+            uli: None,
         }
     }
 
@@ -448,6 +455,10 @@ pub struct SgwcContext {
     far_id_generator: AtomicU64,
     /// Local S11/S5-C control-plane IPv4 address
     s11_addr: RwLock<Option<Ipv4Addr>>,
+    /// Local S5-C control-plane address (#52 criterion 6). Distinct from `s11_addr`.
+    s5c_addr: RwLock<Option<Ipv4Addr>>,
+    /// The PGW's S5/S8-C peer (#52).
+    pgw_s5c_peer: RwLock<Option<std::net::SocketAddr>>,
     /// Advertised SGW-U GTP-U IPv4 address (user-plane endpoints)
     gtpu_addr: RwLock<Option<Ipv4Addr>>,
 
@@ -486,6 +497,8 @@ impl SgwcContext {
             pdr_id_generator: AtomicUsize::new(1),
             far_id_generator: AtomicU64::new(1),
             s11_addr: RwLock::new(None),
+            s5c_addr: RwLock::new(None),
+            pgw_s5c_peer: RwLock::new(None),
             gtpu_addr: RwLock::new(None),
             max_num_of_ue: 0,
             max_num_of_sess: 0,
@@ -570,9 +583,49 @@ impl SgwcContext {
         }
     }
 
-    /// Local S11/S5-C control-plane address
+    /// Local S11 control-plane address
     pub fn s11_address(&self) -> Option<Ipv4Addr> {
         self.s11_addr.read().ok().and_then(|a| *a)
+    }
+
+    /// Set the local S5-C control-plane address (#52 criterion 6).
+    pub fn set_s5c_address(&self, addr: Option<Ipv4Addr>) {
+        if let Ok(mut a) = self.s5c_addr.write() {
+            *a = addr;
+        }
+    }
+
+    /// Local S5-C control-plane address, for the Sender F-TEID of an S5/S8 request.
+    ///
+    /// `build_s5c_create_session_request` reused `s11_address()` before #52, which its
+    /// own comment flagged: the S11 and S5/S8 interfaces are different reference points
+    /// and a deployment may well address them separately. Falls back to the S11 address
+    /// when none is configured — the single-address deployment the shipped compose file
+    /// describes — rather than refusing to build, but the fallback is now a stated
+    /// decision instead of a hardcoded reuse.
+    pub fn s5c_address(&self) -> Option<Ipv4Addr> {
+        self.s5c_addr
+            .read()
+            .ok()
+            .and_then(|a| *a)
+            .or_else(|| self.s11_address())
+    }
+
+    /// Set the PGW's S5/S8-C peer address (#52).
+    pub fn set_pgw_s5c_peer(&self, peer: Option<std::net::SocketAddr>) {
+        if let Ok(mut p) = self.pgw_s5c_peer.write() {
+            *p = peer;
+        }
+    }
+
+    /// The PGW this SGW-C relays Create Session Requests to.
+    ///
+    /// `None` means no PGW is configured, and the SGW-C then refuses the S11 request
+    /// rather than answering it locally — which is the defect #52 exists to fix. There
+    /// is no PGW SELECTION function here: TS 23.401 §4.3.8.1 selects by APN via DNS,
+    /// which this tree does not implement, so one configured peer is the honest model.
+    pub fn pgw_s5c_peer(&self) -> Option<std::net::SocketAddr> {
+        self.pgw_s5c_peer.read().ok().and_then(|p| *p)
     }
 
     /// Set the advertised SGW-U GTP-U address

--- a/src/bins/nextgcore-sgwcd/src/gtp_path.rs
+++ b/src/bins/nextgcore-sgwcd/src/gtp_path.rs
@@ -15,7 +15,9 @@ use std::time::{Duration, Instant};
 use bytes::Bytes;
 
 use nextgcore_gtp::v2::header::Gtp2MessageType;
-use nextgcore_gtp::v2::ie::{Gtp2IeType, Gtp2RecoveryIe};
+use nextgcore_gtp::v2::ie::{
+    Gtp2BearerContextIe, Gtp2FTeidIe, Gtp2IeType, Gtp2PaaIe, Gtp2RecoveryIe,
+};
 use nextgcore_gtp::v2::message::Gtp2Message;
 use nextgcore_gtp::v2::xact::{Gtp2XactConfig, Gtp2XactMgr};
 
@@ -435,6 +437,39 @@ pub fn gtp_open() -> Result<(), String> {
             .or(advertised),
     );
 
+    // ---- S5/S8 (#52) ----
+    //
+    // The dedicated S5-C address (criterion 6). Unset means "same address as S11",
+    // which is what the shipped compose file describes; the accessor's fallback makes
+    // that explicit rather than reusing `s11_address()` inside the builder.
+    ctx.set_s5c_address(
+        std::env::var("SGWC_S5C_ADVERTISE")
+            .ok()
+            .and_then(|v| v.parse::<Ipv4Addr>().ok()),
+    );
+
+    // The PGW this SGW-C anchors sessions at. Unset means the S5/S8 leg cannot be
+    // relayed, and the SGW-C then REFUSES an S11 Create Session Request rather than
+    // answering it from local state — the behaviour #52 exists to remove. Env-configured
+    // like every other address this daemon takes.
+    let pgw_peer = std::env::var("SGWC_PGW_S5C").ok().and_then(|v| {
+        // A bare address means the fixed GTPv2-C port (TS 29.274 §4.1).
+        v.parse::<std::net::SocketAddr>().ok().or_else(|| {
+            v.parse::<Ipv4Addr>()
+                .ok()
+                .map(|ip| std::net::SocketAddr::from((ip, 2123)))
+        })
+    });
+    match pgw_peer {
+        Some(peer) => log::info!("S5/S8 PGW peer: {peer}"),
+        None => log::warn!(
+            "no SGWC_PGW_S5C configured: the S5/S8 leg is unavailable, so a Create Session \
+             Request will be REFUSED rather than answered from local state (TS 29.274 §7.2.1 \
+             requires the SGW to relay it to a PGW)"
+        ),
+    }
+    ctx.set_pgw_s5c_peer(pgw_peer);
+
     set_s11_server(server);
     Ok(())
 }
@@ -735,9 +770,93 @@ fn handle_datagram(inner: &Arc<GtpcInner>, data: &[u8], peer: SocketAddr) {
         {
             dispatch_bearer_response(inner, &msg, peer, data);
         }
+        // ---- S5/S8 (#52) ----
+        //
+        // The PGW's answer to our Create Session Request. This arm is what wires
+        // `s5c_handler` into the receive path at last: it had no production caller, so
+        // no PGW response could ever be acted on.
+        t if t == T::CreateSessionResponse as u8 => {
+            dispatch_s5c_create_session_response(&msg, peer);
+        }
+        // PGW-INITIATED bearer procedures (TS 29.274 §7.2.3, §7.2.15, §7.2.9.2).
+        // Forwarded to the MME, which is the node that owns the UE's NAS session.
+        // `SgwcFsm::handle_s5c_message` was a log-only stub, so these could never be
+        // originated or relayed.
+        t if t == T::CreateBearerRequest as u8
+            || t == T::UpdateBearerRequest as u8
+            || t == T::DeleteBearerRequest as u8 =>
+        {
+            forward_pgw_bearer_procedure_to_mme(inner, &msg, peer, data);
+        }
         other => {
             log::error!("[DROP] Unhandled GTPv2-C message type {other} from {peer}");
         }
+    }
+}
+
+/// Relay a PGW-initiated bearer procedure to the MME (#52 criterion 7).
+///
+/// TS 23.401 §5.4.1/§5.4.2/§5.4.4: the SGW relays the PGW's Create/Update/Delete Bearer
+/// Request to the MME on S11 and relays the MME's response back. The SGW-C is a relay
+/// here, not an endpoint — it re-addresses the message to the MME's S11 TEID and keeps
+/// the PGW's own content, because the bearer parameters are the PGW's decision.
+///
+/// The MME's response comes back through `dispatch_bearer_response`, which already
+/// existed. What was missing was this direction: `SgwcFsm::handle_s5c_message` logged and
+/// returned, so a PGW-initiated procedure died at the SGW-C.
+fn forward_pgw_bearer_procedure_to_mme(
+    inner: &Arc<GtpcInner>,
+    msg: &Gtp2Message,
+    peer: SocketAddr,
+    data: &[u8],
+) {
+    let ctx = sgwc_self();
+    let msg_type = msg.header.message_type;
+
+    // The session this procedure belongs to, by the local S5-C TEID the PGW addressed.
+    let local_teid = msg.header.teid.unwrap_or(0);
+    // `sess_find_by_teid` resolves by the SXA SEID, and that works here because
+    // `sess_add` assigns `sgw_s5c_teid = seid as u32` from the same value
+    // (`context.rs:791-792`) — the S5-C TEID IS the low 32 bits of the SEID. Stated
+    // because it is true by construction rather than by intent: an allocator that
+    // stopped deriving one from the other would break this lookup silently.
+    let Some(sess) = ctx.sess_find_by_teid(local_teid) else {
+        log::warn!(
+            "S5/S8 message type {msg_type} from {peer} for local S5-C TEID {local_teid:#x} \
+             matches no session; cannot relay it to any MME"
+        );
+        return;
+    };
+    let Some(ue) = ctx.ue_find_by_id(sess.sgwc_ue_id) else {
+        log::warn!("S5/S8 message type {msg_type} from {peer}: the session has no UE context");
+        return;
+    };
+    let Some(mme_peer) = ue.mme_addr else {
+        log::warn!(
+            "S5/S8 message type {msg_type} from {peer}: no MME address recorded for this UE, so \
+             the procedure cannot be relayed"
+        );
+        return;
+    };
+
+    // Re-address to the MME: its S11 TEID, and a sequence number from THIS node's
+    // transaction space, because the SGW-C is the initiator on the S11 leg.
+    let mut relayed = msg.clone();
+    relayed.header.teid = Some(ue.mme_s11_teid);
+    let server = GtpcServer {
+        inner: inner.clone(),
+    };
+    let seq = server.alloc_sequence();
+    relayed.header.sequence_number = seq;
+
+    log::info!(
+        "Relaying PGW-initiated S5/S8 message type {msg_type} from {peer} to MME {mme_peer} \
+         (S11 TEID {:#x}, seq {seq})",
+        ue.mme_s11_teid
+    );
+    let _ = data;
+    if let Err(e) = server.send_request(mme_peer, &relayed, sess.id) {
+        log::error!("Relay of S5/S8 message type {msg_type} to MME {mme_peer} failed: {e}");
     }
 }
 
@@ -1028,15 +1147,30 @@ fn dispatch_create_session_request(server: &GtpcServer, msg: &Gtp2Message, peer:
     if let Some(pdn_type) = parsed.pdn_type {
         sess.paa.pdn_type = pdn_type;
     }
-    if let Some(ref paa) = parsed.paa {
-        sess.paa.pdn_type = paa.pdn_type;
-        sess.paa.ipv4_addr = paa.ipv4_addr.map(Ipv4Addr::from);
-        sess.paa.ipv6_addr = paa.ipv6_addr.map(std::net::Ipv6Addr::from);
+    // #52 criterion 5: the MME's PAA is NOT copied onto the session.
+    //
+    // TS 23.401 §5.3.2.1 makes PDN address allocation a PGW function. Copying the MME's
+    // proposal here is what made the SGW-C look like it had allocated something: the UE
+    // received back the address it had asked about, with no node in the deployment
+    // having allocated anything. The session's PAA is now written only in
+    // `dispatch_s5c_create_session_response`, from the PGW's answer.
+    //
+    // The requested PDN TYPE above is kept, because it is the UE's request and the PGW
+    // may answer with a different one (causes 18/19 exist for exactly that).
+    if parsed.paa.is_some() {
+        log::debug!(
+            "Create Session Request carries a PAA; it is a REQUEST and is not applied — the PGW \
+             allocates the PDN address (TS 23.401 §5.3.2.1)"
+        );
     }
     if let Some(ref ambr) = parsed.ambr {
         sess.ambr_ul = ambr.uplink;
         sess.ambr_dl = ambr.downlink;
     }
+    // Held for the S5/S8 relay (#52): the PGW needs both for an E-UTRAN session, and the
+    // SGW-C is the only node that has them.
+    sess.serving_network = parsed.serving_network.clone();
+    sess.uli = parsed.uli.clone();
     ctx.sess_update(&sess);
 
     // Bearer QoS + user-plane endpoint allocation
@@ -1103,29 +1237,204 @@ fn dispatch_create_session_request(server: &GtpcServer, msg: &Gtp2Message, peer:
     // hard-coded REQUEST_ACCEPTED -- before the request had even left, since the transport
     // discarded it -- so the MME was told a bearer existed whose user plane might not.
     let sess = ctx.sess_find_by_id(sess.id).unwrap_or(sess);
-    if let Err(e) = pfcp_path::send_session_establishment_request(
-        &sess,
-        seq as u64,
-        None,
-        0,
-        pfcp_path::S11Continuation::CreateSession {
-            peer,
-            seq,
-            teid: ue.mme_s11_teid,
-        },
-    ) {
-        // The request could not even be queued (no transport running): that IS a local
-        // failure, and the MME is answered now rather than waiting for a response that
-        // will never come.
-        log::error!("PFCP Session Establishment failed: {e}");
+    let continuation = pfcp_path::S11Continuation::CreateSession {
+        peer,
+        seq,
+        teid: ue.mme_s11_teid,
+    };
+
+    // TS 29.274 §7.2.1: "The Create Session Request message shall be sent on the S11
+    // interface by the MME to the SGW, AND ON THE S5/S8 INTERFACE BY THE SGW TO THE
+    // PGW." Both legs are mandatory. This used to skip the second one entirely and
+    // answer the MME from local state, so no node in the deployment allocated a PDN
+    // address and there was no anchor gateway (#52).
+    //
+    // The order is §5.3.2.1's: relay to the PGW FIRST, because the PGW's response
+    // carries the PAA and the PGW-U F-TEID that the SGW-U's Sxa session needs. The Sxa
+    // establishment therefore moves into `s5c_create_session_response`, and the S11
+    // answer stays gated on it exactly as #54 left it.
+    let Some(pgw_peer) = ctx.pgw_s5c_peer() else {
+        // No PGW configured. Refusing is the honest answer: answering locally is the
+        // defect, and TS 29.274 §8.4's cause 72 says which peer is missing.
+        log::error!(
+            "Create Session Request from {peer}: no PGW S5/S8 peer configured, so this session \
+             cannot be anchored; refusing rather than answering from local state"
+        );
         send_cause_response(
             server,
             peer,
             Gtp2MessageType::CreateSessionResponse,
             ue.mme_s11_teid,
             seq,
-            sxa_handler::gtp_cause_from_pfcp(sxa_handler::pfcp_cause::SYSTEM_FAILURE),
+            gtp_cause::REMOTE_PEER_NOT_RESPONDING,
         );
+        return;
+    };
+
+    let s5c_seq = server.alloc_sequence();
+    let msg = match s11_build::build_s5c_create_session_request(&sess, s5c_seq) {
+        Ok(msg) => msg,
+        Err(e) => {
+            log::error!("Create Session Request: cannot build the S5/S8 leg: {e}");
+            send_cause_response(
+                server,
+                peer,
+                Gtp2MessageType::CreateSessionResponse,
+                ue.mme_s11_teid,
+                seq,
+                gtp_cause::SYSTEM_FAILURE,
+            );
+            return;
+        }
+    };
+
+    // Record what the PGW's answer has to continue, before the request goes out: a
+    // response that arrives before the record exists would be uncorrelated and dropped.
+    register_pending_s5c(s5c_seq, sess.id, continuation);
+
+    if let Err(e) = server.send_request(pgw_peer, &msg, sess.id) {
+        log::error!("S5/S8 Create Session Request to {pgw_peer} failed: {e}");
+        take_pending_s5c(s5c_seq);
+        send_cause_response(
+            server,
+            peer,
+            Gtp2MessageType::CreateSessionResponse,
+            ue.mme_s11_teid,
+            seq,
+            gtp_cause::REMOTE_PEER_NOT_RESPONDING,
+        );
+    }
+}
+
+/// What an S5/S8 Create Session Response has to continue (#52).
+///
+/// Keyed by the S5-C sequence number, which is what correlates the PGW's answer to the
+/// request. The S11 continuation rides along untouched, so the MME's answer is still
+/// produced by #54's `sxa_response` path once the SGW-U has confirmed — this stage is
+/// inserted BEFORE that one rather than replacing it.
+static PENDING_S5C: std::sync::Mutex<
+    Option<std::collections::HashMap<u32, (u64, pfcp_path::S11Continuation)>>,
+> = std::sync::Mutex::new(None);
+
+fn register_pending_s5c(seq: u32, sess_id: u64, continuation: pfcp_path::S11Continuation) {
+    if let Ok(mut map) = PENDING_S5C.lock() {
+        map.get_or_insert_with(std::collections::HashMap::new)
+            .insert(seq, (sess_id, continuation));
+    }
+}
+
+fn take_pending_s5c(seq: u32) -> Option<(u64, pfcp_path::S11Continuation)> {
+    PENDING_S5C
+        .lock()
+        .ok()
+        .and_then(|mut map| map.as_mut().and_then(|m| m.remove(&seq)))
+}
+
+/// The PGW answered our S5/S8 Create Session Request (#52 criteria 5 and 7).
+///
+/// This is where the SGW-C stops inventing an answer. The PAA, the PGW's control and
+/// user-plane F-TEIDs and the APN-Restriction are written onto the session from the
+/// PGW's response, and only then is the SGW-U provisioned — so the S11 response #54
+/// builds from that session carries the PGW's values rather than the MME's own PAA
+/// echoed back.
+fn dispatch_s5c_create_session_response(msg: &Gtp2Message, peer: SocketAddr) {
+    let seq = msg.header.sequence_number;
+    let Some((sess_id, continuation)) = take_pending_s5c(seq) else {
+        log::warn!(
+            "S5/S8 Create Session Response from {peer} (seq={seq}) matches no pending request; \
+             dropping rather than acting on a datagram this SGW-C did not ask for"
+        );
+        return;
+    };
+
+    let ctx = sgwc_self();
+    let cause = msg
+        .get_ie(Gtp2IeType::Cause as u8, 0)
+        .and_then(|ie| ie.value.first().copied())
+        .unwrap_or(gtp_cause::SYSTEM_FAILURE);
+
+    // The PGW's control-plane F-TEID is at instance 1 (TS 29.274 Table 7.2.2-1); the
+    // SGW's own echo is at instance 0.
+    let pgw_c = msg
+        .get_ie(Gtp2IeType::FTeid as u8, 1)
+        .and_then(|ie| Gtp2FTeidIe::decode(&ie.value).ok());
+    // The PGW-U endpoint lives in the Bearer Context at instance 2.
+    let pgw_u = msg
+        .get_ie(Gtp2IeType::BearerContext as u8, 0)
+        .and_then(|ie| Gtp2BearerContextIe::decode(&ie.value).ok())
+        .and_then(|bc| bc.fteid(2).ok().flatten());
+
+    // ---- criterion 5: the SGW-C stops inventing the answer ----
+    //
+    // The PAA, the PGW's control address and the APN-Restriction come from the PGW's
+    // response and are written onto the session, which is what #54's `sxa_response`
+    // builds the S11 Create Session Response from. Before #52 the PAA was COPIED from
+    // the MME's request (`parsed.paa` into `sess.paa`), so the UE was handed back the
+    // address it had asked about with no node having allocated anything.
+    if let Some(paa) = msg
+        .get_ie(Gtp2IeType::Paa as u8, 0)
+        .and_then(|ie| Gtp2PaaIe::decode(&ie.value).ok())
+    {
+        if let Some(mut sess) = ctx.sess_find_by_id(sess_id) {
+            sess.paa.pdn_type = paa.pdn_type;
+            sess.paa.ipv4_addr = paa.ipv4_addr.map(std::net::Ipv4Addr::from);
+            sess.paa.ipv6_addr = paa.ipv6_addr.map(std::net::Ipv6Addr::from);
+            if let Some(ft) = pgw_c.as_ref() {
+                sess.pgw_addr = ft.ipv4_addr.map(std::net::Ipv4Addr::from);
+            }
+            ctx.sess_update(&sess);
+            log::info!(
+                "S5/S8 Create Session Response from {peer}: PGW allocated PAA {:?} (pdn_type={})",
+                sess.paa.ipv4_addr,
+                sess.paa.pdn_type
+            );
+        }
+    } else if cause == gtp_cause::REQUEST_ACCEPTED {
+        // An accepted response with no PAA is a PGW that claims success and allocated
+        // nothing. Answering the MME from local state here is exactly the defect.
+        log::error!(
+            "S5/S8 Create Session Response from {peer} was accepted but carries NO PAA: the \
+             session has no PDN address and cannot be completed"
+        );
+        crate::sxa_response::fail_with_cause(continuation, gtp_cause::MANDATORY_IE_MISSING);
+        return;
+    }
+
+    let existing = ctx.sess_find_by_id(sess_id);
+    match crate::s5c_handler::handle_create_session_response(
+        existing.as_ref(),
+        0,
+        &[],
+        cause,
+        pgw_c.map(|ft| ft.teid).unwrap_or(0),
+        pgw_u.map(|ft| ft.teid).unwrap_or(0),
+    ) {
+        crate::s5c_handler::HandlerResult::Error(cause) => {
+            log::error!(
+                "S5/S8 Create Session Response from {peer} REJECTED the session: cause {cause}"
+            );
+            // The PGW refused, so there is no anchor and no user plane to provision. The
+            // MME gets the PGW's own cause rather than a local guess.
+            crate::sxa_response::fail_with_cause(continuation, cause);
+            return;
+        }
+        other => log::debug!("S5/S8 Create Session Response handled: {other:?}"),
+    }
+
+    let Some(sess) = ctx.sess_find_by_id(sess_id) else {
+        log::error!("S5/S8 Create Session Response for session {sess_id}, which is gone");
+        crate::sxa_response::fail(
+            continuation,
+            "the session was removed while the PGW answered",
+        );
+        return;
+    };
+
+    // Now the SGW-U can be provisioned: it has a PGW-U endpoint to tunnel to.
+    if let Err(e) =
+        pfcp_path::send_session_establishment_request(&sess, seq as u64, None, 0, continuation)
+    {
+        log::error!("PFCP Session Establishment failed after the PGW answered: {e}");
     }
 }
 
@@ -1509,20 +1818,70 @@ fn dispatch_bearer_resource_command(server: &GtpcServer, msg: &Gtp2Message, peer
     let result =
         s11_handler::handle_bearer_resource_command(ue.as_ref(), seq as u64, &[], linked_ebi);
 
-    let teid = ue.map(|u| u.mme_s11_teid).unwrap_or(0);
+    let teid = ue.as_ref().map(|u| u.mme_s11_teid).unwrap_or(0);
     match result {
         HandlerResult::ForwardToPgw => {
-            // S5-C forwarding toward a live PGW peer is not wired yet; the
-            // spec triggered message on failure is the Bearer Resource
-            // Failure Indication (TS 29.274 Section 7.2.6)
-            send_cause_response(
-                server,
-                peer,
-                Gtp2MessageType::BearerResourceFailureIndication,
-                teid,
-                seq,
-                gtp_cause::SERVICE_NOT_SUPPORTED,
-            );
+            // #52 criterion 7: forwarded to the PGW instead of refused.
+            //
+            // TS 29.274 §7.2.5: the Bearer Resource Command is relayed by the SGW to the
+            // PGW, which decides. `SERVICE_NOT_SUPPORTED` was the honest answer while no
+            // PGW peer existed — it is no longer, and answering it now would refuse a
+            // procedure this node can carry.
+            let ctx = sgwc_self();
+            match ctx.pgw_s5c_peer() {
+                Some(pgw_peer) => {
+                    let mut relayed = msg.clone();
+                    // Re-addressed to the PGW's control TEID and this node's own
+                    // sequence space, because the SGW-C is the initiator on the S5-C leg.
+                    // The linked bearer names the PDN connection, so the session it
+                    // belongs to is the one whose PGW TEID this command must be
+                    // addressed to. First-of-list would pick the wrong PDN for a
+                    // multi-PDN UE.
+                    let pgw_teid = ue
+                        .as_ref()
+                        .and_then(|u| {
+                            ctx.sess_list_for_ue(u.id).into_iter().find(|s| {
+                                ctx.default_bearer_in_sess(s.id)
+                                    .is_some_and(|b| b.ebi == linked_ebi)
+                            })
+                        })
+                        .map(|s| s.pgw_s5c_teid)
+                        .unwrap_or(0);
+                    relayed.header.teid = Some(pgw_teid);
+                    let s5c_seq = server.alloc_sequence();
+                    relayed.header.sequence_number = s5c_seq;
+                    log::info!(
+                        "Relaying Bearer Resource Command to PGW {pgw_peer} (S5-C TEID \
+                         {pgw_teid:#x}, seq {s5c_seq})"
+                    );
+                    if let Err(e) = server.send_request(pgw_peer, &relayed, 0) {
+                        log::error!("Bearer Resource Command relay to {pgw_peer} failed: {e}");
+                        send_cause_response(
+                            server,
+                            peer,
+                            Gtp2MessageType::BearerResourceFailureIndication,
+                            teid,
+                            seq,
+                            gtp_cause::REMOTE_PEER_NOT_RESPONDING,
+                        );
+                    }
+                }
+                None => {
+                    // Still the honest answer when there is no anchor to ask.
+                    log::info!(
+                        "Bearer Resource Command cannot be forwarded: no PGW S5/S8 peer \
+                         configured"
+                    );
+                    send_cause_response(
+                        server,
+                        peer,
+                        Gtp2MessageType::BearerResourceFailureIndication,
+                        teid,
+                        seq,
+                        gtp_cause::SERVICE_NOT_SUPPORTED,
+                    );
+                }
+            }
         }
         HandlerResult::Error(cause) => {
             send_cause_response(
@@ -1655,6 +2014,20 @@ mod tests {
         ));
         msg.add_ie(Gtp2Ie::from_slice(Gtp2IeType::Imsi as u8, 0, imsi));
         msg.add_ie(Gtp2Ie::from_slice(Gtp2IeType::RatType as u8, 0, &[6]));
+        // A real MME sends both (TS 29.274 Table 7.2.1-1), and the PGW requires them for
+        // an E-UTRAN session, so the fixture sends what the wire actually carries.
+        msg.add_ie(Gtp2Ie::from_slice(
+            Gtp2IeType::ServingNetwork as u8,
+            0,
+            &[0x99, 0xf9, 0x07],
+        ));
+        msg.add_ie(Gtp2Ie::from_slice(
+            Gtp2IeType::Uli as u8,
+            0,
+            &[
+                0x18, 0x99, 0xf9, 0x07, 0x00, 0x01, 0x99, 0xf9, 0x07, 0x00, 0x00, 0x00, 0x01,
+            ],
+        ));
         msg.add_ie(Gtp2FTeidIe::new_ipv4(10, 0xAA01, [127, 0, 0, 1]).to_ie(0));
         msg.add_ie(Gtp2Ie::from_slice(
             Gtp2IeType::Apn as u8,
@@ -1871,6 +2244,268 @@ mod tests {
         .flatten()
     }
 
+    /// A stand-in PGW that answers an S5/S8 Create Session Request with an ALLOCATED
+    /// PDN address and its own F-TEIDs (#52).
+    ///
+    /// This is what makes the chain testable end to end through the SGW-C: S11 in,
+    /// S5/S8 out, S5/S8 in, Sxa out, Sxa in, S11 out. The address it returns is
+    /// deliberately DIFFERENT from anything the MME asks about, so a test can prove the
+    /// PAA the MME receives came from the anchor rather than from its own request.
+    struct StandInPgw {
+        addr: SocketAddr,
+        /// Message types received, in order.
+        seen: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    }
+
+    /// The address this stand-in allocates. Not in 10.45.0.0/16 and not anything a test
+    /// asks for, so its presence in the S11 response can only have come from here.
+    const PGW_ALLOCATED_ADDR: [u8; 4] = [10, 77, 3, 9];
+
+    async fn stand_in_pgw() -> StandInPgw {
+        let sock = std::sync::Arc::new(
+            tokio::net::UdpSocket::bind("127.0.0.1:0")
+                .await
+                .expect("bind stand-in PGW"),
+        );
+        let addr = sock.local_addr().unwrap();
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorded = seen.clone();
+        let handle = sock.clone();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 8192];
+            loop {
+                let Ok((len, from)) = handle.recv_from(&mut buf).await else {
+                    return;
+                };
+                let mut bytes = Bytes::copy_from_slice(&buf[..len]);
+                let Ok(msg) = Gtp2Message::decode(&mut bytes) else {
+                    continue;
+                };
+                recorded
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(msg.header.message_type);
+                if msg.header.message_type != Gtp2MessageType::CreateSessionRequest as u8 {
+                    continue;
+                }
+
+                // Answer as a PGW does: Cause, its own control F-TEID at instance 1, the
+                // ALLOCATED PAA, and a Bearer Context carrying the PGW-U endpoint.
+                let mut resp = Gtp2Message::new(nextgcore_gtp::v2::Gtp2Header::new(
+                    Gtp2MessageType::CreateSessionResponse as u8,
+                    // Addressed to the SGW's own control TEID, which the request's
+                    // Sender F-TEID named.
+                    msg.get_ie(Gtp2IeType::FTeid as u8, 0)
+                        .and_then(|ie| Gtp2FTeidIe::decode(&ie.value).ok())
+                        .map(|ft| ft.teid)
+                        .unwrap_or(0),
+                    msg.header.sequence_number,
+                ));
+                let mut cause_buf = bytes::BytesMut::new();
+                nextgcore_gtp::v2::Gtp2CauseIe::new(gtp_cause::REQUEST_ACCEPTED)
+                    .encode(&mut cause_buf, 0);
+                let mut c = cause_buf.freeze();
+                if let Ok(ie) = nextgcore_gtp::v2::ie::Gtp2Ie::decode(&mut c) {
+                    resp.add_ie(ie);
+                }
+                resp.add_ie(Gtp2FTeidIe::new_ipv4(7, 0x0BEE_F001, [127, 0, 0, 1]).to_ie(1));
+                resp.add_ie(Gtp2PaaIe::ipv4(PGW_ALLOCATED_ADDR).to_ie(0));
+                let mut bc = Gtp2BearerContextIe::new();
+                bc.set_ebi(5);
+                bc.set_fteid(2, &Gtp2FTeidIe::new_ipv4(6, 0x0BEE_F002, [127, 0, 0, 1]));
+                resp.add_bearer_context(0, &bc);
+
+                let _ = handle.send_to(&resp.encode(), from).await;
+            }
+        });
+        let _ = sock;
+        StandInPgw { addr, seen }
+    }
+
+    /// Point the SGW-C at a stand-in PGW. Returns it so the test can assert what it saw.
+    async fn with_stand_in_pgw() -> StandInPgw {
+        let pgw = stand_in_pgw().await;
+        sgwc_self().set_pgw_s5c_peer(Some(pgw.addr));
+        pgw
+    }
+
+    /// #52 criterion 9, the load-bearing assertion of the whole issue: the PDN Address
+    /// the MME receives was ALLOCATED BY THE PGW, not echoed from its own request.
+    ///
+    /// Drives the full chain through the SGW-C over real sockets — S11 in, S5/S8 out,
+    /// S5/S8 in, Sxa out, Sxa in, S11 out — and asserts the address in the S11 Create
+    /// Session Response is the stand-in PGW's, which no other node in the test knows.
+    /// Before #52 the SGW-C copied the MME's PAA onto the session and answered from local
+    /// state, so this assertion could not have held however the test was written.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_paa_the_mme_receives_is_allocated_by_the_pgw() {
+        let _sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::from_millis(0),
+        )
+        .await;
+        // Set AFTER `stand_in_sgwu`: that call takes the guard over this process's
+        // ambient SGW-C configuration, and setting the PGW peer before it is exactly the
+        // unlocked-writer race #308 was about.
+        let pgw = with_stand_in_pgw().await;
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        sock.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x52];
+
+        sock.send_to(&csr(0x5201, &imsi).encode(), server.local_addr())
+            .unwrap();
+
+        let response = recv_s11(&sock).await.expect("the response must arrive");
+        assert_eq!(
+            response.header.message_type,
+            Gtp2MessageType::CreateSessionResponse as u8
+        );
+        assert_eq!(
+            response
+                .get_ie(Gtp2IeType::Cause as u8, 0)
+                .and_then(|ie| ie.value.first().copied()),
+            Some(gtp_cause::REQUEST_ACCEPTED),
+            "the chain must complete"
+        );
+
+        // The PGW was actually asked. Before #52 the SGW-C never sent an S5/S8 message.
+        assert!(
+            pgw.seen
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains(&(Gtp2MessageType::CreateSessionRequest as u8)),
+            "the SGW-C must RELAY a Create Session Request to the PGW (TS 29.274 §7.2.1)"
+        );
+
+        // And the address the MME is given is the anchor's.
+        let paa = response
+            .get_ie(Gtp2IeType::Paa as u8, 0)
+            .and_then(|ie| Gtp2PaaIe::decode(&ie.value).ok())
+            .expect("the response must carry a PAA");
+        assert_eq!(
+            paa.ipv4_addr,
+            Some(PGW_ALLOCATED_ADDR),
+            "the PDN address must be the one the PGW allocated, not the MME's own echoed back"
+        );
+    }
+
+    /// #52: the relayed S5/S8 Create Session Request carries every IE the ANCHOR requires.
+    ///
+    /// Mirrors smfd's `handle_create_session_request` conditional-IE checks, which reject
+    /// with `ConditionalIeMissing` without Serving Network, ULI or PAA. This is the
+    /// cross-daemon parity check #51 needed too: `smfd` is a binary with no lib target, so
+    /// its validation cannot be called from here, and a mirrored list is the strongest
+    /// available guard. It is load-bearing rather than decorative — the first version of
+    /// this PR relayed NEITHER Serving Network nor ULI, and the real anchor refused it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_relayed_s5c_request_carries_what_the_anchor_requires() {
+        let _sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::from_millis(0),
+        )
+        .await;
+        let pgw = with_stand_in_pgw().await;
+        // A recording socket in place of the answering stand-in, so the REQUEST can be
+        // inspected rather than only its effect.
+        let recorder = std::sync::Arc::new(
+            tokio::net::UdpSocket::bind("127.0.0.1:0")
+                .await
+                .expect("bind recorder"),
+        );
+        sgwc_self().set_pgw_s5c_peer(Some(recorder.local_addr().unwrap()));
+        let _ = pgw;
+
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x51];
+        sock.send_to(&csr(0x5101, &imsi).encode(), server.local_addr())
+            .unwrap();
+
+        let mut buf = vec![0u8; 4096];
+        let (len, _) = tokio::time::timeout(Duration::from_secs(3), recorder.recv_from(&mut buf))
+            .await
+            .expect("the SGW-C must relay to the PGW")
+            .expect("recv");
+        let mut bytes = Bytes::copy_from_slice(&buf[..len]);
+        let relayed = Gtp2Message::decode(&mut bytes).expect("the relay must be decodable");
+
+        assert_eq!(
+            relayed.header.message_type,
+            Gtp2MessageType::CreateSessionRequest as u8
+        );
+        for (ie_type, name) in [
+            (Gtp2IeType::Imsi as u8, "IMSI"),
+            (Gtp2IeType::RatType as u8, "RAT Type"),
+            (Gtp2IeType::FTeid as u8, "Sender F-TEID"),
+            (Gtp2IeType::Apn as u8, "APN"),
+            (
+                Gtp2IeType::BearerContext as u8,
+                "Bearer Contexts to be created",
+            ),
+            (Gtp2IeType::ServingNetwork as u8, "Serving Network"),
+            (Gtp2IeType::Uli as u8, "User Location Information"),
+        ] {
+            assert!(
+                relayed.get_ie(ie_type, 0).is_some(),
+                "the anchor requires {name}: without it smfd answers ConditionalIeMissing"
+            );
+        }
+
+        // The Sender F-TEID names the S5/S8 SGW control interface, not S11.
+        let ft = Gtp2FTeidIe::decode(&relayed.get_ie(Gtp2IeType::FTeid as u8, 0).unwrap().value)
+            .expect("decode");
+        assert_eq!(
+            ft.interface_type,
+            s11_build::f_teid_interface::S5_S8_SGW_GTP_C,
+            "the S5/S8 leg must name the S5/S8 interface type"
+        );
+    }
+
+    /// With no PGW configured the SGW-C REFUSES rather than answering from local state.
+    ///
+    /// Answering locally is the defect #52 exists to fix, so the absence of an anchor has
+    /// to be visible to the MME instead of being papered over with a fabricated success.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_create_session_request_with_no_pgw_is_refused() {
+        let _sgwu = stand_in_sgwu(
+            crate::sxa_handler::pfcp_cause::REQUEST_ACCEPTED,
+            Duration::from_millis(0),
+        )
+        .await;
+        // Deliberately NO anchor, set under the same guard the stand-in SGW-U holds.
+        sgwc_self().set_pgw_s5c_peer(None);
+        let server = test_server(1000, 1);
+        set_s11_server(server.clone());
+        let sock = client();
+        sock.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let imsi = [0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x53];
+
+        sock.send_to(&csr(0x5301, &imsi).encode(), server.local_addr())
+            .unwrap();
+
+        let response = recv_s11(&sock)
+            .await
+            .expect("a refusal must still be answered");
+        assert_eq!(
+            response.header.message_type,
+            Gtp2MessageType::CreateSessionResponse as u8
+        );
+        assert_eq!(
+            response
+                .get_ie(Gtp2IeType::Cause as u8, 0)
+                .and_then(|ie| ie.value.first().copied()),
+            Some(gtp_cause::REMOTE_PEER_NOT_RESPONDING),
+            "no anchor must be reported, not fabricated as success"
+        );
+        assert!(
+            response.get_ie(Gtp2IeType::Paa as u8, 0).is_none(),
+            "a refused session must carry no PDN address"
+        );
+    }
+
     /// #54 criterion 6, first half: NO Create Session Response is sent until the PFCP
     /// Session Establishment Response arrives — and then it is the full accepted one.
     ///
@@ -1883,6 +2518,11 @@ mod tests {
             Duration::from_millis(400),
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         // The gated answer is sent through the PROCESS-GLOBAL S11 server (the Sxa response
         // path has no other handle), so this test's own server has to be the installed one.
@@ -1984,6 +2624,11 @@ mod tests {
             Duration::ZERO,
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         set_s11_server(server.clone());
         let sock = client();
@@ -2025,6 +2670,11 @@ mod tests {
             Duration::ZERO,
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         set_s11_server(server.clone());
         let sock = client();
@@ -2087,6 +2737,11 @@ mod tests {
             Duration::ZERO,
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         set_s11_server(server.clone());
         let sock = client();
@@ -2154,6 +2809,11 @@ mod tests {
             Duration::ZERO,
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         set_s11_server(server.clone());
         let sock = client();
@@ -2219,6 +2879,11 @@ mod tests {
             Duration::ZERO,
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         set_s11_server(server.clone());
         let sock = client();
@@ -2282,6 +2947,11 @@ mod tests {
             Duration::ZERO,
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         set_s11_server(server.clone());
         let sock = client();
@@ -2403,6 +3073,11 @@ mod tests {
             Duration::ZERO,
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         set_s11_server(server.clone());
         let sock = client();
@@ -2435,6 +3110,11 @@ mod tests {
             Duration::ZERO,
         )
         .await;
+        // #52: the S11 Create Session Request is now RELAYED to a PGW, so the chain
+        // needs an anchor. Set AFTER `stand_in_sgwu`, because that call is what takes the
+        // guard over this process's ambient SGW-C configuration — setting the PGW peer
+        // before it is exactly the unlocked-writer race #308 was about.
+        let _pgw = with_stand_in_pgw().await;
         let server = test_server(1000, 1);
         set_s11_server(server.clone());
         let sock = client();

--- a/src/bins/nextgcore-sgwcd/src/s11_build.rs
+++ b/src/bins/nextgcore-sgwcd/src/s11_build.rs
@@ -487,7 +487,12 @@ pub fn build_s5c_create_session_request(
         fteid(
             f_teid_interface::S5_S8_SGW_GTP_C,
             sess.sgw_s5c_teid,
-            ctx.s11_address(),
+            // #52 criterion 6: the S5-C address, not the S11 one. The two are different
+            // reference points and a deployment may address them separately; the
+            // accessor falls back to the S11 address for the single-address deployment
+            // the shipped compose file describes, so this is a stated decision rather
+            // than a hardcoded reuse.
+            ctx.s5c_address(),
             None,
         )?
         .to_ie(0),
@@ -499,6 +504,28 @@ pub fn build_s5c_create_session_request(
     Gtp2ApnIe::from_string(apn).encode(&mut apn_buf, 0);
     let mut b = apn_buf.freeze();
     msg.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::decode(&mut b).map_err(|e| e.to_string())?);
+
+    // Serving Network (C) and ULI (C), relayed from the MME's request (#52).
+    //
+    // A conformant PGW requires both for an E-UTRAN session — this tree's own smfd
+    // answers `ConditionalIeMissing` without them — so omitting them makes the relay
+    // refused by the anchor it exists to reach. They are relayed VERBATIM: their content
+    // is the MME's report of where the UE is, and re-deriving it here would be inventing
+    // it.
+    if let Some(ref sn) = sess.serving_network {
+        msg.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::from_slice(
+            Gtp2IeType::ServingNetwork as u8,
+            0,
+            sn,
+        ));
+    }
+    if let Some(ref uli) = sess.uli {
+        msg.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::from_slice(
+            Gtp2IeType::Uli as u8,
+            0,
+            uli,
+        ));
+    }
 
     // Selection Mode (C, instance 0)
     let mut sel_buf = bytes::BytesMut::new();

--- a/src/bins/nextgcore-sgwcd/src/s11_parse.rs
+++ b/src/bins/nextgcore-sgwcd/src/s11_parse.rs
@@ -74,6 +74,16 @@ pub struct ParsedCreateSessionRequest {
     pub paa: Option<Gtp2PaaIe>,
     pub ambr: Option<Gtp2AmbrIe>,
     pub indication: Option<Gtp2IndicationIe>,
+    /// Serving Network (TS 29.274 §8.18) and User Location Information (§8.21),
+    /// retained so they can be RELAYED on the S5/S8 leg (#52).
+    ///
+    /// Neither was parsed before #52, because nothing relayed anything: the SGW-C
+    /// answered the MME locally. A conformant PGW requires both for an E-UTRAN session —
+    /// this tree's own smfd rejects a Create Session Request without them with
+    /// `ConditionalIeMissing` — so a relay that dropped them would be refused by the very
+    /// anchor it was built to reach. Found by building the anchor, not by inspection.
+    pub serving_network: Option<Vec<u8>>,
+    pub uli: Option<Vec<u8>>,
 }
 
 pub fn parse_create_session_request(
@@ -92,6 +102,14 @@ pub fn parse_create_session_request(
         .value
         .first()
         .ok_or_else(|| IeError::incorrect_mandatory(Gtp2IeType::RatType))?;
+
+    // Serving Network and ULI: relayed verbatim on the S5/S8 leg (#52).
+    let serving_network = msg
+        .get_ie(Gtp2IeType::ServingNetwork as u8, 0)
+        .map(|ie| ie.value.to_vec());
+    let uli = msg
+        .get_ie(Gtp2IeType::Uli as u8, 0)
+        .map(|ie| ie.value.to_vec());
 
     // Sender F-TEID for control plane (M)
     let fteid_ie = require(msg, Gtp2IeType::FTeid, 0)?;
@@ -144,6 +162,8 @@ pub fn parse_create_session_request(
         paa,
         ambr,
         indication,
+        serving_network,
+        uli,
     })
 }
 

--- a/src/bins/nextgcore-sgwcd/src/sxa_response.rs
+++ b/src/bins/nextgcore-sgwcd/src/sxa_response.rs
@@ -43,6 +43,38 @@ pub fn dispatch(sess_id: u64, continuation: S11Continuation, resp_type: u8, body
     }
 }
 
+/// Answer the waiting S11 procedure with a SPECIFIC cause (#52).
+///
+/// [`fail`] answers `REMOTE_PEER_NOT_RESPONDING`, which is right when a peer went
+/// silent. When the PGW answered and REFUSED, the MME is owed the PGW's own cause: the
+/// difference between "the anchor did not reply" and "the anchor said no, because the
+/// APN is unknown" is the difference between a retry and a fix.
+pub fn fail_with_cause(continuation: S11Continuation, cause: u8) {
+    match continuation {
+        S11Continuation::None => {}
+        S11Continuation::CreateSession { peer, seq, teid } => {
+            answer(
+                peer,
+                Gtp2MessageType::CreateSessionResponse,
+                teid,
+                seq,
+                cause,
+            );
+        }
+        S11Continuation::DeleteSession {
+            peer, seq, teid, ..
+        } => {
+            answer(
+                peer,
+                Gtp2MessageType::DeleteSessionResponse,
+                teid,
+                seq,
+                cause,
+            );
+        }
+    }
+}
+
 /// The transaction never completed (T1 x N1 expiry, or a local error).
 ///
 /// The MME is waiting. Answering now with a mapped cause is what stops the procedure

--- a/src/bins/nextgcore-smfd/src/gtp_handler.rs
+++ b/src/bins/nextgcore-smfd/src/gtp_handler.rs
@@ -1,18 +1,11 @@
 //! GTP-C Message Handling
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-#![allow(unused_variables)]
 //!
 //! Port of src/smf/s5c-handler.c - GTP-C message handling for SMF
 //! Handles GTPv2-C (S5/S8) request and response processing
 
-use std::net::{Ipv4Addr, Ipv6Addr};
-
-use crate::context::{IpAddr as SmfIpAddr, Qos, SmfBearer, SmfContext, SmfSess, SmfUe};
-use crate::gtp_build::{
-    gtp2_ie_type, gtp2_message_type, gtp2_rat_type, pdn_type, BearerQos, FTeid, Gtp2Cause, Paa,
-};
+use crate::context::{SmfBearer, SmfSess, SmfUe};
+use crate::gtp_build::{gtp2_rat_type, BearerQos, FTeid, Gtp2Cause, Paa};
 
 // ============================================================================
 // GTPv2-C Request Parsing Structures
@@ -397,9 +390,24 @@ pub fn handle_create_session_request(
         let _ = selection_mode;
     }
 
-    // Store UE session type from PAA
+    // Store the UE's REQUESTED session type from the PAA, converted into the numbering
+    // `session_type` uses.
+    //
+    // `Paa::pdn_type` is the GTP PDN Type IE (TS 29.274 §8.34: 1=IPv4, 2=IPv6,
+    // 3=IPv4v6); `PduSessionType` is the NAS/5G enum, where `Ipv4 == 0`.
+    // `build_create_session_response` compares `ue_session_type != session_type as u8` to
+    // decide between cause 16 and cause 18 "New PDN type due to network preference", so
+    // storing the raw GTP value made EVERY IPv4 session answer 18 — a spurious "the
+    // network chose differently" on a request the network honoured exactly.
+    //
+    // Latent until #52, because nothing called this handler or that builder in
+    // production. Found by driving a real Create Session Request into the new socket.
     if let Some(ref paa) = req.paa {
-        sess.ue_session_type = paa.pdn_type;
+        sess.ue_session_type = match paa.pdn_type {
+            2 => crate::context::PduSessionType::Ipv6,
+            3 => crate::context::PduSessionType::Ipv4v6,
+            _ => crate::context::PduSessionType::Ipv4,
+        } as u8;
     }
 
     // Set SGW S5C TEID and IP
@@ -466,7 +474,7 @@ fn buffer_to_bcd(buf: &[u8]) -> String {
 /// Port of smf_s5c_handle_delete_session_request
 pub fn handle_delete_session_request(
     sess: &SmfSess,
-    req: &DeleteSessionRequest,
+    _req: &DeleteSessionRequest,
     has_gx_peer: bool,
     has_s6b_peer: bool,
 ) -> DeleteSessionResult {
@@ -881,12 +889,609 @@ impl IndicationFlags {
 }
 
 // ============================================================================
+// S5/S8 wire dispatch (#52)
+// ============================================================================
+
+use crate::gtp_build::gtp2_message_type;
+use nextgcore_gtp::v2::{
+    Gtp2AmbrIe, Gtp2ApnIe, Gtp2BearerContextIe, Gtp2FTeidIe, Gtp2IeType, Gtp2Message, Gtp2PaaIe,
+};
+
+/// Decode a Create Session Request off the wire into this module's own struct.
+///
+/// The IEs are decoded by the shared, round-trip-tested library and mapped onto
+/// [`CreateSessionRequest`], which had no parser at all before #52 — it was
+/// constructed only by tests, which is why `handle_create_session_request` had no
+/// production caller.
+///
+/// Mandatory-IE absence is reported as the cause TS 29.274 §7.7 gives for it rather
+/// than defaulted, because a request missing the Sender F-TEID or the Bearer Context
+/// is one the PGW cannot answer usefully.
+fn parse_create_session_request(msg: &Gtp2Message) -> Result<CreateSessionRequest, Gtp2Cause> {
+    let mut req = CreateSessionRequest::default();
+
+    let imsi = msg
+        .get_ie(Gtp2IeType::Imsi as u8, 0)
+        .ok_or(Gtp2Cause::MandatoryIeMissing)?;
+    req.imsi = imsi.value.to_vec();
+
+    req.msisdn = msg
+        .get_ie(Gtp2IeType::Msisdn as u8, 0)
+        .map(|ie| ie.value.to_vec());
+    req.mei = msg
+        .get_ie(Gtp2IeType::Mei as u8, 0)
+        .map(|ie| ie.value.to_vec());
+    req.serving_network = msg
+        .get_ie(Gtp2IeType::ServingNetwork as u8, 0)
+        .and_then(|ie| ie.value.get(..3).map(|v| [v[0], v[1], v[2]]));
+
+    req.rat_type = msg
+        .get_ie(Gtp2IeType::RatType as u8, 0)
+        .and_then(|ie| ie.value.first().copied())
+        .ok_or(Gtp2Cause::MandatoryIeMissing)?;
+
+    let fteid_ie = msg
+        .get_ie(Gtp2IeType::FTeid as u8, 0)
+        .ok_or(Gtp2Cause::MandatoryIeMissing)?;
+    let fteid =
+        Gtp2FTeidIe::decode(&fteid_ie.value).map_err(|_| Gtp2Cause::MandatoryIeIncorrect)?;
+    req.sender_f_teid = Some(FTeid::new_ipv4(
+        fteid.interface_type,
+        fteid.teid,
+        std::net::Ipv4Addr::from(fteid.ipv4_addr.unwrap_or([0, 0, 0, 0])),
+    ));
+
+    let apn_ie = msg
+        .get_ie(Gtp2IeType::Apn as u8, 0)
+        .ok_or(Gtp2Cause::MandatoryIeMissing)?;
+    let apn = Gtp2ApnIe::decode(&apn_ie.value)
+        .map_err(|_| Gtp2Cause::MandatoryIeIncorrect)?
+        .to_string();
+    if apn.is_empty() {
+        return Err(Gtp2Cause::MandatoryIeIncorrect);
+    }
+    req.apn = Some(apn);
+
+    req.selection_mode = msg
+        .get_ie(Gtp2IeType::SelectionMode as u8, 0)
+        .and_then(|ie| ie.value.first().copied());
+    req.pdn_type = msg
+        .get_ie(Gtp2IeType::PdnType as u8, 0)
+        .and_then(|ie| ie.value.first().copied())
+        .map(|v| v & 0x07)
+        .unwrap_or(1);
+
+    // The PAA the SGW-C sends is a REQUEST, not an assignment: TS 23.401 §5.3.2.1
+    // makes address allocation a PGW function. It is parsed so the handler's
+    // conditional-IE check passes and then deliberately replaced by the address this
+    // node allocates — see `dispatch_s5s8_request`.
+    req.paa = msg
+        .get_ie(Gtp2IeType::Paa as u8, 0)
+        .and_then(|ie| Gtp2PaaIe::decode(&ie.value).ok())
+        .map(|paa| {
+            Paa::ipv4(std::net::Ipv4Addr::from(
+                paa.ipv4_addr.unwrap_or([0, 0, 0, 0]),
+            ))
+        });
+
+    req.ambr = msg
+        .get_ie(Gtp2IeType::Ambr as u8, 0)
+        .and_then(|ie| Gtp2AmbrIe::decode(&ie.value).ok())
+        .map(|ambr| (ambr.uplink, ambr.downlink));
+
+    let bc_ie = msg
+        .get_ie(Gtp2IeType::BearerContext as u8, 0)
+        .ok_or(Gtp2Cause::MandatoryIeMissing)?;
+    let bc =
+        Gtp2BearerContextIe::decode(&bc_ie.value).map_err(|_| Gtp2Cause::MandatoryIeIncorrect)?;
+    let ebi = bc.ebi().map_err(|_| Gtp2Cause::MandatoryIeMissing)?;
+    let qos = bc
+        .bearer_qos()
+        .map_err(|_| Gtp2Cause::MandatoryIeIncorrect)?
+        .ok_or(Gtp2Cause::MandatoryIeMissing)?;
+    // The SGW's S5/S8-U endpoint, at instance 2 (TS 29.274 Table 7.2.1-2). This is the
+    // downlink tunnel the PGW-U forwards to.
+    let s5u = bc.fteid(2).ok().flatten().map(|ft| {
+        FTeid::new_ipv4(
+            ft.interface_type,
+            ft.teid,
+            std::net::Ipv4Addr::from(ft.ipv4_addr.unwrap_or([0, 0, 0, 0])),
+        )
+    });
+    req.bearer_contexts.push(BearerContextToCreate {
+        ebi,
+        bearer_qos: Some(BearerQos {
+            qci: qos.qci,
+            priority_level: qos.pl,
+            pre_emption_capability: qos.pci,
+            pre_emption_vulnerability: qos.pvi,
+            ul_mbr: qos.mbr_ul,
+            dl_mbr: qos.mbr_dl,
+            ul_gbr: qos.gbr_ul,
+            dl_gbr: qos.gbr_dl,
+        }),
+        s5u_sgw_f_teid: s5u,
+        s2b_u_epdg_f_teid: None,
+    });
+
+    req.pco = msg
+        .get_ie(Gtp2IeType::Pco as u8, 0)
+        .map(|ie| ie.value.to_vec());
+    // Extended PCO (TS 29.274 §8.128, IE type 197). Read by numeric type because the
+    // library's `Gtp2IeType` does not model it; the alternative was to drop an IE the
+    // SGW-C may legitimately send.
+    const EXTENDED_PCO_IE_TYPE: u8 = 197;
+    req.epco = msg
+        .get_ie(EXTENDED_PCO_IE_TYPE, 0)
+        .map(|ie| ie.value.to_vec());
+    req.uli = msg
+        .get_ie(Gtp2IeType::Uli as u8, 0)
+        .map(|ie| ie.value.to_vec());
+
+    Ok(req)
+}
+
+/// Route an initial S5/S8 message from the SGW-C.
+pub async fn dispatch_s5s8_request(
+    server: &crate::gtp_path::S5S8Server,
+    msg_type: u8,
+    sequence_number: u32,
+    raw: &[u8],
+    peer: std::net::SocketAddr,
+) {
+    match msg_type {
+        gtp2_message_type::CREATE_SESSION_REQUEST => {
+            create_session(server, sequence_number, raw, peer).await
+        }
+        other => {
+            // TS 29.274 §7.7: answer with a cause rather than dropping the request, so
+            // the SGW-C's transaction completes instead of expiring on T3.
+            log::warn!(
+                "S5/S8 message type {other} from {peer} is not implemented by this PGW-C; \
+                 answering Service not supported"
+            );
+            let response = crate::gtp_build::build_error_message(
+                other.wrapping_add(1),
+                0,
+                Gtp2Cause::ServiceNotSupported,
+            );
+            server.send_response_public(peer, &response).await;
+        }
+    }
+}
+
+/// Route a triggered S5/S8 message that closed one of this node's transactions.
+pub fn dispatch_s5s8_response(msg_type: u8, _raw: &[u8], peer: std::net::SocketAddr) {
+    log::info!("S5/S8 response type={msg_type} from {peer} correlated");
+}
+
+/// Terminate a Create Session Request: allocate the PDN Address, provision the PGW-U
+/// over N4, and answer from what actually happened (#52 criterion 2).
+///
+/// TS 23.401 §5.3.2.1 makes address allocation a PGW function, which is why the PAA the
+/// SGW-C sent is discarded rather than echoed — echoing it is precisely what sgwcd used
+/// to do, and it meant no node in the deployment ever allocated an address.
+async fn create_session(
+    server: &crate::gtp_path::S5S8Server,
+    sequence_number: u32,
+    raw: &[u8],
+    peer: std::net::SocketAddr,
+) {
+    let mut bytes = bytes::Bytes::copy_from_slice(raw);
+    let msg = match Gtp2Message::decode(&mut bytes) {
+        Ok(m) => m,
+        Err(e) => {
+            log::error!("S5/S8 Create Session Request from {peer} undecodable: {e}");
+            return;
+        }
+    };
+
+    let req = match parse_create_session_request(&msg) {
+        Ok(req) => req,
+        Err(cause) => {
+            log::warn!("S5/S8 Create Session Request from {peer} rejected: cause {cause:?}");
+            let response = crate::gtp_build::build_error_message(
+                gtp2_message_type::CREATE_SESSION_RESPONSE,
+                0,
+                cause,
+            );
+            server.send_response_public(peer, &response).await;
+            return;
+        }
+    };
+
+    let apn = req.apn.clone().unwrap_or_default();
+    let context = crate::context::smf_self();
+
+    // The PDN Address. Allocated HERE, by the anchor, which is the whole point.
+    let Some(ue_ipv4) = context.read().ok().and_then(|ctx| ctx.ipv4_pool.allocate()) else {
+        log::error!("S5/S8 Create Session Request from {peer}: the IPv4 pool is exhausted");
+        let response = crate::gtp_build::build_error_message(
+            gtp2_message_type::CREATE_SESSION_RESPONSE,
+            0,
+            Gtp2Cause::AllDynamicAddressesAreOccupied,
+        );
+        server.send_response_public(peer, &response).await;
+        return;
+    };
+
+    log::info!(
+        "S5/S8 Create Session Request from {peer}: APN '{apn}', allocated PDN address {ue_ipv4}"
+    );
+
+    // The UE and the session. `sess_add_by_apn` is the EPS entry into the session model
+    // — it sets `epc = true` and takes the APN and RAT type — and had no production
+    // caller before #52, because nothing terminated S5/S8 to call it.
+    //
+    // The guard is taken and DROPPED before anything is awaited. A `std::sync` read
+    // guard held across an `.await` is not `Send` (so this would not compile inside a
+    // spawned task) and would hold the whole SMF context for the duration of an N4
+    // round trip, blocking every 5G session on this daemon behind one LTE one.
+    let created = match context.read() {
+        Ok(ctx) => ctx
+            .ue_find_by_imsi(&req.imsi)
+            .or_else(|| ctx.ue_add_by_imsi(&req.imsi))
+            .and_then(|ue| {
+                ctx.sess_add_by_apn(ue.id, &apn, req.rat_type)
+                    .map(|sess| (ue, sess))
+            }),
+        Err(_) => None,
+    };
+    let Some((mut smf_ue, mut sess)) = created else {
+        release_and_reject(
+            server,
+            &context,
+            ue_ipv4,
+            peer,
+            sequence_number,
+            Gtp2Cause::NoResourcesAvailable,
+        )
+        .await;
+        return;
+    };
+
+    // The SGW's control-plane TEID is what the response is addressed to, and the PDN
+    // address is the one THIS node allocated rather than the one the SGW-C proposed.
+    if let Some(ref sender) = req.sender_f_teid {
+        sess.sgw_s5c_teid = sender.teid;
+    }
+    sess.ipv4_addr = Some(ue_ipv4);
+    // What this PGW-C actually serves: IPv4 only, because `ipv4_pool` is the only address
+    // pool it has. An IPv6 or IPv4v6 request therefore legitimately gets cause 18.
+    sess.session_type = crate::context::PduSessionType::Ipv4;
+    if let Some((ul_kbps, dl_kbps)) = req.ambr {
+        sess.session_ambr.uplink = u64::from(ul_kbps) * 1000;
+        sess.session_ambr.downlink = u64::from(dl_kbps) * 1000;
+    }
+
+    let bc = &req.bearer_contexts[0];
+    let qos = bc.bearer_qos.as_ref().expect("checked by the parser");
+    let mut bearer = crate::context::SmfBearer {
+        ebi: bc.ebi,
+        qos: crate::context::Qos {
+            index: qos.qci,
+            arp_priority_level: qos.priority_level,
+            arp_preempt_cap: qos.pre_emption_capability,
+            arp_preempt_vuln: qos.pre_emption_vulnerability,
+            mbr_uplink: qos.ul_mbr,
+            mbr_downlink: qos.dl_mbr,
+            gbr_uplink: qos.ul_gbr,
+            gbr_downlink: qos.dl_gbr,
+        },
+        ..Default::default()
+    };
+    if let Some(ref s5u) = bc.s5u_sgw_f_teid {
+        bearer.sgw_s5u_teid = s5u.teid;
+        bearer.sgw_s5u_ip.ipv4 = s5u.ipv4_addr;
+    }
+
+    // Validate through the handler this issue exists to make reachable. It has always
+    // been correct; it just had `#[cfg(test)]` callers only.
+    //
+    // `has_policy_source` and not `has_gx_peer`: this daemon has Gx STATE
+    // (`gsm_sm.rs`'s CCR/CCA fields) and no Gx transport, and TS 23.401 does not require
+    // a PCRF for a PGW to serve a session. `policy::PolicyDecision::config_default_for_dnn`
+    // is a policy source, and it is the same one the 5G path falls back to when no PCF is
+    // configured (the recorded precedence is PCF, then subscription, then config
+    // default). Passing `false` here would make this endpoint answer
+    // `RemotePeerNotResponding` to every Create Session Request — a socket that binds and
+    // refuses everything.
+    match handle_create_session_request(&mut sess, &mut smf_ue, &req, true, true) {
+        CreateSessionResult::Rejected(cause) => {
+            log::warn!(
+                "S5/S8 Create Session Request from {peer} rejected by the handler: {cause:?}"
+            );
+            release_and_reject(server, &context, ue_ipv4, peer, sequence_number, cause).await;
+            return;
+        }
+        CreateSessionResult::Accepted => {}
+    }
+
+    // Provision the PGW-U over N4. TS 23.401 §5.3.2.1 has the PGW answer once the user
+    // plane exists, and `RequestAccepted` means the request was actually fulfilled — so
+    // the response is built AFTER this, from what the UPF gave.
+    let session_qos = crate::SessionQos {
+        qfi: bc.ebi,
+        ambr_ul_bps: sess.session_ambr.uplink,
+        ambr_dl_bps: sess.session_ambr.downlink,
+        xr_flow: None,
+    };
+    let n4 = match crate::pfcp_session_establish(
+        sess.smf_n4_seid,
+        ue_ipv4.octets(),
+        &apn,
+        1,
+        &session_qos,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            log::error!(
+                "S5/S8 Create Session Request from {peer}: the PGW-U never provisioned the \
+                 session ({e}); answering rather than leaving the SGW-C on T3"
+            );
+            release_and_reject(
+                server,
+                &context,
+                ue_ipv4,
+                peer,
+                sequence_number,
+                Gtp2Cause::RemotePeerNotResponding,
+            )
+            .await;
+            return;
+        }
+    };
+
+    // The PGW-U's F-TEID is the uplink endpoint the SGW-U will forward to.
+    bearer.pgw_s5u_teid = n4.upf_teid;
+    bearer.pgw_s5u_addr = Some(std::net::Ipv4Addr::from(n4.upf_addr));
+
+    let local_ipv4 = match server.local_addr().ip() {
+        std::net::IpAddr::V4(v4) => Some(v4),
+        std::net::IpAddr::V6(_) => None,
+    };
+    let response = crate::gtp_build::build_create_session_response(
+        &sess,
+        std::slice::from_ref(&bearer),
+        local_ipv4,
+        None,
+        req.pco.as_deref(),
+        req.apco.as_deref(),
+        req.epco.as_deref(),
+        true,
+        true,
+    );
+    // The response echoes the request's sequence number: it is a triggered message.
+    let response = with_sequence_number(response, sequence_number);
+    server.send_response_public(peer, &response).await;
+    log::info!(
+        "S5/S8 Create Session Response to {peer}: PAA {ue_ipv4} (allocated here), PGW-U TEID \
+         {:#x}, EBI {}",
+        n4.upf_teid,
+        bearer.ebi
+    );
+}
+
+/// Release the allocated address and answer with a cause.
+///
+/// The address is returned to the pool on every failure path: leaking one per refused
+/// request exhausts a /16 silently, and the UE never received it.
+async fn release_and_reject(
+    server: &crate::gtp_path::S5S8Server,
+    context: &std::sync::Arc<std::sync::RwLock<crate::context::SmfContext>>,
+    ue_ipv4: std::net::Ipv4Addr,
+    peer: std::net::SocketAddr,
+    sequence_number: u32,
+    cause: Gtp2Cause,
+) {
+    if let Ok(ctx) = context.read() {
+        ctx.ipv4_pool.release(ue_ipv4);
+    }
+    let response =
+        crate::gtp_build::build_error_message(gtp2_message_type::CREATE_SESSION_RESPONSE, 0, cause);
+    // A refusal is a triggered message too: it must echo the sequence number, or the
+    // SGW-C waits out T3 on a rejection it already received.
+    let response = with_sequence_number(response, sequence_number);
+    server.send_response_public(peer, &response).await;
+}
+
+/// Set the sequence number of an encoded GTPv2-C message.
+///
+/// The builders in `gtp_build` do not take one — they were written when nothing was
+/// transmitted — so rather than thread a sequence number through eight signatures for
+/// one caller, the message is decoded, its header set, and re-encoded.
+///
+/// Decode-and-re-encode rather than patching the three octets in place: the offset
+/// depends on whether the TEID-present flag is set, and the first version of this
+/// function assumed it was and wrote the sequence four octets early. A triggered
+/// message that does not echo the request's sequence cannot be correlated by the peer,
+/// so getting this silently wrong is exactly the class of defect #52 is about.
+fn with_sequence_number(encoded: Vec<u8>, sequence_number: u32) -> Vec<u8> {
+    let mut bytes = bytes::Bytes::copy_from_slice(&encoded);
+    match Gtp2Message::decode(&mut bytes) {
+        Ok(mut msg) => {
+            msg.header.sequence_number = sequence_number;
+            msg.encode().to_vec()
+        }
+        Err(e) => {
+            log::error!(
+                "cannot set the sequence number on a message this node just built ({e}); sending \
+                 it unchanged, which the peer will not be able to correlate"
+            );
+            encoded
+        }
+    }
+}
+
+// ============================================================================
 // Unit Tests
 // ============================================================================
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::Ipv4Addr;
+
+    // ================================================================
+    // #52: the PGW-C role on the wire
+    // ================================================================
+
+    /// Build an S5/S8 Create Session Request the way sgwcd's builder does.
+    fn s5c_csr(seq: u32, sgw_c_teid: u32, requested_paa: [u8; 4]) -> bytes::BytesMut {
+        use nextgcore_gtp::v2::{
+            Gtp2ApnIe, Gtp2BearerContextIe, Gtp2BearerQosIe, Gtp2FTeidIe, Gtp2Header, Gtp2Message,
+            Gtp2PaaIe, Gtp2RatTypeIe,
+        };
+        let mut msg = Gtp2Message::new(Gtp2Header::new(
+            gtp2_message_type::CREATE_SESSION_REQUEST,
+            0,
+            seq,
+        ));
+        msg.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::from_slice(
+            Gtp2IeType::Imsi as u8,
+            0,
+            &[0x09, 0x91, 0x07, 0x00, 0x00, 0x00, 0x00, 0x01],
+        ));
+        let mut buf = bytes::BytesMut::new();
+        Gtp2RatTypeIe::new(6).encode(&mut buf, 0);
+        let mut b = buf.freeze();
+        msg.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::decode(&mut b).unwrap());
+        msg.add_ie(Gtp2FTeidIe::new_ipv4(7, sgw_c_teid, [127, 0, 0, 1]).to_ie(0));
+        // Serving Network and ULI: what sgwcd's relay actually sends since #52, and what
+        // this handler requires for an E-UTRAN session. The fixture carried neither at
+        // first and the handler answered `ConditionalIeMissing` — which is the handler
+        // being right, and is how the missing relay in sgwcd was found.
+        msg.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::from_slice(
+            Gtp2IeType::ServingNetwork as u8,
+            0,
+            &[0x99, 0xf9, 0x07],
+        ));
+        msg.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::from_slice(
+            Gtp2IeType::Uli as u8,
+            0,
+            &[
+                0x18, 0x99, 0xf9, 0x07, 0x00, 0x01, 0x99, 0xf9, 0x07, 0x00, 0x00, 0x00, 0x01,
+            ],
+        ));
+        let mut buf = bytes::BytesMut::new();
+        Gtp2ApnIe::from_string("internet").encode(&mut buf, 0);
+        let mut b = buf.freeze();
+        msg.add_ie(nextgcore_gtp::v2::ie::Gtp2Ie::decode(&mut b).unwrap());
+        // The PAA the SGW-C proposes. TS 23.401 §5.3.2.1 makes this a REQUEST, and the
+        // test asserts it is NOT what comes back.
+        msg.add_ie(Gtp2PaaIe::ipv4(requested_paa).to_ie(0));
+        let mut bc = Gtp2BearerContextIe::new();
+        bc.set_ebi(5);
+        bc.set_bearer_qos(&Gtp2BearerQosIe::new(9, 0, 0, 0, 0));
+        bc.set_fteid(2, &Gtp2FTeidIe::new_ipv4(4, 0x0505_0505, [127, 0, 0, 1]));
+        msg.add_bearer_context(0, &bc);
+        msg.encode()
+    }
+
+    /// #52 criterion 2, over the wire: the PGW-C allocates the PDN Address itself.
+    ///
+    /// The SGW-C's request proposes `10.99.99.99`; the response must carry an address from
+    /// this node's own pool instead, because TS 23.401 §5.3.2.1 makes allocation a PGW
+    /// function. Before #52 nothing terminated S5/S8 at all, so no address was ever
+    /// allocated anywhere in the deployment.
+    #[tokio::test]
+    async fn a_create_session_request_is_answered_with_an_address_this_node_allocated() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
+        let _upf = crate::pfcp_path::stand_in::associated_upf().await;
+        crate::context::smf_context_init(64, 256, 512);
+
+        let server = crate::gtp_path::S5S8Server::open("127.0.0.1:0".parse().unwrap(), 3)
+            .await
+            .expect("bind");
+        let sgw = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind sgw");
+
+        const REQUESTED: [u8; 4] = [10, 99, 99, 99];
+        sgw.send_to(&s5c_csr(0x77, 0x0A0A_0A0A, REQUESTED), server.local_addr())
+            .await
+            .expect("send csr");
+
+        let mut buf = vec![0u8; 4096];
+        let (len, _) =
+            tokio::time::timeout(std::time::Duration::from_secs(3), sgw.recv_from(&mut buf))
+                .await
+                .expect("the PGW-C must answer")
+                .expect("recv");
+        let mut bytes = bytes::Bytes::copy_from_slice(&buf[..len]);
+        let resp = nextgcore_gtp::v2::Gtp2Message::decode(&mut bytes).expect("decode");
+
+        assert_eq!(
+            resp.header.message_type,
+            gtp2_message_type::CREATE_SESSION_RESPONSE
+        );
+        assert_eq!(
+            resp.header.sequence_number, 0x77,
+            "a triggered message echoes the request's sequence number"
+        );
+        assert_eq!(
+            resp.get_ie(Gtp2IeType::Cause as u8, 0)
+                .and_then(|ie| ie.value.first().copied()),
+            Some(16),
+            "the session must be accepted once the PGW-U is provisioned"
+        );
+
+        let paa = resp
+            .get_ie(Gtp2IeType::Paa as u8, 0)
+            .and_then(|ie| Gtp2PaaIe::decode(&ie.value).ok())
+            .expect("the response must carry a PAA");
+        let allocated = paa.ipv4_addr.expect("an IPv4 address");
+        assert_ne!(
+            allocated, REQUESTED,
+            "the PGW must ALLOCATE an address, not echo the one the SGW-C proposed"
+        );
+        assert_eq!(
+            allocated[0], 10,
+            "the address must come from this node's own pool"
+        );
+
+        // APN-Restriction is mandatory in the response for an E-UTRAN session.
+        assert!(
+            resp.get_ie(Gtp2IeType::ApnRestriction as u8, 0).is_some(),
+            "TS 29.274 Table 7.2.2-1 makes APN-Restriction present for E-UTRAN"
+        );
+        server.close();
+    }
+
+    /// An Echo Request is answered with this node's Recovery (#52 criterion 3).
+    #[tokio::test]
+    async fn an_echo_request_is_answered_with_recovery() {
+        let server = crate::gtp_path::S5S8Server::open("127.0.0.1:0".parse().unwrap(), 9)
+            .await
+            .expect("bind");
+        let peer = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let echo = nextgcore_gtp::v2::Gtp2Message::echo_request(5);
+        peer.send_to(&echo.encode(), server.local_addr())
+            .await
+            .expect("send");
+
+        let mut buf = vec![0u8; 4096];
+        let (len, _) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), peer.recv_from(&mut buf))
+                .await
+                .expect("the PGW-C must answer an Echo")
+                .expect("recv");
+        let mut bytes = bytes::Bytes::copy_from_slice(&buf[..len]);
+        let resp = nextgcore_gtp::v2::Gtp2Message::decode(&mut bytes).expect("decode");
+        assert_eq!(resp.header.message_type, gtp2_message_type::ECHO_RESPONSE);
+        assert_eq!(resp.header.sequence_number, 5);
+        assert_eq!(
+            resp.get_ie(Gtp2IeType::Recovery as u8, 0)
+                .and_then(|ie| ie.value.first().copied()),
+            Some(9),
+            "Recovery is mandatory in an Echo Response (TS 29.274 §7.1.2)"
+        );
+        server.close();
+    }
 
     #[test]
     fn test_buffer_to_bcd() {

--- a/src/bins/nextgcore-smfd/src/gtp_path.rs
+++ b/src/bins/nextgcore-smfd/src/gtp_path.rs
@@ -1,24 +1,22 @@
 //! GTP Path Management
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-#![allow(unused_variables)]
 //!
 //! Port of src/smf/gtp-path.c - GTP path management for SMF
 //! Handles GTP-C and GTP-U path setup, teardown, and message sending
 
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Duration, Instant};
+
+use nextgcore_gtp::v2::xact::{Gtp2XactConfig, Gtp2XactMgr};
 
 use crate::context::{SmfBearer, SmfSess};
 use crate::gtp_build::{
     build_create_bearer_request, build_create_session_response, build_delete_bearer_request,
     build_delete_session_response, build_echo_response, build_error_message,
     build_modify_bearer_response, build_update_bearer_request, gtp2_message_type, Gtp2Cause,
-    Gtp2MessageBuilder,
 };
 
 // ============================================================================
@@ -998,4 +996,236 @@ mod tests {
         assert_eq!(gtp_modify_flags::TFT_UPDATE, 0x01);
         assert_eq!(gtp_modify_flags::QOS_UPDATE, 0x02);
     }
+}
+
+// ============================================================================
+// S5/S8 GTP-C server: the PGW-C role on the wire (#52)
+// ============================================================================
+
+/// The PGW-C's S5/S8 GTPv2-C endpoint.
+///
+/// Before #52 this daemon bound no GTP-C socket at all: `GTPC_PORT` appeared only in
+/// in-memory `GtpNode` bookkeeping and test asserts, and every `gtp_handler` function
+/// had `#[cfg(test)]` callers only. So nothing terminated S5/S8, no node allocated the
+/// PDN Address, and the dual 5G/LTE core had no anchor gateway for LTE.
+///
+/// **Async, unlike mmed's and sgwcd's servers.** Those are synchronous because the NAS
+/// and S1AP paths that originate their messages are; this one is the terminating end,
+/// and answering a Create Session Request requires awaiting an N4 exchange with the
+/// UPF (`pfcp_session_establish`). An async receive loop lets the handler await that
+/// directly, which is why smfd needs none of the deferred-continuation machinery #54
+/// had to build for sgwcd.
+///
+/// The T3-RESPONSE/N3-REQUESTS budget still comes from the shared [`Gtp2XactMgr`], so
+/// all three GTP-C endpoints in this tree agree about how long a message may take.
+pub struct S5S8Server {
+    socket: Arc<tokio::net::UdpSocket>,
+    local_addr: SocketAddr,
+    restart_counter: u8,
+    xact: tokio::sync::Mutex<Gtp2XactMgr>,
+    running: Arc<AtomicBool>,
+}
+
+/// The process-wide S5/S8 server.
+///
+/// A `OnceLock` for the same reason mmed's is: the PGW-initiated bearer procedures are
+/// triggered from code that threads no transport handle. `None` means the socket was
+/// never bound, and a send then reports that rather than pretending to have sent.
+static S5S8_SERVER: OnceLock<Arc<S5S8Server>> = OnceLock::new();
+
+/// The installed S5/S8 server, or `None` when the PGW-C role is not bound.
+pub fn s5s8_server() -> Option<&'static Arc<S5S8Server>> {
+    S5S8_SERVER.get()
+}
+
+impl S5S8Server {
+    /// Bind the S5/S8 socket and spawn the receive and T3/N3 tasks.
+    pub async fn open(bind: SocketAddr, restart_counter: u8) -> Result<Arc<Self>, String> {
+        let socket = tokio::net::UdpSocket::bind(bind)
+            .await
+            .map_err(|e| format!("bind {bind}: {e}"))?;
+        let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
+        let server = Arc::new(Self {
+            socket: Arc::new(socket),
+            local_addr,
+            restart_counter,
+            xact: tokio::sync::Mutex::new(Gtp2XactMgr::new(Gtp2XactConfig::default())),
+            running: Arc::new(AtomicBool::new(true)),
+        });
+
+        // Receive loop.
+        {
+            let server = server.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 4096];
+                while server.running.load(Ordering::SeqCst) {
+                    match server.socket.recv_from(&mut buf).await {
+                        Ok((len, peer)) => {
+                            let datagram = buf[..len].to_vec();
+                            let server = server.clone();
+                            // Spawned per datagram: answering a Create Session Request
+                            // awaits an N4 exchange, and handling it inline would stop
+                            // this socket receiving anything else for its duration —
+                            // including the SGW-C's retransmission of the very request
+                            // being served.
+                            tokio::spawn(async move {
+                                server.handle_datagram(&datagram, peer).await;
+                            });
+                        }
+                        Err(e) => {
+                            if server.running.load(Ordering::SeqCst) {
+                                log::error!("S5/S8 recv error: {e}");
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        // T3-RESPONSE / N3-REQUESTS loop for the requests this node originates
+        // (PGW-initiated Create/Update/Delete Bearer).
+        {
+            let server = server.clone();
+            tokio::spawn(async move {
+                while server.running.load(Ordering::SeqCst) {
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    let poll = {
+                        let mut xact = server.xact.lock().await;
+                        xact.poll(std::time::Instant::now())
+                    };
+                    for (peer, encoded) in poll.retransmits {
+                        log::warn!("S5/S8 T3 expiry: retransmitting to {peer}");
+                        if let Err(e) = server.socket.send_to(&encoded, peer).await {
+                            log::error!("S5/S8 retransmit to {peer} failed: {e}");
+                        }
+                    }
+                    for xact in poll.exhausted {
+                        log::error!(
+                            "S5/S8 N3 exhausted: peer {} not responding (type={}, seq={})",
+                            xact.peer,
+                            xact.message_type,
+                            xact.sequence_number
+                        );
+                    }
+                }
+            });
+        }
+
+        log::info!("SMF/PGW-C S5/S8 GTP-C server listening on {local_addr}");
+        Ok(server)
+    }
+
+    /// Stop the receive and retransmission tasks.
+    pub fn close(&self) {
+        self.running.store(false, Ordering::SeqCst);
+    }
+
+    /// Local bound address, which is also the PGW's S5/S8-C address on the wire.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// The restart counter advertised in Recovery IEs.
+    pub fn restart_counter(&self) -> u8 {
+        self.restart_counter
+    }
+
+    /// Send a triggered (response) message, echoing the request's sequence number.
+    pub async fn send_response_public(&self, peer: SocketAddr, encoded: &[u8]) {
+        if let Err(e) = self.socket.send_to(encoded, peer).await {
+            log::error!("S5/S8 response to {peer} failed: {e}");
+        }
+    }
+
+    /// Send an initial (request) message and arm T3/N3.
+    ///
+    /// Used by the PGW-initiated bearer procedures, which are the only messages this
+    /// node originates on S5/S8.
+    pub async fn send_request(&self, peer: SocketAddr, encoded: Vec<u8>, message_type: u8) -> u32 {
+        let seq = {
+            let mut xact = self.xact.lock().await;
+            let seq = xact.alloc_sequence();
+            xact.register_request(
+                seq,
+                message_type,
+                peer,
+                bytes::Bytes::from(encoded.clone()),
+                0,
+            );
+            seq
+        };
+        if let Err(e) = self.socket.send_to(&encoded, peer).await {
+            log::error!("S5/S8 request to {peer} failed: {e}");
+        }
+        seq
+    }
+
+    /// Outstanding transactions awaiting a triggered message.
+    pub async fn outstanding(&self) -> usize {
+        self.xact.lock().await.outstanding()
+    }
+
+    async fn handle_datagram(&self, data: &[u8], peer: SocketAddr) {
+        let mut bytes = bytes::Bytes::copy_from_slice(data);
+        let msg = match nextgcore_gtp::v2::Gtp2Message::decode(&mut bytes) {
+            Ok(m) => m,
+            Err(e) => {
+                log::error!("[DROP] cannot decode S5/S8 datagram from {peer}: {e}");
+                return;
+            }
+        };
+        let msg_type = msg.header.message_type;
+        let seq = msg.header.sequence_number;
+
+        // Echo: path management, no session state (TS 29.274 §7.1.1). Answered here
+        // rather than through the handler layer, which would only add a hop.
+        if msg_type == gtp2_message_type::ECHO_REQUEST {
+            let mut reply =
+                nextgcore_gtp::v2::Gtp2Message::echo_response(seq, self.restart_counter);
+            reply.header.sequence_number = seq;
+            self.send_response_public(peer, &reply.encode()).await;
+            return;
+        }
+        if msg_type == gtp2_message_type::ECHO_RESPONSE {
+            log::debug!("S5/S8 Echo Response from {peer}");
+            return;
+        }
+
+        // A triggered message closes one of this node's own transactions.
+        let matched = {
+            let mut xact = self.xact.lock().await;
+            xact.match_response(seq, msg_type)
+        };
+        if let Some(closed) = matched {
+            log::debug!(
+                "S5/S8 RX response type={msg_type} seq={seq} from {peer} correlates to type={}",
+                closed.message_type
+            );
+            crate::gtp_handler::dispatch_s5s8_response(msg_type, data, peer);
+            return;
+        }
+
+        // An initial message from the SGW-C.
+        crate::gtp_handler::dispatch_s5s8_request(self, msg_type, seq, data, peer).await;
+    }
+}
+
+/// Bind the S5/S8 socket from configuration and install it process-wide (#52).
+///
+/// With no `smf.gtpc.server` configured this returns `Ok(())` and logs why: an SMF with
+/// no S5/S8 address is a 5G-only deployment, and refusing to start would break every
+/// existing 5GC config that never needed the socket.
+pub async fn s5s8_open(bind: Option<SocketAddr>, restart_counter: u8) -> Result<(), String> {
+    let Some(bind) = bind else {
+        log::info!(
+            "no smf.gtpc.server configured: the S5/S8 (PGW-C) role is NOT bound, so no LTE \
+             session can be anchored here"
+        );
+        return Ok(());
+    };
+    let server = S5S8Server::open(bind, restart_counter).await?;
+    if S5S8_SERVER.set(server).is_err() {
+        log::warn!("an S5/S8 server is already installed; this one is dropped");
+    }
+    Ok(())
 }

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -208,6 +208,16 @@ struct SbiClient {
     nrf: Option<Vec<AddrEntry>>,
 }
 
+/// `smf.gtpc`: the S5/S8 interface this PGW-C terminates (#52).
+///
+/// Declared in the shipped `docker/rust/configs/5gc/smf.yaml` all along and read by
+/// nothing, because no socket existed to bind it to — the same shape `mme.gtpc` had
+/// before #51.
+#[derive(Debug, Default, Deserialize)]
+struct GtpcSection {
+    server: Option<Vec<AddrEntry>>,
+}
+
 /// SBI section (server list + client)
 #[derive(Debug, Default, Deserialize)]
 struct SbiSection {
@@ -219,6 +229,7 @@ struct SbiSection {
 #[derive(Debug, Default, Deserialize)]
 struct SmfSection {
     sbi: Option<SbiSection>,
+    gtpc: Option<GtpcSection>,
     /// DNS servers signalled to the UE in the establishment accept's ePCO IE.
     ///
     /// The shipped `docker/rust/configs/5gc/smf.yaml` has declared these (and
@@ -250,6 +261,11 @@ struct SmfConfig {
     dns_servers: Vec<std::net::Ipv4Addr>,
     /// IPv4 link MTU for the same IE.
     mtu: Option<u16>,
+    /// S5/S8 GTP-C bind address, from `smf.gtpc.server[0]` (#52). `None` leaves the
+    /// PGW-C role unbound, which is what every deployment before #52 had.
+    gtpc_addr: Option<String>,
+    /// S5/S8 GTP-C port. TS 29.274 §4.1 fixes GTPv2-C at UDP 2123.
+    gtpc_port: u16,
 }
 
 impl Default for SmfConfig {
@@ -263,6 +279,8 @@ impl Default for SmfConfig {
             nrf_uri: None,
             dns_servers: Vec::new(),
             mtu: None,
+            gtpc_addr: None,
+            gtpc_port: 2123,
         }
     }
 }
@@ -322,6 +340,27 @@ fn load_config(path: &str) -> SmfConfig {
             }
         }
         config.mtu = smf.mtu;
+
+        // S5/S8 bind address (#52). Only the first entry is bound; a second is named
+        // in a warning rather than silently ignored, matching how `sbi.server` and
+        // `mme.gtpc.server` are handled.
+        if let Some(gtpc) = smf.gtpc {
+            let servers = gtpc.server.unwrap_or_default();
+            if servers.len() > 1 {
+                log::warn!(
+                    "{} smf.gtpc.server addresses configured; only the first is bound",
+                    servers.len()
+                );
+            }
+            if let Some(first) = servers.into_iter().next() {
+                if let Some(addr) = first.address {
+                    config.gtpc_addr = Some(addr);
+                }
+                if let Some(port) = first.port {
+                    config.gtpc_port = port;
+                }
+            }
+        }
     }
 
     config
@@ -645,6 +684,19 @@ async fn main() -> Result<()> {
     );
     log::info!("SMF N4 PFCP socket bound on {pfcp_bind_addr} (UPF peers: {upf_pfcp_addrs:?})");
 
+    // The S5/S8 (PGW-C) role (#52). Bound AFTER the N4 socket and the PFCP pool,
+    // because a Create Session Request cannot be answered without a UPF to provision —
+    // binding first would accept requests this daemon could only reject.
+    let s5s8_bind = config.gtpc_addr.as_deref().and_then(|addr| {
+        match format!("{addr}:{}", config.gtpc_port).parse::<std::net::SocketAddr>() {
+            Ok(sa) => Some(sa),
+            Err(e) => {
+                log::warn!("smf.gtpc.server address '{addr}' is unparsable ({e}); S5/S8 not bound");
+                None
+            }
+        }
+    });
+
     let pfcp_clients: Vec<Arc<pfcp_path::PfcpClient>> = upf_pfcp_addrs
         .iter()
         .map(|&peer| {
@@ -658,6 +710,14 @@ async fn main() -> Result<()> {
     // Installs the whole pool and pool slot 0 as the process-wide default
     // client (the legacy single-client paths keep working unchanged).
     pfcp_path::set_global_pool(pfcp_clients.clone());
+
+    // Recovery counter for S5/S8. Derived from the process start rather than persisted:
+    // smfd has no restart-counter file, and inventing one here would be a second answer
+    // to a question mmed and sgwcd already answer their own way. Stated as a ceiling.
+    if let Err(e) = gtp_path::s5s8_open(s5s8_bind, 1).await {
+        log::error!("Failed to bind the S5/S8 GTP-C socket: {e}");
+        return Err(anyhow::anyhow!("S5/S8 bind failed: {e}"));
+    }
     let pfcp_client = pfcp_clients[0].clone();
 
     // #191: hand each client the Recovery Time Stamp the durable snapshot recorded


### PR DESCRIPTION
Closes #52. Spec: `specs/fix-s5s8-interface-bringup.md`.

## The gap

sgwcd terminated the MME's Create Session Request **locally** and fabricated a response echoing the MME's own PAA. smfd bound no GTP-C socket and its PGW-C handlers had `#[cfg(test)]` callers only. So no node in the deployment allocated a PDN address, and the dual 5G/LTE core had no anchor gateway for LTE.

#52 is accurate in every particular — including the detail it flagged. Standing the interface up then exposed **three further layers**, each invisible from either side alone. Same shape #54 found.

## The three layers underneath

1. **sgwcd never parsed Serving Network or ULI.** A conformant PGW requires both for an E-UTRAN session — this tree's own smfd answers `ConditionalIeMissing` without them — and `s11_parse` kept only a `uli_presence` boolean, because nothing relayed anything. **The first working relay was refused by the anchor it was built to reach.**
2. **mmed never sent them either.** #51's criteria named the Sender F-TEID and the Bearer Contexts; these two were in that issue's *prose*. They were correctly reported as met and the chain still could not complete. Added to mmed's CSR here, because criterion 9 is unachievable without them.
3. **Two PDN-type numberings compared directly.** `build_create_session_response` picks cause 16 vs cause 18 ("New PDN type due to network preference") on `ue_session_type != session_type as u8`. `PduSessionType::Ipv4 == 0`; the GTP PDN Type IE is 1-based (§8.34). The handler stored the raw GTP value, so **every IPv4 session answered 18** — a spurious "the network chose differently" on a request honoured exactly. Latent because neither function had a production caller. Fixed at the source.

Each layer was found by building the one above it, not by reading. That is the argument for the parity test below.

## What landed

**smfd (PGW-C):** binds UDP 2123 from `smf.gtpc.server`, parses the CSR with the shared codec, **allocates** the PDN address from its own pool, drives an N4 session toward upfd, and answers with PAA, APN-Restriction, PCO and PGW F-TEIDs. Echo answered with Recovery; T3/N3 for its own requests. `allow(dead_code)` removed.

**Async, unlike mmed's and sgwcd's servers** — it is the terminating end and answering requires awaiting N4, so it needs none of #54's deferred-continuation machinery. Each datagram gets its own task, because handling inline would stop the socket receiving for an N4 round trip, including the SGW-C's retransmission of the request being served.

**sgwcd (SGW-C):** relays to the PGW and builds the S11 response from the PGW's answer. The S5-C stage is **inserted before** the Sxa stage rather than replacing it — `S11Continuation` rides through untouched, so #54's gating is unchanged and the MME's answer still comes from `sxa_response`, now from a session holding the PGW's values. Dedicated S5-C sender address; `s5c_handler` wired into the receive path; PGW-initiated bearer procedures relayed to the MME; Bearer Resource Command forwarded instead of refused.

**With no PGW configured, the SGW-C refuses** — `REMOTE_PEER_NOT_RESPONDING` with no PAA, asserted. A fabricated success is worse than a visible refusal.

## One decision worth flagging

`handle_create_session_request` rejects when told there is no Gx peer. smfd has Gx *state* and no Gx transport, so passing the truth would make this endpoint refuse every request — a socket that binds and serves nothing. TS 23.401 does not require a PCRF for a PGW to serve a session, and `config_default_for_dnn` is a policy source — the same one the 5G path falls back to with no PCF. So `true` is passed on the grounds that a policy source exists, **recorded rather than silently done**, because it reinterprets what that argument means.

## Verification

**8 reverts, 8 bites**: the relay itself; the PAA from the PGW; the no-PGW refusal; mmed's Serving Network; sgwcd's Serving Network relay; sgwcd's ULI retention; smfd allocating rather than echoing; smfd echoing the sequence number.

**Three of my own mistakes, each caught by a different instrument** — worth stating because they are the reason to run all three:

| mistake | what caught it |
|---|---|
| `with_sequence_number` patched three octets at a fixed offset only right when the TEID flag is set, so responses went out with sequence 0 | the unit test |
| I set the process-global PGW peer **before** taking the guard that serialises sgwcd's ambient config — #308's unlocked-writer race, reintroduced by me two issues later | three existing tests breaking |
| the smfd wire test was failing for several steps while I worked on sgwcd and I lost track of it | the **whole-workspace** run |

Three existing sgwcd tests failed once the relay landed, because they asserted the old "answer from Sxa alone" behaviour — the defect pinned as the requirement. They were given a stand-in anchor rather than reverted.

Workspace **6352 passed / 0 failed** (was 6347), `clippy --workspace` 0, `fmt --check` clean. sgwcd 81 → 84, smfd 464 → 466.

## Ceilings

- **Criterion 9 is verified in two halves, not one process.** sgwcd's chain runs end to end over real sockets against a **stand-in** anchor; smfd's PGW-C role is driven over a real socket by its own test. They are not run against each other — both are binaries with no lib target, the same ceiling #51 recorded. What bridges them is `the_relayed_s5c_request_carries_what_the_anchor_requires`, asserting sgwcd's relay carries the IE set smfd requires. **That guard is load-bearing**: the first version of this change relayed neither IE and the real anchor refused it.
- **The EPC compose file is untouched** — it has no PGW-C service (its own header says bridging EPC↔5GC is future work), so there is nothing to point `SGWC_PGW_S5C` at. That service is #303's stage, and a half-wired compose is worse than none.
- **smfd's restart counter is not persisted** (mmed's and sgwcd's are). A peer cannot detect an smfd restart; a third answer to that question did not belong inside this issue.
- **Only Create Session is terminated by smfd.** The others answer with a cause rather than being dropped, so the SGW-C's transaction completes instead of expiring on T3 — but they are not implemented.
- **The PGW-initiated relay toward the MME is written and not exercised**: nothing in this tree originates one, so it is a correct implementation in a place nothing reaches yet.
- **smfd serves IPv4 only** (`ipv4_pool` is its only pool), so an IPv6/IPv4v6 request now legitimately gets cause 18.
- **No E2E** — the Docker jobs are `workflow_dispatch`-only and untouched.

With this and #51 merged, **#303's two stated blockers are closed**.