### PR TITLE
fix(sbi): serve a pre-bound listener so no test port is unbound before use (#313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,22 +39,29 @@ jobs:
         with:
           workspaces: src
       - name: cargo test
-        # No retry. There was one, for two named races: process-global state and
-        # the free_port TOCTOU. #308 fixed the first (one ambient test lock per
-        # crate, covering readers as well as writers) and measured what the retry
-        # had been hiding -- about 1 whole-workspace run in 5, in three smfd tests,
-        # for months, because a single retry passes ~96% of the time at that rate
-        # and the warning annotation went unread. A retry that can hide a 20% flake
-        # is not a flake mitigation, it is a detector for exactly the failures
-        # nobody investigates.
+        # No retry, and nothing left for one to hide. There was one, for two named
+        # races: process-global state and the free_port TOCTOU.
         #
-        # What genuinely remains is #313: free_port hands out a port and unbinds it
-        # before the caller binds, and each test BINARY has its own issued-port set,
-        # so two crates can be given the same port. That fails as a bind panic, not
-        # as a wrong answer, and it did not occur once in ~60 whole-crate runs under
-        # synthetic 40-way load. Closing it needs SbiServer to accept a pre-bound
-        # listener, which is #313's subject; until then a rare red here is the
-        # honest signal and should be re-run, not retried automatically.
+        # #308 fixed the first (one ambient test lock per crate, covering readers
+        # as well as writers) and measured what the retry had been hiding -- about
+        # 1 whole-workspace run in 5, in three smfd tests, for months, because a
+        # single retry passes ~96% of the time at that rate and the warning
+        # annotation went unread. A retry that can hide a 20% flake is not a flake
+        # mitigation, it is a detector for exactly the failures nobody
+        # investigates.
+        #
+        # #313 CLOSED the second. `free_port` used to hand out a port and unbind it
+        # before the caller bound it, with a per-BINARY issued-port set, so two
+        # crates could be given the same port and one would fail to bind.
+        # `test_support::bound_listener` now keeps the port bound and
+        # `SbiServer::on_listener` serves that listener, so there is no window:
+        # all 243 ephemeral-port server starts in this workspace now reserve.
+        # `free_port` survives only for the 10 callers that want a port with
+        # NOTHING listening on it (transport-error and degrade-open tests), where
+        # being unbound is the point, plus one integration test that hands ports to
+        # a child PROCESS and so cannot pass a socket at all.
+        #
+        # So a red here is a real failure. Read it, do not re-run it.
         run: cd src && cargo test --workspace
 
       - name: cargo test (non-default features)

--- a/specs/fix-sbi-prebound-listener.md
+++ b/specs/fix-sbi-prebound-listener.md
@@ -1,0 +1,179 @@
+# nextgcore #313: close the cross-process port window by serving a pre-bound listener
+
+Verified against `main` @ `46a1aa1`.
+
+#313 is the second half of #308. The symptom is a bind failure inside
+`SbiServer::start` under `cargo test --workspace`; the mechanism is that
+`test_support::free_port` chooses a port and then **releases it** before the caller
+binds, and each test binary has its own issued-port set, so two crates running
+concurrently can be handed the same number.
+
+Its scope estimates are the part that was stale. The API change it asks for is
+exactly right; the counts are out by an order of magnitude, in both directions.
+
+## Verified against current main
+
+| claim in the issue | site on `46a1aa1` | still true? |
+|---|---|---|
+| `free_port` probes, records the port, drops the probe, returns the number | `test_support.rs:46-60` | yes |
+| its own doc states the limit and says the API change is "tracked separately" | `test_support.rs:29-35` — it names #313, which #308 filed | yes, and already corrected once |
+| `SbiServer` binds internally, taking only a `SocketAddr` | `server.rs:959` | yes |
+| the failure presents as a bind panic, not a wrong answer | `Failed to bind: Address already in use (os error 98)`, reproduced deliberately below | yes |
+| "~21 `free_port` callers that start an `SbiServer`" | **243** ephemeral-port server starts | **false — 11.5x low** |
+| "`rg 'fn free_port' src/bins` finds 15+ private duplicates that do NOT even have the in-process `ISSUED` guard" | 26 crate-local helpers, of which **19 were one-line delegates** to the shared helper and only **5** had a raw probe-drop body | **false** — the duplicates were migrated by an earlier issue; only 5 were unguarded |
+| UDP callers (PFCP/GTP stand-ins) need the same treatment | **they have no window**: every test-side UDP socket binds `127.0.0.1:0` or `loopback(0)` and keeps it | **false, and this is the good news** |
+
+The undercount matters because it changes the shape of the fix: at 21 sites a
+hand-migration is a morning's work; at 243 it needs a mechanical transform and the
+compiler as the net, which is how this was done.
+
+## Decision 1: the server adopts a listener; it does not consult a registry
+
+`SbiServer::on_listener(config, listener)` stores the listener and `start()` takes
+it. `test_support::bound_listener()` returns a `BoundListener` — a bound socket and
+its address travelling together, so there is no moment when the port has been
+chosen and nothing holds it.
+
+The alternative considered and rejected was a process-global map from address to
+reserved listener, which `start()` would consult. It is tempting because it needs a
+**one-token diff** at each of 243 call sites instead of a two-line one. Rejected for
+three reasons, in order of weight:
+
+1. **It is the #308 defect shape.** A global that one function writes and another
+   reads, with no ownership visible at either end, is precisely the ambient state
+   that session removed four locks' worth of. Trading a compile-time guarantee for
+   an invisible agreement is a bad trade on a test helper.
+2. **It would have changed what some tests measure.** Ten callers use `free_port`
+   to get an address with *nothing listening* — bounded-timeout transport errors,
+   degrade-open paths, discovery of a dead peer. A registry keyed on address is
+   only safe if those callers are perfectly separated from the reserving ones
+   forever; with an explicit type the compiler enforces the separation.
+3. **File descriptors.** A reservation never consumed leaks one fd for the life of
+   the test binary. Bounded in practice, unbounded in principle.
+
+`config.addr` is overwritten from the listener rather than checked against it. A
+server whose config disagreed with the socket it serves would misreport itself in
+`stop()`'s log and in anything deriving a URI from the config, and the disagreement
+would be silent. `on_listener_overwrites_a_placeholder_config_address` pins it.
+
+## Decision 2: `free_port` is kept, and its remaining callers are the point
+
+The obvious reading of criterion 4 is that the helper is deleted along with its
+stale doc. It is not, and the reason is a real distinction rather than a shortcut:
+
+- **10 callers want an address with nothing bound to it.** `smfd::policy`'s two
+  bounded-timeout PCF/NSACF tests, `amfd::sbi_path`'s two degrade-open tests,
+  `pcfd`'s dead-UDR and dead-callback tests, `nefd`'s dead-producer test. Handing
+  these a bound listener makes the port *reachable*, which inverts what they
+  assert. Each site now sits under a doc comment that says so.
+- **1 integration test cannot take a socket at all.** `n32_two_sepp.rs` passes two
+  ports to a real child process on the command line, and a third to
+  `start_n32_listener(host, port, tls)` — a production entry point whose signature
+  is a configured host and port. Threading a listener through production API for a
+  test's benefit is the wrong trade; the child-process case cannot be fixed at all
+  without fd inheritance, which nothing in this tree does.
+
+What did change there: that file's copy of `free_port` was **raw**, with no
+in-process issued set, so two threads in one binary could collide. It now delegates
+to the shared helper. The same is true of `udmd/tests/sor_upu_strict_peer.rs` and
+`pcfd/tests/strict_peer_bsfd.rs` (three nested copies), which became dead once
+their callers moved and were deleted.
+
+`free_port`'s doc no longer claims the API change is tracked elsewhere; it now
+describes the window it still has and points at `bound_listener` for anything that
+will be served.
+
+## Decision 3: two retry loops are deleted rather than kept as belt-and-braces
+
+`http3.rs`'s h2 leg and `benches/transport.rs`'s `start_h2_server` each looped
+**five times** over "probe a port, try to start, accept a failure" — local
+workarounds for the window this removes. Both are now single-attempt, because a
+retry that can absorb a real bind failure is the same instrument #308 removed from
+`ci.yml`: it converts a signal into a warning nobody reads. The bench's own
+`free_port` (unguarded, no issued set) is deleted with it.
+
+## Decision 4: 19 dead crate-local delegates are removed
+
+Nineteen `fn free_port()` / `fn ephemeral_addr()` one-line delegates became
+unreferenced when their callers moved to reservations, across amfd (2), ausfd (2),
+bsfd, dccfd, lmfd (3), mbsmfd, nefd, nsacfd, nssfd, nwdafd, pcfd, smfd, udmd (2),
+udrd. Deleted rather than left: the issue's criterion 3 asks for exactly this, and a
+delegate with no callers makes the shared helper look less used than it is.
+
+Two crate-local helpers are kept and renamed to say what they are:
+`scpd::proxy::reserve_port` and `amfd::sbi_path::nsacf_reserved_port`, both
+returning a `BoundListener`. `scpd` also keeps its own because its 15 `start_*`
+stubs take the reservation as their first parameter, which is what let 109 call
+sites migrate by changing one argument each.
+
+## Verification
+
+The load-bearing claim — "no port is unbound between selection and use" — is pinned
+by a **differential** test rather than a property test:
+`a_reserved_port_is_bound_and_a_free_port_is_not` asserts both that a competing bind
+of a reserved port fails with `AddrInUse` **and** that the same bind of a
+`free_port` address succeeds. The second half is the defect; without it a
+`bound_listener` that had quietly reverted to probe-drop would satisfy the first
+half's negative reading.
+
+| claim | how it was made to fail | result |
+|---|---|---|
+| the reservation actually holds the port | first attempt: revert `bound_listener` to probe-drop-then-rebind | **did NOT bite** — rebinding restores the property, so the revert tested nothing. Recorded because it is the mistake, not the method |
+| `start()` genuinely serves the reserved listener | replace `self.prebound.lock().await.take()` with `None`, so `start()` falls back to binding `config.addr` | **fails**: `sbi server start: ServerError("Failed to bind: Address already in use (os error 98)")` — #313's production message, produced on demand |
+| a `free_port` address is claimable, i.e. the window is real | the second half of the differential test, on the fixed branch | **passes** — the bind succeeds, which is the window |
+| `config.addr` follows the socket, not the caller's placeholder | `on_listener` with a `:0` config | port equals the reservation's |
+| both reservation routes share one issued set | 16 reservations held, 200 `free_port` draws | no overlap |
+| a reserved server is reachable on exactly the reserved address | real `TcpStream::connect` after `sbi_server_on_free_port` | connects |
+| the migration did not change what any test measures | whole workspace | **6357 passed / 0 failed** (baseline 6352 + 5 new) |
+| the gate is stable | 36 `cargo test --workspace` runs on the final tree (20 + 12, plus 4 immediately after `clippy --all-targets`), counting `Address already in use` occurrences | **0 failures, 0 bind errors** — but see the first ceiling: two earlier failures went uncaptured |
+| the three other gates | `cargo clippy --workspace`; `--all-targets`; `cargo fmt --all --check`; `-p nextgcore-easdfd --features dns-udp` test + clippy | 0 errors each; 51 passed |
+
+## Ceilings
+
+- **Two single-test failures were observed and NEITHER was identified.** This is the
+  weakest part of the evidence and it is stated first rather than buried. One
+  occurred on a mid-migration tree (amfd's `sbi_path` not yet moved, the dead
+  delegates not yet removed) with `failed=1` and **zero** `Address already in use`
+  occurrences. The second occurred on the final tree, reporting 1503 passed / 1
+  failed — the low count meaning cargo stopped after the failing binary, so the
+  crate is not even known. Both loops discarded the output. Three subsequent
+  measurements, all with capture, found nothing: 20 runs, then 12 runs, then 4 runs
+  immediately after `clippy --all-targets` (which forces a full test-binary rebuild,
+  so tests run under heavy compile load — the shape #308 used deliberately to
+  surface state races). **36 clean runs; that hypothesis is tested and not
+  confirmed.** What the counters do rule out is this issue's subject: a port
+  collision presents as `Address already in use`, and the one failure whose bind
+  count was recorded had none. The honest summary is that something in this suite
+  fails at a rate under roughly 1 in 18 and it is not the port window.
+- **36 clean runs bound the port-collision rate; they do not prove zero.** #313's
+  measured rate was ~2 in 29 whole-workspace runs, so 36 clean runs put that
+  residual under roughly 8% at 95% confidence — enough to say the mechanism is
+  closed (there is no unbound window left to lose), not enough to certify the suite
+  deterministic. The mechanism argument is the stronger one here and the statistics
+  are corroboration.
+- **The `stop()`/`start()` restart path re-binds.** The reservation is consumed by
+  the first `start()`, so a restarted server binds `config.addr` and reopens the
+  window for that one bind. Nothing in this workspace restarts a server on a
+  reserved port; if something does, it needs a second reservation.
+- **A reserved port accepts into the kernel backlog before `start()` adopts it.** A
+  client connecting in that gap is queued rather than refused, where previously it
+  was refused. No test asserts refusal on a reserved port — the 10 refusal tests all
+  use `free_port`, which is why that helper survives — but the behaviour differs
+  from main and is stated rather than discovered later.
+- **The child-process case in `n32_two_sepp.rs` is unfixed and unfixable as
+  written.** Two ports go to a spawned binary's argv; closing that needs fd
+  inheritance. If the workspace gate reddens again with a bind failure, this is the
+  first place to look, and it will present as a startup timeout rather than a bind
+  panic because the failure happens in the child.
+- **`start_n32_listener` keeps its `(host, port)` signature.** A production sibling
+  taking a listener would close the third seppd site. No issue has asked for it and
+  it is production API churn for a test.
+- **No E2E.** Everything here is one process's test binary. The Docker jobs remain
+  `workflow_dispatch`-only and untouched.
+- **The 243 migrations were mechanical, with the compiler and the suite as the net.**
+  Two scripted transforms did the bulk; three syntax errors and one type error were
+  caught by `cargo check`, and one of them (a dropped closing paren) would have been
+  invisible to review of the script alone. The residual risk is a reservation
+  attached to the wrong server in a test with two servers in one function — which
+  would fail the test rather than pass silently, because the wrong port would be
+  served.

--- a/src/bins/nextgcore-amfd/src/lib.rs
+++ b/src/bins/nextgcore-amfd/src/lib.rs
@@ -1076,15 +1076,6 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -1125,12 +1116,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         crate::context::amf_context_init(64, 1024, 4096);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Amf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(crate::namf_server::namf_request_handler)
             .await

--- a/src/bins/nextgcore-amfd/src/namf_server.rs
+++ b/src/bins/nextgcore-amfd/src/namf_server.rs
@@ -2574,25 +2574,17 @@ mod tests {
             .to_string()
     }
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     /// Start a capture server on an ephemeral port; returns (server, port, rx)
     async fn start_capture_server() -> (
         SbiServer,
         u16,
         tokio::sync::mpsc::Receiver<(String, String)>,
     ) {
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let (tx, rx) = tokio::sync::mpsc::channel::<(String, String)>(16);
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
         server
             .start(move |req: SbiRequest| {
                 let tx = tx.clone();
@@ -4052,9 +4044,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_namf_server_http_roundtrip() {
         amf_context_init(64, 1024, 4096);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
         server
             .start(namf_request_handler)
             .await

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -8176,10 +8176,11 @@ mod tests {
     ) {
         use nextgcore_sbi::message::{SbiRequest, SbiResponse};
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
-        let port = nextgcore_sbi::test_support::free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let (tx, rx) = mpsc::channel(8);
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
         server
             .start(move |req: SbiRequest| {
                 let tx = tx.clone();
@@ -8565,8 +8566,8 @@ mod tests {
         let seen: Arc<std::sync::Mutex<Vec<(String, Vec<u8>)>>> =
             Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = Arc::clone(&seen);
-        let addr = nextgcore_sbi::test_support::ephemeral_addr();
-        let server = NSbiServer::new(NSbiCfg::new(addr));
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let server = NSbiServer::on_listener(NSbiCfg::new(addr), addr_listener);
         server
             .start(move |req: SReq| {
                 let sink = Arc::clone(&sink);

--- a/src/bins/nextgcore-amfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-amfd/src/sbi_path.rs
@@ -2115,7 +2115,16 @@ mod tests {
     // UeACRequestData and maps 204 / 200-acuFailureList / 403, degrade-open.
     // ------------------------------------------------------------------
 
-    /// Reserve a loopback port for the NSACF stub server.
+    /// Reserve a loopback port by KEEPING IT BOUND, for a stub server this
+    /// process is about to serve (#313).
+    fn nsacf_reserved_port() -> nextgcore_sbi::test_support::BoundListener {
+        nextgcore_sbi::test_support::bound_listener()
+    }
+
+    /// A loopback port with NOTHING listening on it, for the two tests that
+    /// assert the degrade-open path on a transport error. These deliberately do
+    /// not want a reservation: a bound port would be reachable, which is the
+    /// opposite of what they measure.
     fn nsacf_free_port() -> u16 {
         nextgcore_sbi::test_support::free_port()
     }
@@ -2173,10 +2182,12 @@ mod tests {
         // it describes a dev-profile deployment (issue #63). Declared explicitly
         // rather than inherited from the environment.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
-        let port = nsacf_free_port();
-        let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-        let server = nextgcore_sbi::server::SbiServer::new(
+        let reservation = nsacf_reserved_port();
+        let port = reservation.port();
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
             nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server.start(stub_nsacf_ue).await.expect("start stub NSACF");
 
@@ -2843,10 +2854,12 @@ mod tests {
     }
 
     async fn start_pcf_ue_policy_stub() -> (nextgcore_sbi::server::SbiServer, u16) {
-        let port = nsacf_free_port();
-        let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-        let server = nextgcore_sbi::server::SbiServer::new(
+        let reservation = nsacf_reserved_port();
+        let port = reservation.port();
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
             nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(stub_pcf_ue_policy)

--- a/src/bins/nextgcore-ausfd/src/app.rs
+++ b/src/bins/nextgcore-ausfd/src/app.rs
@@ -2287,15 +2287,6 @@ mod tests {
         }
     }
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     /// Full HTTP-level flow: 5G-AKA success + failure, EAP-AKA' success +
     /// failure, strict-peer rejections (missing attrs, bad SNN).
     ///
@@ -2317,21 +2308,25 @@ mod tests {
             ausf_context_init(64);
 
             // --- mock UDM on an ephemeral port ---
-            let udm_port = free_port();
-            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udm_port,
-            ))));
+            let (udm_listener, udm_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udm_port = udm_addr.port();
+            let udm_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udm_port))),
+                udm_listener,
+            );
             udm_server.start(mock_udm_handler).await.expect("udm start");
             std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
             std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
 
             // --- real AUSF handler on an ephemeral port ---
-            let ausf_port = free_port();
-            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                ausf_port,
-            ))));
+            let (ausf_listener, ausf_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let ausf_port = ausf_addr.port();
+            let ausf_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], ausf_port))),
+                ausf_listener,
+            );
             ausf_server
                 .start(ausf_sbi_request_handler)
                 .await
@@ -2686,21 +2681,25 @@ mod tests {
             ausf_context_init(128);
 
             // Mock UDM
-            let udm_port = free_port();
-            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udm_port,
-            ))));
+            let (udm_listener, udm_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udm_port = udm_addr.port();
+            let udm_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udm_port))),
+                udm_listener,
+            );
             udm_server.start(mock_udm_handler).await.expect("udm start");
             std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
             std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
 
             // Real AUSF handler
