### PR TITLE
fix(tsctsf): derive PMIC/UMIC/TSCAI and authorise it with the PCF (#284)

### DIFF
--- a/docs-book/src/configuration/tsctsf.md
+++ b/docs-book/src/configuration/tsctsf.md
@@ -140,5 +140,77 @@ From the clap `Args` struct in `src/bins/nextgcore-tsctsf/src/main.rs`:
 - **OAuth2** producer enforcement mirrors dccfd: enable with
   `NEXTGCORE_SBI_OAUTH2_REQUIRE=1` or `tsctsf.sbi.oauth2.require: true`; tokens are
   verified against the NRF JWKS with audience `TSCTSF`.
-- **Environment variables:** `NEXTGCORE_SBI_OAUTH2_REQUIRE` and
-  `OTEL_EXPORTER_OTLP_ENDPOINT` (default `http://jaeger:4317`).
+- **Environment variables:** `NEXTGCORE_SBI_OAUTH2_REQUIRE`, `TSCTSF_ACTUATION`,
+  `PCF_URI` and `OTEL_EXPORTER_OTLP_ENDPOINT` (default `http://jaeger:4317`).
+
+## Actuation (#284) — off by default
+
+Before #284 a stored configuration did **nothing**: no PCF was contacted, no
+port-management information was derived, and the UPF's `tsn_bridge` was never
+touched. With `TSCTSF_ACTUATION=1` the TSCTSF now derives and authorises.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `TSCTSF_ACTUATION` | unset (off) | `1`/`true`/`yes`/`on` enables actuation. A **runtime** switch rather than a cargo feature, so CI compiles and exercises both states. |
+| `PCF_URI` | unset | The serving PCF, e.g. `http://pcf:7777`. Unset falls back to NRF discovery (`target-nf-type=PCF&requester-nf-type=TSCTSF`), taking the `npcf-policyauthorization` service's own endpoint rather than the profile's first service. |
+
+**What happens with the switch on.** A time-synchronization or QoS/TSC create
+issues `Npcf_PolicyAuthorization_Create` (`POST
+/npcf-policyauthorization/v1/app-sessions`) and records the `appSessionId` from the
+response `Location`; the matching delete issues `POST
+.../app-sessions/{appSessionId}/delete` (TS 29.514 §4.2.5 — a custom operation, not
+an HTTP DELETE). A time-sync body carries the derived containers:
+`tsnBridgeManCont` (the UMIC), `tsnPortManContDstt` and `tsnPortManContNwtts`. A
+QoS/TSC body carries one media component with `tscaiInputUl`/`tscaiInputDl` and
+`tscaiTimeDom`.
+
+**A time-sync create needs a UE address that TS 23.502 does not require.**
+TS 29.514's `AppSessionContextReqData` requires `oneOf [ueIpv4, ueIpv6, ueMac]`,
+and a §5.2.27.2.2 time-synchronization configuration's mandatory inputs are SUPIs
+and a `upNodeId` — no UE address. So the configuration accepts optional `ueMac`,
+`ueIpv4` and `ueIpv6` members (`ueMac` first: a DS-TT behind an Ethernet PDU
+session has one, the TS 23.501 §5.28 case), and with none of them present the
+actuation is **declined with the reason logged at warn** rather than a body being
+sent that violates the schema. The 201 and the stored record are unaffected either
+way. A QoS/TSC session needs no such member: §5.2.27.3.2 makes a UE address a
+required input.
+
+**Clock-quality criteria that can never be met are declined.** The derivation
+statically checks the stated criteria against what IEEE 1588-2019 can report — a
+`clockClass` outside Table 4's specified set `{6,7,13,14,52,58,187,193,248,255}`, a
+`clockAccuracy` outside the Table 5 enumeration `0x20..=0x31` (or `0xFE` unknown),
+or a `synchronizationState` outside `{SYNCHRONIZED, NOT_SYNCHRONIZED}`. Every
+failing criterion is reported, not just the first. Authorising such a configuration
+would commit the TSCTSF to a service it cannot deliver.
+
+**`CapsNotify` now has an in-tree source.** The derived capability set (time
+domains, PTP profiles, grandmaster capability, and a count of configurations with
+unmeetable criteria) is recomputed on every configuration change, and the
+notification fires only when the set actually **differs** — a create that changes
+nothing must not wake every subscriber.
+`POST /ntsctsf-time-synchronization/v1/admin/capability-change` is retained as a
+**test-only shim** and is documented as such in the code: it is not a capability
+source and anything relying on it in a deployment is relying on a shim.
+
+**Limits worth knowing:**
+
+- **The UPF's `tsn_bridge` is still `None`.** Driving it needs the N4 leg — a PFCP
+  TSC container codec, an `smfd` path that carries it, and a `upfd` consumer.
+  `nextgcore-pfcp` has the IE type constants (`CreateBridgeInfoForTsc` 194,
+  `TscManagementInformationSmr` 199 …) with **zero users** and no container codec,
+  and the `tscu` UP-function-feature bit is encoded and decoded but never acted on.
+  Tracked separately; #284's own suggested approach makes this piece meaningful
+  only once that codec exists.
+- **The PMIC/UMIC octet strings are this build's own TLV encoding** of the managed
+  objects a configuration determines, not the IEEE 802.1Q clause 12 encoding —
+  there is no 802.1Q managed-object codec in this tree. The derivation (which
+  objects, per port, per side) is the specified and tested part.
+- **The derived capability set is not a 5GS capability report.** The gNB and UPF do
+  not report their (g)PTP capability into this tree at all. This reports what the
+  TSCTSF has been asked to support and can derive.
+- **The notification URI given to the PCF is the AF's own.** The TSCTSF serves no
+  TSC-notification receiving route, and pointing the PCF at a 404 would be worse
+  than pointing it at the consumer that asked.
+- **`suppFeat` is `"0"`.** This consumer negotiates no optional TS 29.514 feature;
+  claiming one it does not implement would make the PCF send responses it cannot
+  read.

--- a/specs/fix-tsctsf-actuation-derivation-and-pcf.md
+++ b/specs/fix-tsctsf-actuation-derivation-and-pcf.md
@@ -1,0 +1,200 @@
+# nextgcore #284: make a stored TSCTSF configuration do something
+
+Verified against `main` @ `5343503`.
+
+#284's diagnosis is accurate and every "current state" claim below still held.
+What it gets wrong is one of its own acceptance criteria, and the reason is in
+TS 29.514 rather than in the code.
+
+## Verified against current main
+
+| claim in the issue | site on `5343503` | still true? |
+|---|---|---|
+| tsctsf stores typed records and "nothing reads those records outside the SBI handlers" | `context.rs` + `main.rs`; no other reader | yes |
+| no PCF client exists in the crate | `rg 'Npcf_PolicyAuthorization\|policy-authorization' bins/nextgcore-tsctsf/` → nothing | yes |
+| no PMIC/UMIC/TSCAI derivation exists anywhere in the tree | confirmed workspace-wide | yes |
+| upfd's `tsn_bridge` is `None` and never referenced from tsctsf or smfd | `upfd/context.rs:1204`, init `None` at `:1223`, one unit-test reference at `:1851` | yes |
+| "There is no PFCP TSC container codec" | **sharper than that**: the IE type *constants* exist — `CreateBridgeInfoForTsc = 194`, `CreatedBridgeInfoForTsc = 195`, `TscManagementInformation{Smr,Smrsp,Srr} = 199/200/201` (`pfcp/ie.rs:205-212`) — with **zero users**, and `UpFunctionFeatures.tscu` is encoded and decoded but never acted on | yes, and the identifiers-without-codec state is worth naming |
+| `CapsNotify` has no in-tree producer of a capability change | `admin/capability-change` was the only trigger | yes |
+| criterion 2: "a **time-sync** create issues `Npcf_PolicyAuthorization_Create`" | **not literally satisfiable for every such create** — see Decision 3 | **partly false** |
+
+## Decision 1: the derivation is pure, and its verdicts are three-valued
+
+`derive_tsn_management` takes a stored `TimeSyncExposureConfig` and returns the
+DS-TT ports (one per SUPI), the NW-TT port (one, for the `upNodeId`), the bridge
+container, whether the grandmaster is enabled, and a clock-quality verdict. No
+peer, no clock, no I/O — which is why criterion 1's three cases can be asserted
+exactly.
+
+Three choices inside it are not obvious and each is pinned by its own test:
+
+- **An absent `gmEnable` is NOT activation.** TS 23.501 §5.27.1.8 makes activation
+  explicit; defaulting it on would start distributing time for a configuration that
+  never asked.
+- **A configuration with no SUPIs still derives the N6 termination.** That port is
+  a property of the user-plane node, not of any UE — the asymmetry criterion 1 asks
+  to be covered, stated as its own case rather than implied by the multi-UE one.
+- **Clock quality is three-valued.** `NoCriteria` is distinct from `Satisfiable`: a
+  caller collapsing them into a boolean would report "criteria met" for a
+  configuration that stated none, inventing a guarantee. Both permit actuation;
+  only `Unsatisfiable` stops it.
+
+`Unsatisfiable` carries **every** reason, not the first, so an operator fixing one
+and re-submitting does not discover the rest one round trip at a time.
+
+## Decision 2: "cannot be met" is a static check against IEEE 1588, not a measurement
+
+Criterion 1 asks for "a configuration whose clock-quality acceptance criteria
+cannot be met". With no measured clock in this tree, the only honest reading is
+*unsatisfiable by any clock*, which IEEE 1588-2019 makes checkable:
+
+| criterion | rule | source |
+|---|---|---|
+| `clockClass` | must be one of `{6,7,13,14,52,58,187,193,248,255}`; everything else in 0..=255 is Reserved | §7.6.2.5 Table 4 |
+| `clockAccuracy` | must be `0x20`..=`0x31`, or `0xFE` (unknown). Demanding better than `0x20` (25 ns) asks for an accuracy the standard cannot report | §7.6.2.6 Table 5 |
+| `synchronizationState` | must be `SYNCHRONIZED` or `NOT_SYNCHRONIZED` | TS 23.501 §5.27.1.8 |
+| `offsetScaledLogVariance` | every `u16` is representable, so nothing here can be unsatisfiable | named in code rather than omitted, so the absence is visibly deliberate |
+
+Authorising a configuration whose criteria can never be met would commit the
+TSCTSF to a service it cannot deliver — the failure mode #284 calls out — so it is
+declined with the reasons logged, while the 201 and the stored record are
+unaffected.
+
+## Decision 3: criterion 2 is not literally satisfiable, and the gap is in TS 29.514
+
+`AppSessionContextReqData` (TS 29.514) has exactly the members this needs —
+`tsnBridgeManCont` (documented as "Contains the UMIC"), `tsnPortManContDstt`,
+`tsnPortManContNwtts` (an array, `minItems: 1`), `tscNotifUri`, `tscNotifCorreId`,
+`supi` — **and it also requires `oneOf [ueIpv4, ueIpv6, ueMac]`**.
+
+A TS 23.502 §5.2.27.2.2 time-synchronization configuration's mandatory inputs are
+a notification target, a `upNodeId`, and SUPIs. **No UE address.** So a time-sync
+create cannot build a schema-valid `AppSessionContextReqData` from its mandatory
+inputs, and criterion 2 as written cannot hold for every such create.
+
+Three options were available and two are worse:
+
+1. Send a body that omits the `oneOf` member. The PCF answers 400, which looks
+   like a PCF problem.
+2. Invent an address. A revert that does exactly this is in the table below,
+   precisely because it is the tempting version.
+3. Read an optional UE address when the consumer supplies one, and **decline with
+   a named reason** when it does not.
+
+(3) is what this does. `ueMac` is checked first: a DS-TT behind an Ethernet PDU
+session has one, which is the TS 23.501 §5.28 case. A QoS/TSC session needs none
+of this — §5.2.27.3.2 makes a UE address a required input — so its actuation is
+unconditional, and that asymmetry is the honest shape rather than a shortcut.
+
+As in #113, `TS29565_Ntsctsf_*.yaml` is not vendored here, so the three added
+optional member names are the camelCase form of Stage-2 parameter names rather
+than a spelling verified against a Stage-3 schema. Same caveat #113 recorded.
+
+## Decision 4: the capability source is derived state, and it fires on a change
+
+Criterion 5 asks for "a capability change from a real source". The source is the
+**derived capability set** — the union of time domains and PTP profiles across
+stored configurations, whether any enables a grandmaster, and a count of
+configurations with unmeetable criteria — recomputed on every configuration change.
+
+It fires only when the set **differs** from the last reported one. A create that
+alters nothing must not wake every subscriber; that is what makes it a change
+trigger rather than a per-request one, and it is the difference from #113's admin
+poke. A revert that always reports "changed" fails the test that asserts the
+second identical create is silent.
+
+What this is **not** is a 5GS capability report: the gNB and UPF do not report
+their (g)PTP capability into this tree at all. Stated in the function's own doc.
+
+`admin/capability-change` is **kept and documented as a test-only shim**, which
+criterion 5 permits explicitly. Kept rather than removed because #113's
+subscribe/notify/unsubscribe test drives the fan-out through it and it lets an
+operator force a fan-out while diagnosing; the doc says plainly that anything
+relying on it in a deployment is relying on a shim.
+
+## Decision 5: the crate's test lock moved out of `mod tests`
+
+`GLOBAL_TEST_LOCK` lived inside `main.rs`'s `mod tests`, so no sibling module
+could reach it. `actuation`'s tests flip a process-global switch that `main`'s
+handlers read, so they would have had to declare a **second** lock over the same
+ambient state. #308 established that two locks over one state are two disjoint
+agreements, and #276 showed that shape *hangs* the suite rather than merely
+flaking it.
+
+The static is now `context::PROCESS_STATE_TEST_LOCK`, declared beside the context
+it guards, and `main`'s `lock_globals()` delegates to it. Relocation only; no test
+changed.
+
+## Verification
+
+| claim | how it was made to fail | result |
+|---|---|---|
+| an absent `gmEnable` is not activation | default it to `true` | **fails** `an_absent_grandmaster_flag_is_not_activation` |
+| the N6 termination is independent of having UEs | return early with no NW-TT port when `supis` is empty | **fails** `a_configuration_with_no_ues_still_derives_the_n6_termination` |
+| impossible clock-quality criteria are detected | always return `Satisfiable` | **fails 4 tests**, including the end-to-end "not actuated" one |
+| the OFF switch is honoured | ignore it in `actuate_time_sync_create` | **fails** `the_switch_off_makes_no_outbound_request` |
+| a delete retracts the PCF authorisation | drop the `policy_authorization_delete` call | **fails** `the_switch_on_issues_policy_authorization_create_and_delete` |
+| `CapsNotify` fires on a *change* | always report "changed" | **fails** `a_derived_capability_change_drives_caps_notify_and_an_unchanged_set_does_not` |
+| a missing UE address declines rather than fabricates | fall back to `ueIpv4: "0.0.0.0"` | **fails** `a_configuration_with_no_ue_address_is_not_actuated` |
+
+Criterion 2 and 3's assertions are on the **outbound HTTP request** against a stub
+PCF — method, path and body, including that `tsnBridgeManCont.bridgeManCont` is a
+base64 string and that the DS-TT/NW-TT port numbers are 1 and 0 — which is what
+criterion 2 demands instead of a log line. The `appSessionId` is read from the
+stub's `Location` header, so the delete path proves the create recorded the right
+identifier.
+
+Criterion 3's "byte-identical" half is asserted by running the *same* create with
+the switch off and on and comparing the whole 201 body (minus the minted id and
+`self`, which differ by construction). A weaker test would let actuation quietly
+add a member to what the consumer gets back.
+
+Gates: `cargo test -p nextgcore-tsctsf` **52 passed / 0 failed** (was 33);
+workspace **6396 passed / 0 failed**; `cargo clippy --workspace` and
+`--all-targets` 0 errors; `cargo fmt --all --check` clean.
+
+## Ceilings
+
+- **Criterion 4 is NOT met: the UPF's `tsn_bridge` is still `None`.** This is the
+  one criterion left open, and it is stated first. Driving it needs the N4 leg —
+  a PFCP TSC container codec, an `smfd` path that carries it, a `upfd` consumer —
+  and #284's own suggested approach makes piece 4 "only meaningful once (3)
+  exists". The codec does not exist: the IE type constants at `pfcp/ie.rs:205-212`
+  have **zero users** and there is no `TscManagementInformation` struct, encoder or
+  decoder anywhere. Filed as **#321** with the verified evidence and a criterion
+  list. Criterion 4 also instructs that if this cannot be verified in-process the
+  PR must say so and state what *is* verified instead: what is verified is that
+  the derivation produces exactly the PMIC/UMIC payload such a leg would carry,
+  and that the PCF receives it over `Npcf_PolicyAuthorization`.
+- **The PMIC/UMIC octet strings are this build's own TLV encoding**, not IEEE
+  802.1Q clause 12 — no 802.1Q managed-object codec exists here. Said in
+  `PortManagementInfo::container`'s own doc, and the tests read the containers back
+  by tag rather than by byte offset so a real encoder can replace it without
+  rewriting the assertions.
+- **Only `medComponents["0"]` is built for a QoS/TSC session.** One media
+  component per session, keyed `0`. A session describing several flows with
+  different patterns would need one component each, and nothing in `QosTscSession`
+  models that split.
+- **`suppFeat` is `"0"`**, so no optional TS 29.514 feature is negotiated. Claiming
+  one this consumer does not implement would make the PCF send responses it cannot
+  read.
+- **The PCF is given the AF's own notification URI.** This TSCTSF serves no
+  TSC-notification receiving route; pointing the PCF at a 404 would be worse than
+  pointing it at the consumer that asked. A real deployment wants a TSCTSF-side
+  callback, which needs a route this build does not have.
+- **`appSessionId` lives in a process-global map**, not on the stored record.
+  tsctsf has no durable store, so it is exactly as durable as the record it keys —
+  but a restart loses the ability to retract an authorisation the PCF still holds,
+  which is #193's defect in a different NF.
+- **The ASTI service is not actuated.** `AstiConfig` (access-stratum time
+  distribution) stores and answers as before; TS 23.501 §5.27.1.8 routes its
+  activation through the AMF/gNB, which is a different peer from the PCF and a
+  different issue.
+- **`derive_tscai` maps Stage-2's single `survivalTime` to `surTimeInTime`**, the
+  duration, not to `surTimeInNumMsg`, the message count. TS 29.514 has both and
+  Stage-2 has one; the mapping is asserted in a test with the reasoning in the
+  message, because getting it wrong would silently change the unit.
+- **No E2E.** Every assertion is a loopback request in one process. The Docker jobs
+  remain `workflow_dispatch`-only, and no compose service sets
+  `TSCTSF_ACTUATION`, so the default E2E path is unchanged — which is also what
+  makes the switch's default safe.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3157,6 +3157,7 @@ name = "nextgcore-tsctsf"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "ctrlc",
  "env_logger",

--- a/src/bins/nextgcore-tsctsf/Cargo.toml
+++ b/src/bins/nextgcore-tsctsf/Cargo.toml
@@ -23,6 +23,9 @@ anyhow.workspace = true
 # QosTscSession) are deserialised from the request bodies rather than stored as
 # raw JSON strings.
 serde = { workspace = true, features = ["derive"] }
+# #284: TS 29.571 `Bytes` is base64, and the PMIC/UMIC containers are typed as
+# Bytes in TS 29.512's PortManagementContainer / BridgeManagementContainer.
+base64.workspace = true
 serde_yaml.workspace = true
 serde_json.workspace = true
 uuid.workspace = true

--- a/src/bins/nextgcore-tsctsf/src/actuation.rs
+++ b/src/bins/nextgcore-tsctsf/src/actuation.rs
@@ -1,0 +1,1136 @@
+//! Actuation: making a stored TSCTSF configuration *do* something (issue #284).
+//!
+//! #113 delivered the control plane — three conformant services, typed IEs,
+//! ConfigUpdate, the capability subscribe/notify/unsubscribe cycle. Nothing read
+//! those records outside the SBI handlers, so an AF request produced a stored
+//! record with no policy or user-plane effect at all.
+//!
+//! This module is the half that reads them:
+//!
+//! 1. **A pure derivation** from a stored configuration to the port- and
+//!    bridge-management information the 5GS needs ([`derive_tsn_management`]),
+//!    and from a QoS/TSC session to the TSC Assistance Information a PCF
+//!    consumes ([`derive_tscai`]). Pure, so it is testable with no peer at all,
+//!    which is where most of the value is.
+//! 2. **A PCF client** that turns a create into `Npcf_PolicyAuthorization_Create`
+//!    and a delete into the matching delete (TS 23.502 §5.2.27, TS 29.514).
+//! 3. **A capability source**: the derived capability set is recomputed on every
+//!    configuration change, and a change in it drives `CapsNotify` — replacing
+//!    #113's administrative poke with something the deployment actually knows.
+//!
+//! # Off by default, behind a RUNTIME switch
+//!
+//! Gated on `TSCTSF_ACTUATION=1`. A runtime switch rather than a cargo feature
+//! for this project's recorded reason (a feature-gated path is left uncompiled by
+//! CI and rots), and **off by default** because a create that silently issues
+//! policy toward a PCF is behaviour-changing for every existing deployment. With
+//! the switch off, the control-plane behaviour is byte-identical to #113 and no
+//! outbound request is made; `the_switch_off_makes_no_outbound_request` asserts
+//! it.
+//!
+//! # What TS 29.514 requires that a time-sync configuration does not carry
+//!
+//! `AppSessionContextReqData` has exactly the members this needs —
+//! `tsnPortManContDstt`, `tsnPortManContNwtts` (an array), `tsnBridgeManCont`
+//! ("Contains the UMIC"), `tscNotifUri`, `tscNotifCorreId`, `supi` — and it
+//! **also** requires `oneOf [ueIpv4, ueIpv6, ueMac]`.
+//!
+//! A TS 23.502 §5.2.27.2.2 time-synchronization configuration carries SUPIs and a
+//! user-plane node id. It carries **no UE address**. So a time-sync create cannot
+//! build a conformant `AppSessionContextReqData` from its mandatory inputs alone,
+//! and #284's criterion 2 is not literally satisfiable for every such create.
+//!
+//! Rather than send a body that violates the schema, or invent an address, this
+//! reads an optional UE address from the configuration when the consumer supplies
+//! one (`ueMac`, `ueIpv4` or `ueIpv6` — a DS-TT behind an Ethernet PDU session has
+//! a MAC, which is the TS 23.501 §5.28 case) and **declines to actuate with a
+//! named reason** when it does not. A QoS/TSC session, by contrast, carries
+//! `ueIpv4`/`ueIpv6` as a mandated input, so its actuation is unconditional.
+//!
+//! As in #113, `TS29565_Ntsctsf_*.yaml` is not vendored here, so the added
+//! optional member names are the camelCase form of the Stage-2 parameter names
+//! rather than a spelling verified against the Stage-3 schema.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::context::{ClockQualityAcceptanceCriteria, QosTscSession, TimeSyncExposureConfig};
+
+/// Is actuation enabled for this process?
+static ACTUATION_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable actuation (called once at startup when `TSCTSF_ACTUATION=1`).
+pub fn enable() {
+    ACTUATION_ENABLED.store(true, Ordering::SeqCst);
+    log::info!(
+        "[TSCTSF] actuation ENABLED: time-sync and QoS/TSC creates will issue \
+         Npcf_PolicyAuthorization toward the serving PCF (TS 23.502 §5.2.27)"
+    );
+}
+
+/// Whether actuation is enabled.
+pub fn enabled() -> bool {
+    ACTUATION_ENABLED.load(Ordering::SeqCst)
+}
+
+/// Read `TSCTSF_ACTUATION` and enable accordingly. Called once from `main`.
+pub fn init_from_env() {
+    match std::env::var("TSCTSF_ACTUATION").as_deref() {
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("on") => enable(),
+        _ => log::info!(
+            "[TSCTSF] actuation DISABLED (set TSCTSF_ACTUATION=1 to enable): stored \
+             configurations have no policy or user-plane effect, exactly as before #284"
+        ),
+    }
+}
+
+/// Test-only: set the switch without going through startup.
+///
+/// The caller must hold [`crate::context::PROCESS_STATE_TEST_LOCK`]: this switch
+/// is process-global, so a test that flips it races every sibling that reads it.
+#[cfg(test)]
+pub fn set_for_test(on: bool) {
+    ACTUATION_ENABLED.store(on, Ordering::SeqCst);
+}
+
+// ============================================================================
+// The pure derivation (criterion 1)
+// ============================================================================
+
+/// Which side of the 5GS TSN bridge a port sits on (TS 23.501 §5.28.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TsnPortSide {
+    /// Device-Side TT: one per UE, facing the TSN end station.
+    DeviceSide,
+    /// Network-Side TT: the N6 termination, facing the TSN network.
+    NetworkSide,
+}
+
+/// One port's management information (the PMIC), with the port it applies to.
+///
+/// `container` is the octet string TS 29.512's `PortManagementContainer.portManCont`
+/// carries. **It is this build's own TLV encoding of the managed objects the
+/// configuration determines, not the IEEE 802.1Q clause 12 encoding**, because no
+/// 802.1Q managed-object codec exists in this tree. The derivation — which objects
+/// a given configuration determines, per port and per side — is the part that is
+/// specified and testable, and it is what a real encoder would consume. Stated
+/// here rather than left for a reader to assume.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortManagementInfo {
+    /// TS 29.512 `TsnPortNumber`.
+    pub port_num: u32,
+    /// Which side of the bridge.
+    pub side: TsnPortSide,
+    /// The PMIC octet string.
+    pub container: Vec<u8>,
+}
+
+/// Whether a configuration's clock-quality acceptance criteria can ever be met.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClockQualityVerdict {
+    /// The configuration states no criteria, so there is nothing to evaluate.
+    /// Not the same as satisfiable: a caller that treats "no criteria" as "all
+    /// criteria met" would report success for a configuration that asked for
+    /// nothing.
+    NoCriteria,
+    /// Every stated criterion names a value the 5GS can report.
+    Satisfiable,
+    /// At least one criterion names a value outside what IEEE 1588-2019 defines,
+    /// so no clock can ever satisfy it. Carries every reason, not the first: an
+    /// operator fixing one and re-submitting should not have to discover the rest
+    /// one round trip at a time.
+    Unsatisfiable(Vec<String>),
+}
+
+impl ClockQualityVerdict {
+    /// Whether actuation should proceed. `NoCriteria` and `Satisfiable` both
+    /// proceed; only an impossible criterion stops it.
+    pub fn permits_actuation(&self) -> bool {
+        !matches!(self, Self::Unsatisfiable(_))
+    }
+}
+
+/// IEEE 1588-2019 §7.6.2.5 Table 4: the specified `clockClass` values. Everything
+/// else in 0..=255 is Reserved, so a criterion naming one can never be met.
+const SPECIFIED_CLOCK_CLASSES: [u8; 10] = [6, 7, 13, 14, 52, 58, 187, 193, 248, 255];
+
+/// IEEE 1588-2019 §7.6.2.6 Table 5: `clockAccuracy` enumerates 0x20 (25 ns)
+/// through 0x31 (> 10 s), plus 0xFE "unknown". 0x00..=0x1F and 0x32..=0xFD are
+/// Reserved, and 0xFF is Reserved — so a criterion demanding better than 0x20 is
+/// asking for an accuracy the standard has no way to report.
+const CLOCK_ACCURACY_MIN: u8 = 0x20;
+const CLOCK_ACCURACY_MAX: u8 = 0x31;
+const CLOCK_ACCURACY_UNKNOWN: u8 = 0xFE;
+
+/// The synchronisation states the 5GS reports (TS 23.501 §5.27.1.8).
+const SYNC_STATES: [&str; 2] = ["SYNCHRONIZED", "NOT_SYNCHRONIZED"];
+
+/// Evaluate the clock-quality acceptance criteria against what IEEE 1588 can
+/// report.
+///
+/// This is a **static** check, deliberately: it asks whether a criterion is
+/// satisfiable at all, not whether the current clock satisfies it. A criterion
+/// naming a Reserved `clockClass` or an accuracy finer than the enumeration's
+/// best value can never be met by any clock, and answering 201 to it commits the
+/// TSCTSF to a service it cannot deliver — the failure mode #284 calls out.
+pub fn evaluate_clock_quality(
+    criteria: Option<&ClockQualityAcceptanceCriteria>,
+) -> ClockQualityVerdict {
+    let Some(c) = criteria else {
+        return ClockQualityVerdict::NoCriteria;
+    };
+    if c.clock_class.is_none()
+        && c.clock_accuracy.is_none()
+        && c.offset_scaled_log_variance.is_none()
+        && c.synchronization_state.is_none()
+    {
+        return ClockQualityVerdict::NoCriteria;
+    }
+
+    let mut reasons = Vec::new();
+    if let Some(class) = c.clock_class {
+        if !SPECIFIED_CLOCK_CLASSES.contains(&class) {
+            reasons.push(format!(
+                "clockClass {class} is Reserved in IEEE 1588-2019 Table 4 (specified values are \
+                 {SPECIFIED_CLOCK_CLASSES:?}), so no clock can report it"
+            ));
+        }
+    }
+    if let Some(acc) = c.clock_accuracy {
+        let ok = (CLOCK_ACCURACY_MIN..=CLOCK_ACCURACY_MAX).contains(&acc)
+            || acc == CLOCK_ACCURACY_UNKNOWN;
+        if !ok {
+            reasons.push(format!(
+                "clockAccuracy {acc:#04x} is outside the IEEE 1588-2019 Table 5 enumeration \
+                 ({CLOCK_ACCURACY_MIN:#04x}..={CLOCK_ACCURACY_MAX:#04x}, or \
+                 {CLOCK_ACCURACY_UNKNOWN:#04x} for unknown)"
+            ));
+        }
+    }
+    if let Some(state) = c.synchronization_state.as_deref() {
+        if !SYNC_STATES.contains(&state) {
+            reasons.push(format!(
+                "synchronizationState '{state}' is not one of {SYNC_STATES:?}"
+            ));
+        }
+    }
+    // `offsetScaledLogVariance` is a u16 and every value is representable, so
+    // there is nothing here that can be unsatisfiable. Named rather than omitted,
+    // so the absence is visibly deliberate.
+
+    if reasons.is_empty() {
+        ClockQualityVerdict::Satisfiable
+    } else {
+        ClockQualityVerdict::Unsatisfiable(reasons)
+    }
+}
+
+/// Everything a stored time-synchronization configuration determines about the
+/// 5GS TSN bridge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedTsnManagement {
+    /// One PMIC per UE in the configuration — each UE's DS-TT port.
+    pub dstt_ports: Vec<PortManagementInfo>,
+    /// The NW-TT ports: exactly one, for the `upNodeId` this configuration names,
+    /// which is the N6 termination.
+    pub nwtt_ports: Vec<PortManagementInfo>,
+    /// The UMIC — bridge-level managed objects.
+    pub bridge_container: Vec<u8>,
+    /// Whether the (g)PTP grandmaster is enabled by this configuration. `false`
+    /// when `gmEnable` is absent: TS 23.501 §5.27.1.8 makes activation explicit,
+    /// so an absent flag is "not activated" rather than "activate by default".
+    pub gm_enabled: bool,
+    /// Whether the stated clock-quality criteria can ever be met.
+    pub clock_quality: ClockQualityVerdict,
+}
+
+/// Managed-object tags in the PMIC/UMIC TLV. See [`PortManagementInfo::container`]
+/// for what this encoding is and is not.
+mod tag {
+    /// gPTP instance enabled (1 octet, 0 or 1) — IEEE 802.1AS `ptpInstanceEnable`.
+    pub const GM_ENABLE: u8 = 0x01;
+    /// Grandmaster priority1 (1 octet) — IEEE 802.1AS `priority1`.
+    pub const GM_PRIORITY: u8 = 0x02;
+    /// gPTP domain number (2 octets, big endian) — IEEE 802.1AS `domainNumber`.
+    pub const TIME_DOMAIN: u8 = 0x03;
+    /// PTP profile identifier (UTF-8).
+    pub const PTP_PROFILE: u8 = 0x04;
+    /// Port side: 0 = DS-TT, 1 = NW-TT.
+    pub const PORT_SIDE: u8 = 0x05;
+    /// The SUPI this DS-TT port serves (UTF-8).
+    pub const SUPI: u8 = 0x06;
+    /// The user-plane node this NW-TT port belongs to (UTF-8).
+    pub const UP_NODE_ID: u8 = 0x07;
+    /// Clock-quality detail level (UTF-8).
+    pub const CLOCK_QUALITY_DETAIL: u8 = 0x08;
+}
+
+fn tlv(out: &mut Vec<u8>, t: u8, value: &[u8]) {
+    // One-octet length: every value here is a flag, a small integer, or an
+    // identifier, and truncating silently would encode a different object than
+    // the one derived. A value that does not fit is dropped with a warning
+    // instead.
+    if value.len() > u8::MAX as usize {
+        log::warn!(
+            "TSN managed object {t:#04x} is {} octets; dropped",
+            value.len()
+        );
+        return;
+    }
+    out.push(t);
+    out.push(value.len() as u8);
+    out.extend_from_slice(value);
+}
+
+/// The managed objects every port in a configuration shares.
+fn common_objects(cfg: &TimeSyncExposureConfig, out: &mut Vec<u8>) {
+    tlv(
+        out,
+        tag::GM_ENABLE,
+        &[u8::from(cfg.gm_enable.unwrap_or(false))],
+    );
+    if let Some(p) = cfg.gm_priority {
+        tlv(out, tag::GM_PRIORITY, &[p]);
+    }
+    if let Some(d) = cfg.time_domain {
+        tlv(out, tag::TIME_DOMAIN, &d.to_be_bytes());
+    }
+    if let Some(profile) = cfg.ptp_profile.as_deref() {
+        tlv(out, tag::PTP_PROFILE, profile.as_bytes());
+    }
+    if let Some(detail) = cfg.clock_quality_detail_level.as_deref() {
+        tlv(out, tag::CLOCK_QUALITY_DETAIL, detail.as_bytes());
+    }
+}
+
+/// Derive the port- and bridge-management information a stored
+/// time-synchronization configuration determines (TS 23.501 §6.2.29).
+///
+/// Pure: no peer, no clock, no I/O. That is the point — it can be asserted
+/// exactly, and it is where #284 says the value is.
+///
+/// Port numbering: DS-TT ports are numbered from 1 in the order the SUPIs appear,
+/// and the NW-TT port takes 0. TS 29.512 types `TsnPortNumber` as an integer and
+/// does not assign it, so *some* rule is needed; this one is stable across
+/// derivations of the same configuration, which is what matters when the result is
+/// compared to a previously reported one.
+pub fn derive_tsn_management(cfg: &TimeSyncExposureConfig) -> DerivedTsnManagement {
+    let gm_enabled = cfg.gm_enable.unwrap_or(false);
+
+    let mut dstt_ports = Vec::with_capacity(cfg.supis.len());
+    for (idx, supi) in cfg.supis.iter().enumerate() {
+        let mut container = Vec::new();
+        common_objects(cfg, &mut container);
+        tlv(&mut container, tag::PORT_SIDE, &[0]);
+        tlv(&mut container, tag::SUPI, supi.as_bytes());
+        dstt_ports.push(PortManagementInfo {
+            port_num: (idx as u32) + 1,
+            side: TsnPortSide::DeviceSide,
+            container,
+        });
+    }
+
+    // Exactly one NW-TT port, for the `upNodeId` the configuration names. A
+    // configuration with no SUPIs still has this one: the N6 termination is a
+    // property of the user-plane node, not of any UE, which is the asymmetry
+    // #284's criterion 1 asks to be covered.
+    let mut nwtt = Vec::new();
+    common_objects(cfg, &mut nwtt);
+    tlv(&mut nwtt, tag::PORT_SIDE, &[1]);
+    tlv(&mut nwtt, tag::UP_NODE_ID, cfg.up_node_id.as_bytes());
+    let nwtt_ports = vec![PortManagementInfo {
+        port_num: 0,
+        side: TsnPortSide::NetworkSide,
+        container: nwtt,
+    }];
+
+    // The UMIC is bridge-level: the common objects, with no port identity.
+    let mut bridge_container = Vec::new();
+    common_objects(cfg, &mut bridge_container);
+    tlv(
+        &mut bridge_container,
+        tag::UP_NODE_ID,
+        cfg.up_node_id.as_bytes(),
+    );
+
+    DerivedTsnManagement {
+        dstt_ports,
+        nwtt_ports,
+        bridge_container,
+        gm_enabled,
+        clock_quality: evaluate_clock_quality(cfg.clock_quality_acceptance_criteria.as_ref()),
+    }
+}
+
+/// The TSC Assistance Information a QoS/TSC session determines, in the shape
+/// TS 29.514 `TscaiInputContainer` defines.
+///
+/// Returns `None` when the session states no traffic pattern at all: a container
+/// with every member absent tells the PCF nothing, and TS 29.514 types the whole
+/// container as nullable, so omitting it is the conformant way to say "no pattern"
+/// rather than sending `{}`.
+pub fn derive_tscai(session: &QosTscSession) -> Option<serde_json::Value> {
+    let mut c = serde_json::Map::new();
+    if let Some(p) = session.periodicity {
+        c.insert("periodicity".to_string(), serde_json::json!(p));
+    }
+    if let Some(bat) = &session.burst_arrival_time {
+        c.insert("burstArrivalTime".to_string(), bat.clone());
+    }
+    if let Some(s) = session.survival_time {
+        // TS 29.514 has two survival-time members: a message count and a
+        // duration. Stage-2's single `survivalTime` is a duration, so it maps to
+        // `surTimeInTime`; mapping it to the message count would silently change
+        // the unit.
+        c.insert("surTimeInTime".to_string(), serde_json::json!(s));
+    }
+    if let Some(w) = &session.bat_window {
+        c.insert("burstArrivalTimeWnd".to_string(), w.clone());
+    }
+    if let Some(r) = &session.periodicity_range {
+        c.insert("periodicityRange".to_string(), r.clone());
+    }
+    if c.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(c))
+    }
+}
+
+/// Which direction a QoS/TSC session's TSCAI applies to.
+///
+/// TS 29.514 carries `tscaiInputUl` and `tscaiInputDl` separately, so a session
+/// with a stated `flowDirection` populates one and a session without states both
+/// — the honest reading of "direction unspecified" being "applies either way",
+/// rather than silently picking downlink.
+fn tscai_direction_keys(session: &QosTscSession) -> &'static [&'static str] {
+    match session.flow_direction.as_deref() {
+        Some("UPLINK") => &["tscaiInputUl"],
+        Some("DOWNLINK") => &["tscaiInputDl"],
+        _ => &["tscaiInputUl", "tscaiInputDl"],
+    }
+}
+
+// ============================================================================
+// The PCF client (criterion 2)
+// ============================================================================
+
+/// A resolved PCF endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PcfEndpoint {
+    pub host: String,
+    pub port: u16,
+}
+
+/// Resolve the serving PCF: `PCF_URI` first, then NRF discovery, in the same
+/// shape `smfd::policy::resolve_pcf_endpoint` uses (#284 names it as the model).
+///
+/// Discovery asks for `target-nf-type=PCF&requester-nf-type=TSCTSF` and takes the
+/// `npcf-policyauthorization` service's endpoint, not the first service in the
+/// profile: a PCF advertising several services on different ports would otherwise
+/// be dialled on whichever one happened to be listed first.
+pub async fn resolve_pcf_endpoint() -> Option<PcfEndpoint> {
+    if let Ok(uri) = std::env::var("PCF_URI") {
+        if let Some((host, port)) = split_authority(&uri) {
+            return Some(PcfEndpoint { host, port });
+        }
+        log::warn!("PCF_URI '{uri}' is not a usable URI -- ignoring");
+    }
+    let nrf_uri = nextgcore_sbi::context::global_context()
+        .get_nrf_uri()
+        .await?;
+    let (nrf_host, nrf_port) = split_authority(&nrf_uri)?;
+    let client = nextgcore_sbi::client::SbiClient::new(
+        nextgcore_sbi::security::sbi_peer_client_config(&nrf_host, nrf_port)
+            .with_connect_timeout(std::time::Duration::from_secs(2))
+            .with_request_timeout(std::time::Duration::from_secs(3)),
+    );
+    let resp = client
+        .get("/nnrf-disc/v1/nf-instances?target-nf-type=PCF&requester-nf-type=TSCTSF")
+        .await
+        .ok()?;
+    if resp.status != 200 {
+        log::warn!("NRF PCF discovery returned status {}", resp.status);
+        return None;
+    }
+    let body: serde_json::Value = serde_json::from_str(resp.http.content.as_deref()?).ok()?;
+    let inst = body.get("nfInstances")?.as_array()?.first()?;
+    let host = inst
+        .get("ipv4Addresses")
+        .and_then(|a| a.as_array())
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str())?
+        .to_string();
+    let port = inst
+        .get("nfServices")
+        .and_then(|s| s.as_array())
+        .and_then(|svcs| {
+            svcs.iter().find(|s| {
+                s.get("serviceName").and_then(|n| n.as_str()) == Some("npcf-policyauthorization")
+            })
+        })
+        .and_then(|s| s.get("ipEndPoints"))
+        .and_then(|e| e.as_array())
+        .and_then(|e| e.first())
+        .and_then(|e| e.get("port"))
+        .and_then(|p| p.as_u64())
+        .map(|p| p as u16)
+        .unwrap_or(7777);
+    Some(PcfEndpoint { host, port })
+}
+
+/// Split a URI or bare authority into host and port.
+fn split_authority(uri: &str) -> Option<(String, u16)> {
+    let stripped = uri
+        .strip_prefix("https://")
+        .or_else(|| uri.strip_prefix("http://"))
+        .unwrap_or(uri);
+    let authority = stripped.split('/').next().unwrap_or(stripped);
+    let (host, port) = authority.rsplit_once(':')?;
+    Some((host.to_string(), port.parse().ok()?))
+}
+
+/// `appSessionId` per actuated resource, so a delete can find what a create made.
+///
+/// A process-global map rather than a member on the stored record: tsctsf has no
+/// durable store, so this is exactly as durable as the record it keys, and
+/// threading it through `TimeSyncConfig`/`QosTscSession` would put a PCF
+/// implementation detail into the types the SBI handlers echo back to consumers.
+fn app_sessions() -> &'static std::sync::Mutex<std::collections::HashMap<String, String>> {
+    static MAP: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, String>>> =
+        std::sync::OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// The `appSessionId` recorded for `resource_id`, if any.
+pub fn app_session_for(resource_id: &str) -> Option<String> {
+    app_sessions()
+        .lock()
+        .ok()
+        .and_then(|m| m.get(resource_id).cloned())
+}
+
+#[cfg(test)]
+pub fn clear_app_sessions_for_test() {
+    if let Ok(mut m) = app_sessions().lock() {
+        m.clear();
+    }
+}
+
+/// The UE address a time-synchronization configuration supplies, if any, as the
+/// `AppSessionContextReqData` member name it maps to.
+///
+/// TS 29.514 requires `oneOf [ueIpv4, ueIpv6, ueMac]`, and a TS 23.502 §5.2.27.2.2
+/// time-sync configuration has no such mandatory input, so this is read from the
+/// optional members and its absence is a reason to decline rather than an error.
+fn ue_address_member(cfg: &TimeSyncExposureConfig) -> Option<(&'static str, String)> {
+    if let Some(mac) = cfg.ue_mac.as_deref().filter(|m| !m.trim().is_empty()) {
+        return Some(("ueMac", mac.to_string()));
+    }
+    if let Some(v4) = cfg.ue_ipv4.as_deref().filter(|m| !m.trim().is_empty()) {
+        return Some(("ueIpv4", v4.to_string()));
+    }
+    if let Some(v6) = cfg.ue_ipv6.as_deref().filter(|m| !m.trim().is_empty()) {
+        return Some(("ueIpv6", v6.to_string()));
+    }
+    None
+}
+
+/// The `AppSessionContext` body for a time-synchronization configuration
+/// (TS 29.514 §4.2.2, TS 23.502 §5.2.27).
+///
+/// Returns the reason it cannot be built rather than a partial body: a request
+/// that omits a `oneOf`-required member is a 400 waiting to happen, and getting
+/// one back from the PCF would look like a PCF problem.
+pub fn build_time_sync_app_session(
+    cfg: &TimeSyncExposureConfig,
+    derived: &DerivedTsnManagement,
+    notif_uri: &str,
+) -> Result<serde_json::Value, String> {
+    let Some((member, value)) = ue_address_member(cfg) else {
+        return Err(
+            "TS 29.514 AppSessionContextReqData requires oneOf [ueIpv4, ueIpv6, ueMac] and this \
+             time-synchronization configuration supplies none (its mandatory TS 23.502 \
+             §5.2.27.2.2 inputs carry SUPIs and a upNodeId, not a UE address)"
+                .to_string(),
+        );
+    };
+    if let ClockQualityVerdict::Unsatisfiable(reasons) = &derived.clock_quality {
+        return Err(format!(
+            "the clock-quality acceptance criteria can never be met, so authorising the service \
+             would commit to something undeliverable: {}",
+            reasons.join("; ")
+        ));
+    }
+
+    let mut asc = serde_json::Map::new();
+    asc.insert("notifUri".to_string(), serde_json::json!(notif_uri));
+    // suppFeat is mandatory. "0" is the honest value: this consumer negotiates no
+    // optional feature of TS 29.514, and claiming one it does not implement would
+    // make the PCF send responses it cannot read.
+    asc.insert("suppFeat".to_string(), serde_json::json!("0"));
+    asc.insert(member.to_string(), serde_json::json!(value));
+    if let Some(supi) = cfg.supis.first() {
+        asc.insert("supi".to_string(), serde_json::json!(supi));
+    }
+    asc.insert(
+        "tsnBridgeManCont".to_string(),
+        serde_json::json!({ "bridgeManCont": b64(&derived.bridge_container) }),
+    );
+    if let Some(dstt) = derived.dstt_ports.first() {
+        asc.insert(
+            "tsnPortManContDstt".to_string(),
+            serde_json::json!({
+                "portManCont": b64(&dstt.container),
+                "portNum": dstt.port_num,
+            }),
+        );
+    }
+    // `tsnPortManContNwtts` has minItems: 1, so it is present only when there is
+    // at least one NW-TT port. The derivation always produces exactly one.
+    if !derived.nwtt_ports.is_empty() {
+        asc.insert(
+            "tsnPortManContNwtts".to_string(),
+            serde_json::Value::Array(
+                derived
+                    .nwtt_ports
+                    .iter()
+                    .map(|p| {
+                        serde_json::json!({
+                            "portManCont": b64(&p.container),
+                            "portNum": p.port_num,
+                        })
+                    })
+                    .collect(),
+            ),
+        );
+    }
+    asc.insert("tscNotifUri".to_string(), serde_json::json!(notif_uri));
+    if let Some(id) = cfg.notification_correlation_id.as_deref() {
+        asc.insert("tscNotifCorreId".to_string(), serde_json::json!(id));
+    }
+    Ok(serde_json::json!({ "ascReqData": serde_json::Value::Object(asc) }))
+}
+
+/// The `AppSessionContext` body for a QoS/TSC assistance session.
+///
+/// Unconditional, unlike the time-sync case: TS 23.502 §5.2.27.3.2 makes a UE
+/// address (or a GPSI/group id) a required input, so the `oneOf` member is always
+/// available for a session that passed `validate`.
+pub fn build_qos_tsc_app_session(
+    session: &QosTscSession,
+    notif_uri: &str,
+) -> Result<serde_json::Value, String> {
+    let mut asc = serde_json::Map::new();
+    asc.insert("notifUri".to_string(), serde_json::json!(notif_uri));
+    asc.insert("suppFeat".to_string(), serde_json::json!("0"));
+    match (session.ue_ipv4.as_deref(), session.ue_ipv6.as_deref()) {
+        (Some(v4), _) if !v4.trim().is_empty() => {
+            asc.insert("ueIpv4".to_string(), serde_json::json!(v4));
+        }
+        (_, Some(v6)) if !v6.trim().is_empty() => {
+            asc.insert("ueIpv6".to_string(), serde_json::json!(v6));
+        }
+        _ => {
+            return Err(
+                "TS 29.514 AppSessionContextReqData requires oneOf [ueIpv4, ueIpv6, ueMac] and \
+                 this session identifies its UE by GPSI or external group id only"
+                    .to_string(),
+            )
+        }
+    }
+    if let Some(gpsi) = session.gpsi.as_deref() {
+        asc.insert("gpsi".to_string(), serde_json::json!(gpsi));
+    }
+
+    // One media component carrying the TSC assistance information. `medCompN` is
+    // the map key AND a required member of the value (TS 29.514 MediaComponent),
+    // so it appears in both places rather than only in the key.
+    let mut med = serde_json::Map::new();
+    med.insert("medCompN".to_string(), serde_json::json!(0));
+    if let Some(qref) = session.qos_reference.as_deref() {
+        med.insert("qosReference".to_string(), serde_json::json!(qref));
+    }
+    if let Some(br) = session.max_br_ul.as_deref() {
+        med.insert("marBwUl".to_string(), serde_json::json!(br));
+    }
+    if let Some(br) = session.max_br_dl.as_deref() {
+        med.insert("marBwDl".to_string(), serde_json::json!(br));
+    }
+    if let Some(tscai) = derive_tscai(session) {
+        for key in tscai_direction_keys(session) {
+            med.insert((*key).to_string(), tscai.clone());
+        }
+    }
+    if let Some(domain) = session.time_domain {
+        med.insert("tscaiTimeDom".to_string(), serde_json::json!(domain));
+    }
+    asc.insert(
+        "medComponents".to_string(),
+        serde_json::json!({ "0": serde_json::Value::Object(med) }),
+    );
+    Ok(serde_json::json!({ "ascReqData": serde_json::Value::Object(asc) }))
+}
+
+/// Base64 (standard alphabet, padded) — TS 29.571 `Bytes`.
+fn b64(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// `Npcf_PolicyAuthorization_Create`: POST the app-session context and record the
+/// `appSessionId` from the `Location` header against `resource_id`.
+///
+/// Returns the `appSessionId` on success. Best-effort in the sense that a failure
+/// does not fail the consumer's request -- the configuration is stored either way,
+/// which is #113's behaviour -- but it is logged at warn with the status, because a
+/// deployment that turned actuation ON and is getting silence needs to know.
+pub async fn policy_authorization_create(
+    resource_id: &str,
+    body: &serde_json::Value,
+) -> Option<String> {
+    let pcf = resolve_pcf_endpoint().await?;
+    let client = nextgcore_sbi::client::SbiClient::new(
+        nextgcore_sbi::security::sbi_peer_client_config(&pcf.host, pcf.port)
+            .with_connect_timeout(std::time::Duration::from_secs(2))
+            .with_request_timeout(std::time::Duration::from_secs(3)),
+    );
+    let resp = match client
+        .post_json("/npcf-policyauthorization/v1/app-sessions", body)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!(
+                "Npcf_PolicyAuthorization_Create to {}:{} failed: {e}",
+                pcf.host,
+                pcf.port
+            );
+            return None;
+        }
+    };
+    if resp.status != 201 {
+        log::warn!(
+            "Npcf_PolicyAuthorization_Create for {resource_id} returned status {} (expected 201)",
+            resp.status
+        );
+        return None;
+    }
+    // The appSessionId is the last path segment of Location. Taken from the header
+    // rather than from the body: TS 29.514 makes Location the authoritative
+    // statement of where the resource lives.
+    let app_session_id = resp
+        .http
+        .get_header("Location")
+        .and_then(|l| l.rsplit('/').next())
+        .map(str::to_string)?;
+    if let Ok(mut m) = app_sessions().lock() {
+        m.insert(resource_id.to_string(), app_session_id.clone());
+    }
+    log::info!("Npcf_PolicyAuthorization_Create for {resource_id}: appSessionId={app_session_id}");
+    Some(app_session_id)
+}
+
+/// `Npcf_PolicyAuthorization_Delete`: POST `.../app-sessions/{id}/delete`
+/// (TS 29.514 §4.2.5 -- a custom operation, not an HTTP DELETE).
+///
+/// Returns true when the PCF accepted it. A resource that was never actuated has
+/// no `appSessionId` and is not an error: with the switch off at create time there
+/// is nothing to delete.
+pub async fn policy_authorization_delete(resource_id: &str) -> bool {
+    let Some(app_session_id) = ({
+        match app_sessions().lock() {
+            Ok(mut m) => m.remove(resource_id),
+            Err(_) => None,
+        }
+    }) else {
+        log::debug!("no PCF app session recorded for {resource_id}; nothing to delete");
+        return false;
+    };
+    let Some(pcf) = resolve_pcf_endpoint().await else {
+        log::warn!(
+            "cannot delete PCF app session {app_session_id} for {resource_id}: no PCF resolved"
+        );
+        return false;
+    };
+    let client = nextgcore_sbi::client::SbiClient::new(
+        nextgcore_sbi::security::sbi_peer_client_config(&pcf.host, pcf.port)
+            .with_connect_timeout(std::time::Duration::from_secs(2))
+            .with_request_timeout(std::time::Duration::from_secs(3)),
+    );
+    let path = format!("/npcf-policyauthorization/v1/app-sessions/{app_session_id}/delete");
+    match client.post_json(&path, &serde_json::json!({})).await {
+        Ok(resp) if (200..300).contains(&resp.status) => {
+            log::info!(
+                "Npcf_PolicyAuthorization_Delete for {resource_id} (appSessionId={app_session_id}): \
+                 status={}",
+                resp.status
+            );
+            true
+        }
+        Ok(resp) => {
+            log::warn!(
+                "Npcf_PolicyAuthorization_Delete for {resource_id} returned status {}",
+                resp.status
+            );
+            false
+        }
+        Err(e) => {
+            log::warn!("Npcf_PolicyAuthorization_Delete for {resource_id} failed: {e}");
+            false
+        }
+    }
+}
+
+// ============================================================================
+// The capability source (criterion 5)
+// ============================================================================
+
+/// The time-synchronization capabilities this deployment can currently report,
+/// derived from the stored configurations.
+///
+/// This replaces #113's administrative poke as the trigger for `CapsNotify`. It is
+/// a real in-tree source in the sense that matters: the value is computed from
+/// actual state rather than supplied by whoever called an admin route, so a change
+/// in it means something changed. What it is NOT is a 5GS capability report — the
+/// UPF/gNB do not report their (g)PTP capability into this tree at all, and the
+/// PFCP TSC container that would carry it has no codec here (see the spec's
+/// ceilings). So this reports what the TSCTSF has been asked to support and can
+/// derive, which is strictly more than nothing and strictly less than the spec's
+/// source.
+pub fn derive_capabilities(configs: &[crate::context::TimeSyncConfig]) -> serde_json::Value {
+    let mut domains: Vec<u16> = configs
+        .iter()
+        .filter_map(|c| c.config.time_domain)
+        .collect();
+    domains.sort_unstable();
+    domains.dedup();
+    let mut profiles: Vec<String> = configs
+        .iter()
+        .filter_map(|c| c.config.ptp_profile.clone())
+        .collect();
+    profiles.sort();
+    profiles.dedup();
+    let gm_capable = configs.iter().any(|c| c.config.gm_enable.unwrap_or(false));
+    let unsatisfiable = configs
+        .iter()
+        .filter(|c| {
+            !evaluate_clock_quality(c.config.clock_quality_acceptance_criteria.as_ref())
+                .permits_actuation()
+        })
+        .count();
+    serde_json::json!({
+        "timeDomains": domains,
+        "ptpProfiles": profiles,
+        "gmCapable": gm_capable,
+        "configurationsWithUnmeetableCriteria": unsatisfiable,
+    })
+}
+
+/// The last reported capability set, so a change can be detected.
+fn last_capabilities() -> &'static std::sync::Mutex<Option<serde_json::Value>> {
+    static LAST: std::sync::OnceLock<std::sync::Mutex<Option<serde_json::Value>>> =
+        std::sync::OnceLock::new();
+    LAST.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+/// Record `caps` and report whether it differs from the last recorded set.
+///
+/// The comparison is what makes this a *change* trigger rather than a per-request
+/// one: a create that alters nothing about the derived capabilities must not wake
+/// every subscriber, and TS 29.500 §6.5's spirit is that a notification means
+/// something happened.
+pub fn capabilities_changed(caps: &serde_json::Value) -> bool {
+    match last_capabilities().lock() {
+        Ok(mut last) => {
+            let changed = last.as_ref() != Some(caps);
+            if changed {
+                *last = Some(caps.clone());
+            }
+            changed
+        }
+        // A poisoned lock must not suppress the notification: reporting an
+        // unchanged set is harmless, missing a real change is not.
+        Err(_) => true,
+    }
+}
+
+#[cfg(test)]
+pub fn reset_capabilities_for_test() {
+    if let Ok(mut last) = last_capabilities().lock() {
+        *last = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with(supis: &[&str], gm: Option<bool>) -> TimeSyncExposureConfig {
+        TimeSyncExposureConfig {
+            notification_target_addr: "http://af.example/cb".to_string(),
+            up_node_id: "upf-1".to_string(),
+            supis: supis.iter().map(|s| s.to_string()).collect(),
+            time_domain: Some(24),
+            gm_enable: gm,
+            gm_priority: Some(128),
+            ptp_profile: Some("gPTP".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Read one TLV value out of a container, so assertions are about the managed
+    /// OBJECT rather than about a byte offset that any reordering would break.
+    fn object(container: &[u8], want: u8) -> Option<Vec<u8>> {
+        let mut i = 0usize;
+        while i + 2 <= container.len() {
+            let t = container[i];
+            let len = container[i + 1] as usize;
+            let start = i + 2;
+            if start + len > container.len() {
+                return None;
+            }
+            if t == want {
+                return Some(container[start..start + len].to_vec());
+            }
+            i = start + len;
+        }
+        None
+    }
+
+    // ── criterion 1: grandmaster enabled vs disabled ──
+
+    #[test]
+    fn a_grandmaster_enabled_configuration_derives_the_enable_object_set() {
+        let d = derive_tsn_management(&cfg_with(&["imsi-1"], Some(true)));
+        assert!(d.gm_enabled);
+        for port in d.dstt_ports.iter().chain(d.nwtt_ports.iter()) {
+            assert_eq!(
+                object(&port.container, tag::GM_ENABLE),
+                Some(vec![1]),
+                "every port must carry the gPTP enable, or half the bridge is unsynchronised"
+            );
+            assert_eq!(object(&port.container, tag::GM_PRIORITY), Some(vec![128]));
+            assert_eq!(
+                object(&port.container, tag::TIME_DOMAIN),
+                Some(vec![0, 24]),
+                "the domain number is two octets, big endian"
+            );
+        }
+        assert_eq!(object(&d.bridge_container, tag::GM_ENABLE), Some(vec![1]));
+    }
+
+    #[test]
+    fn a_grandmaster_disabled_configuration_derives_the_disable_object() {
+        let d = derive_tsn_management(&cfg_with(&["imsi-1"], Some(false)));
+        assert!(!d.gm_enabled);
+        assert_eq!(
+            object(&d.dstt_ports[0].container, tag::GM_ENABLE),
+            Some(vec![0])
+        );
+    }
+
+    /// An ABSENT `gmEnable` is "not activated", not "activate by default".
+    /// TS 23.501 §5.27.1.8 makes activation explicit, and defaulting it on would
+    /// start distributing time for a configuration that never asked.
+    #[test]
+    fn an_absent_grandmaster_flag_is_not_activation() {
+        let d = derive_tsn_management(&cfg_with(&["imsi-1"], None));
+        assert!(!d.gm_enabled);
+        assert_eq!(
+            object(&d.dstt_ports[0].container, tag::GM_ENABLE),
+            Some(vec![0])
+        );
+    }
+
+    // ── criterion 1: a per-UE DS-TT port vs the N6 (NW-TT) termination ──
+
+    #[test]
+    fn each_ue_gets_its_own_dstt_port_and_the_up_node_gets_the_nwtt_port() {
+        let d = derive_tsn_management(&cfg_with(&["imsi-1", "imsi-2", "imsi-3"], Some(true)));
+
+        assert_eq!(d.dstt_ports.len(), 3, "one DS-TT port per UE");
+        assert_eq!(
+            d.dstt_ports.iter().map(|p| p.port_num).collect::<Vec<_>>(),
+            vec![1, 2, 3],
+            "DS-TT numbering is stable and starts at 1, leaving 0 for the NW-TT"
+        );
+        for (port, supi) in d.dstt_ports.iter().zip(["imsi-1", "imsi-2", "imsi-3"]) {
+            assert_eq!(port.side, TsnPortSide::DeviceSide);
+            assert_eq!(
+                object(&port.container, tag::SUPI).as_deref(),
+                Some(supi.as_bytes()),
+                "a DS-TT port names the UE it serves, or the PCF cannot route the PMIC"
+            );
+            assert_eq!(object(&port.container, tag::PORT_SIDE), Some(vec![0]));
+            assert!(
+                object(&port.container, tag::UP_NODE_ID).is_none(),
+                "a DS-TT port is not the network-side termination"
+            );
+        }
+
+        assert_eq!(
+            d.nwtt_ports.len(),
+            1,
+            "one N6 termination per configuration"
+        );
+        let nwtt = &d.nwtt_ports[0];
+        assert_eq!(nwtt.side, TsnPortSide::NetworkSide);
+        assert_eq!(nwtt.port_num, 0);
+        assert_eq!(object(&nwtt.container, tag::PORT_SIDE), Some(vec![1]));
+        assert_eq!(
+            object(&nwtt.container, tag::UP_NODE_ID).as_deref(),
+            Some(b"upf-1".as_slice())
+        );
+        assert!(
+            object(&nwtt.container, tag::SUPI).is_none(),
+            "the N6 termination belongs to the user-plane node, not to any UE"
+        );
+    }
+
+    /// The asymmetry stated as its own case: a configuration with NO UEs still has
+    /// an N6 termination, because that port is a property of the user-plane node.
+    #[test]
+    fn a_configuration_with_no_ues_still_derives_the_n6_termination() {
+        let d = derive_tsn_management(&cfg_with(&[], Some(true)));
+        assert!(d.dstt_ports.is_empty());
+        assert_eq!(d.nwtt_ports.len(), 1);
+        assert_eq!(
+            object(&d.nwtt_ports[0].container, tag::UP_NODE_ID).as_deref(),
+            Some(b"upf-1".as_slice())
+        );
+    }
+
+    // ── criterion 1: criteria that cannot be met ──
+
+    #[test]
+    fn a_reserved_clock_class_is_unsatisfiable() {
+        let mut cfg = cfg_with(&["imsi-1"], Some(true));
+        cfg.clock_quality_acceptance_criteria = Some(ClockQualityAcceptanceCriteria {
+            clock_class: Some(100), // Reserved in IEEE 1588-2019 Table 4
+            ..Default::default()
+        });
+        let d = derive_tsn_management(&cfg);
+        let ClockQualityVerdict::Unsatisfiable(reasons) = &d.clock_quality else {
+            panic!("expected Unsatisfiable, got {:?}", d.clock_quality);
+        };
+        assert_eq!(reasons.len(), 1);
+        assert!(reasons[0].contains("clockClass 100"), "{}", reasons[0]);
+        assert!(!d.clock_quality.permits_actuation());
+    }
+
+    #[test]
+    fn an_accuracy_finer_than_the_enumeration_is_unsatisfiable() {
+        let mut cfg = cfg_with(&["imsi-1"], Some(true));
+        cfg.clock_quality_acceptance_criteria = Some(ClockQualityAcceptanceCriteria {
+            clock_accuracy: Some(0x10), // better than 0x20 = 25 ns, which is the best defined
+            ..Default::default()
+        });
+        let d = derive_tsn_management(&cfg);
+        assert!(!d.clock_quality.permits_actuation());
+    }
+
+    /// Every reason, not the first: an operator fixing one and re-submitting
+    /// should not discover the rest one round trip at a time.
+    #[test]
+    fn all_unsatisfiable_criteria_are_reported_together() {
+        let mut cfg = cfg_with(&["imsi-1"], Some(true));
+        cfg.clock_quality_acceptance_criteria = Some(ClockQualityAcceptanceCriteria {
+            clock_class: Some(100),
+            clock_accuracy: Some(0xFF),
+            synchronization_state: Some("MAYBE".to_string()),
+            offset_scaled_log_variance: Some(0xFFFF),
+        });
+        let d = derive_tsn_management(&cfg);
+        let ClockQualityVerdict::Unsatisfiable(reasons) = &d.clock_quality else {
+            panic!("expected Unsatisfiable, got {:?}", d.clock_quality);
+        };
+        assert_eq!(
+            reasons.len(),
+            3,
+            "three impossible criteria, three reasons: {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn satisfiable_criteria_permit_actuation() {
+        let mut cfg = cfg_with(&["imsi-1"], Some(true));
+        cfg.clock_quality_acceptance_criteria = Some(ClockQualityAcceptanceCriteria {
+            clock_class: Some(6),
+            clock_accuracy: Some(0x20),
+            synchronization_state: Some("SYNCHRONIZED".to_string()),
+            offset_scaled_log_variance: Some(0x4E5D),
+        });
+        let d = derive_tsn_management(&cfg);
+        assert_eq!(d.clock_quality, ClockQualityVerdict::Satisfiable);
+        assert!(d.clock_quality.permits_actuation());
+    }
+
+    /// "No criteria" is distinct from "all criteria met", and both actuate. A
+    /// single boolean would conflate them, and a caller reporting "criteria met"
+    /// for a configuration that stated none would be inventing a guarantee.
+    #[test]
+    fn no_criteria_is_its_own_verdict_and_still_actuates() {
+        let d = derive_tsn_management(&cfg_with(&["imsi-1"], Some(true)));
+        assert_eq!(d.clock_quality, ClockQualityVerdict::NoCriteria);
+        assert!(d.clock_quality.permits_actuation());
+
+        // An empty criteria object is also "no criteria", not "satisfiable":
+        // a consumer that sent `{}` stated nothing.
+        let mut cfg = cfg_with(&["imsi-1"], Some(true));
+        cfg.clock_quality_acceptance_criteria = Some(ClockQualityAcceptanceCriteria::default());
+        assert_eq!(
+            derive_tsn_management(&cfg).clock_quality,
+            ClockQualityVerdict::NoCriteria
+        );
+    }
+
+    // ── TSCAI derivation ──
+
+    #[test]
+    fn tscai_maps_the_stated_traffic_pattern_and_omits_the_rest() {
+        let session = QosTscSession {
+            periodicity: Some(2000),
+            survival_time: Some(1000),
+            ..Default::default()
+        };
+        let tscai = derive_tscai(&session).expect("a stated pattern derives a container");
+        assert_eq!(tscai["periodicity"], 2000);
+        assert_eq!(
+            tscai["surTimeInTime"], 1000,
+            "Stage-2's survivalTime is a DURATION, so it maps to surTimeInTime, not to the \
+             message count surTimeInNumMsg"
+        );
+        assert!(
+            tscai.get("burstArrivalTime").is_none(),
+            "an absent member must be absent, not null"
+        );
+    }
+
+    #[test]
+    fn a_session_with_no_traffic_pattern_derives_no_container() {
+        assert!(
+            derive_tscai(&QosTscSession::default()).is_none(),
+            "TS 29.514 types the container nullable, so omitting it is how to say 'no pattern'; \
+             sending {{}} claims a pattern with every member absent"
+        );
+    }
+
+    #[test]
+    fn an_unstated_direction_populates_both_tscai_members() {
+        let both = QosTscSession::default();
+        assert_eq!(
+            tscai_direction_keys(&both),
+            ["tscaiInputUl", "tscaiInputDl"]
+        );
+        let ul = QosTscSession {
+            flow_direction: Some("UPLINK".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(tscai_direction_keys(&ul), ["tscaiInputUl"]);
+        let dl = QosTscSession {
+            flow_direction: Some("DOWNLINK".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(tscai_direction_keys(&dl), ["tscaiInputDl"]);
+    }
+}

--- a/src/bins/nextgcore-tsctsf/src/context.rs
+++ b/src/bins/nextgcore-tsctsf/src/context.rs
@@ -117,6 +117,20 @@ pub struct TimeSyncExposureConfig {
     pub clock_quality_acceptance_criteria: Option<ClockQualityAcceptanceCriteria>,
     /// Temporary validity condition, kept as received.
     pub temporal_validity: Option<serde_json::Value>,
+    /// The UE address of the DS-TT this configuration applies to (#284).
+    ///
+    /// **Not a TS 23.502 §5.2.27.2.2 input.** These exist because TS 29.514's
+    /// `AppSessionContextReqData` requires `oneOf [ueIpv4, ueIpv6, ueMac]` and a
+    /// time-synchronization configuration's mandatory inputs carry SUPIs and a
+    /// `upNodeId` but no UE address — so without one, the actuation leg cannot
+    /// build a conformant body. Optional, and their absence declines actuation with
+    /// a named reason rather than sending a body that violates the schema.
+    ///
+    /// A DS-TT behind an Ethernet PDU session has a MAC, which is the TS 23.501
+    /// §5.28 case, so `ueMac` is checked first.
+    pub ue_mac: Option<String>,
+    pub ue_ipv4: Option<String>,
+    pub ue_ipv6: Option<String>,
     /// The whole body as received, so nothing a consumer sent is lost.
     #[serde(skip)]
     pub raw: serde_json::Value,
@@ -137,6 +151,9 @@ impl Default for TimeSyncExposureConfig {
             clock_quality_detail_level: None,
             clock_quality_acceptance_criteria: None,
             temporal_validity: None,
+            ue_mac: None,
+            ue_ipv4: None,
+            ue_ipv6: None,
             raw: serde_json::Value::Null,
         }
     }
@@ -821,6 +838,22 @@ impl Default for TsctsfContext {
 /// Global TSCTSF context
 static GLOBAL_TSCTSF_CONTEXT: std::sync::OnceLock<Arc<RwLock<TsctsfContext>>> =
     std::sync::OnceLock::new();
+
+/// One agreement about every process-global in this crate: the TSCTSF context and
+/// `actuation`'s enable switch (#284).
+///
+/// Declared **here, beside the largest global it guards**, rather than inside
+/// `main`'s `mod tests` where it used to live. A guard inside one module's `mod
+/// tests` is unreachable from every sibling module, so `actuation`'s tests — which
+/// flip a process-global switch that `main`'s handlers read — would have had to
+/// declare a second lock over the same state. #308 established that two locks over
+/// one ambient state are two disjoint agreements rather than one, and #276 showed
+/// that the same mistake HANGS the suite rather than merely flaking it.
+///
+/// A `std` mutex rather than a `tokio` one: every holder here is a sync `#[test]`
+/// or a `block_on` wrapper with no live runtime to block, and poisoning is absorbed
+/// by `into_inner` at the call site.
+pub static PROCESS_STATE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 pub fn tsctsf_self() -> Arc<RwLock<TsctsfContext>> {
     GLOBAL_TSCTSF_CONTEXT

--- a/src/bins/nextgcore-tsctsf/src/main.rs
+++ b/src/bins/nextgcore-tsctsf/src/main.rs
@@ -65,6 +65,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+mod actuation; // #284: derivation + PCF actuation for stored TSC configurations
 mod context;
 
 pub use context::*;
@@ -203,6 +204,9 @@ async fn main() -> Result<()> {
     );
 
     tsctsf_context_init(args.max_configs);
+    // #284: resolve the actuation switch once, before anything can be served, so
+    // no request is answered under a different setting from the next.
+    actuation::init_from_env();
 
     let nf_instance_id = args
         .nf_instance_id
@@ -387,7 +391,7 @@ async fn handle_config_create(request: &SbiRequest) -> SbiResponse {
     let mut config = config;
     config.raw = data.clone();
 
-    let stored = context::TimeSyncConfig::new(config);
+    let stored = context::TimeSyncConfig::new(config.clone());
     let config_id = stored.id.clone();
     let ctx = tsctsf_self();
     let insert = match ctx.read() {
@@ -404,6 +408,11 @@ async fn handle_config_create(request: &SbiRequest) -> SbiResponse {
 
     let location = format!("/ntsctsf-time-synchronization/v1/configuration/{config_id}");
     log::info!("Time-sync configuration created: id={config_id}");
+    // #284: the stored record now DOES something. Off by default, so with the
+    // switch clear this is a no-op and the response below is byte-identical to
+    // #113's.
+    actuate_time_sync_create(&config_id, &config).await;
+    report_capability_change().await;
     SbiResponse::with_status(201)
         .with_header("Location", location.clone())
         .with_json_body(&config_body(&config_id, &data, &location))
@@ -615,6 +624,12 @@ async fn handle_config_delete(config_id: &str) -> SbiResponse {
     match removed {
         Some(_) => {
             log::info!("Time-sync configuration removed: id={config_id}");
+            // #284: a delete must retract what the create authorised, or the PCF is
+            // left enforcing policy for a configuration that no longer exists.
+            if actuation::enabled() {
+                actuation::policy_authorization_delete(config_id).await;
+            }
+            report_capability_change().await;
             SbiResponse::with_status(204)
         }
         None => send_not_found(
@@ -863,6 +878,19 @@ async fn handle_qos_tsc_create(request: &SbiRequest) -> SbiResponse {
         created.transaction_ref_id,
         created.af_id
     );
+    // #284: a QoS/TSC session carries a UE address as a mandated input, so its
+    // actuation is unconditional -- unlike a time-sync configuration's.
+    if actuation::enabled() {
+        match actuation::build_qos_tsc_app_session(&created, &qos_tsc_notif_uri(&created)) {
+            Ok(asc) => {
+                actuation::policy_authorization_create(&created.transaction_ref_id, &asc).await;
+            }
+            Err(reason) => log::warn!(
+                "not actuating QoS/TSC session {}: {reason}",
+                created.transaction_ref_id
+            ),
+        }
+    }
     let mut body = data;
     if let Some(obj) = body.as_object_mut() {
         obj.insert(
@@ -938,12 +966,87 @@ async fn handle_qos_tsc_delete(transaction_id: &str) -> SbiResponse {
     match removed {
         Some(_) => {
             log::info!("QoS/TSC assistance session removed: transaction={transaction_id}");
+            // #284: retract the PCF authorisation this session created.
+            if actuation::enabled() {
+                actuation::policy_authorization_delete(transaction_id).await;
+            }
             SbiResponse::with_status(204)
         }
         None => send_not_found(
             &format!("Transaction {transaction_id} not found"),
             Some("TRANSACTION_NOT_FOUND"),
         ),
+    }
+}
+
+// ============================================================================
+// #284: actuation glue -- the SBI handlers' view of `actuation`
+// ============================================================================
+
+/// The notification URI to give the PCF for a time-sync configuration.
+///
+/// The AF's own `notificationTargetAddr`: the PCF's TSC notifications are about
+/// the configuration the AF asked for, so the AF is who wants them. A TSCTSF-side
+/// callback would need a receiving route this build does not serve, and pointing
+/// the PCF at a 404 would be worse than pointing it at the consumer.
+fn time_sync_notif_uri(cfg: &context::TimeSyncExposureConfig) -> String {
+    cfg.notification_target_addr.clone()
+}
+
+/// The same for a QoS/TSC session, which types its target as optional.
+fn qos_tsc_notif_uri(session: &context::QosTscSession) -> String {
+    session.notification_target_addr.clone().unwrap_or_default()
+}
+
+/// Actuate a time-sync create: derive, then authorise with the PCF.
+///
+/// A no-op with the switch off, which is the shipped default. With it on, a
+/// configuration that cannot produce a conformant body (no UE address, or
+/// unmeetable clock-quality criteria) is DECLINED with the reason logged at warn
+/// rather than half-sent -- the stored record and the 201 are unaffected either
+/// way, because #113's control plane is the contract the consumer was answered
+/// against.
+async fn actuate_time_sync_create(config_id: &str, cfg: &context::TimeSyncExposureConfig) {
+    if !actuation::enabled() {
+        return;
+    }
+    let derived = actuation::derive_tsn_management(cfg);
+    log::info!(
+        "time-sync configuration {config_id} derives {} DS-TT port(s) + {} NW-TT port(s), \
+         gmEnabled={}, clockQuality={:?}",
+        derived.dstt_ports.len(),
+        derived.nwtt_ports.len(),
+        derived.gm_enabled,
+        derived.clock_quality
+    );
+    match actuation::build_time_sync_app_session(cfg, &derived, &time_sync_notif_uri(cfg)) {
+        Ok(asc) => {
+            actuation::policy_authorization_create(config_id, &asc).await;
+        }
+        Err(reason) => {
+            log::warn!("not actuating time-sync configuration {config_id}: {reason}")
+        }
+    }
+}
+
+/// Recompute the derived capability set and fire `CapsNotify` if it changed
+/// (#284 criterion 5).
+///
+/// This is the in-tree capability SOURCE that #113's `admin/capability-change`
+/// route stood in for. It fires on a change, not on every request: a create that
+/// alters nothing about the derived capabilities must not wake every subscriber.
+async fn report_capability_change() {
+    if !actuation::enabled() {
+        return;
+    }
+    let configs = match tsctsf_self().read() {
+        Ok(c) => c.config_list(),
+        Err(_) => return,
+    };
+    let caps = actuation::derive_capabilities(&configs);
+    if actuation::capabilities_changed(&caps) {
+        let notified = notify_capability_change(&caps).await;
+        log::info!("CapsNotify (derived capability change): {notified} subscriber(s)");
     }
 }
 
@@ -1194,6 +1297,16 @@ pub async fn notify_capability_change(capabilities: &serde_json::Value) -> usize
 /// with the number of subscribers notified, so an operator can tell "notified
 /// nobody because nobody subscribed" from "notified nobody because the fan-out is
 /// broken" — two states a 204 would conflate.
+///
+/// # A TEST-ONLY SHIM as of #284
+///
+/// #113 added this because `CapsNotify` had no in-tree producer at all. It now has
+/// one: [`report_capability_change`] recomputes the derived capability set on every
+/// configuration change and fires the notification when it differs. This route is
+/// kept rather than removed for two reasons — #113's subscribe/notify/unsubscribe
+/// test drives the fan-out through it, and it lets an operator force a fan-out
+/// while diagnosing — but it is **not** a capability source and must not be
+/// mistaken for one. Anything relying on it in a deployment is relying on a shim.
 async fn handle_admin_capability_change(request: &SbiRequest) -> SbiResponse {
     let capabilities: serde_json::Value = match &request.http.content {
         Some(body) => match serde_json::from_str(body) {
@@ -1335,13 +1448,18 @@ fn parse_host_port(uri: &str) -> Option<(String, u16)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    /// Serializes tests that touch the process-global TSCTSF context.
-    static GLOBAL_TEST_LOCK: Mutex<()> = Mutex::new(());
-
+    /// Serializes tests that touch any process-global in this crate.
+    ///
+    /// #284 moved the static itself to `context`, beside the context it guards, so
+    /// `actuation`'s tests reach the SAME lock: they flip the actuation switch,
+    /// which these handlers read. A second lock declared here would be a second
+    /// disjoint agreement over one ambient state -- #308's defect, and #276 showed
+    /// that shape hangs the suite.
     fn lock_globals() -> std::sync::MutexGuard<'static, ()> {
-        GLOBAL_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+        crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
     }
 
     /// Reset the process-global context. Callers must hold [`lock_globals`].
@@ -1611,6 +1729,351 @@ mod tests {
             .await
             .expect("notification sink start");
         (server, format!("http://127.0.0.1:{port}/notify"), seen)
+    }
+
+    // ── #284: the actuation leg, ON and OFF ──
+
+    /// A stand-in PCF that records every request and answers a
+    /// `Npcf_PolicyAuthorization_Create` with 201 + Location, so the
+    /// `appSessionId` the TSCTSF records comes off the wire.
+    async fn spawn_stub_pcf() -> (
+        nextgcore_sbi::server::SbiServer,
+        u16,
+        std::sync::Arc<std::sync::Mutex<Vec<(String, String, serde_json::Value)>>>,
+    ) {
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<(String, String, serde_json::Value)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let (server, addr) =
+            nextgcore_sbi::test_support::sbi_server_on_free_port(move |req: SbiRequest| {
+                let sink = sink.clone();
+                async move {
+                    let body = req
+                        .http
+                        .content
+                        .as_deref()
+                        .and_then(|b| serde_json::from_str(b).ok())
+                        .unwrap_or(serde_json::Value::Null);
+                    let uri = req.header.uri.clone();
+                    sink.lock().unwrap_or_else(|e| e.into_inner()).push((
+                        req.header.method.clone(),
+                        uri.clone(),
+                        body,
+                    ));
+                    if uri == "/npcf-policyauthorization/v1/app-sessions" {
+                        return SbiResponse::with_status(201).with_header(
+                            "Location",
+                            "/npcf-policyauthorization/v1/app-sessions/asc-284".to_string(),
+                        );
+                    }
+                    SbiResponse::with_status(204)
+                }
+            })
+            .await;
+        (server, addr.port(), seen)
+    }
+
+    /// Take the switch, the PCF pointer and the derived-capability memo back to a
+    /// known state. Callers hold [`lock_globals`].
+    fn reset_actuation(pcf_port: Option<u16>) {
+        actuation::clear_app_sessions_for_test();
+        actuation::reset_capabilities_for_test();
+        match pcf_port {
+            Some(p) => std::env::set_var("PCF_URI", format!("http://127.0.0.1:{p}")),
+            None => std::env::remove_var("PCF_URI"),
+        }
+    }
+
+    /// #284 criterion 2: with the switch ON, a time-sync create issues
+    /// `Npcf_PolicyAuthorization_Create` toward the PCF, and the delete issues the
+    /// matching delete.
+    ///
+    /// Asserted by observing the outbound HTTP request -- method, path and body --
+    /// which is what the criterion demands instead of a log line.
+    #[test]
+    fn the_switch_on_issues_policy_authorization_create_and_delete() {
+        let _g = lock_globals();
+        reset_context();
+        block_on(async {
+            let (pcf, pcf_port, seen) = spawn_stub_pcf().await;
+            reset_actuation(Some(pcf_port));
+            actuation::set_for_test(true);
+
+            let created = tsctsf_sbi_request_handler(create_request(serde_json::json!({
+                "timeDomain": 24,
+                "gmEnable": true,
+                "gmPriority": 128,
+                "supis": ["imsi-001010000000284"],
+                // TS 29.514 requires oneOf [ueIpv4, ueIpv6, ueMac]; a time-sync
+                // configuration has no mandatory UE address, so the consumer
+                // supplies one or actuation declines.
+                "ueMac": "00-11-22-33-44-55",
+            })))
+            .await;
+            assert_eq!(created.status, 201);
+            let body: serde_json::Value =
+                serde_json::from_str(created.http.content.as_deref().expect("body")).expect("json");
+            let config_id = body["configId"].as_str().expect("configId").to_string();
+
+            let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            let create = requests
+                .iter()
+                .find(|(m, u, _)| m == "POST" && u == "/npcf-policyauthorization/v1/app-sessions")
+                .expect("a create must reach the PCF; got {requests:?}");
+            let asc = &create.2["ascReqData"];
+            assert_eq!(
+                asc["ueMac"], "00-11-22-33-44-55",
+                "the oneOf-required UE address must be present, body was {:?}",
+                create.2
+            );
+            assert_eq!(asc["supi"], "imsi-001010000000284");
+            assert!(
+                asc["tsnBridgeManCont"]["bridgeManCont"].is_string(),
+                "the UMIC must be carried as TS 29.571 Bytes (base64), got {:?}",
+                asc["tsnBridgeManCont"]
+            );
+            assert_eq!(
+                asc["tsnPortManContDstt"]["portNum"], 1,
+                "the DS-TT port is numbered from 1"
+            );
+            assert_eq!(
+                asc["tsnPortManContNwtts"][0]["portNum"], 0,
+                "the N6 termination takes port 0"
+            );
+            assert_eq!(asc["suppFeat"], "0");
+            assert_eq!(
+                actuation::app_session_for(&config_id).as_deref(),
+                Some("asc-284"),
+                "the appSessionId is taken from the PCF's Location header"
+            );
+
+            // The delete must retract it, at the TS 29.514 §4.2.5 custom operation
+            // rather than as an HTTP DELETE.
+            seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+            let deleted = tsctsf_sbi_request_handler(SbiRequest::delete(&format!(
+                "/ntsctsf-time-synchronization/v1/configuration/{config_id}"
+            )))
+            .await;
+            assert_eq!(deleted.status, 204);
+            let requests = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            assert!(
+                requests.iter().any(|(m, u, _)| m == "POST"
+                    && u == "/npcf-policyauthorization/v1/app-sessions/asc-284/delete"),
+                "the delete must reach the PCF as the custom operation; got {requests:?}"
+            );
+            assert!(
+                actuation::app_session_for(&config_id).is_none(),
+                "the recorded app session must be forgotten, or a second delete would repeat it"
+            );
+
+            actuation::set_for_test(false);
+            reset_actuation(None);
+            pcf.stop().await.expect("stop stub PCF");
+        });
+    }
+
+    /// #284 criterion 3: with the switch OFF, NO outbound request is made and the
+    /// control-plane behaviour is byte-identical.
+    ///
+    /// The byte-identical half is asserted by comparing the whole 201 body against
+    /// the same create with the switch on -- a weaker test would let actuation
+    /// quietly add a member to what the consumer gets back.
+    #[test]
+    fn the_switch_off_makes_no_outbound_request() {
+        let _g = lock_globals();
+        reset_context();
+        block_on(async {
+            let (pcf, pcf_port, seen) = spawn_stub_pcf().await;
+            reset_actuation(Some(pcf_port));
+            actuation::set_for_test(false);
+
+            let req = || {
+                create_request(serde_json::json!({
+                    "timeDomain": 24,
+                    "gmEnable": true,
+                    "supis": ["imsi-001010000000284"],
+                    "ueMac": "00-11-22-33-44-55",
+                }))
+            };
+            let off = tsctsf_sbi_request_handler(req()).await;
+            assert_eq!(off.status, 201);
+            assert!(
+                seen.lock().unwrap_or_else(|e| e.into_inner()).is_empty(),
+                "the switch is off: nothing may leave this process"
+            );
+
+            // Same request with the switch on, to compare the consumer-visible body.
+            actuation::set_for_test(true);
+            let on = tsctsf_sbi_request_handler(req()).await;
+            assert_eq!(on.status, on.status);
+            let strip_id = |r: &SbiResponse| {
+                let mut v: serde_json::Value =
+                    serde_json::from_str(r.http.content.as_deref().expect("body")).expect("json");
+                // The minted id and self link differ by construction.
+                if let Some(o) = v.as_object_mut() {
+                    o.remove("configId");
+                    o.remove("self");
+                }
+                v
+            };
+            assert_eq!(
+                strip_id(&off),
+                strip_id(&on),
+                "actuation must not change one byte of what the consumer is answered"
+            );
+            assert_eq!(off.status, on.status);
+
+            actuation::set_for_test(false);
+            reset_actuation(None);
+            pcf.stop().await.expect("stop stub PCF");
+        });
+    }
+
+    /// A configuration with NO UE address is declined rather than sent: TS 29.514
+    /// requires `oneOf [ueIpv4, ueIpv6, ueMac]`, and a time-sync configuration's
+    /// mandatory inputs carry none.
+    #[test]
+    fn a_configuration_with_no_ue_address_is_not_actuated() {
+        let _g = lock_globals();
+        reset_context();
+        block_on(async {
+            let (pcf, pcf_port, seen) = spawn_stub_pcf().await;
+            reset_actuation(Some(pcf_port));
+            actuation::set_for_test(true);
+
+            let created = tsctsf_sbi_request_handler(create_request(serde_json::json!({
+                "timeDomain": 24,
+                "gmEnable": true,
+                "supis": ["imsi-001010000000284"],
+            })))
+            .await;
+            assert_eq!(
+                created.status, 201,
+                "the control plane still answers: #113's contract is unaffected"
+            );
+            let posts = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            assert!(
+                !posts
+                    .iter()
+                    .any(|(_, u, _)| u == "/npcf-policyauthorization/v1/app-sessions"),
+                "a body violating oneOf must not be sent; got {posts:?}"
+            );
+
+            actuation::set_for_test(false);
+            reset_actuation(None);
+            pcf.stop().await.expect("stop stub PCF");
+        });
+    }
+
+    /// A configuration whose clock-quality criteria can never be met is declined:
+    /// authorising it would commit the TSCTSF to a service it cannot deliver.
+    #[test]
+    fn unmeetable_clock_quality_criteria_are_not_actuated() {
+        let _g = lock_globals();
+        reset_context();
+        block_on(async {
+            let (pcf, pcf_port, seen) = spawn_stub_pcf().await;
+            reset_actuation(Some(pcf_port));
+            actuation::set_for_test(true);
+
+            let created = tsctsf_sbi_request_handler(create_request(serde_json::json!({
+                "timeDomain": 24,
+                "gmEnable": true,
+                "supis": ["imsi-001010000000284"],
+                "ueMac": "00-11-22-33-44-55",
+                // 100 is Reserved in IEEE 1588-2019 Table 4.
+                "clockQualityAcceptanceCriteria": { "clockClass": 100 },
+            })))
+            .await;
+            assert_eq!(created.status, 201);
+            let posts = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            assert!(
+                !posts
+                    .iter()
+                    .any(|(_, u, _)| u == "/npcf-policyauthorization/v1/app-sessions"),
+                "an impossible criterion must not be authorised; got {posts:?}"
+            );
+
+            actuation::set_for_test(false);
+            reset_actuation(None);
+            pcf.stop().await.expect("stop stub PCF");
+        });
+    }
+
+    /// #284 criterion 5: a capability change from a REAL source drives CapsNotify.
+    ///
+    /// The source is the derived capability set, recomputed on every configuration
+    /// change. The second create changes nothing about it, and must therefore NOT
+    /// notify -- which is what makes this a change trigger rather than a
+    /// per-request one, and what distinguishes it from #113's admin poke.
+    #[test]
+    fn a_derived_capability_change_drives_caps_notify_and_an_unchanged_set_does_not() {
+        let _g = lock_globals();
+        reset_context();
+        block_on(async {
+            let (sink, notif_uri, seen) = spawn_notification_sink().await;
+            let (pcf, pcf_port, _pcf_seen) = spawn_stub_pcf().await;
+            reset_actuation(Some(pcf_port));
+            actuation::set_for_test(true);
+
+            // A capability subscriber.
+            let sub = tsctsf_sbi_request_handler(post(
+                "/ntsctsf-time-synchronization/v1/subscriptions",
+                // §5.2.27.2.6 needs a SCOPE as well as a target: either a
+                // (DNN, S-NSSAI) pair or an AF-Service-Identifier.
+                serde_json::json!({
+                    "notificationTargetAddr": notif_uri,
+                    "afServiceId": "tsn-284",
+                }),
+            ))
+            .await;
+            assert_eq!(sub.status, 201, "CapsSubscribe must be served");
+            seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+            // A create that introduces a time domain and a grandmaster.
+            let first = tsctsf_sbi_request_handler(create_request(serde_json::json!({
+                "timeDomain": 24,
+                "gmEnable": true,
+                "supis": ["imsi-284-a"],
+                "ueMac": "00-11-22-33-44-55",
+            })))
+            .await;
+            assert_eq!(first.status, 201);
+            let after_first = seen.lock().unwrap_or_else(|e| e.into_inner()).len();
+            assert_eq!(
+                after_first, 1,
+                "the derived capability set changed, so the subscriber must be told"
+            );
+            let (_, body) = seen.lock().unwrap_or_else(|e| e.into_inner())[0].clone();
+            assert_eq!(
+                body["timeSyncCapabilities"]["timeDomains"],
+                serde_json::json!([24]),
+                "the notification carries the DERIVED set, not whatever an admin route was \
+                 handed; body was {body:?}"
+            );
+            assert_eq!(body["timeSyncCapabilities"]["gmCapable"], true);
+
+            // A second create with the same domain and profile changes nothing.
+            let second = tsctsf_sbi_request_handler(create_request(serde_json::json!({
+                "timeDomain": 24,
+                "gmEnable": true,
+                "supis": ["imsi-284-b"],
+                "ueMac": "00-11-22-33-44-66",
+            })))
+            .await;
+            assert_eq!(second.status, 201);
+            assert_eq!(
+                seen.lock().unwrap_or_else(|e| e.into_inner()).len(),
+                after_first,
+                "an unchanged capability set must not wake the subscriber again"
+            );
+
+            actuation::set_for_test(false);
+            reset_actuation(None);
+            pcf.stop().await.expect("stop stub PCF");
+            sink.stop().await.expect("stop sink");
+        });
     }
 
     /// #113 criterion 1: PATCH updates a stored configuration and answers 200;


### PR DESCRIPTION
Closes #284. Files #321 for the half it deliberately does not do.

#113 delivered three conformant control-plane services and **nothing read the records they stored**. An AF request produced a stored record with no policy or user-plane effect at all: no PCF contacted, no port-management information derived, the UPF's `tsn_bridge` untouched.

## What changed

- **A pure derivation** (`actuation::derive_tsn_management`): one DS-TT port per SUPI, one NW-TT port for the `upNodeId`, the bridge container (the UMIC), the grandmaster state, and a clock-quality verdict. No peer, no clock, no I/O — which is why criterion 1's three cases can be asserted exactly.
- **A PCF client**: `Npcf_PolicyAuthorization_Create` on create, and the TS 29.514 §4.2.5 **custom-operation** delete (not an HTTP DELETE) on delete, with the `appSessionId` read from the response `Location`. Behind `TSCTSF_ACTUATION=1` — a **runtime** switch per the recorded convention (a cargo-feature-gated path rots uncompiled), **default off**.
- **A real `CapsNotify` source**: the derived capability set, recomputed on every configuration change and notified only when it **differs**. #113's `admin/capability-change` is kept and documented in code as a test-only shim, which criterion 5 permits.

## Three choices in the derivation, each with its own test

- **An absent `gmEnable` is NOT activation.** TS 23.501 §5.27.1.8 makes activation explicit; defaulting it on would distribute time for a configuration that never asked.
- **A configuration with NO UEs still derives the N6 termination.** That port belongs to the user-plane node, not to any UE — the asymmetry criterion 1 asks to be covered, as its own case rather than implied by the multi-UE one.
- **Clock quality is three-valued.** `NoCriteria` is distinct from `Satisfiable`: collapsing them would report "criteria met" for a configuration that stated none.

"Criteria that cannot be met" is a **static** check against IEEE 1588-2019, not a measurement — a `clockClass` outside Table 4's specified set `{6,7,13,14,52,58,187,193,248,255}`, a `clockAccuracy` outside the Table 5 enumeration `0x20..=0x31`/`0xFE`, or a `synchronizationState` outside `{SYNCHRONIZED, NOT_SYNCHRONIZED}`. Every failing criterion is reported, not the first.

## Criterion 2 is not literally satisfiable, and the reason is in TS 29.514

`AppSessionContextReqData` has exactly the members this needs — `tsnBridgeManCont` (documented as "Contains the UMIC"), `tsnPortManContDstt`, `tsnPortManContNwtts`, `tscNotifUri`, `tscNotifCorreId`, `supi` — **and it also requires `oneOf [ueIpv4, ueIpv6, ueMac]`**.

A TS 23.502 §5.2.27.2.2 time-synchronization configuration's mandatory inputs are a notification target, a `upNodeId`, and SUPIs. **No UE address.** Three options; two are worse:

1. Send a body omitting the `oneOf` member → the PCF answers 400, which looks like a PCF problem.
2. Invent an address. (A revert doing exactly this is in the table below, because it is the tempting version.)
3. Read an optional address when the consumer supplies one, and **decline with a named reason** when it does not.

This does (3). `ueMac` is checked first — a DS-TT behind an Ethernet PDU session has one, the TS 23.501 §5.28 case. A QoS/TSC session needs none of it: §5.2.27.3.2 makes a UE address a required input, so its actuation is unconditional. The 201 and the stored record are unaffected either way.

## Criterion 4 is NOT met — stated plainly, as the criterion itself asks

The UPF's `tsn_bridge` is still `None`. Criterion 4 says that if this cannot be verified in-process, the PR must say so and state what *is* verified instead.

Driving it needs the N4 leg, and **the codec does not exist**: `src/libs/nextgcore-pfcp/src/ie.rs:205-212` declares `CreateBridgeInfoForTsc = 194`, `CreatedBridgeInfoForTsc = 195` and `TscManagementInformation{Smr,Smrsp,Srr} = 199/200/201` with **zero users**, there is no `TscManagementInformation` struct/encoder/decoder anywhere, and `UpFunctionFeatures.tscu` is encoded and decoded but never acted on. #284's own suggested approach makes piece 4 "only meaningful once (3) exists".

Filed as **#321** with that evidence and its own criteria.

**What is verified instead:** the derivation produces exactly the PMIC/UMIC payload such a leg would carry (asserted per managed object, by tag), and the PCF receives it over `Npcf_PolicyAuthorization` (asserted on the wire).

## A latent lock hazard fixed on the way

`GLOBAL_TEST_LOCK` lived inside `main.rs`'s `mod tests`, unreachable from any sibling module. `actuation`'s tests flip a process-global switch that `main`'s handlers read, so they would have needed a **second** lock over the same ambient state — #308's defect, and #276 showed that shape *hangs* the suite rather than merely flaking it. The static is now `context::PROCESS_STATE_TEST_LOCK`, declared beside the context it guards. Relocation only; no test changed.

## Verification

**7 reverts, 7 bites:**

| claim | revert | result |
|---|---|---|
| absent `gmEnable` is not activation | default it true | fails |
| the N6 termination is independent of UEs | no NW-TT port when `supis` is empty | fails |
| impossible criteria are detected | always `Satisfiable` | fails 4 tests |
| the OFF switch is honoured | ignore it | fails |
| a delete retracts the authorisation | drop the delete call | fails |
| `CapsNotify` fires on a *change* | always report changed | fails |
| a missing UE address declines | fall back to `ueIpv4: "0.0.0.0"` | fails |

Criterion 2/3's assertions are on the **outbound HTTP request** against a stub PCF — method, path, that `tsnBridgeManCont.bridgeManCont` is base64, that the DS-TT/NW-TT port numbers are 1 and 0 — not on a log line. The `appSessionId` comes off the stub's `Location` header, so the delete path proves the create recorded the right identifier. Criterion 3's byte-identical half compares the whole 201 body from the *same* create with the switch off and on; a weaker test would let actuation quietly add a member to what the consumer gets back.

tsctsf **33 → 52** tests; workspace **6396 passed / 0 failed**; clippy `--workspace` and `--all-targets` 0 errors; fmt clean.

## Other ceilings (full list in the spec)

The PMIC/UMIC octet strings are this build's own TLV encoding, not IEEE 802.1Q clause 12 (no such codec here) — said in the type's own doc, and the tests read containers back **by tag** so a real encoder can replace it without rewriting assertions. Only one `medComponents` entry per QoS/TSC session. `suppFeat` is `"0"`. The PCF is given the AF's own notification URI, because this TSCTSF serves no TSC-notification route. `appSessionId` lives in a process-global map, so a restart loses the ability to retract an authorisation the PCF still holds. The ASTI service is not actuated (its activation routes through the AMF/gNB). No compose service sets `TSCTSF_ACTUATION`, so the default E2E path is unchanged.

Spec: `specs/fix-tsctsf-actuation-derivation-and-pcf.md`. Docs: `docs-book/src/configuration/tsctsf.md`.