-            let ausf_port = free_port();
-            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                ausf_port,
-            ))));
+            let (ausf_listener, ausf_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let ausf_port = ausf_addr.port();
+            let ausf_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], ausf_port))),
+                ausf_listener,
+            );
             ausf_server
                 .start(ausf_sbi_request_handler)
                 .await
@@ -2982,20 +2981,24 @@ mod tests {
             ausf_context_init(128);
 
             // Mock UDM (real Milenage + 5G KDFs) + real AUSF handler.
-            let udm_port = free_port();
-            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udm_port,
-            ))));
+            let (udm_listener, udm_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udm_port = udm_addr.port();
+            let udm_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udm_port))),
+                udm_listener,
+            );
             udm_server.start(mock_udm_handler).await.expect("udm start");
             std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
             std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
 
-            let ausf_port = free_port();
-            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                ausf_port,
-            ))));
+            let (ausf_listener, ausf_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let ausf_port = ausf_addr.port();
+            let ausf_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], ausf_port))),
+                ausf_listener,
+            );
             ausf_server
                 .start(ausf_sbi_request_handler)
                 .await
@@ -3114,20 +3117,24 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(60), async {
             ausf_context_init(128);
 
-            let udm_port = free_port();
-            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udm_port,
-            ))));
+            let (udm_listener, udm_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udm_port = udm_addr.port();
+            let udm_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udm_port))),
+                udm_listener,
+            );
             udm_server.start(mock_udm_handler).await.expect("udm start");
             std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
             std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
 
-            let ausf_port = free_port();
-            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                ausf_port,
-            ))));
+            let (ausf_listener, ausf_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let ausf_port = ausf_addr.port();
+            let ausf_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], ausf_port))),
+                ausf_listener,
+            );
             ausf_server
                 .start(ausf_sbi_request_handler)
                 .await
@@ -3304,20 +3311,24 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(60), async {
             ausf_context_init(64);
 
-            let udm_port = free_port();
-            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udm_port,
-            ))));
+            let (udm_listener, udm_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udm_port = udm_addr.port();
+            let udm_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udm_port))),
+                udm_listener,
+            );
             udm_server.start(mock_udm_handler).await.expect("udm start");
             std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
             std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
 
-            let ausf_port = free_port();
-            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                ausf_port,
-            ))));
+            let (ausf_listener, ausf_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let ausf_port = ausf_addr.port();
+            let ausf_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], ausf_port))),
+                ausf_listener,
+            );
             ausf_server
                 .start(ausf_sbi_request_handler)
                 .await
@@ -3438,21 +3449,25 @@ mod tests {
             ausf_context_init(128);
 
             // Mock UDM (so the permissive/matching case can reach 201).
-            let udm_port = free_port();
-            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udm_port,
-            ))));
+            let (udm_listener, udm_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udm_port = udm_addr.port();
+            let udm_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udm_port))),
+                udm_listener,
+            );
             udm_server.start(mock_udm_handler).await.expect("udm start");
             std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
             std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
 
             // Real AUSF handler.
-            let ausf_port = free_port();
-            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                ausf_port,
-            ))));
+            let (ausf_listener, ausf_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let ausf_port = ausf_addr.port();
+            let ausf_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], ausf_port))),
+                ausf_listener,
+            );
             ausf_server
                 .start(ausf_sbi_request_handler)
                 .await
@@ -3587,20 +3602,24 @@ mod tests {
             ausf_context_init(128);
 
             // Mock UDM (real Milenage + 5G KDFs) + real AUSF dispatcher.
-            let udm_port = free_port();
-            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udm_port,
-            ))));
+            let (udm_listener, udm_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udm_port = udm_addr.port();
+            let udm_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udm_port))),
+                udm_listener,
+            );
             udm_server.start(mock_udm_handler).await.expect("udm start");
             std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
             std::env::set_var("UDM_SBI_PORT", udm_port.to_string());
 
-            let ausf_port = free_port();
-            let ausf_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                ausf_port,
-            ))));
+            let (ausf_listener, ausf_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let ausf_port = ausf_addr.port();
+            let ausf_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], ausf_port))),
+                ausf_listener,
+            );
             ausf_server
                 .start(ausf_sbi_request_handler)
                 .await
@@ -3778,10 +3797,6 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -3822,12 +3837,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         super::ausf_context_init(64);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Ausf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(super::ausf_sbi_request_handler)
             .await

--- a/src/bins/nextgcore-bsfd/src/lib.rs
+++ b/src/bins/nextgcore-bsfd/src/lib.rs
@@ -2820,16 +2820,11 @@ mod tests {
     use nextgcore_sbi::client::SbiClient;
     use serde_json::json;
 
-    /// Loopback address on a shared-helper-issued ephemeral port.
-    fn ephemeral_addr() -> SocketAddr {
-        nextgcore_sbi::test_support::ephemeral_addr()
-    }
-
     async fn start_bsf() -> (SbiServer, SbiClient) {
         // The handlers consult the global BSF context: initialize it once.
         bsf_context_init(1024);
-        let addr = ephemeral_addr();
-        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let server = SbiServer::on_listener(NextgcoreSbiServerConfig::new(addr), addr_listener);
         server
             .start(bsf_sbi_request_handler)
             .await
@@ -2882,12 +2877,12 @@ mod tests {
     /// and the BSF audience.
     async fn start_bsf_oauth2(jwks: serde_json::Value) -> (SbiServer, SbiClient) {
         bsf_context_init(1024);
-        let addr = ephemeral_addr();
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
         let mut cfg = NextgcoreSbiServerConfig::new(addr);
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Bsf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, addr_listener);
         server
             .start(bsf_sbi_request_handler)
             .await
@@ -4657,8 +4652,8 @@ mod tests {
         let recorded: Arc<std::sync::Mutex<Vec<serde_json::Value>>> =
             Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = Arc::clone(&recorded);
-        let cb_addr = ephemeral_addr();
-        let cb = SbiServer::new(NextgcoreSbiServerConfig::new(cb_addr));
+        let (cb_listener, cb_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let cb = SbiServer::on_listener(NextgcoreSbiServerConfig::new(cb_addr), cb_listener);
         cb.start(move |req: SbiRequest| {
             let sink = Arc::clone(&sink);
             async move {
@@ -4804,8 +4799,8 @@ mod tests {
         let recorded: Arc<std::sync::Mutex<Vec<serde_json::Value>>> =
             Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = Arc::clone(&recorded);
-        let cb_addr = ephemeral_addr();
-        let cb = SbiServer::new(NextgcoreSbiServerConfig::new(cb_addr));
+        let (cb_listener, cb_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let cb = SbiServer::on_listener(NextgcoreSbiServerConfig::new(cb_addr), cb_listener);
         cb.start(move |req: SbiRequest| {
             let sink = Arc::clone(&sink);
             async move {

--- a/src/bins/nextgcore-dccfd/src/main.rs
+++ b/src/bins/nextgcore-dccfd/src/main.rs
@@ -663,15 +663,6 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -712,12 +703,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         super::dccf_context_init(256);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Dccf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(dccf_request_handler)
             .await
@@ -851,11 +843,12 @@ mod data_management_tests {
     async fn spawn_consumer() -> (SbiServer, u16, Arc<StdMutex<Vec<serde_json::Value>>>) {
         let seen: Arc<StdMutex<Vec<serde_json::Value>>> = Arc::new(StdMutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let server = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         server
             .start(move |req: SbiRequest| {
                 let sink = sink.clone();
@@ -1175,11 +1168,13 @@ mod data_management_tests {
             // Producer: counts the subscriptions created on it.
             let created = Arc::new(std::sync::atomic::AtomicUsize::new(0));
             let counter = created.clone();
-            let producer_port = nextgcore_sbi::test_support::free_port();
-            let producer = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                producer_port,
-            ))));
+            let (producer_listener, producer_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let producer_port = producer_addr.port();
+            let producer = SbiServer::on_listener(
+                SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], producer_port))),
+                producer_listener,
+            );
             producer
                 .start(move |req: SbiRequest| {
                     let counter = counter.clone();
@@ -1197,11 +1192,13 @@ mod data_management_tests {
 
             // NRF: answers the NF profile retrieval with an event-exposure service
             // pointing at the producer above.
-            let nrf_port = nextgcore_sbi::test_support::free_port();
-            let nrf = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                nrf_port,
-            ))));
+            let (nrf_listener, nrf_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let nrf_port = nrf_addr.port();
+            let nrf = SbiServer::on_listener(
+                SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], nrf_port))),
+                nrf_listener,
+            );
             nrf.start(move |_req: SbiRequest| async move {
                 SbiResponse::ok()
                     .with_json_body(&serde_json::json!({

--- a/src/bins/nextgcore-easdfd/src/main.rs
+++ b/src/bins/nextgcore-easdfd/src/main.rs
@@ -1502,11 +1502,15 @@ easdf:
         let seen: std::sync::Arc<Mutex<Vec<serde_json::Value>>> =
             std::sync::Arc::new(Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let smf =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                std::net::SocketAddr::from(([127, 0, 0, 1], port)),
-            ));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let smf = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                port,
+            ))),
+            port_listener,
+        );
         smf.start(move |req: SbiRequest| {
             let sink = sink.clone();
             async move {

--- a/src/bins/nextgcore-eesd/src/notifier.rs
+++ b/src/bins/nextgcore-eesd/src/notifier.rs
@@ -477,28 +477,29 @@ mod tests {
     /// index, return `(status, Retry-After?)`.
     type Responder = Arc<dyn Fn(usize) -> (u16, Option<String>) + Send + Sync>;
 
-    /// Reserve a loopback port for a test server.
+    /// Reserve a loopback port for a test server by KEEPING IT BOUND (#313).
     ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
+    /// Every caller here goes on to serve the port, so none of them wants the
+    /// bare number `free_port` returns: that leaves the port unbound between
+    /// selection and use, and a concurrently-starting test binary can take it.
+    fn reserve_port() -> nextgcore_sbi::test_support::BoundListener {
+        nextgcore_sbi::test_support::bound_listener()
     }
 
-    /// Spin a `nextgcore-sbi` `SbiServer` on `127.0.0.1:port` acting as the
+    /// Spin a `nextgcore-sbi` `SbiServer` on the reserved port acting as the
     /// subscriber callback receiver. It counts every POST, records the decoded
     /// JSON body, and answers per `responder`.
     async fn start_receiver(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
         bodies: Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
         responder: Responder,
     ) -> nextgcore_sbi::SbiServer {
-        use std::net::SocketAddr;
-        let server = nextgcore_sbi::SbiServer::new(nextgcore_sbi::SbiServerConfig::new(
-            SocketAddr::from(([127, 0, 0, 1], port)),
-        ));
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::SbiServer::on_listener(
+            nextgcore_sbi::SbiServerConfig::new(addr),
+            listener,
+        );
         let handler = move |req: SbiRequest| {
             let counter = counter.clone();
             let bodies = bodies.clone();
@@ -543,11 +544,12 @@ mod tests {
     /// spec JSON we sent, the receiver's 204 ends the exchange, nothing dropped.
     #[tokio::test]
     async fn test_sbi_notifier_delivers_one_post() {
-        let port = free_port();
+        let reservation = reserve_port();
+        let port = reservation.port();
         let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let bodies = Arc::new(std::sync::Mutex::new(Vec::new()));
         let responder: Responder = Arc::new(|_| (204, None));
-        let server = start_receiver(port, counter.clone(), bodies.clone(), responder).await;
+        let server = start_receiver(reservation, counter.clone(), bodies.clone(), responder).await;
 
         let n = SbiNotifier::spawn(SbiNotifierConfig {
             base_backoff: Duration::from_millis(10),
@@ -584,11 +586,12 @@ mod tests {
     /// attempts observed and eventual success (no drop).
     #[tokio::test]
     async fn test_sbi_notifier_retries_then_succeeds() {
-        let port = free_port();
+        let reservation = reserve_port();
+        let port = reservation.port();
         let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let bodies = Arc::new(std::sync::Mutex::new(Vec::new()));
         let responder: Responder = Arc::new(|n| if n < 2 { (500, None) } else { (204, None) });
-        let server = start_receiver(port, counter.clone(), bodies.clone(), responder).await;
+        let server = start_receiver(reservation, counter.clone(), bodies.clone(), responder).await;
 
         let n = SbiNotifier::spawn(SbiNotifierConfig {
             max_attempts: 3,
@@ -619,11 +622,12 @@ mod tests {
     /// POSTs then a counted drop (no infinite loop, no panic).
     #[tokio::test]
     async fn test_sbi_notifier_exhausts_then_drops() {
-        let port = free_port();
+        let reservation = reserve_port();
+        let port = reservation.port();
         let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let bodies = Arc::new(std::sync::Mutex::new(Vec::new()));
         let responder: Responder = Arc::new(|_| (500, None));
-        let server = start_receiver(port, counter.clone(), bodies.clone(), responder).await;
+        let server = start_receiver(reservation, counter.clone(), bodies.clone(), responder).await;
 
         let n = SbiNotifier::spawn(SbiNotifierConfig {
             max_attempts: 3,
@@ -654,7 +658,8 @@ mod tests {
     /// ~1 s (far above the tiny base backoff), proving the header is honoured.
     #[tokio::test]
     async fn test_sbi_notifier_honors_retry_after() {
-        let port = free_port();
+        let reservation = reserve_port();
+        let port = reservation.port();
         let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let bodies = Arc::new(std::sync::Mutex::new(Vec::new()));
         let responder: Responder = Arc::new(|n| {
@@ -664,7 +669,7 @@ mod tests {
                 (204, None)
             }
         });
-        let server = start_receiver(port, counter.clone(), bodies.clone(), responder).await;
+        let server = start_receiver(reservation, counter.clone(), bodies.clone(), responder).await;
 
         let n = SbiNotifier::spawn(SbiNotifierConfig {
             max_attempts: 3,
@@ -718,11 +723,12 @@ mod tests {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
 
-        let port = free_port();
+        let reservation = reserve_port();
+        let port = reservation.port();
         let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let bodies = Arc::new(std::sync::Mutex::new(Vec::new()));
         let responder: Responder = Arc::new(|_| (204, None));
-        let server = start_receiver(port, counter.clone(), bodies.clone(), responder).await;
+        let server = start_receiver(reservation, counter.clone(), bodies.clone(), responder).await;
 
         // Install the real sender as THE process notifier for this test.
         install_sbi_notifier(SbiNotifierConfig {

--- a/src/bins/nextgcore-lmfd/src/main.rs
+++ b/src/bins/nextgcore-lmfd/src/main.rs
@@ -4883,15 +4883,6 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -4932,12 +4923,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         super::lmf_context_init(256);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Lmf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(super::lmf_sbi_request_handler)
             .await
@@ -5114,14 +5106,11 @@ mod a8_event_notify_tests {
             .insert(path.to_string(), status);
     }
 
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     async fn start_sink() -> (SbiServer, u16) {
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server.start(sink_handler).await.expect("sink server start");
         (server, port)
     }
@@ -5440,10 +5429,6 @@ mod positioning_chain_strict_peer {
     /// (never-reset) global AMF context.
     static NEXT_NGAP_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(88_000);
 
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn body_json(resp: &SbiResponse) -> serde_json::Value {
         serde_json::from_str(resp.http.content.as_deref().unwrap_or("{}")).expect("json body")
     }
@@ -5585,9 +5570,9 @@ mod positioning_chain_strict_peer {
     ) {
         let (tap_tx, tap_rx) = tokio::sync::mpsc::channel::<(String, Vec<u8>)>(4);
 
-        let amf_port = free_port();
-        let amf_addr: SocketAddr = format!("127.0.0.1:{amf_port}").parse().expect("amf addr");
-        let amf_server = SbiServer::new(SbiServerConfig::new(amf_addr));
+        let (amf_listener, amf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let amf_port = amf_addr.port();
+        let amf_server = SbiServer::on_listener(SbiServerConfig::new(amf_addr), amf_listener);
         amf_server
             .start(move |req: SbiRequest| {
                 let tap_tx = tap_tx.clone();
@@ -5634,9 +5619,9 @@ mod positioning_chain_strict_peer {
             .await
             .expect("amf server start");
 
-        let nrf_port = free_port();
-        let nrf_addr: SocketAddr = format!("127.0.0.1:{nrf_port}").parse().expect("nrf addr");
-        let nrf_server = SbiServer::new(SbiServerConfig::new(nrf_addr));
+        let (nrf_listener, nrf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let nrf_port = nrf_addr.port();
+        let nrf_server = SbiServer::on_listener(SbiServerConfig::new(nrf_addr), nrf_listener);
         let search = serde_json::json!({
             "nfInstances": [{
                 "nfInstanceId": "amf-strict-peer",

--- a/src/bins/nextgcore-mbsmfd/src/main.rs
+++ b/src/bins/nextgcore-mbsmfd/src/main.rs
@@ -3576,11 +3576,12 @@ mod tests {
     #[tokio::test]
     async fn percent_encoded_tmgi_list_deallocates_and_does_not_400() {
         mbsmf_context_init(256);
-        let port = nextgcore_sbi::test_support::free_port();
-        let server = SbiServer::new(NextgcoreSbiServerConfig::new(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let server = SbiServer::on_listener(
+            NextgcoreSbiServerConfig::new(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         server
             .start(mbsmf_sbi_request_handler)
             .await
@@ -4048,15 +4049,6 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -4097,12 +4089,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         super::mbsmf_context_init(256);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Mbsmf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(super::mbsmf_sbi_request_handler)
             .await

--- a/src/bins/nextgcore-nefd/src/main.rs
+++ b/src/bins/nextgcore-nefd/src/main.rs
@@ -3387,10 +3387,6 @@ mod northbound_auth_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -3432,12 +3428,13 @@ mod northbound_auth_tests {
 
     async fn start_enforcing_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         super::nef_context_init(256, 256);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Nef);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(super::nef_sbi_request_handler)
             .await

--- a/src/bins/nextgcore-nrfd/src/main.rs
+++ b/src/bins/nextgcore-nrfd/src/main.rs
@@ -3797,9 +3797,9 @@ mod tests {
     async fn test_http_lifecycle_register_discover_patch_deregister() {
         use serde_json::json;
 
-        let addr = nextgcore_sbi::test_support::ephemeral_addr();
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
 
-        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(NextgcoreSbiServerConfig::new(addr), addr_listener);
         server
             .start(nrf_sbi_request_handler)
             .await
@@ -4106,8 +4106,8 @@ mod tests {
     async fn test_shared_deregister_self_removes_the_profile_from_the_real_nrf() {
         use serde_json::json;
 
-        let addr = nextgcore_sbi::test_support::ephemeral_addr();
-        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let server = SbiServer::on_listener(NextgcoreSbiServerConfig::new(addr), addr_listener);
         server
             .start(nrf_sbi_request_handler)
             .await
@@ -6127,8 +6127,8 @@ mod tests {
         let received: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
         let sink = Arc::clone(&received);
 
-        let addr = nextgcore_sbi::test_support::ephemeral_addr();
-        let subscriber = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let subscriber = SbiServer::on_listener(NextgcoreSbiServerConfig::new(addr), addr_listener);
         subscriber
             .start(move |req: SbiRequest| {
                 let sink = Arc::clone(&sink);

--- a/src/bins/nextgcore-nsacfd/src/main.rs
+++ b/src/bins/nextgcore-nsacfd/src/main.rs
@@ -2534,15 +2534,6 @@ nsacf:
     // HTTP-level tests (ephemeral ports, bounded timeouts)
     // -----------------------------------------------------------------
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     /// Serializes every test that touches the PROCESS-GLOBAL NSACF context.
     /// `start_nsacf_server*` re-inits (wipes) the shared store, so two such
     /// tests running on parallel test threads corrupt each other's quota/UE
@@ -2555,11 +2546,12 @@ nsacf:
     async fn start_nsacf_server() -> (SbiServer, u16, tokio::sync::MutexGuard<'static, ()>) {
         let guard = GLOBAL_CTX_TEST_LOCK.lock().await;
         nsacf_context_init(64);
-        let port = free_port();
-        let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let server = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         server
             .start(nsacf_sbi_request_handler)
             .await
@@ -2615,12 +2607,13 @@ nsacf:
     ) -> (SbiServer, u16, tokio::sync::MutexGuard<'static, ()>) {
         let guard = GLOBAL_CTX_TEST_LOCK.lock().await;
         nsacf_context_init(64);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Nsacf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(nsacf_sbi_request_handler)
             .await
@@ -3080,11 +3073,12 @@ nsacf:
         let (server, port, _ctx_guard) = start_nsacf_server().await;
         let client = SbiClient::with_host_port("127.0.0.1", port);
 
-        let recv_port = free_port();
-        let receiver = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            recv_port,
-        ))));
+        let (recv_listener, recv_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let recv_port = recv_addr.port();
+        let receiver = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], recv_port))),
+            recv_listener,
+        );
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         receiver
             .start(move |req: SbiRequest| {
@@ -3277,11 +3271,12 @@ nsacf:
         let client = SbiClient::with_host_port("127.0.0.1", port);
 
         // Notification receiver
-        let recv_port = free_port();
-        let receiver = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            recv_port,
-        ))));
+        let (recv_listener, recv_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let recv_port = recv_addr.port();
+        let receiver = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], recv_port))),
+            recv_listener,
+        );
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         receiver
             .start(move |req: SbiRequest| {

--- a/src/bins/nextgcore-nssfd/src/main.rs
+++ b/src/bins/nextgcore-nssfd/src/main.rs
@@ -3235,15 +3235,6 @@ mod tests {
         out
     }
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     /// Serializes tests that mutate the *global* NSSF availability/restriction
     /// state (the context is a process-wide singleton). Without this, the
     /// PLMN-supported restriction one test installs could leak into another
@@ -3258,11 +3249,12 @@ mod tests {
 
     async fn start_nssf_server() -> (SbiServer, u16) {
         nssf_context_init(512);
-        let port = free_port();
-        let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let server = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         server
             .start(nssf_sbi_request_handler)
             .await
@@ -3315,12 +3307,13 @@ mod tests {
     /// and the NSSF audience.
     async fn start_nssf_server_oauth2(jwks: serde_json::Value) -> (SbiServer, u16) {
         nssf_context_init(512);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Nssf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(nssf_sbi_request_handler)
             .await
@@ -3532,11 +3525,12 @@ mod tests {
         let client = SbiClient::with_host_port("127.0.0.1", port);
 
         // Notification receiver on its own ephemeral port
-        let recv_port = free_port();
-        let receiver = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            recv_port,
-        ))));
+        let (recv_listener, recv_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let recv_port = recv_addr.port();
+        let receiver = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], recv_port))),
+            recv_listener,
+        );
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         receiver
             .start(move |req: SbiRequest| {

--- a/src/bins/nextgcore-nwdafd/src/main.rs
+++ b/src/bins/nextgcore-nwdafd/src/main.rs
@@ -1238,11 +1238,12 @@ mod g21_strict_peer_tests {
         nwdaf_context_init("nwdaf-test".to_string(), 1024);
 
         // Real nwdafd SBI server on a free localhost port.
-        let port = nextgcore_sbi::test_support::free_port();
-        let server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let server = SbiServer::on_listener(
+            NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         server
             .start(nwdaf_sbi_request_handler)
             .await
@@ -1403,15 +1404,6 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -1452,12 +1444,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         super::nwdaf_context_init("nwdaf-h8-test".to_string(), 256);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Nwdaf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(super::nwdaf_sbi_request_handler)
             .await

--- a/src/bins/nextgcore-pcfd/src/app.rs
+++ b/src/bins/nextgcore-pcfd/src/app.rs
@@ -3569,9 +3569,11 @@ mod tests {
         // suite indefinitely while holding the shared pcf_context).
         let mut started: Option<(SbiServer, u16)> = None;
         for attempt in 0..4u32 {
-            let port = nextgcore_sbi::test_support::free_port();
+            let (port_listener, port_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let port = port_addr.port();
             let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-            let server = SbiServer::new(SbiServerConfig::new(addr));
+            let server = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
             match tokio::time::timeout(
                 Duration::from_secs(10),
                 server.start(pcf_sbi_request_handler),
@@ -4220,9 +4222,10 @@ mod tests {
     ) -> nextgcore_sbi::server::SbiServer {
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
-        let port = nextgcore_sbi::test_support::free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
         let handler = move |req: SbiRequest| {
             let am_data = am_data.clone();
             async move {
@@ -4294,9 +4297,9 @@ mod tests {
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
 
         let notified = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let smf_port = nextgcore_sbi::test_support::free_port();
-        let smf_addr = SocketAddr::from(([127, 0, 0, 1], smf_port));
-        let smf = SbiServer::new(SbiServerConfig::new(smf_addr));
+        let (smf_listener, smf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let smf_port = smf_addr.port();
+        let smf = SbiServer::on_listener(SbiServerConfig::new(smf_addr), smf_listener);
         let seen = notified.clone();
         smf.start(move |req: SbiRequest| {
             let seen = seen.clone();
@@ -4318,9 +4321,9 @@ mod tests {
         .expect("stub SMF starts");
 
         let udr_queries = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let udr_port = nextgcore_sbi::test_support::free_port();
-        let udr_addr = SocketAddr::from(([127, 0, 0, 1], udr_port));
-        let udr = SbiServer::new(SbiServerConfig::new(udr_addr));
+        let (udr_listener, udr_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr_port = udr_addr.port();
+        let udr = SbiServer::on_listener(SbiServerConfig::new(udr_addr), udr_listener);
         let queries = udr_queries.clone();
         udr.start(move |req: SbiRequest| {
             let sm_data_for = sm_data_for.clone();
@@ -4709,9 +4712,9 @@ mod tests {
         // An NRF that advertises a UDR on a port with nothing listening: discovery
         // succeeds, every nudr-dr GET fails.
         let dead_udr_port = nextgcore_sbi::test_support::free_port();
-        let nrf_port = nextgcore_sbi::test_support::free_port();
-        let nrf_addr = SocketAddr::from(([127, 0, 0, 1], nrf_port));
-        let nrf = SbiServer::new(SbiServerConfig::new(nrf_addr));
+        let (nrf_listener, nrf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let nrf_port = nrf_addr.port();
+        let nrf = SbiServer::on_listener(SbiServerConfig::new(nrf_addr), nrf_listener);
         nrf.start(move |_req: SbiRequest| async move {
             SbiResponse::with_status(200)
                 .with_json_body(&serde_json::json!({
@@ -5030,9 +5033,9 @@ mod tests {
         let seen: Arc<StdMutex<Vec<(String, serde_json::Value)>>> =
             Arc::new(StdMutex::new(Vec::new()));
         let sink = Arc::clone(&seen);
-        let amf_port = nextgcore_sbi::test_support::free_port();
-        let amf_addr = SocketAddr::from(([127, 0, 0, 1], amf_port));
-        let amf = SbiServer::new(SbiServerConfig::new(amf_addr));
+        let (amf_listener, amf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let amf_port = amf_addr.port();
+        let amf = SbiServer::on_listener(SbiServerConfig::new(amf_addr), amf_listener);
         amf.start(move |req: SbiRequest| {
             let sink = Arc::clone(&sink);
             async move {
@@ -5162,9 +5165,10 @@ mod tests {
         // Primary: always 500, so every attempt against it fails.
         let primary_hits = Arc::new(AtomicUsize::new(0));
         let hits = Arc::clone(&primary_hits);
-        let primary_port = nextgcore_sbi::test_support::free_port();
-        let primary_addr = SocketAddr::from(([127, 0, 0, 1], primary_port));
-        let primary = SbiServer::new(SbiServerConfig::new(primary_addr));
+        let (primary_listener, primary_addr) =
+            nextgcore_sbi::test_support::bound_listener().into_parts();
+        let primary_port = primary_addr.port();
+        let primary = SbiServer::on_listener(SbiServerConfig::new(primary_addr), primary_listener);
         primary
             .start(move |_req: SbiRequest| {
                 let hits = Arc::clone(&hits);
@@ -5179,9 +5183,9 @@ mod tests {
         // Alternate: accepts.
         let alt_hits = Arc::new(AtomicUsize::new(0));
         let hits = Arc::clone(&alt_hits);
-        let alt_port = nextgcore_sbi::test_support::free_port();
-        let alt_addr = SocketAddr::from(([127, 0, 0, 1], alt_port));
-        let alternate = SbiServer::new(SbiServerConfig::new(alt_addr));
+        let (alt_listener, alt_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let alt_port = alt_addr.port();
+        let alternate = SbiServer::on_listener(SbiServerConfig::new(alt_addr), alt_listener);
         alternate
             .start(move |_req: SbiRequest| {
                 let hits = Arc::clone(&hits);
@@ -5223,9 +5227,9 @@ mod tests {
         // A 4xx is a decision, not a transient fault: it must NOT be retried.
         let rejecting_hits = Arc::new(AtomicUsize::new(0));
         let hits = Arc::clone(&rejecting_hits);
-        let rej_port = nextgcore_sbi::test_support::free_port();
-        let rej_addr = SocketAddr::from(([127, 0, 0, 1], rej_port));
-        let rejecting = SbiServer::new(SbiServerConfig::new(rej_addr));
+        let (rej_listener, rej_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let rej_port = rej_addr.port();
+        let rejecting = SbiServer::on_listener(SbiServerConfig::new(rej_addr), rej_listener);
         rejecting
             .start(move |_req: SbiRequest| {
                 let hits = Arc::clone(&hits);
@@ -5627,9 +5631,10 @@ mod tests {
         let seen: Arc<StdMutex<Vec<(String, serde_json::Value)>>> =
             Arc::new(StdMutex::new(Vec::new()));
         let sink = Arc::clone(&seen);
-        let port = nextgcore_sbi::test_support::free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let af = SbiServer::new(SbiServerConfig::new(addr));
+        let af = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
         af.start(move |req: SbiRequest| {
             let sink = Arc::clone(&sink);
             async move {
@@ -5871,9 +5876,10 @@ mod tests {
     ) {
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
-        let port = nextgcore_sbi::test_support::free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
         let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = std::sync::Arc::clone(&recorded);
         let handler = move |req: SbiRequest| {
@@ -6822,9 +6828,10 @@ mod tests {
         pcf_context_init(64, 64);
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
 
-        let port = nextgcore_sbi::test_support::free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let nrf = SbiServer::new(SbiServerConfig::new(addr));
+        let nrf = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
         // Every registration PUT, recorded with the id it targeted.
         let puts = std::sync::Arc::new(std::sync::Mutex::new(
             Vec::<(String, serde_json::Value)>::new(),
@@ -7049,15 +7056,6 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -7098,12 +7096,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         super::pcf_context_init(64, 64);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Pcf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(super::pcf_sbi_request_handler)
             .await

--- a/src/bins/nextgcore-pcfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-pcfd/src/sbi_path.rs
@@ -1833,9 +1833,10 @@ mod tests {
             Resp::with_status(404)
         }
 
-        let port = nextgcore_sbi::test_support::free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
         server.start(stub_smf).await.expect("start stub SMF");
 
         let uri = format!("http://127.0.0.1:{port}/nsmf-callback/v1/sm-policy-notify/42");
@@ -1907,9 +1908,10 @@ mod tests {
         use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
         use std::time::Duration;
 
-        let port = nextgcore_sbi::test_support::free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), port_listener);
 
         // Mock NRF/UDR: the closure captures its own port so the NRF
         // SearchResult advertises a UDR endpoint that points back at itself.

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_bsfd.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_bsfd.rs
@@ -244,16 +244,9 @@ async fn pcfd_client_registers_binding_with_real_bsfd_over_http() {
         .unwrap_or_else(|e| e.into_inner());
     init_peers();
 
-    fn ephemeral_addr() -> std::net::SocketAddr {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe binds");
-        let addr = probe.local_addr().expect("probe addr");
-        drop(probe);
-        addr
-    }
-
     // Real bsfd SBI server.
-    let bsf_addr = ephemeral_addr();
-    let bsf_server = SbiServer::new(SbiServerConfig::new(bsf_addr));
+    let (bsf_listener, bsf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+    let bsf_server = SbiServer::on_listener(SbiServerConfig::new(bsf_addr), bsf_listener);
     bsf_server
         .start(nextgcore_bsfd::bsf_sbi_request_handler)
         .await
@@ -261,8 +254,8 @@ async fn pcfd_client_registers_binding_with_real_bsfd_over_http() {
 
     // Mock NRF advertising ONLY the real BSF endpoint (discovery bootstrap).
     let bsf_port = bsf_addr.port();
-    let nrf_addr = ephemeral_addr();
-    let nrf_server = SbiServer::new(SbiServerConfig::new(nrf_addr));
+    let (nrf_listener, nrf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+    let nrf_server = SbiServer::on_listener(SbiServerConfig::new(nrf_addr), nrf_listener);
     let nrf_handler = move |req: SbiRequest| async move {
         let path = req.header.uri.split('?').next().unwrap_or("");
         if path == "/nnrf-disc/v1/nf-instances" {
@@ -333,23 +326,16 @@ async fn pcfd_updates_binding_ip_at_real_bsfd_over_http() {
         .unwrap_or_else(|e| e.into_inner());
     init_peers();
 
-    fn ephemeral_addr() -> std::net::SocketAddr {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe binds");
-        let addr = probe.local_addr().expect("probe addr");
-        drop(probe);
-        addr
-    }
-
-    let bsf_addr = ephemeral_addr();
-    let bsf_server = SbiServer::new(SbiServerConfig::new(bsf_addr));
+    let (bsf_listener, bsf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+    let bsf_server = SbiServer::on_listener(SbiServerConfig::new(bsf_addr), bsf_listener);
     bsf_server
         .start(nextgcore_bsfd::bsf_sbi_request_handler)
         .await
         .expect("start real bsfd");
 
     let bsf_port = bsf_addr.port();
-    let nrf_addr = ephemeral_addr();
-    let nrf_server = SbiServer::new(SbiServerConfig::new(nrf_addr));
+    let (nrf_listener, nrf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+    let nrf_server = SbiServer::on_listener(SbiServerConfig::new(nrf_addr), nrf_listener);
     let nrf_handler = move |req: SbiRequest| async move {
         let path = req.header.uri.split('?').next().unwrap_or("");
         if path == "/nnrf-disc/v1/nf-instances" {
@@ -452,23 +438,16 @@ async fn sm_policy_update_wires_the_bsf_binding_update() {
     nextgcore_pcfd::test_support::init_context();
     nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
 
-    fn ephemeral_addr() -> std::net::SocketAddr {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe binds");
-        let addr = probe.local_addr().expect("probe addr");
-        drop(probe);
-        addr
-    }
-
-    let bsf_addr = ephemeral_addr();
-    let bsf_server = SbiServer::new(SbiServerConfig::new(bsf_addr));
+    let (bsf_listener, bsf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+    let bsf_server = SbiServer::on_listener(SbiServerConfig::new(bsf_addr), bsf_listener);
     bsf_server
         .start(nextgcore_bsfd::bsf_sbi_request_handler)
         .await
         .expect("start real bsfd");
     let bsf_port = bsf_addr.port();
 
-    let nrf_addr = ephemeral_addr();
-    let nrf_server = SbiServer::new(SbiServerConfig::new(nrf_addr));
+    let (nrf_listener, nrf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+    let nrf_server = SbiServer::on_listener(SbiServerConfig::new(nrf_addr), nrf_listener);
     let nrf_handler = move |req: SbiRequest| async move {
         let path = req.header.uri.split('?').next().unwrap_or("");
         if path == "/nnrf-disc/v1/nf-instances" {

--- a/src/bins/nextgcore-pcfd/tests/strict_peer_updp_result.rs
+++ b/src/bins/nextgcore-pcfd/tests/strict_peer_updp_result.rs
@@ -194,9 +194,11 @@ async fn start_stub_consumer() -> (
 ) {
     let seen: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
     let sink = Arc::clone(&seen);
-    let addr = nextgcore_sbi::test_support::ephemeral_addr();
-    let server =
-        nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(addr));
+    let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+    let server = nextgcore_sbi::server::SbiServer::on_listener(
+        nextgcore_sbi::server::SbiServerConfig::new(addr),
+        addr_listener,
+    );
     server
         .start(move |req: nextgcore_sbi::message::SbiRequest| {
             let sink = Arc::clone(&sink);

--- a/src/bins/nextgcore-scpd/src/proxy.rs
+++ b/src/bins/nextgcore-scpd/src/proxy.rs
@@ -2146,7 +2146,6 @@ impl ScpProxy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::SocketAddr;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     // ------------------------------------------------------------------
@@ -2417,15 +2416,28 @@ mod tests {
     /// Delegates to the shared helper. This crate previously carried its own
     /// process-wide dedup (PR #138); that logic now lives in one place so all
     /// 21 crates share it and there is a single site to harden further.
-    fn ephemeral_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
+    /// Reserve a loopback port by KEEPING IT BOUND (#313).
+    ///
+    /// Every port this module acquires is then served -- by one of the
+    /// `start_*` helpers or by an inline `SbiServer` -- so none of them wants
+    /// the bare number `free_port` returns. That number leaves the port unbound
+    /// between selection and use, and this file is where the symptom was first
+    /// measured: roughly 1 run in 10 failed to bind before the in-process
+    /// issued-port set was added, and that set does not cover a second test
+    /// BINARY.
+    fn reserve_port() -> nextgcore_sbi::test_support::BoundListener {
+        nextgcore_sbi::test_support::bound_listener()
     }
 
     /// Start a mock producer that echoes the request (method, uri, body and
     /// selected headers) as JSON and returns Binding/Oci headers.
-    async fn start_mock_producer(port: u16) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+    async fn start_mock_producer(
+        reservation: nextgcore_sbi::test_support::BoundListener,
+    ) -> nextgcore_sbi::server::SbiServer {
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(|request: SbiRequest| async move {
@@ -2460,10 +2472,15 @@ mod tests {
     }
 
     /// Start the SCP itself: an SbiServer fronting a ScpProxy.
-    async fn start_scp(port: u16, config: ScpProxyConfig) -> nextgcore_sbi::server::SbiServer {
+    async fn start_scp(
+        reservation: nextgcore_sbi::test_support::BoundListener,
+        config: ScpProxyConfig,
+    ) -> nextgcore_sbi::server::SbiServer {
         let proxy = Arc::new(ScpProxy::new(config));
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| {
@@ -2485,10 +2502,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_model_c_forwarding_end_to_end() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
-        let producer = start_mock_producer(producer_port).await;
-        let scp = start_scp(scp_port, ScpProxyConfig::default()).await;
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
+        let producer = start_mock_producer(producer_listener).await;
+        let scp = start_scp(scp_listener, ScpProxyConfig::default()).await;
 
         let request = SbiRequest::post("/nudm-uecm/v1/registrations")
             .with_body(r#"{"hello":"world"}"#, "application/json")
@@ -2541,12 +2560,14 @@ mod tests {
     /// Start a mock NRF whose nnrf-disc answers with a single-producer
     /// SearchResult, counting how many discovery queries it served.
     async fn start_mock_nrf(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         producer_port: u16,
         hits: Arc<AtomicU64>,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| {
@@ -2602,15 +2623,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_model_d_discovery_forwarding_and_binding_stickiness() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let nrf_hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_mock_producer(producer_port).await;
-        let nrf = start_mock_nrf(nrf_port, producer_port, nrf_hits.clone()).await;
+        let producer = start_mock_producer(producer_listener).await;
+        let nrf = start_mock_nrf(nrf_listener, producer_port, nrf_hits.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -2667,12 +2691,14 @@ mod tests {
     async fn test_upstream_error_body_is_preserved() {
         // A producer that always answers 409 with a ProblemDetails body:
         // the SCP must relay it verbatim, not replace it.
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
-        let server =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], producer_port)),
-            ));
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(producer_listener.addr()),
+            producer_listener.into_listener(),
+        );
         server
             .start(|_request: SbiRequest| async move {
                 SbiResponse::with_status(409).with_body(
@@ -2682,7 +2708,7 @@ mod tests {
             })
             .await
             .expect("producer start");
-        let scp = start_scp(scp_port, ScpProxyConfig::default()).await;
+        let scp = start_scp(scp_listener, ScpProxyConfig::default()).await;
 
         let request = SbiRequest::post("/nudm-uecm/v1/registrations").with_header(
             "3gpp-Sbi-Target-apiRoot",
@@ -2724,11 +2750,12 @@ mod tests {
     #[tokio::test]
     async fn test_slow_producer_is_504_within_bounded_timeout() {
         // A producer that never answers within the SCP's request timeout.
-        let producer_port = ephemeral_port();
-        let server =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], producer_port)),
-            ));
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(producer_listener.addr()),
+            producer_listener.into_listener(),
+        );
         server
             .start(|_request: SbiRequest| async move {
                 tokio::time::sleep(Duration::from_secs(5)).await;
@@ -2769,11 +2796,12 @@ mod tests {
     /// change that.
     #[tokio::test]
     async fn test_nrf_returning_no_candidates_is_404_discovery_failure() {
-        let nrf_port = ephemeral_port();
-        let server =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], nrf_port)),
-            ));
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(nrf_listener.addr()),
+            nrf_listener.into_listener(),
+        );
         server
             .start(|_request: SbiRequest| async move {
                 SbiResponse::ok().with_body(r#"{"nfInstances":[]}"#, "application/json")
@@ -2855,11 +2883,12 @@ mod tests {
     /// since the NRF answered and answered badly.
     #[tokio::test]
     async fn test_nrf_error_response_is_502_discovery_failure() {
-        let nrf_port = ephemeral_port();
-        let server =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], nrf_port)),
-            ));
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(nrf_listener.addr()),
+            nrf_listener.into_listener(),
+        );
         server
             .start(|_request: SbiRequest| async move {
                 SbiResponse::with_status(500)
@@ -2889,11 +2918,12 @@ mod tests {
             discovery_failure_of(&proxy_with_nrf("http://127.0.0.1:1".to_string())).await;
 
         // 2. NRF answers non-200.
-        let erroring_port = ephemeral_port();
-        let erroring =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], erroring_port)),
-            ));
+        let erroring_listener = reserve_port();
+        let erroring_port = erroring_listener.port();
+        let erroring = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(erroring_listener.addr()),
+            erroring_listener.into_listener(),
+        );
         erroring
             .start(|_request: SbiRequest| async move { SbiResponse::with_status(503) })
             .await
@@ -2903,11 +2933,12 @@ mod tests {
                 .await;
 
         // 3. NRF answers 200 with an empty SearchResult.
-        let empty_port = ephemeral_port();
-        let empty =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], empty_port)),
-            ));
+        let empty_listener = reserve_port();
+        let empty_port = empty_listener.port();
+        let empty = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(empty_listener.addr()),
+            empty_listener.into_listener(),
+        );
         empty
             .start(|_request: SbiRequest| async move {
                 SbiResponse::ok().with_body(r#"{"nfInstances":[]}"#, "application/json")
@@ -2990,13 +3021,15 @@ mod tests {
     /// the nnrf-oauth2 access-token endpoint, so the SCP can perform delegated
     /// discovery and then acquire an OAuth2 token. Counts token requests.
     async fn start_mock_nrf_with_oauth2(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         producer_port: u16,
         token: &'static str,
         token_hits: Arc<AtomicU64>,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| {
@@ -3049,9 +3082,13 @@ mod tests {
 
     /// A producer that echoes back the Authorization header it received, so a
     /// test can assert the SCP attached a delegated Bearer token.
-    async fn start_auth_echo_producer(port: u16) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+    async fn start_auth_echo_producer(
+        reservation: nextgcore_sbi::test_support::BoundListener,
+    ) -> nextgcore_sbi::server::SbiServer {
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(|request: SbiRequest| async move {
@@ -3073,21 +3110,24 @@ mod tests {
     /// Authorization the consumer sent.
     #[tokio::test]
     async fn test_model_d_attaches_delegated_bearer_token() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let token_hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_auth_echo_producer(producer_port).await;
+        let producer = start_auth_echo_producer(producer_listener).await;
         let nrf = start_mock_nrf_with_oauth2(
-            nrf_port,
+            nrf_listener,
             producer_port,
             "scp-delegated-token",
             token_hits.clone(),
         )
         .await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 nf_instance_id: Some("scp-instance-1".into()),
@@ -3133,13 +3173,15 @@ mod tests {
     /// it, so each test states its own expectation about the identity the SCP
     /// asserted.
     async fn start_recording_nrf(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         producer_port: u16,
         token: &'static str,
         token_bodies: Arc<tokio::sync::Mutex<Vec<String>>>,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| {
@@ -3181,9 +3223,13 @@ mod tests {
 
     /// A producer that echoes the Authorization it received AND whether the
     /// consumer's CCA header leaked through to it.
-    async fn start_header_echo_producer(port: u16) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+    async fn start_header_echo_producer(
+        reservation: nextgcore_sbi::test_support::BoundListener,
+    ) -> nextgcore_sbi::server::SbiServer {
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(|request: SbiRequest| async move {
@@ -3233,15 +3279,24 @@ mod tests {
     /// against the consumer's registered key (TS 33.501 §13.4.1.3.2).
     #[tokio::test]
     async fn delegated_token_asserts_the_consumer_identity_when_the_consumer_attests_it() {
-        let (producer_port, nrf_port, scp_port) =
-            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
 
-        let producer = start_header_echo_producer(producer_port).await;
-        let nrf =
-            start_recording_nrf(nrf_port, producer_port, "consumer-token", bodies.clone()).await;
+        let producer = start_header_echo_producer(producer_listener).await;
+        let nrf = start_recording_nrf(
+            nrf_listener,
+            producer_port,
+            "consumer-token",
+            bodies.clone(),
+        )
+        .await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 nf_instance_id: Some("scp-instance-1".into()),
@@ -3297,14 +3352,19 @@ mod tests {
     /// after #64, because the CCA we can sign has `sub` = the SCP.
     #[tokio::test]
     async fn delegated_token_stays_scp_attested_without_a_consumer_cca() {
-        let (producer_port, nrf_port, scp_port) =
-            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
 
-        let producer = start_header_echo_producer(producer_port).await;
-        let nrf = start_recording_nrf(nrf_port, producer_port, "scp-token", bodies.clone()).await;
+        let producer = start_header_echo_producer(producer_listener).await;
+        let nrf =
+            start_recording_nrf(nrf_listener, producer_port, "scp-token", bodies.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 nf_instance_id: Some("scp-instance-1".into()),
@@ -3339,14 +3399,18 @@ mod tests {
     /// authentication: assert the consumer's identity with no assertion.
     #[tokio::test]
     async fn trust_requester_identity_asserts_the_consumer_without_a_cca() {
-        let (producer_port, nrf_port, scp_port) =
-            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
 
-        let producer = start_header_echo_producer(producer_port).await;
-        let nrf = start_recording_nrf(nrf_port, producer_port, "tok", bodies.clone()).await;
+        let producer = start_header_echo_producer(producer_listener).await;
+        let nrf = start_recording_nrf(nrf_listener, producer_port, "tok", bodies.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 nf_instance_id: Some("scp-instance-1".into()),
@@ -3384,14 +3448,18 @@ mod tests {
     /// `nudm-sdm`, so only reading the header can produce the right token.
     #[tokio::test]
     async fn access_scope_header_sets_the_delegated_token_scope() {
-        let (producer_port, nrf_port, scp_port) =
-            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
 
-        let producer = start_header_echo_producer(producer_port).await;
-        let nrf = start_recording_nrf(nrf_port, producer_port, "tok", bodies.clone()).await;
+        let producer = start_header_echo_producer(producer_listener).await;
+        let nrf = start_recording_nrf(nrf_listener, producer_port, "tok", bodies.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 nf_instance_id: Some("scp-instance-1".into()),
@@ -3429,14 +3497,18 @@ mod tests {
     /// authorisation at the producer.
     #[tokio::test]
     async fn two_consumers_of_one_target_scope_each_get_their_own_token() {
-        let (producer_port, nrf_port, scp_port) =
-            (ephemeral_port(), ephemeral_port(), ephemeral_port());
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
 
-        let producer = start_header_echo_producer(producer_port).await;
-        let nrf = start_recording_nrf(nrf_port, producer_port, "tok", bodies.clone()).await;
+        let producer = start_header_echo_producer(producer_listener).await;
+        let nrf = start_recording_nrf(nrf_listener, producer_port, "tok", bodies.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 nf_instance_id: Some("scp-instance-1".into()),
@@ -3579,12 +3651,14 @@ mod tests {
     /// hits, so a test can assert **which** endpoint served a request — and that
     /// a live producer was *not* contacted.
     async fn start_named_producer(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         name: &'static str,
         hits: Arc<AtomicU64>,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| {
@@ -3606,11 +3680,13 @@ mod tests {
     /// A mock NRF that answers every `nnrf-disc` query with `search_result`, and
     /// serves the token endpoint the Model D path needs.
     async fn start_nrf_serving(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         search_result: serde_json::Value,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| {
@@ -3640,17 +3716,21 @@ mod tests {
     /// visible: the sdm producer is live and would have answered 200 too.
     #[tokio::test]
     async fn test_model_d_addresses_the_requested_services_endpoint() {
-        let sdm_port = ephemeral_port();
-        let uecm_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let sdm_listener = reserve_port();
+        let sdm_port = sdm_listener.port();
+        let uecm_listener = reserve_port();
+        let uecm_port = uecm_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let sdm_hits = Arc::new(AtomicU64::new(0));
         let uecm_hits = Arc::new(AtomicU64::new(0));
 
-        let sdm = start_named_producer(sdm_port, "sdm", sdm_hits.clone()).await;
-        let uecm = start_named_producer(uecm_port, "uecm", uecm_hits.clone()).await;
+        let sdm = start_named_producer(sdm_listener, "sdm", sdm_hits.clone()).await;
+        let uecm = start_named_producer(uecm_listener, "uecm", uecm_hits.clone()).await;
         let nrf = start_nrf_serving(
-            nrf_port,
+            nrf_listener,
             serde_json::json!({
                 "validityPeriod": 3600,
                 "nfInstances": [{
@@ -3676,7 +3756,7 @@ mod tests {
         )
         .await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -3717,14 +3797,17 @@ mod tests {
     /// the SCP declined rather than that the forward happened to fail.
     #[tokio::test]
     async fn test_model_d_unsupported_api_version_is_400_invalid_api() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_named_producer(producer_port, "uecm-v1", hits.clone()).await;
+        let producer = start_named_producer(producer_listener, "uecm-v1", hits.clone()).await;
         let nrf = start_nrf_serving(
-            nrf_port,
+            nrf_listener,
             serde_json::json!({
                 "validityPeriod": 3600,
                 "nfInstances": [{
@@ -3743,7 +3826,7 @@ mod tests {
         )
         .await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -3831,15 +3914,18 @@ mod tests {
     async fn test_model_d_reselects_the_next_candidate_when_the_first_refuses() {
         // Port 1 on loopback refuses immediately (privileged, nothing listening).
         const DEAD_PORT: u16 = 1;
-        let live_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let live_listener = reserve_port();
+        let live_port = live_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let live_hits = Arc::new(AtomicU64::new(0));
 
-        let live = start_named_producer(live_port, "second", live_hits.clone()).await;
-        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[DEAD_PORT, live_port])).await;
+        let live = start_named_producer(live_listener, "second", live_hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_listener, uecm_instances(&[DEAD_PORT, live_port])).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 connect_timeout: Duration::from_millis(500),
@@ -3882,9 +3968,10 @@ mod tests {
     /// #211's `(504, NRF_NOT_REACHABLE)`: the cause still names which node failed.
     #[tokio::test]
     async fn test_model_d_exhausted_candidates_is_504_distinct_from_discovery_failure() {
-        let nrf_port = ephemeral_port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
         // Two candidates, both refusing.
-        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[1, 2])).await;
+        let nrf = start_nrf_serving(nrf_listener, uecm_instances(&[1, 2])).await;
         let proxy = ScpProxy::new(ScpProxyConfig {
             nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
             connect_timeout: Duration::from_millis(500),
@@ -3897,11 +3984,12 @@ mod tests {
         assert_eq!(exhausted, (504, "TARGET_NF_NOT_REACHABLE".to_string()));
 
         // A genuine discovery error: the NRF answers non-200.
-        let broken_port = ephemeral_port();
-        let broken =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], broken_port)),
-            ));
+        let broken_listener = reserve_port();
+        let broken_port = broken_listener.port();
+        let broken = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(broken_listener.addr()),
+            broken_listener.into_listener(),
+        );
         broken
             .start(|_r: SbiRequest| async move { SbiResponse::with_status(500) })
             .await
@@ -3934,18 +4022,23 @@ mod tests {
     /// "did not reselect" from "reselected and the second also failed".
     #[tokio::test]
     async fn test_model_d_does_not_reselect_on_a_producer_error() {
-        let erroring_port = ephemeral_port();
-        let live_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let erroring_listener = reserve_port();
+        let erroring_port = erroring_listener.port();
+        let live_listener = reserve_port();
+        let live_port = live_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let erroring_hits = Arc::new(AtomicU64::new(0));
         let live_hits = Arc::new(AtomicU64::new(0));
 
-        let erroring = start_counting_500_producer(erroring_port, erroring_hits.clone()).await;
-        let live = start_named_producer(live_port, "second", live_hits.clone()).await;
-        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[erroring_port, live_port])).await;
+        let erroring = start_counting_500_producer(erroring_listener, erroring_hits.clone()).await;
+        let live = start_named_producer(live_listener, "second", live_hits.clone()).await;
+        let nrf =
+            start_nrf_serving(nrf_listener, uecm_instances(&[erroring_port, live_port])).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 connect_timeout: Duration::from_millis(500),
@@ -3982,12 +4075,14 @@ mod tests {
     /// possible.
     #[tokio::test]
     async fn test_max_producer_attempts_bounds_the_reselection_walk() {
-        let live_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
+        let live_listener = reserve_port();
+        let live_port = live_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
         let live_hits = Arc::new(AtomicU64::new(0));
 
-        let live = start_named_producer(live_port, "third", live_hits.clone()).await;
-        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[1, 2, live_port])).await;
+        let live = start_named_producer(live_listener, "third", live_hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_listener, uecm_instances(&[1, 2, live_port])).await;
 
         let bounded = ScpProxy::new(ScpProxyConfig {
             nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
@@ -4030,18 +4125,23 @@ mod tests {
     /// be served by the sibling rather than shed with a 503.
     #[tokio::test]
     async fn test_an_open_circuit_reselects_rather_than_shedding() {
-        let flapping_port = ephemeral_port();
-        let live_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let flapping_listener = reserve_port();
+        let flapping_port = flapping_listener.port();
+        let live_listener = reserve_port();
+        let live_port = live_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let flapping_hits = Arc::new(AtomicU64::new(0));
         let live_hits = Arc::new(AtomicU64::new(0));
 
-        let flapping = start_counting_500_producer(flapping_port, flapping_hits.clone()).await;
-        let live = start_named_producer(live_port, "sibling", live_hits.clone()).await;
-        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[flapping_port, live_port])).await;
+        let flapping = start_counting_500_producer(flapping_listener, flapping_hits.clone()).await;
+        let live = start_named_producer(live_listener, "sibling", live_hits.clone()).await;
+        let nrf =
+            start_nrf_serving(nrf_listener, uecm_instances(&[flapping_port, live_port])).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 connect_timeout: Duration::from_millis(500),
@@ -4120,23 +4220,26 @@ mod tests {
     /// untouched and the consumer gets the 504 the slow producer earned.
     #[tokio::test]
     async fn test_a_timeout_does_not_reselect() {
-        let slow_port = ephemeral_port();
-        let live_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
+        let slow_listener = reserve_port();
+        let slow_port = slow_listener.port();
+        let live_listener = reserve_port();
+        let live_port = live_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
         let live_hits = Arc::new(AtomicU64::new(0));
 
-        let slow =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], slow_port)),
-            ));
+        let slow = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(slow_listener.addr()),
+            slow_listener.into_listener(),
+        );
         slow.start(|_r: SbiRequest| async move {
             tokio::time::sleep(Duration::from_secs(5)).await;
             SbiResponse::ok()
         })
         .await
         .expect("slow producer start");
-        let live = start_named_producer(live_port, "second", live_hits.clone()).await;
-        let nrf = start_nrf_serving(nrf_port, uecm_instances(&[slow_port, live_port])).await;
+        let live = start_named_producer(live_listener, "second", live_hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_listener, uecm_instances(&[slow_port, live_port])).await;
 
         let proxy = ScpProxy::new(ScpProxyConfig {
             nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
@@ -4167,12 +4270,14 @@ mod tests {
     /// A producer answering `201` with `Location: <location>`, optionally naming
     /// itself in `3gpp-Sbi-Producer-Id`, and echoing the URI it was asked for.
     async fn start_location_producer(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         location: Option<&'static str>,
         own_producer_id: Option<&'static str>,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| async move {
@@ -4223,15 +4328,18 @@ mod tests {
     /// so this drives both and compares them.
     #[tokio::test]
     async fn test_producer_id_is_identical_on_a_cache_miss_and_the_following_hit() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_named_producer(producer_port, "udm", hits.clone()).await;
-        let nrf = start_nrf_serving(nrf_port, udm_with_set_and_group(producer_port)).await;
+        let producer = start_named_producer(producer_listener, "udm", hits.clone()).await;
+        let nrf = start_nrf_serving(nrf_listener, udm_with_set_and_group(producer_port)).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -4286,15 +4394,19 @@ mod tests {
     /// would pass against the overwriting code.
     #[tokio::test]
     async fn test_a_downstream_producer_id_is_not_overwritten() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
 
         let producer =
-            start_location_producer(producer_port, None, Some("nfinst=downstream-chosen")).await;
-        let nrf = start_nrf_serving(nrf_port, udm_with_set_and_group(producer_port)).await;
+            start_location_producer(producer_listener, None, Some("nfinst=downstream-chosen"))
+                .await;
+        let nrf = start_nrf_serving(nrf_listener, udm_with_set_and_group(producer_port)).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -4327,16 +4439,22 @@ mod tests {
     /// `route()`'s Model C path proves it is actionable.
     #[tokio::test]
     async fn test_relative_location_after_retargeting_gains_a_usable_target_apiroot() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
 
-        let producer =
-            start_location_producer(producer_port, Some("/nudm-uecm/v1/registrations/42"), None)
-                .await;
-        let nrf = start_nrf_serving(nrf_port, udm_with_set_and_group(producer_port)).await;
+        let producer = start_location_producer(
+            producer_listener,
+            Some("/nudm-uecm/v1/registrations/42"),
+            None,
+        )
+        .await;
+        let nrf = start_nrf_serving(nrf_listener, udm_with_set_and_group(producer_port)).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -4387,19 +4505,22 @@ mod tests {
     /// applied to every 2xx.
     #[tokio::test]
     async fn test_absolute_location_gets_no_target_apiroot() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
 
         let producer = start_location_producer(
-            producer_port,
+            producer_listener,
             Some("http://udm.example.org:8080/nudm-uecm/v1/registrations/42"),
             None,
         )
         .await;
-        let nrf = start_nrf_serving(nrf_port, udm_with_set_and_group(producer_port)).await;
+        let nrf = start_nrf_serving(nrf_listener, udm_with_set_and_group(producer_port)).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -4434,13 +4555,18 @@ mod tests {
     /// echoing its own apiRoot back at it would be noise.
     #[tokio::test]
     async fn test_model_c_relative_location_is_not_annotated() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
 
-        let producer =
-            start_location_producer(producer_port, Some("/nudm-uecm/v1/registrations/42"), None)
-                .await;
-        let scp = start_scp(scp_port, ScpProxyConfig::default()).await;
+        let producer = start_location_producer(
+            producer_listener,
+            Some("/nudm-uecm/v1/registrations/42"),
+            None,
+        )
+        .await;
+        let scp = start_scp(scp_listener, ScpProxyConfig::default()).await;
 
         let request = SbiRequest::post("/nudm-uecm/v1/registrations").with_header(
             custom_header::TARGET_APIROOT,
@@ -4474,13 +4600,15 @@ mod tests {
     /// The counters are the point: the callback path must not touch either
     /// endpoint, and asserting a 200 alone would pass while a token was minted.
     async fn start_counting_nrf(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         producer_port: u16,
         disc_hits: Arc<AtomicU64>,
         token_hits: Arc<AtomicU64>,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| {
@@ -4521,19 +4649,27 @@ mod tests {
     /// `test_callback_with_an_absolute_uri_is_routed_in_process`).
     #[tokio::test]
     async fn test_callback_with_discovery_headers_is_not_discovery_gated() {
-        let callback_port = ephemeral_port();
-        let decoy_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
+        let callback_listener = reserve_port();
+        let callback_port = callback_listener.port();
+        let decoy_listener = reserve_port();
+        let decoy_port = decoy_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
         let callback_hits = Arc::new(AtomicU64::new(0));
         let decoy_hits = Arc::new(AtomicU64::new(0));
         let disc_hits = Arc::new(AtomicU64::new(0));
         let token_hits = Arc::new(AtomicU64::new(0));
 
         let callback_target =
-            start_named_producer(callback_port, "callback-target", callback_hits.clone()).await;
-        let decoy = start_named_producer(decoy_port, "decoy", decoy_hits.clone()).await;
-        let nrf =
-            start_counting_nrf(nrf_port, decoy_port, disc_hits.clone(), token_hits.clone()).await;
+            start_named_producer(callback_listener, "callback-target", callback_hits.clone()).await;
+        let decoy = start_named_producer(decoy_listener, "decoy", decoy_hits.clone()).await;
+        let nrf = start_counting_nrf(
+            nrf_listener,
+            decoy_port,
+            disc_hits.clone(),
+            token_hits.clone(),
+        )
+        .await;
         let proxy = ScpProxy::new(ScpProxyConfig {
             nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
             connect_timeout: Duration::from_millis(500),
@@ -4587,23 +4723,32 @@ mod tests {
     /// discriminates is `test_callback_with_discovery_headers_is_not_discovery_gated`.
     #[tokio::test]
     async fn test_callback_routes_without_discovery_or_token() {
-        let callback_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let callback_listener = reserve_port();
+        let callback_port = callback_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let callback_hits = Arc::new(AtomicU64::new(0));
         let disc_hits = Arc::new(AtomicU64::new(0));
         let token_hits = Arc::new(AtomicU64::new(0));
         // A producer the SCP would have discovered had it taken the delegated path.
-        let decoy_port = ephemeral_port();
+        let decoy_listener = reserve_port();
+        let decoy_port = decoy_listener.port();
         let decoy_hits = Arc::new(AtomicU64::new(0));
 
         let callback_target =
-            start_named_producer(callback_port, "callback-target", callback_hits.clone()).await;
-        let decoy = start_named_producer(decoy_port, "decoy", decoy_hits.clone()).await;
-        let nrf =
-            start_counting_nrf(nrf_port, decoy_port, disc_hits.clone(), token_hits.clone()).await;
+            start_named_producer(callback_listener, "callback-target", callback_hits.clone()).await;
+        let decoy = start_named_producer(decoy_listener, "decoy", decoy_hits.clone()).await;
+        let nrf = start_counting_nrf(
+            nrf_listener,
+            decoy_port,
+            disc_hits.clone(),
+            token_hits.clone(),
+        )
+        .await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -4672,16 +4817,18 @@ mod tests {
     /// its query intact, not the absolute URI.
     #[tokio::test]
     async fn test_callback_with_an_absolute_uri_is_routed_in_process() {
-        let callback_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
+        let callback_listener = reserve_port();
+        let callback_port = callback_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
         let callback_hits = Arc::new(AtomicU64::new(0));
         let disc_hits = Arc::new(AtomicU64::new(0));
         let token_hits = Arc::new(AtomicU64::new(0));
 
         let callback_target =
-            start_named_producer(callback_port, "callback-target", callback_hits.clone()).await;
+            start_named_producer(callback_listener, "callback-target", callback_hits.clone()).await;
         let nrf = start_counting_nrf(
-            nrf_port,
+            nrf_listener,
             callback_port,
             disc_hits.clone(),
             token_hits.clone(),
@@ -4813,10 +4960,12 @@ mod tests {
     /// OAuth2 client; the SCP does not strip or replace it).
     #[tokio::test]
     async fn test_model_c_preserves_consumer_authorization() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
-        let producer = start_auth_echo_producer(producer_port).await;
-        let scp = start_scp(scp_port, ScpProxyConfig::default()).await;
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
+        let producer = start_auth_echo_producer(producer_listener).await;
+        let scp = start_scp(scp_listener, ScpProxyConfig::default()).await;
 
         let request = SbiRequest::post("/nudm-uecm/v1/registrations")
             .with_header(
@@ -4844,9 +4993,14 @@ mod tests {
     // ------------------------------------------------------------------
 
     /// A producer that always answers a fixed error status with a small body.
-    async fn start_status_producer(port: u16, status: u16) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+    async fn start_status_producer(
+        reservation: nextgcore_sbi::test_support::BoundListener,
+        status: u16,
+    ) -> nextgcore_sbi::server::SbiServer {
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |_request: SbiRequest| async move {
@@ -4863,11 +5017,13 @@ mod tests {
     /// A producer that 401s (Bearer challenge) for its first `fail_count`
     /// requests, then answers 200 — used to drive the scpd-07 token retry.
     async fn start_token_gated_producer(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         fail_count: u64,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         let calls = Arc::new(AtomicU64::new(0));
         server
@@ -4898,12 +5054,14 @@ mod tests {
     /// An NRF whose nnrf-disc records every query parameter it received into
     /// `captured`, then returns a one-producer SearchResult.
     async fn start_mock_nrf_capturing(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         producer_port: u16,
         captured: Arc<std::sync::Mutex<HashMap<String, String>>>,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |request: SbiRequest| {
@@ -4960,10 +5118,12 @@ mod tests {
     /// body and status stay verbatim; the SCP does not stamp `Server` on it.
     #[tokio::test]
     async fn test_relayed_error_gains_via_verbatim_body() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
-        let producer = start_status_producer(producer_port, 409).await;
-        let scp = start_scp(scp_port, ScpProxyConfig::default()).await;
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
+        let producer = start_status_producer(producer_listener, 409).await;
+        let scp = start_scp(scp_listener, ScpProxyConfig::default()).await;
 
         let request = SbiRequest::post("/nudm-uecm/v1/registrations").with_header(
             "3gpp-Sbi-Target-apiRoot",
@@ -5029,10 +5189,12 @@ mod tests {
     /// the SCP's own Via on the request seen by the producer.
     #[tokio::test]
     async fn test_forward_decrements_hops_and_inserts_via() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
-        let producer = start_mock_producer(producer_port).await;
-        let scp = start_scp(scp_port, ScpProxyConfig::default()).await;
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
+        let producer = start_mock_producer(producer_listener).await;
+        let scp = start_scp(scp_listener, ScpProxyConfig::default()).await;
 
         let request = SbiRequest::get("/nudm-uecm/v1/registrations")
             .with_header(
@@ -5061,10 +5223,12 @@ mod tests {
     /// params pass through (TS 29.500 §6.10.2.6).
     #[tokio::test]
     async fn test_ck_cache_key_param_is_stripped() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
-        let producer = start_mock_producer(producer_port).await;
-        let scp = start_scp(scp_port, ScpProxyConfig::default()).await;
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
+        let producer = start_mock_producer(producer_listener).await;
+        let scp = start_scp(scp_listener, ScpProxyConfig::default()).await;
 
         let request = SbiRequest::get("/nudm-uecm/v1/registrations")
             .with_param("ck", "cache-key-abc")
@@ -5094,15 +5258,18 @@ mod tests {
     /// NRF as its nnrf-disc query parameter.
     #[tokio::test]
     async fn test_all_discovery_factors_forwarded_to_nrf() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let captured = Arc::new(std::sync::Mutex::new(HashMap::new()));
 
-        let producer = start_mock_producer(producer_port).await;
-        let nrf = start_mock_nrf_capturing(nrf_port, producer_port, captured.clone()).await;
+        let producer = start_mock_producer(producer_listener).await;
+        let nrf = start_mock_nrf_capturing(nrf_listener, producer_port, captured.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -5165,21 +5332,24 @@ mod tests {
     /// once — the consumer sees 200 and the NRF served ≥2 token requests.
     #[tokio::test]
     async fn test_delegated_401_refreshes_token_and_retries_once() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let token_hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_token_gated_producer(producer_port, 1).await;
+        let producer = start_token_gated_producer(producer_listener, 1).await;
         let nrf = start_mock_nrf_with_oauth2(
-            nrf_port,
+            nrf_listener,
             producer_port,
             "scp-delegated-token",
             token_hits.clone(),
         )
         .await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 nf_instance_id: Some("scp-instance-1".into()),
@@ -5214,21 +5384,24 @@ mod tests {
     /// to the consumer after the single retry.
     #[tokio::test]
     async fn test_delegated_persistent_401_is_relayed() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let token_hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_token_gated_producer(producer_port, u64::MAX).await;
+        let producer = start_token_gated_producer(producer_listener, u64::MAX).await;
         let nrf = start_mock_nrf_with_oauth2(
-            nrf_port,
+            nrf_listener,
             producer_port,
             "scp-delegated-token",
             token_hits.clone(),
         )
         .await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 nf_instance_id: Some("scp-instance-1".into()),
@@ -5256,15 +5429,18 @@ mod tests {
     /// single NRF discovery hit (the second is served from the cache).
     #[tokio::test]
     async fn test_discovery_cache_serves_second_request() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let nrf_hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_mock_producer(producer_port).await;
-        let nrf = start_mock_nrf(nrf_port, producer_port, nrf_hits.clone()).await;
+        let producer = start_mock_producer(producer_listener).await;
+        let nrf = start_mock_nrf(nrf_listener, producer_port, nrf_hits.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -5297,17 +5473,20 @@ mod tests {
     /// cause ACCESS_TOKEN_DENIED rather than forwarding tokenless.
     #[tokio::test]
     async fn test_delegated_token_rejection_maps_to_403() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
 
-        let producer = start_mock_producer(producer_port).await;
+        let producer = start_mock_producer(producer_listener).await;
         // NRF answers discovery but rejects the access-token request (not with
         // MISSING_PARAMETER) — the SCP must map this to 403 ACCESS_TOKEN_DENIED.
-        let nrf_server =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], nrf_port)),
-            ));
+        let nrf_server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(nrf_listener.addr()),
+            nrf_listener.into_listener(),
+        );
         nrf_server
             .start(move |request: SbiRequest| async move {
                 if request.header.uri == "/nnrf-oauth2/v1/access-token" {
@@ -5335,7 +5514,7 @@ mod tests {
             .expect("nrf start");
 
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -5366,15 +5545,18 @@ mod tests {
     /// URI seen by the producer.
     #[tokio::test]
     async fn test_apiprefix_propagates_into_forwarded_uri() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
 
-        let producer = start_mock_producer(producer_port).await;
-        let nrf_server =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], nrf_port)),
-            ));
+        let producer = start_mock_producer(producer_listener).await;
+        let nrf_server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(nrf_listener.addr()),
+            nrf_listener.into_listener(),
+        );
         nrf_server
             .start(move |request: SbiRequest| async move {
                 // A real NRF serves both nnrf-disc and nnrf-oauth2; the SCP
@@ -5404,7 +5586,7 @@ mod tests {
             .await
             .expect("nrf start");
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -5434,11 +5616,13 @@ mod tests {
     /// stripped as in the default next-hop-producer deployment).
     #[tokio::test]
     async fn test_next_hop_scp_reinserts_target_apiroot() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
-        let producer = start_mock_producer(producer_port).await;
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
+        let producer = start_mock_producer(producer_listener).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 next_hop_scp: true,
                 ..Default::default()
@@ -5504,15 +5688,18 @@ mod tests {
     /// producer to the consumer via `3gpp-Sbi-Producer-Id` in `nfinst=` form.
     #[tokio::test]
     async fn test_sticky_reselection_reports_producer_id() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let nrf_hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_mock_producer(producer_port).await;
-        let nrf = start_mock_nrf(nrf_port, producer_port, nrf_hits.clone()).await;
+        let producer = start_mock_producer(producer_listener).await;
+        let nrf = start_mock_nrf(nrf_listener, producer_port, nrf_hits.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -5549,15 +5736,18 @@ mod tests {
     /// Producer-Id when the profile declares an NF set.
     #[tokio::test]
     async fn test_group_and_set_member_selection_reports_ids() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
 
-        let producer = start_mock_producer(producer_port).await;
-        let nrf_server =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                SocketAddr::from(([127, 0, 0, 1], nrf_port)),
-            ));
+        let producer = start_mock_producer(producer_listener).await;
+        let nrf_server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(nrf_listener.addr()),
+            nrf_listener.into_listener(),
+        );
         nrf_server
             .start(move |request: SbiRequest| async move {
                 // A real NRF serves both nnrf-disc and nnrf-oauth2; the SCP
@@ -5588,7 +5778,7 @@ mod tests {
             .await
             .expect("nrf start");
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -5628,15 +5818,18 @@ mod tests {
     /// Producer-Id (status-gated to 2xx), but still gains the relay Via.
     #[tokio::test]
     async fn test_relayed_500_carries_no_producer_id() {
-        let producer_port = ephemeral_port();
-        let nrf_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let nrf_listener = reserve_port();
+        let nrf_port = nrf_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let nrf_hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_status_producer(producer_port, 500).await;
-        let nrf = start_mock_nrf(nrf_port, producer_port, nrf_hits.clone()).await;
+        let producer = start_status_producer(producer_listener, 500).await;
+        let nrf = start_mock_nrf(nrf_listener, producer_port, nrf_hits.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 nrf_uri: Some(format!("http://127.0.0.1:{nrf_port}")),
                 ..Default::default()
@@ -5812,11 +6005,13 @@ mod tests {
 
     /// A producer that always answers 500 and counts the requests that reach it.
     async fn start_counting_500_producer(
-        port: u16,
+        reservation: nextgcore_sbi::test_support::BoundListener,
         hits: Arc<AtomicU64>,
     ) -> nextgcore_sbi::server::SbiServer {
-        let server = nextgcore_sbi::server::SbiServer::new(
-            nextgcore_sbi::server::SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+        let (listener, addr) = reservation.into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(addr),
+            listener,
         );
         server
             .start(move |_request: SbiRequest| {
@@ -5839,13 +6034,15 @@ mod tests {
     /// and after the open timeout admits a single half-open probe.
     #[tokio::test]
     async fn test_circuit_breaker_opens_sheds_load_then_probes() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
         let hits = Arc::new(AtomicU64::new(0));
 
-        let producer = start_counting_500_producer(producer_port, hits.clone()).await;
+        let producer = start_counting_500_producer(producer_listener, hits.clone()).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 circuit_failure_threshold: 2,
                 circuit_open_timeout: Duration::from_millis(200),
@@ -5905,11 +6102,13 @@ mod tests {
     /// many forwards — success resets the failure count.
     #[tokio::test]
     async fn test_circuit_breaker_stays_closed_on_success() {
-        let producer_port = ephemeral_port();
-        let scp_port = ephemeral_port();
-        let producer = start_mock_producer(producer_port).await;
+        let producer_listener = reserve_port();
+        let producer_port = producer_listener.port();
+        let scp_listener = reserve_port();
+        let scp_port = scp_listener.port();
+        let producer = start_mock_producer(producer_listener).await;
         let scp = start_scp(
-            scp_port,
+            scp_listener,
             ScpProxyConfig {
                 circuit_failure_threshold: 2,
                 ..Default::default()

--- a/src/bins/nextgcore-seppd/tests/n32_two_sepp.rs
+++ b/src/bins/nextgcore-seppd/tests/n32_two_sepp.rs
@@ -16,7 +16,6 @@
 //! 5. Capability mismatch -> negotiation failure (HTTP 400,
 //!    NEGOTIATION_NOT_ALLOWED)
 
-use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
@@ -30,12 +29,25 @@ use nextgcore_seppd::prins::{protect_message, N32fErrorType};
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
 const PHASE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// A loopback port for a peer that binds it itself.
+///
+/// #313 replaced the probe-drop shape with a reservation everywhere the server
+/// is an `SbiServer` this process starts. **The three callers here cannot take
+/// one**, and the reasons are structural rather than effort:
+///
+/// - `ChildSepp::spawn_inner` passes its two ports to a real CHILD PROCESS on
+///   the command line. A bound listener cannot travel that way without fd
+///   inheritance, which nothing in this tree does.
+/// - `n32_error_reports_are_delivered_to_the_peer` hands its port to
+///   `start_n32_listener(host, port, tls)`, a PRODUCTION entry point whose
+///   signature is a configured host and port. Threading a listener through it
+///   would change production API for a test's benefit.
+///
+/// What this does fix is that the copy was raw: it had no in-process issued-port
+/// set at all, so two threads in this binary could be handed the same port. It
+/// now delegates to the shared helper, which has one.
 fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind ephemeral")
-        .local_addr()
-        .expect("local addr")
-        .port()
+    nextgcore_sbi::test_support::free_port()
 }
 
 /// A peer SEPP running as a real child process; killed on drop.

--- a/src/bins/nextgcore-smfd/src/easdf.rs
+++ b/src/bins/nextgcore-smfd/src/easdf.rs
@@ -440,11 +440,13 @@ pub(crate) mod tests {
 
         // EASDF: 201 + Location + dnsContextId on create, 204 on delete.
         let sink = seen.clone();
-        let easdf_port = nextgcore_sbi::test_support::free_port();
-        let easdf = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            easdf_port,
-        ))));
+        let (easdf_listener, easdf_addr) =
+            nextgcore_sbi::test_support::bound_listener().into_parts();
+        let easdf_port = easdf_addr.port();
+        let easdf = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], easdf_port))),
+            easdf_listener,
+        );
         easdf
             .start(move |req: SbiRequest| {
                 let sink = sink.clone();
@@ -469,11 +471,12 @@ pub(crate) mod tests {
         // NRF: one EASDF advertising BOTH services, the dnscontext one pointing at
         // the EASDF above and the other at a dead port — so selecting the wrong
         // service fails loudly rather than silently working.
-        let nrf_port = nextgcore_sbi::test_support::free_port();
-        let nrf = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            nrf_port,
-        ))));
+        let (nrf_listener, nrf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let nrf_port = nrf_addr.port();
+        let nrf = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], nrf_port))),
+            nrf_listener,
+        );
         nrf.start(move |_req: SbiRequest| async move {
             SbiResponse::with_status(200)
                 .with_json_body(&serde_json::json!({

--- a/src/bins/nextgcore-smfd/src/eps_iwk.rs
+++ b/src/bins/nextgcore-smfd/src/eps_iwk.rs
@@ -430,11 +430,12 @@ mod tests {
         let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let amf = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let amf = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         amf.start(move |req: SbiRequest| {
             let sink = sink.clone();
             async move {

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -6315,16 +6315,20 @@ mod tests {
         // deployment; the default profile is Production and would require client
         // TLS material this test has no business inventing.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
-        let port = nextgcore_sbi::test_support::free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         type Seen = (Vec<String>, Vec<std::collections::HashMap<String, String>>);
         let seen: Arc<std::sync::Mutex<Seen>> =
             Arc::new(std::sync::Mutex::new((Vec::new(), Vec::new())));
         let seen_in_handler = Arc::clone(&seen);
 
-        let server =
-            nextgcore_sbi::server::SbiServer::new(nextgcore_sbi::server::SbiServerConfig::new(
-                std::net::SocketAddr::from(([127, 0, 0, 1], port)),
-            ));
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
+            nextgcore_sbi::server::SbiServerConfig::new(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                port,
+            ))),
+            port_listener,
+        );
         server
             .start(move |req: SbiRequest| {
                 let seen = Arc::clone(&seen_in_handler);
@@ -6794,11 +6798,12 @@ mod tests {
         let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let udm = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let udm = SbiServer::on_listener(
+            SbiServerConfig::new(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         udm.start(move |req: SbiRequest| {
             let sink = sink.clone();
             let sm_data = sm_data.clone();
@@ -6895,11 +6900,12 @@ mod tests {
         let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let amf = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let amf = SbiServer::on_listener(
+            SbiServerConfig::new(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         amf.start(move |req: SbiRequest| {
             let sink = sink.clone();
             async move {
@@ -8444,11 +8450,12 @@ mod tests {
         let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let consumer = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let consumer = SbiServer::on_listener(
+            SbiServerConfig::new(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         consumer
             .start(move |req: SbiRequest| {
                 let sink = sink.clone();
@@ -8941,11 +8948,12 @@ mod tests {
         let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let amf = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let amf = SbiServer::on_listener(
+            SbiServerConfig::new(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         amf.start(move |req: SbiRequest| {
             let sink = sink.clone();
             async move {
@@ -9044,11 +9052,12 @@ mod tests {
         let seen: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let amf = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let amf = SbiServer::on_listener(
+            SbiServerConfig::new(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         amf.start(move |req: SbiRequest| {
             let sink = sink.clone();
             async move {
@@ -9105,15 +9114,6 @@ mod oauth2_h8_tests {
     use nextgcore_sbi::types::NfType;
     use std::time::Duration;
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     /// Mint an ES256 access token in the NRF's shape, signed by `sk`.
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
@@ -9156,12 +9156,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         smf_context_init(64, 256, 512);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Smf);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(smf_sbi_request_handler)
             .await

--- a/src/bins/nextgcore-smfd/src/policy.rs
+++ b/src/bins/nextgcore-smfd/src/policy.rs
@@ -1840,11 +1840,12 @@ mod tests {
         nextgcore_sbi::message::SbiResponse::with_status(404)
     }
 
-    /// Reserve a loopback port for a test server.
+    /// A loopback port with **nothing listening on it**.
     ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
+    /// Both callers assert a bounded-timeout transport error against an absent
+    /// peer, so a reservation would defeat them: `bound_listener` keeps the port
+    /// bound, which makes it reachable. The stub servers in this module take a
+    /// reservation instead (#313); these two deliberately do not.
     fn free_port() -> u16 {
         nextgcore_sbi::test_support::free_port()
     }
@@ -1854,10 +1855,12 @@ mod tests {
         // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
         // dev-profile deployment (issue #63). Declared rather than inherited.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-        let server = nextgcore_sbi::server::SbiServer::new(
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
             nextgcore_sbi::server::SbiServerConfig::new(addr),
+            port_listener,
         );
         server
             .start(stub_pcf_handler)
@@ -1980,10 +1983,12 @@ mod tests {
         // Drives production peer-call code against a loopback PLAINTEXT peer, i.e. a
         // dev-profile deployment (issue #63). Declared rather than inherited.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-        let server = nextgcore_sbi::server::SbiServer::new(
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
             nextgcore_sbi::server::SbiServerConfig::new(addr),
+            port_listener,
         );
         server
             .start(stub_nsacf_handler)

--- a/src/bins/nextgcore-smfd/src/udm.rs
+++ b/src/bins/nextgcore-smfd/src/udm.rs
@@ -797,11 +797,12 @@ mod tests {
         let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String, String)>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let udm = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let udm = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         udm.start(move |req: SbiRequest| {
             let sink = sink.clone();
             async move {

--- a/src/bins/nextgcore-tsctsf/src/main.rs
+++ b/src/bins/nextgcore-tsctsf/src/main.rs
@@ -1586,11 +1586,12 @@ mod tests {
         let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        let port = nextgcore_sbi::test_support::free_port();
-        let server = SbiServer::new(SbiServerConfig::new(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
+        let server = SbiServer::on_listener(
+            SbiServerConfig::new(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
+            port_listener,
+        );
         server
             .start(move |req: SbiRequest| {
                 let sink = sink.clone();

--- a/src/bins/nextgcore-udmd/src/app.rs
+++ b/src/bins/nextgcore-udmd/src/app.rs
@@ -3814,15 +3814,6 @@ mod tests {
             .unwrap_or_else(|_| SbiResponse::with_status(500))
     }
 
-    /// Reserve a loopback port for a test server.
-    ///
-    /// Delegates to the shared helper: 21 crates each had a private
-    /// probe-and-drop copy of this, which is TOCTOU and flaked under parallel
-    /// `cargo test`. One implementation means one place to harden.
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn unhex(s: &str) -> Vec<u8> {
         crate::nudm_handler::hex_to_bytes(s)
     }
@@ -3856,21 +3847,25 @@ mod tests {
             }
 
             // --- mock UDR on an ephemeral port ---
-            let udr_port = free_port();
-            let udr_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udr_port,
-            ))));
+            let (udr_listener, udr_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udr_port = udr_addr.port();
+            let udr_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udr_port))),
+                udr_listener,
+            );
             udr_server.start(mock_udr_handler).await.expect("udr start");
             std::env::set_var("UDR_SBI_ADDR", "127.0.0.1");
             std::env::set_var("UDR_SBI_PORT", udr_port.to_string());
 
             // --- real UDM handler on an ephemeral port ---
-            let udm_port = free_port();
-            let udm_server = SbiServer::new(NextgcoreSbiServerConfig::new(SocketAddr::from((
-                [127, 0, 0, 1],
-                udm_port,
-            ))));
+            let (udm_listener, udm_addr) =
+                nextgcore_sbi::test_support::bound_listener().into_parts();
+            let udm_port = udm_addr.port();
+            let udm_server = SbiServer::on_listener(
+                NextgcoreSbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], udm_port))),
+                udm_listener,
+            );
             udm_server
                 .start(udm_sbi_request_handler)
                 .await
@@ -5491,9 +5486,10 @@ mod tests {
     /// backing store.
     async fn start_mock_udr_context_data() -> (SbiServer, CtxStore) {
         let store: CtxStore = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(NextgcoreSbiServerConfig::new(addr), port_listener);
         let handler_store = Arc::clone(&store);
         server
             .start(move |req: SbiRequest| {
@@ -5517,9 +5513,10 @@ mod tests {
 
     /// Start the real UDM SBI server and return it with a client for it.
     async fn start_real_udm() -> (SbiServer, nextgcore_sbi::client::SbiClient) {
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(NextgcoreSbiServerConfig::new(addr), port_listener);
         server
             .start(udm_sbi_request_handler)
             .await
@@ -5792,9 +5789,10 @@ mod tests {
 
         let hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let counter = Arc::clone(&hits);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let server = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let server = SbiServer::on_listener(NextgcoreSbiServerConfig::new(addr), port_listener);
         server
             .start(move |_req: SbiRequest| {
                 let counter = Arc::clone(&counter);
@@ -5839,9 +5837,10 @@ mod tests {
         state
             .patch_status
             .store(204, std::sync::atomic::Ordering::SeqCst);
-        let udr_port = free_port();
-        let udr_addr = SocketAddr::from(([127, 0, 0, 1], udr_port));
-        let udr_server = SbiServer::new(NextgcoreSbiServerConfig::new(udr_addr));
+        let (udr_listener, udr_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr_port = udr_addr.port();
+        let udr_server =
+            SbiServer::on_listener(NextgcoreSbiServerConfig::new(udr_addr), udr_listener);
         let handler_state = Arc::clone(&state);
         udr_server
             .start(move |req: SbiRequest| {
@@ -6449,9 +6448,10 @@ mod tests {
 
         // Stand up amfd's REAL Namf handler and register it as the serving AMF.
         let amf_instance_id = "amf-for-mt-test";
-        let amf_port = free_port();
-        let amf_addr = SocketAddr::from(([127, 0, 0, 1], amf_port));
-        let amf_server = SbiServer::new(NextgcoreSbiServerConfig::new(amf_addr));
+        let (amf_listener, amf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let amf_port = amf_addr.port();
+        let amf_server =
+            SbiServer::on_listener(NextgcoreSbiServerConfig::new(amf_addr), amf_listener);
         amf_server
             .start(nextgcore_amfd::namf_request_handler)
             .await
@@ -6540,10 +6540,6 @@ mod oauth2_h8_tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
-    fn free_port() -> u16 {
-        nextgcore_sbi::test_support::free_port()
-    }
-
     fn build_es256_token(
         sk: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -6584,12 +6580,13 @@ mod oauth2_h8_tests {
 
     async fn start_server(jwks: serde_json::Value) -> (SbiServer, u16) {
         super::udm_context_init(64, 64);
-        let port = free_port();
+        let (port_listener, port_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = port_addr.port();
         let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
         cfg = cfg.with_expected_audience_nf_type(NfType::Udm);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, port_listener);
         server
             .start(super::udm_sbi_request_handler)
             .await

--- a/src/bins/nextgcore-udmd/src/notify.rs
+++ b/src/bins/nextgcore-udmd/src/notify.rs
@@ -266,8 +266,8 @@ mod tests {
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
         let seen: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
         let sink = Arc::clone(&seen);
-        let addr = nextgcore_sbi::test_support::ephemeral_addr();
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), addr_listener);
         server
             .start(move |req: SbiRequest| {
                 let sink = Arc::clone(&sink);

--- a/src/bins/nextgcore-udmd/src/sbi_path.rs
+++ b/src/bins/nextgcore-udmd/src/sbi_path.rs
@@ -1139,9 +1139,10 @@ mod tests {
         // Production profile would make the client attempt TLS against it.
         nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
 
-        let addr = nextgcore_sbi::test_support::ephemeral_addr();
-        let server = nextgcore_sbi::server::SbiServer::new(
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let server = nextgcore_sbi::server::SbiServer::on_listener(
             nextgcore_sbi::server::SbiServerConfig::new(addr),
+            addr_listener,
         );
         server
             .start(|_req: SbiRequest| async move {

--- a/src/bins/nextgcore-udmd/src/uecm.rs
+++ b/src/bins/nextgcore-udmd/src/uecm.rs
@@ -2209,8 +2209,8 @@ mod tests {
         let supi = "imsi-001010000000883";
         let seen: Arc<StdMutex<Vec<Value>>> = Arc::new(StdMutex::new(Vec::new()));
         let sink = Arc::clone(&seen);
-        let addr = nextgcore_sbi::test_support::ephemeral_addr();
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), addr_listener);
         server
             .start(move |req: SReq| {
                 let sink = Arc::clone(&sink);

--- a/src/bins/nextgcore-udmd/tests/sor_upu_strict_peer.rs
+++ b/src/bins/nextgcore-udmd/tests/sor_upu_strict_peer.rs
@@ -139,13 +139,6 @@ fn test_kausf(tag: u8) -> [u8; 32] {
     k
 }
 
-fn free_port() -> u16 {
-    let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
-    let port = probe.local_addr().expect("probe addr").port();
-    drop(probe);
-    port
-}
-
 /// Seed the ausfd per-SUPI anchor store (F-02) with a known KAUSF, exactly as
 /// a completed primary authentication would (TS 33.501 §6.14.1). `anchor_refresh`
 /// resets both counters to 0x0001 (§6.14.2.3 / §6.15.2.2).
@@ -219,11 +212,12 @@ async fn sor_upu_strict_peer_end_to_end() {
 
     tokio::time::timeout(Duration::from_secs(60), async {
         // Stand up the REAL ausfd SBI HTTP/2 server + dispatcher.
-        let ausf_port = free_port();
-        let ausf_server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            ausf_port,
-        ))));
+        let (ausf_listener, ausf_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let ausf_port = ausf_addr.port();
+        let ausf_server = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], ausf_port))),
+            ausf_listener,
+        );
         ausf_server
             .start(ausf_sbi_request_handler)
             .await

--- a/src/bins/nextgcore-udrd/src/main.rs
+++ b/src/bins/nextgcore-udrd/src/main.rs
@@ -4128,11 +4128,6 @@ udr:
     use std::time::Duration;
     use tokio::sync::mpsc;
 
-    /// Loopback address on a shared-helper-issued ephemeral port.
-    fn ephemeral_addr() -> SocketAddr {
-        nextgcore_sbi::test_support::ephemeral_addr()
-    }
-
     /// Serializes tests that depend on the global nextgcore-dbi backend
     /// state: the WSB-6 tests enable the in-memory dbi test store while
     /// `test_http_auth_provisioning_and_plmn_validation` asserts the
@@ -4170,16 +4165,21 @@ udr:
         u16,
         mpsc::UnboundedReceiver<(String, String)>,
     ) {
-        let udr_addr = ephemeral_addr();
-        let udr_server = SbiServer::new(NextgcoreSbiServerConfig::new(udr_addr));
+        let (udr_listener, udr_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr_server =
+            SbiServer::on_listener(NextgcoreSbiServerConfig::new(udr_addr), udr_listener);
         udr_server
             .start(udr_sbi_request_handler)
             .await
             .expect("UDR SBI server starts");
 
-        let listener_addr = ephemeral_addr();
+        let (listener_listener, listener_addr) =
+            nextgcore_sbi::test_support::bound_listener().into_parts();
         let (tx, rx) = mpsc::unbounded_channel::<(String, String)>();
-        let listener = SbiServer::new(NextgcoreSbiServerConfig::new(listener_addr));
+        let listener = SbiServer::on_listener(
+            NextgcoreSbiServerConfig::new(listener_addr),
+            listener_listener,
+        );
         listener
             .start(move |req: SbiRequest| {
                 let tx = tx.clone();
@@ -4679,8 +4679,8 @@ udr:
         // backend lock so it cannot overlap with the WSB-6 tests that enable
         // the in-memory dbi test store.
         let _backend = DBI_BACKEND_LOCK.lock().await;
-        let udr_addr = ephemeral_addr();
-        let udr = SbiServer::new(NextgcoreSbiServerConfig::new(udr_addr));
+        let (udr_listener, udr_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr = SbiServer::on_listener(NextgcoreSbiServerConfig::new(udr_addr), udr_listener);
         udr.start(udr_sbi_request_handler)
             .await
             .expect("UDR SBI server starts");
@@ -4960,8 +4960,8 @@ udr:
     /// imsi- and suci- must be unchanged.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_varueid_routing() {
-        let udr_addr = ephemeral_addr();
-        let udr = SbiServer::new(NextgcoreSbiServerConfig::new(udr_addr));
+        let (udr_listener, udr_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr = SbiServer::on_listener(NextgcoreSbiServerConfig::new(udr_addr), udr_listener);
         udr.start(udr_sbi_request_handler)
             .await
             .expect("UDR SBI server starts");
@@ -5291,8 +5291,8 @@ udr:
 
     /// Spin up the UDR SBI server and return a client for it.
     async fn start_udr() -> (SbiServer, SbiClient) {
-        let addr = ephemeral_addr();
-        let udr = SbiServer::new(NextgcoreSbiServerConfig::new(addr));
+        let (addr_listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr = SbiServer::on_listener(NextgcoreSbiServerConfig::new(addr), addr_listener);
         udr.start(udr_sbi_request_handler)
             .await
             .expect("UDR SBI server starts");
@@ -5584,8 +5584,8 @@ udr:
     #[tokio::test]
     async fn wsb6_patch_stores_exact_sqn_no_side_effect() {
         let _store = DbiTestStore::enable().await;
-        let udr_addr = ephemeral_addr();
-        let udr = SbiServer::new(NextgcoreSbiServerConfig::new(udr_addr));
+        let (udr_listener, udr_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr = SbiServer::on_listener(NextgcoreSbiServerConfig::new(udr_addr), udr_listener);
         udr.start(udr_sbi_request_handler)
             .await
             .expect("UDR SBI server starts");
@@ -5633,8 +5633,8 @@ udr:
     #[tokio::test]
     async fn wsb6_auth_status_put_delete_no_sqn_side_effect() {
         let _store = DbiTestStore::enable().await;
-        let udr_addr = ephemeral_addr();
-        let udr = SbiServer::new(NextgcoreSbiServerConfig::new(udr_addr));
+        let (udr_listener, udr_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr = SbiServer::on_listener(NextgcoreSbiServerConfig::new(udr_addr), udr_listener);
         udr.start(udr_sbi_request_handler)
             .await
             .expect("UDR SBI server starts");
@@ -5693,8 +5693,8 @@ udr:
     #[tokio::test]
     async fn wsb6_udm_av_flow_advances_sqn_one_step_per_av() {
         let _store = DbiTestStore::enable().await;
-        let udr_addr = ephemeral_addr();
-        let udr = SbiServer::new(NextgcoreSbiServerConfig::new(udr_addr));
+        let (udr_listener, udr_addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let udr = SbiServer::on_listener(NextgcoreSbiServerConfig::new(udr_addr), udr_listener);
         udr.start(udr_sbi_request_handler)
             .await
             .expect("UDR SBI server starts");

--- a/src/libs/nextgcore-sbi/benches/transport.rs
+++ b/src/libs/nextgcore-sbi/benches/transport.rs
@@ -52,18 +52,12 @@ fn fixed_body_handler(
     }
 }
 
-/// Pick a free loopback port (probe-bind-drop; single-process bench, and
-/// server starts retry to absorb the small TOCTOU window).
-fn free_port() -> u16 {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .expect("probe bind")
-        .local_addr()
-        .expect("probe addr")
-        .port()
-}
-
-/// Start an `SbiServer` on a free port, retrying if the probed port was
-/// stolen between probe and bind.
+/// Start an `SbiServer` on a **reserved** loopback port.
+///
+/// This carried its own unguarded probe-bind-drop `free_port` plus a five-attempt
+/// retry to absorb the window it created. #313 removed the window instead: the
+/// shared reservation stays bound until the server adopts it, so one attempt is
+/// correct and a failure is a real failure.
 async fn start_h2_server<H>(
     make_config: impl Fn(SocketAddr) -> SbiServerConfig,
     handler: H,
@@ -75,14 +69,10 @@ where
         + Sync
         + 'static,
 {
-    for _ in 0..5 {
-        let port = free_port();
-        let server = SbiServer::new(make_config(SocketAddr::from(([127, 0, 0, 1], port))));
-        if server.start(handler.clone()).await.is_ok() {
-            return (server, port);
-        }
-    }
-    panic!("could not bind an SbiServer after 5 attempts");
+    let (listener, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+    let server = SbiServer::on_listener(make_config(addr), listener);
+    server.start(handler).await.expect("SbiServer starts");
+    (server, addr.port())
 }
 
 /// One warm GET against an `SbiClient`, asserting success and full body.

--- a/src/libs/nextgcore-sbi/src/http3.rs
+++ b/src/libs/nextgcore-sbi/src/http3.rs
@@ -472,25 +472,15 @@ mod tests {
     /// handler returns a body byte-identical to the HTTP/2 path.
     #[tokio::test]
     async fn http3_body_is_byte_identical_to_http2() {
-        // HTTP/2 (h2c) side — probe-bind-drop to pick a free port (the
-        // server binds only its configured address), retrying if a parallel
-        // test steals the port in the probe→bind window.
-        let (h2_server, port) = {
-            let mut started = None;
-            for _ in 0..5 {
-                let port = crate::test_support::free_port();
-                let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-                    [127, 0, 0, 1],
-                    port,
-                ))));
-                if server.start(fixed_json_handler).await.is_ok() {
-                    started = Some((server, port));
-                    break;
-                }
-            }
-            started.expect("h2 server after 5 attempts")
-        };
-        let h2_client = SbiClient::with_host_port("127.0.0.1", port);
+        // HTTP/2 (h2c) side. This used to probe-bind-drop for a port and RETRY
+        // FIVE TIMES, because the port was unbound between the probe and the
+        // server's own bind and a parallel test could take it. #313 removed the
+        // window rather than the symptom: the reservation stays bound and the
+        // server serves it, so a single attempt is now correct and a failure
+        // here means a real failure.
+        let (h2_server, h2_addr) =
+            crate::test_support::sbi_server_on_free_port(fixed_json_handler).await;
+        let h2_client = SbiClient::with_host_port("127.0.0.1", h2_addr.port());
         let h2_response = h2_client.get(REQ_PATH).await.expect("h2 GET");
         assert_eq!(h2_response.status, 200);
         let h2_body = h2_response.http.content.expect("h2 body");

--- a/src/libs/nextgcore-sbi/src/security.rs
+++ b/src/libs/nextgcore-sbi/src/security.rs
@@ -1014,7 +1014,6 @@ mod mtls_oauth2_e2e {
     use crate::message::{SbiRequest, SbiResponse};
     use crate::oauth::OAuth2Client;
     use crate::server::{SbiServer, SbiServerConfig};
-    use std::net::SocketAddr;
     use std::sync::Arc;
 
     /// A CA plus a server leaf and a client leaf signed by it, written as PEM.
@@ -1130,11 +1129,9 @@ mod mtls_oauth2_e2e {
 
     /// A stub NRF that answers the access-token endpoint with `token`.
     async fn start_stub_nrf(token: String) -> (SbiServer, u16) {
-        let port = crate::test_support::free_port();
-        let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (listener, addr) = crate::test_support::bound_listener().into_parts();
+        let port = addr.port();
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), listener);
         server
             .start(move |_req: SbiRequest| {
                 let token = token.clone();
@@ -1157,7 +1154,8 @@ mod mtls_oauth2_e2e {
     /// The producer: mTLS listener that requires an OAuth2 token whose audience
     /// is its own NF type, configured through the PRODUCTION profile.
     async fn start_producer(pki: &Pki, jwks: serde_json::Value) -> (SbiServer, u16) {
-        let port = crate::test_support::free_port();
+        let (listener, addr) = crate::test_support::bound_listener().into_parts();
+        let port = addr.port();
         let policy = SbiSecurityPolicy {
             tls_paths: TlsPaths {
                 cert: pki.server_cert.clone(),
@@ -1169,7 +1167,7 @@ mod mtls_oauth2_e2e {
             },
             ..SbiSecurityPolicy::production()
         };
-        let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
+        let mut cfg = SbiServerConfig::new(addr);
         // A static JWKS stands in for the NRF's live one, so the producer's
         // verification is exercised without a second network dependency.
         cfg.oauth2_jwks = Some(jwks);
@@ -1183,7 +1181,7 @@ mod mtls_oauth2_e2e {
         .expect("production profile applies");
         assert!(cfg.verify_client && cfg.require_oauth2);
 
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, listener);
         server
             .start(|_req: SbiRequest| async move { SbiResponse::ok() })
             .await
@@ -1380,7 +1378,8 @@ mod mtls_oauth2_e2e {
         let pki = pki_with_uri_san("peercert", "urn:uuid:consumer-42");
         let signing = crate::oauth::generate_es256_key();
 
-        let port = crate::test_support::free_port();
+        let (listener, addr) = crate::test_support::bound_listener().into_parts();
+        let port = addr.port();
         let policy = SbiSecurityPolicy {
             tls_paths: TlsPaths {
                 cert: pki.server_cert.clone(),
@@ -1392,7 +1391,7 @@ mod mtls_oauth2_e2e {
             },
             ..SbiSecurityPolicy::production()
         };
-        let mut cfg = SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port)));
+        let mut cfg = SbiServerConfig::new(addr);
         cfg.oauth2_jwks = Some(jwks(signing.verifying_key()));
         let cfg = apply_sbi_security_policy(
             cfg,
@@ -1404,7 +1403,7 @@ mod mtls_oauth2_e2e {
         .expect("production profile applies");
 
         // The handler reports back what identity the server saw.
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, listener);
         server
             .start(|req: SbiRequest| async move {
                 let seen = req.peer_cert_nf_instance_id.clone().unwrap_or_default();
@@ -1444,11 +1443,9 @@ mod mtls_oauth2_e2e {
     /// identity is `None` rather than anything a caller could act on.
     #[tokio::test]
     async fn a_plaintext_connection_surfaces_no_peer_identity() {
-        let port = crate::test_support::free_port();
-        let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let (listener, addr) = crate::test_support::bound_listener().into_parts();
+        let port = addr.port();
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), listener);
         server
             .start(|req: SbiRequest| async move {
                 let present = req.peer_cert_nf_instance_id.is_some();

--- a/src/libs/nextgcore-sbi/src/server.rs
+++ b/src/libs/nextgcore-sbi/src/server.rs
@@ -896,6 +896,10 @@ pub struct SbiServer {
     config: SbiServerConfig,
     /// Server state
     state: Arc<Mutex<ServerState>>,
+    /// A listener the caller bound before constructing this server, for
+    /// [`SbiServer::on_listener`]. Taken by the first `start()`; `None` there
+    /// means `start()` binds `config.addr` itself, which is the ordinary path.
+    prebound: Arc<Mutex<Option<std::net::TcpListener>>>,
 }
 
 impl SbiServer {
@@ -904,12 +908,57 @@ impl SbiServer {
         Self {
             config,
             state: Arc::new(Mutex::new(ServerState::Stopped)),
+            prebound: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Create a server with address
     pub fn with_addr(addr: SocketAddr) -> Self {
         Self::new(SbiServerConfig::new(addr))
+    }
+
+    /// Create a server that will serve on a listener the caller has **already
+    /// bound**, rather than binding `config.addr` itself (#313).
+    ///
+    /// # Why this exists
+    ///
+    /// The ordinary path picks an address and binds it inside [`start`](Self::start).
+    /// For a test that needs an unused port, that means asking the OS for one
+    /// (bind `:0`, read the port, drop the probe) and then binding it again —
+    /// and between the drop and the real bind the port belongs to nobody, so a
+    /// concurrently-starting process can take it. `cargo test --workspace` runs
+    /// one test binary per crate at once, so that window is reachable: it
+    /// surfaces as a bind failure inside `start()`, not as a wrong answer.
+    ///
+    /// Handing the server the listener removes the window entirely — the port is
+    /// bound from the moment it is chosen. See
+    /// [`crate::test_support::bound_listener`] for the reservation helper and
+    /// [`crate::test_support::sbi_server_on_free_port`] for the whole shape.
+    ///
+    /// # `config.addr` is overwritten
+    ///
+    /// Deliberately: the listener's real local address is authoritative, and a
+    /// server whose `config.addr` disagreed with the socket it serves would
+    /// misreport itself in `stop()`'s log and in any URI derived from the
+    /// config. That also lets a caller pass a config built with a placeholder
+    /// address. If `local_addr()` fails — it does not for a bound listener —
+    /// `config.addr` is left as supplied.
+    ///
+    /// # Restart
+    ///
+    /// The listener is consumed by the first `start()`. A `stop()`/`start()`
+    /// cycle re-binds `config.addr` like any other server, which reopens the
+    /// same window for that one re-bind; nothing in this workspace restarts a
+    /// server on a reserved port.
+    pub fn on_listener(mut config: SbiServerConfig, listener: std::net::TcpListener) -> Self {
+        if let Ok(actual) = listener.local_addr() {
+            config.addr = actual;
+        }
+        Self {
+            config,
+            state: Arc::new(Mutex::new(ServerState::Stopped)),
+            prebound: Arc::new(Mutex::new(Some(listener))),
+        }
     }
 
     /// Get the server configuration
@@ -956,9 +1005,24 @@ impl SbiServer {
             return Err(SbiError::ServerError("Server already running".to_string()));
         }
 
-        let listener = TcpListener::bind(self.config.addr)
-            .await
-            .map_err(|e| SbiError::ServerError(format!("Failed to bind: {e}")))?;
+        // #313: serve a caller-supplied listener when one was reserved, so the
+        // chosen port is never unbound between selection and use. Taken (not
+        // cloned) so a later restart falls back to the ordinary bind.
+        let listener = match self.prebound.lock().await.take() {
+            Some(std_listener) => {
+                std_listener.set_nonblocking(true).map_err(|e| {
+                    SbiError::ServerError(format!(
+                        "Failed to set pre-bound listener nonblocking: {e}"
+                    ))
+                })?;
+                TcpListener::from_std(std_listener).map_err(|e| {
+                    SbiError::ServerError(format!("Failed to adopt pre-bound listener: {e}"))
+                })?
+            }
+            None => TcpListener::bind(self.config.addr)
+                .await
+                .map_err(|e| SbiError::ServerError(format!("Failed to bind: {e}")))?,
+        };
 
         let tls_acceptor = if self.config.scheme == UriScheme::Https {
             Some(self.build_tls_acceptor()?)
@@ -1839,13 +1903,12 @@ mod tests {
         use crate::client::SbiClient;
         use crate::message::SbiPart;
 
-        // Find a free localhost port for the test server.
-        let port = crate::test_support::free_port();
+        // #313: a reserved listener, so the port is never unbound between
+        // selection and use.
+        let (listener, addr) = crate::test_support::bound_listener().into_parts();
+        let port = addr.port();
 
-        let server = SbiServer::new(SbiServerConfig::new(SocketAddr::from((
-            [127, 0, 0, 1],
-            port,
-        ))));
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), listener);
         server
             .start(|request: SbiRequest| async move {
                 // hyper delivered the custom header lowercased; the
@@ -1921,11 +1984,14 @@ mod tests {
         mut config: SbiServerConfig,
         handler: H,
     ) -> (SbiServer, u16) {
-        let port = crate::test_support::free_port();
-        config.addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let server = SbiServer::new(config);
+        // #313: the reservation stays bound, and `on_listener` overwrites
+        // `config.addr` from the socket, so the caller's placeholder address is
+        // irrelevant.
+        let (listener, addr) = crate::test_support::bound_listener().into_parts();
+        config.addr = addr;
+        let server = SbiServer::on_listener(config, listener);
         server.start(handler).await.expect("value expected");
-        (server, port)
+        (server, addr.port())
     }
 
     #[tokio::test]
@@ -2115,12 +2181,12 @@ mod tests {
             Arc::new(std::sync::Mutex::new(None));
         let sink = Arc::clone(&seen);
 
-        let port = crate::test_support::free_port();
-        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let (listener, addr) = crate::test_support::bound_listener().into_parts();
+        let port = addr.port();
         let mut cfg = SbiServerConfig::new(addr);
         cfg.require_oauth2 = true;
         cfg.oauth2_jwks = Some(jwks);
-        let server = SbiServer::new(cfg);
+        let server = SbiServer::on_listener(cfg, listener);
         server
             .start(move |req: SbiRequest| {
                 let sink = Arc::clone(&sink);
@@ -2172,9 +2238,9 @@ mod tests {
             Arc::new(std::sync::Mutex::new(None));
         let sink = Arc::clone(&seen);
 
-        let port = crate::test_support::free_port();
-        let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        let server = SbiServer::new(SbiServerConfig::new(addr));
+        let (listener, addr) = crate::test_support::bound_listener().into_parts();
+        let port = addr.port();
+        let server = SbiServer::on_listener(SbiServerConfig::new(addr), listener);
         server
             .start(move |req: SbiRequest| {
                 let sink = Arc::clone(&sink);

--- a/src/libs/nextgcore-sbi/src/test_support.rs
+++ b/src/libs/nextgcore-sbi/src/test_support.rs
@@ -6,49 +6,60 @@
 //! convention (see `nextgcore-bsfd`, `-amfd`, `-ausfd`, `-pcfd`, `-udmd`).
 
 use std::collections::HashSet;
-use std::net::SocketAddr;
+use std::net::{SocketAddr, TcpListener};
 use std::sync::{Mutex, OnceLock};
+
+use crate::server::{SbiServer, SbiServerConfig};
+
+/// Every port this module has handed out in this process, by either route.
+///
+/// One set for both [`free_port`] and [`bound_listener`]: a bare-port caller and
+/// a reserved-listener caller in the same process must not be given the same
+/// number either. Declared at module scope rather than inside `free_port` so the
+/// second route can reach it — the same "declare the global beside what guards
+/// it" shape #308 imposed on the process-state test locks.
+fn issued_ports() -> &'static Mutex<HashSet<u16>> {
+    static ISSUED: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
+    ISSUED.get_or_init(|| Mutex::new(HashSet::new()))
+}
 
 /// Reserve a loopback port for a test server, never handing the same port to
 /// two callers in this process.
 ///
-/// # The window this closes, and the one it does not
+/// # Prefer [`bound_listener`] when the port will be served
 ///
-/// The obvious implementation — bind `127.0.0.1:0`, read the assigned port,
-/// drop the probe, let the caller bind it — is inherently TOCTOU: between the
-/// drop and the caller's real bind the port is unbound, so the OS may hand it
-/// to the next probe. Twenty-one crates each had a private copy of exactly that
-/// helper, and under parallel `cargo test` it surfaced as spurious
-/// `Address already in use` failures: `nextgcore-scpd` at roughly 1 run in 10
-/// before it was mitigated, and `nextgcore-nssfd` on a clean merged main.
+/// This helper still has the probe-drop window: it binds `127.0.0.1:0`, reads
+/// the assigned port, drops the probe and returns a bare number, so between the
+/// drop and the caller's real bind the port belongs to nobody. Excluding
+/// already-issued ports closes the *in-process* race — the one parallel test
+/// threads create — but each test BINARY has its own `ISSUED` set, so under
+/// `cargo test --workspace`, which runs one binary per crate at once, two crates
+/// can still be handed the same port and one of them then fails to bind. That
+/// was #313, and the fix is [`bound_listener`] (plus
+/// [`SbiServer::on_listener`]): the port is bound from the moment it is chosen,
+/// so there is no window at all.
 ///
-/// Excluding already-issued ports closes the *in-process* race, which is the
-/// one parallel test threads create and the only one actually observed here.
+/// What is left for this helper is the callers that need a port but never bind
+/// it — a "nothing is listening here" address for a connection-refused test, a
+/// URI in a notification body that is never dialled, a UDP peer. Holding a TCP
+/// listener on those would change what the test measures, which is why #313 did
+/// not delete this function.
 ///
-/// It does NOT close the probe-drop window itself: a foreign process can still
-/// claim the port in that gap. Eliminating that requires handing callers a
-/// PRE-BOUND `TcpListener` — the port is then never unbound — which in turn
-/// requires [`crate::server::SbiServer`] to accept a listener instead of only a
-/// `SocketAddr` (it binds internally today). That API change is tracked as #313;
-/// when it lands, every caller of this helper inherits it, which is the point of
-/// having one implementation rather than 21. (It said "tracked separately" for
-/// months while no such issue existed — #308 filed it.)
-///
-/// Note that each test BINARY has its own `ISSUED` set, so the cross-process case
-/// this cannot close is precisely `cargo test --workspace`, where one binary per
-/// crate runs concurrently. That is why #313 matters more than the low rate
-/// suggests, and why `ci.yml` names it where the blanket retry used to be.
+/// The original symptom, for the record: 21 crates each had a private copy of
+/// the unguarded probe-drop helper, and under parallel `cargo test` it surfaced
+/// as spurious `Address already in use` failures — `nextgcore-scpd` at roughly 1
+/// run in 10 before it was mitigated, and `nextgcore-nssfd` on a clean merged
+/// main.
 ///
 /// # Panics
 ///
 /// If 256 consecutive probes all return already-issued ports, which would mean
 /// the ephemeral range is effectively exhausted.
 pub fn free_port() -> u16 {
-    static ISSUED: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
-    let issued = ISSUED.get_or_init(|| Mutex::new(HashSet::new()));
+    let issued = issued_ports();
 
     for _ in 0..256 {
-        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+        let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
         let port = probe.local_addr().expect("probe addr").port();
         drop(probe);
         // insert() returns false when the port was already handed out.
@@ -61,8 +72,112 @@ pub fn free_port() -> u16 {
 
 /// A loopback `SocketAddr` on a port from [`free_port`], for the callers that
 /// want an address rather than a bare port.
+///
+/// Carries [`free_port`]'s window. Use [`bound_listener`] when the address will
+/// actually be served.
 pub fn ephemeral_addr() -> SocketAddr {
     SocketAddr::from(([127, 0, 0, 1], free_port()))
+}
+
+/// A loopback listener that is **already bound**, together with the address it
+/// is bound to (#313).
+///
+/// The point of the type is that the port and the socket travel together: there
+/// is no moment at which the port has been chosen but nothing holds it. Hand the
+/// listener to [`SbiServer::on_listener`] (or to
+/// [`BoundListener::into_listener`] for anything else that can adopt a
+/// `std::net::TcpListener`).
+#[derive(Debug)]
+pub struct BoundListener {
+    listener: TcpListener,
+    addr: SocketAddr,
+}
+
+impl BoundListener {
+    /// The address the listener is bound to. Never port 0.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// The port the listener is bound to.
+    pub fn port(&self) -> u16 {
+        self.addr.port()
+    }
+
+    /// Give up the listener, keeping it bound.
+    pub fn into_listener(self) -> TcpListener {
+        self.listener
+    }
+
+    /// Both halves, for a caller that needs the address after moving the
+    /// listener.
+    pub fn into_parts(self) -> (TcpListener, SocketAddr) {
+        (self.listener, self.addr)
+    }
+}
+
+/// Reserve a loopback port by **keeping it bound**, closing the window
+/// [`free_port`] leaves open (#313).
+///
+/// The returned listener is still bound when it reaches the caller, so no other
+/// process — not just no other thread — can take the port in between. The port
+/// is also recorded in [`free_port`]'s issued set, so the two helpers cannot
+/// hand out the same port to one process.
+///
+/// # Panics
+///
+/// If `127.0.0.1:0` cannot be bound, or its local address cannot be read.
+pub fn bound_listener() -> BoundListener {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind reserved listener");
+    let addr = listener.local_addr().expect("reserved listener addr");
+    // Share one issued set with free_port(), so a bare-port caller and a
+    // reserved-listener caller in the same process cannot be handed the same
+    // number either. No retry loop is needed here and having one would be
+    // wrong: the port is already held, so a duplicate would mean the OS reissued
+    // a port free_port() probed and released — recording it is what stops
+    // free_port() returning it a second time.
+    issued_ports()
+        .lock()
+        .expect("issued lock")
+        .insert(addr.port());
+    BoundListener { listener, addr }
+}
+
+/// Build and start an [`SbiServer`] on a reserved loopback port, with no window
+/// in which the port is unbound (#313).
+///
+/// The common shape: `let (server, addr) = sbi_server_on_free_port(handler).await;`
+/// replaces `free_port()` plus `SbiServer::new(SbiServerConfig::new(addr))` plus
+/// `start()`.
+///
+/// # Panics
+///
+/// If the server fails to start, which after this change means a genuine
+/// failure rather than a lost race.
+pub async fn sbi_server_on_free_port<H: crate::server::SbiRequestHandler>(
+    handler: H,
+) -> (SbiServer, SocketAddr) {
+    sbi_server_on_free_port_with(SbiServerConfig::new, handler).await
+}
+
+/// [`sbi_server_on_free_port`] for a caller that needs a customised
+/// [`SbiServerConfig`] — TLS, an expected audience, an overload reporter.
+///
+/// `build` receives the reserved address, so a config that derives anything from
+/// its own address still sees the real one.
+///
+/// # Panics
+///
+/// If the server fails to start.
+pub async fn sbi_server_on_free_port_with<H, F>(build: F, handler: H) -> (SbiServer, SocketAddr)
+where
+    H: crate::server::SbiRequestHandler,
+    F: FnOnce(SocketAddr) -> SbiServerConfig,
+{
+    let (listener, addr) = bound_listener().into_parts();
+    let server = SbiServer::on_listener(build(addr), listener);
+    server.start(handler).await.expect("sbi server start");
+    (server, addr)
 }
 
 #[cfg(test)]
@@ -101,5 +216,87 @@ mod tests {
         let a = ephemeral_addr();
         assert!(a.ip().is_loopback());
         assert_ne!(a.port(), 0);
+    }
+
+    /// The whole point of #313, pinned as a **difference** between the two
+    /// helpers rather than as a property of one.
+    ///
+    /// `bound_listener` still holds the port when the caller gets it, so a
+    /// competing bind fails; `free_port`/`ephemeral_addr` do not, so the same
+    /// bind succeeds. The second half is the defect, and asserting it here is
+    /// what makes the first half mean something: a `bound_listener` that had
+    /// quietly reverted to the probe-drop shape would make BOTH binds succeed,
+    /// and only a test that knows what the broken shape does can tell them
+    /// apart.
+    #[test]
+    fn a_reserved_port_is_bound_and_a_free_port_is_not() {
+        let reserved = bound_listener();
+        let err = TcpListener::bind(reserved.addr())
+            .expect_err("the reserved port must still be held by the reservation");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::AddrInUse,
+            "expected the reserved port to be in use, got {err}"
+        );
+
+        // The window, demonstrated: a free_port address is claimable by whoever
+        // asks first. This is why free_port must not be used for a port that
+        // will be served.
+        let unheld = ephemeral_addr();
+        let squatter =
+            TcpListener::bind(unheld).expect("a free_port address is unbound, that IS the window");
+        drop(squatter);
+    }
+
+    /// `free_port` cannot hand back a port a reservation is already holding:
+    /// both routes share one issued set.
+    #[test]
+    fn reserved_ports_are_excluded_from_free_port() {
+        let reserved: Vec<_> = (0..16).map(|_| bound_listener()).collect();
+        let held: Set<u16> = reserved.iter().map(BoundListener::port).collect();
+        for _ in 0..200 {
+            let p = free_port();
+            assert!(!held.contains(&p), "free_port returned reserved port {p}");
+        }
+    }
+
+    /// The reservation survives being split from its address.
+    #[test]
+    fn into_parts_keeps_the_listener_bound() {
+        let (listener, addr) = bound_listener().into_parts();
+        assert_eq!(listener.local_addr().expect("addr"), addr);
+        assert!(TcpListener::bind(addr).is_err());
+    }
+
+    /// End to end: a server started on a reservation serves on exactly the
+    /// reserved address, and `config.addr` reports that address rather than
+    /// whatever placeholder the config was built with.
+    #[tokio::test]
+    async fn a_server_on_a_reservation_serves_the_reserved_address() {
+        async fn ok200(_req: crate::message::SbiRequest) -> crate::message::SbiResponse {
+            crate::server::send_error(200, "OK", "OK", None)
+        }
+
+        let (server, addr) = sbi_server_on_free_port(ok200).await;
+        assert_eq!(server.config().addr, addr, "config must report the socket");
+        assert!(server.is_running().await);
+
+        // A real connection, so this is not a claim about configuration only.
+        let stream = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("the started server accepts on the reserved address");
+        drop(stream);
+
+        server.stop().await.expect("stop");
+    }
+
+    /// A placeholder address in the config is replaced by the listener's real
+    /// one; the config never wins over the socket.
+    #[test]
+    fn on_listener_overwrites_a_placeholder_config_address() {
+        let (listener, addr) = bound_listener().into_parts();
+        let placeholder = SocketAddr::from(([127, 0, 0, 1], 0));
+        let server = SbiServer::on_listener(SbiServerConfig::new(placeholder), listener);
+        assert_eq!(server.config().addr, addr);
     }
 }


### PR DESCRIPTION
Closes #313.

`test_support::free_port` chose a port and then **released it**, leaving the caller to bind it again. Each test binary has its own issued-port set, so under `cargo test --workspace` — one binary per crate, concurrently — two crates could be handed the same number and one would fail to bind. #308 removed the blanket retry that had been absorbing this, which is what makes it worth closing rather than tolerating.

## What changed

- **`SbiServer::on_listener(config, listener)`** adopts a caller-bound listener; `start()` takes it instead of binding. `config.addr` is overwritten *from* the socket, because a server whose config disagreed with what it serves would misreport itself in `stop()`'s log and in any URI derived from the config — silently.
- **`test_support::bound_listener()`** returns a `BoundListener`: socket and address travelling together, so there is no moment when the port has been chosen and nothing holds it. Plus `sbi_server_on_free_port{,_with}` for the common shape.
- **All 243 ephemeral-port server starts now reserve.** Two scripted transforms did the bulk; `cargo check` caught three syntax errors and one type error, including a dropped closing paren that no review of the script would have found.
- **19 dead crate-local delegates deleted**, and the 5 copies with no in-process guard at all (three test files, one bench) removed or pointed at the shared helper.
- **Two five-attempt retry loops deleted** (`http3.rs`, `benches/transport.rs`). They were local workarounds for exactly this window, and a retry that can absorb a real bind failure is the instrument #308 just removed from `ci.yml`.
- `ci.yml`'s comment updated: nothing is left for a retry to hide, so a red there is a real failure.

## Three of the issue's numbers were stale, in both directions

| issue says | actual |
|---|---|
| "~21 `free_port` callers that start an `SbiServer`" | **243** |
| "15+ private duplicates that do NOT even have the in-process `ISSUED` guard" | 26 crate-local helpers, of which **19 were already one-line delegates**; only **5** were raw |
| "UDP callers need the same treatment with `UdpSocket`" | **they need none** — every test-side UDP socket binds `:0` and *keeps* it, so this window never existed there |

The undercount changed the shape of the work: at 21 sites this is a hand-migration; at 243 it needs a mechanical transform with the compiler as the net.

## `free_port` is kept on purpose

Ten callers want an address with **nothing listening on it** — bounded-timeout transport errors in `smfd::policy`, degrade-open paths in `amfd::sbi_path`, a dead UDR/callback/producer in `pcfd`/`nefd`. Handing those a bound listener makes the port *reachable*, which inverts what they assert. Each site is now documented as such. One integration test (`n32_two_sepp.rs`) also cannot take a socket at all: it passes two ports to a real **child process** on the command line, and a third to `start_n32_listener(host, port, tls)` — a production signature I did not churn for a test's benefit.

## Verification

Reverting `start()`'s adoption of the reservation produces #313's production message on demand:

```
sbi server start: ServerError("Failed to bind: Address already in use (os error 98)")
```

The core guarantee is pinned as a **difference**, not a property: one test asserts both that a competing bind of a *reserved* port fails with `AddrInUse` **and** that the same bind of a `free_port` address succeeds. Only the second half distinguishes the fix from a silent regression back to probe-drop.

My first revert attempt **did not bite** — I reverted `bound_listener` to probe-drop-*then-rebind*, which restores the very property under test. The spec records that rather than the tidy version.

Workspace **6357 passed / 0 failed** (was 6352; +5 new tests). 36 clean `cargo test --workspace` runs.

## Stated honestly: two failures I could not identify

Two single-test failures were observed and **neither was diagnosed**. One on a mid-migration tree, `failed=1` with **zero** `Address already in use` occurrences. One on the final tree, 1503 passed / 1 failed — the low count meaning cargo stopped after the failing binary, so the crate is not even known. Both loops discarded their output.

Three subsequent measurements with capture found nothing: 20 runs, 12 runs, then 4 immediately after `clippy --all-targets` (a full test-binary rebuild, so tests run under heavy compile load — the shape #308 used to surface state races). **That hypothesis is tested and not confirmed.**

What the counters do rule out is this PR's subject: a port collision presents as `Address already in use`, and the one failure whose bind count was recorded had none. Something in this suite fails at a rate under roughly 1 in 18 and it is not the port window.

Spec: `specs/fix-sbi-prebound-listener.md` (claim/site/still-true table, revert table including the revert that failed to bite, and eight ceilings).
