### PR TITLE
fix(eesd): add the ECS role and make the EDGE-6 client survive an outage (#107)

### DIFF
--- a/docs-book/src/configuration/ees.md
+++ b/docs-book/src/configuration/ees.md
@@ -67,7 +67,41 @@ From the clap `Args` struct in `src/bins/nextgcore-eesd/src/main.rs`:
 ## Behavior notes
 
 - **OAuth2 is fail-closed and per-operation** (eesd-08, `auth.rs`): every `eees-*` route runs `require_oauth2` *before* method dispatch. No JWKS configured, or a missing/invalid/expired bearer → 401; a valid token whose space-delimited `scope` lacks the per-API scope (the scope string equals the apiName, e.g. `eees-easregistration`) → 403 `INSUFFICIENT_SCOPE`. The shipped docker-compose command passes no `--oauth2-jwks-file`, so in that deployment every protected EES operation answers 401; `main.rs` logs a startup warning to that effect.
-- **ECS, not NRF**: with `--ecs-uri` set, the EES POSTs an `EESRegistration` to `{ecsApiRoot}/eecs-eesregistration/v1/registrations` and, on 200/201, spawns a refresh task that PUTs the resource every 60 s. A failed initial POST is logged (`will operate without ECS`) and **not retried**; without `--ecs-uri` the daemon runs standalone.
+- **ECS, not NRF**: with `--ecs-uri` set, the EES POSTs an `EESRegistration` to `{ecsApiRoot}/eecs-eesregistration/v1/registrations` and, on 200/201, spawns a refresh task that PUTs the resource every 60 s; without `--ecs-uri` the daemon runs standalone. As of #107 the initial POST is **retried with capped exponential backoff** (5 attempts, 500 ms doubling to a 30 s cap) instead of being abandoned after one failure, the refresh **re-POSTs** on any non-2xx instead of looping on a resource the ECS no longer has, and the body carries live `easIds` and an `expTime` instead of `null` — see *Restoring a lost registration* below.
+
+## Restoring a lost registration, and the ECS role (#107)
+
+Three things were silently brittle before #107, and one thing was missing entirely.
+
+**The EDGE-6 client.**
+
+| was | now |
+|---|---|
+| one POST, then `warn!("will operate without ECS")` forever — a transient blip during startup dropped the EES from the registry permanently | retried up to `MAX_REGISTRATION_ATTEMPTS` (5) with backoff `500 ms → 1 s → 2 s → 4 s`, capped at 30 s. The body is **rebuilt each attempt**, so an EAS that registered while the ECS was unreachable appears in the registration that finally lands |
+| the refresh only ever PUT; a 404 — what an ECS returns for a resource lost across a restart — was logged and the loop kept PUTting forever | any **non-2xx** re-POSTs and adopts the new `registrationId`. Not only 404: a 410 or a schema-version 400 leave the EES in the identical state, and re-creating is idempotent from this side, so the narrower check would buy nothing and loop forever on those |
+| `easIds: null` and `expTime: null`, so the ECS's view of this EES was wrong even on the happy path and target-EES selection could never match it | both derived from live state on every POST **and** every refresh. `expTime` is 10 minutes out and the refresh runs every 60 s, so a live EES is never expired while one that stopped refreshing is |
+
+`easIds` is absent rather than `[]` when the EES serves no EAS: the member is optional, and an empty array asserts "serves no EAS" where absent says "not stated". Either way the ECS's discovery does not match it, which is the point — an EES advertising no EAS cannot be selected as a target.
+
+**The ECS role.** All eight ECS-side APIs were unimplemented anywhere in the workspace, so an EEC had no EDGE-4 bootstrap and an EES could not be brought into a deployment through an ECS. `ECS_ROLE=1` now makes this process serve three of them:
+
+| API | Path | What it does |
+|---|---|---|
+| `Eecs_EESRegistration` | `POST/PUT/GET/DELETE /eecs-eesregistration/v1/registrations[/{registrationId}]` | EDGE-6. Mints the `registrationId` server-side and returns it in `Location`. **404 for an id it does not hold**, which is what makes the client's re-POST recovery reachable. |
+| `Eecs_ServiceProvisioning` | `POST /eecs-serviceprovisioning/v1/provisioning-requests` | EDGE-4. Returns the registered EES endpoints an EEC needs. `eecId` is mandatory. An ECS with no EES answers **200 with an empty list**, not 404 — "none available yet" and "not served here" are different states. |
+| `Eecs_TargetEESDiscovery` | `POST /eecs-targeteesdiscovery/v1/target-ees-discovery` | Matches `easId` (directly, or via an AC profile's `easIds`) against the registered `eesProf.easIds`. An unfiltered query returns every EES: "which EESs exist" is a legitimate discovery. |
+
+| Variable | Default | Effect |
+|---|---|---|
+| `ECS_ROLE` | unset (off) | `1`/`true`/`yes`/`on` serves the three `eecs-*` APIs from this process. A **runtime** switch rather than a cargo feature, per this project's convention that a feature-gated path is left uncompiled by CI and rots. |
+
+**Limits worth knowing:**
+
+- **Five of the eight ECS APIs are not implemented** — `Eecs_ECSDiscovery`, `Eecs_EASInfoManagement`, `Eecs_ACREvents`, `Eecs_ECSServiceProvisioning` and `Ecas_SelectedEES`. They answer 404, deliberately: a route returning a fabricated 2xx is worse than one that is honest about not existing. #107's own suggested approach scoped the initial surface to three.
+- **The role is a role, not a separate `ecsd`.** An ECS has no `nfType` in TS 29.510 — the same fact that made EDGE-6 registration replace this daemon's old NRF self-registration — so a separate binary would gain none of the NF machinery that justifies one, and the registry an ECS matches against is the EAS pool this process already keeps. With `ECS_ROLE` unset the `eecs-*` paths answer 404 exactly as before.
+- **The ECS registry is in memory**, like every other piece of EES state, so it is lost on restart — which is precisely the case the hardened client's re-POST recovery handles.
+- **The `eecs-*` routes are not OAuth2-gated.** They are a different reference point (EDGE-4/EDGE-6) with different consumers, and requiring an `eees-*` scope would make an EEC's bootstrap need an EAS's token. A test pins the contrast.
+- **`ECS_ROLE` is not set by any compose service**, so the default E2E path is unchanged.
 - **Capacity and rejection**: the single `--max-eas` value caps each resource family independently in `context.rs` — EAS registrations, EEC registrations, discovery subscriptions, AC-information subscriptions, ACR-management-event subscriptions, ACR-events subscriptions, and stored EEC contexts. On exhaustion, create handlers return **507** with cause `INSUFFICIENT_RESOURCES`. Mandatory-IE violations return 400 `MANDATORY_IE_MISSING`; malformed JSON returns 400 `INVALID_MSG_FORMAT`; changing an immutable `easId`/`eecId` on update returns 403 `MODIFICATION_NOT_ALLOWED`.
 - **Registration lifecycle** (eesd-12): a sweep every 30 s (`LIFECYCLE_SWEEP_INTERVAL_SECS`) drops expired EAS/EEC registrations; an EEC registration created without `expTime` is minted one 3600 s out (`DEFAULT_EEC_REG_LIFETIME_SECS` in `eec.rs`). All state is in-memory only — there is no state file, and the context is cleared on shutdown.
 - **Notification callbacks** (D6, `notifier.rs`): every subscription callback is POSTed to its `notificationDestination` through a bounded queue (default capacity 1024; a full queue drops the newest with a warning) with bounded retry per the `--callback-*` flags; `suppFeat` negotiation echoes the hex-AND of the consumer's mask with `EES_SUPPORTED_FEATURES = 0x1` (`types.rs`).

--- a/specs/fix-ecs-role-and-edge6-hardening.md
+++ b/specs/fix-ecs-role-and-edge6-hardening.md
@@ -1,0 +1,176 @@
+# nextgcore #107: give the deployment an ECS, and make the EES's EDGE-6 client survive one
+
+Verified against `main` @ `8f38870`.
+
+Every claim in #107's "Current implementation" section, all of which it recorded
+against `76ea248`, still held. That is unusual for this backlog and worth saying:
+this issue's cites did not go stale.
+
+## Verified against current main
+
+| claim in the issue | site on `8f38870` | still true? |
+|---|---|---|
+| the only `eecs-*` surface in the workspace is a *client* | `eesd/ecs_registration.rs`; `rg 'eecs-'` finds nothing server-side | yes |
+| no `ecsd` binary exists | no workspace member references it | yes |
+| self-registration is skipped when `--ecs-uri` is unset | `ecs_registration.rs:119-126` | yes |
+| on POST failure it logs a warning and permanently gives up | `:136-139`, one attempt, no retry | yes |
+| `spawn_refresh` only PUTs; a non-2xx is only logged and it never re-POSTs | `:187-205`, `log::warn!("… refresh returned status {}")` at `:200` | yes |
+| the body is static: `eas_ids: None`, `exp_time: None` | `:81`, `:83` | yes |
+| eesd routes only `eees-*`; no `eecs-*` server routing | router in `main.rs`, ~30 arms, all `eees-*` | yes |
+| all 8 ECS-side APIs are unimplemented server-side | confirmed | yes |
+
+## Decision 1: a role inside eesd, not a new `ecsd` binary
+
+#107 offers either. Three reasons for the role:
+
+- **An ECS is not a 5GC NF.** It has no `nfType` in TS 29.510 — the same fact that
+  made `ecs_registration` replace eesd's old (incorrect) NRF self-registration. So a
+  separate binary gains none of the NF machinery (NRF profile, heartbeat, discovery)
+  that justifies one for nefd/easdfd/tsctsf, the precedents #107 cites.
+- **The registry an ECS matches against is the registry this process already
+  keeps.** `Eecs_TargetEESDiscovery` matches on registered `easIds`, and the EAS pool
+  those come from lives here. Crossing a process boundary to read it would mean
+  inventing a protocol TS 29.558 does not define.
+- **It costs one runtime switch** instead of a Dockerfile, a compose service, a
+  config file and a health probe, none of which #107 asks for.
+
+`ECS_ROLE=1`, off by default, and a **runtime** switch rather than the cargo feature
+#107 suggests — this project has a recorded convention for that, because a
+feature-gated path is left uncompiled by CI and rots. With the switch off,
+`ecs_role::route` returns `None` and the router's own 404 answers, so the paths
+behave exactly as before rather than merely being quiet.
+
+## Decision 2: three of the eight APIs, and the other five stay 404
+
+#107's own suggested approach scopes the initial surface to
+`Eecs_ServiceProvisioning`, `Eecs_EESRegistration` and `Eecs_TargetEESDiscovery`,
+"to stay implementable". The remaining five — `Eecs_ECSDiscovery`,
+`Eecs_EASInfoManagement`, `Eecs_ACREvents`, `Eecs_ECSServiceProvisioning`,
+`Ecas_SelectedEES` — answer 404 rather than a stub. A route returning a fabricated
+2xx is worse than one that is honest about not existing: this crate already made
+that call for three `eees-*` APIs in #106, which answer 501 for the same reason.
+
+Two response-code choices inside the three are deliberate and each has a test:
+
+- **A refresh for an id the ECS does not hold is 404**, not 200 and not a silent
+  re-create. That 404 is precisely what the hardened client's recovery keys on, so
+  an ECS that answered 200 would make criterion 4's recovery *unreachable* — the
+  server and the client have to agree, and a revert of this arm fails the client's
+  test as well as the server's.
+- **Provisioning with no registered EES is 200 with an empty list**, not 404. "No
+  EES is available yet" and "this ECS does not serve provisioning" are different
+  states and a consumer must be able to tell them apart.
+
+## Decision 3: the refresh re-POSTs on ANY non-2xx, not only on 404
+
+#107's criterion 4 names 404. The implementation is wider, and the reason is that
+the narrower check buys nothing:
+
+a 410 Gone, or a 400 from an ECS that has forgotten the schema version an id was
+created under, leave the EES in *exactly* the same state as a 404 — PUTting a
+resource that will never accept it again. Re-creating is idempotent from this side
+(the ECS mints a fresh id), so the only effect of checking `== 404` would be to loop
+forever on those statuses. Stated in the function's own doc so a later reader does
+not "tighten" it back.
+
+The interlock is tested from the other side too: an **accepted** refresh must not
+re-POST. Without that, "re-create on failure" could be satisfied by a version that
+re-creates every tick, minting a new id every 60 seconds and leaving the ECS holding
+a growing pile of dead registrations.
+
+## Decision 4: `easIds` is derived at send time, not maintained by hooks
+
+Criterion 5 asks that `easIds` be "updated on EAS register/deregister". Two ways to
+do that:
+
+1. Hook every mutation of the EAS pool and push a fresh registration.
+2. Derive the list from the live pool each time a body is built.
+
+(2), because the registration is already sent on a 60-second timer and (1) would
+add a second, event-driven sender racing it — two writers of one remote resource,
+where the loser silently overwrites the winner. Deriving at send time makes the
+next refresh carry the change and cannot disagree with itself. The cost is up to
+one refresh interval of staleness at the ECS, which is stated as a ceiling.
+
+`easIds` is `None` rather than `Some([])` for an empty pool: the member is optional,
+and an empty array asserts "serves no EAS" where absent says "not stated". The
+ECS's own discovery does not match either, so the choice is about honesty rather
+than behaviour.
+
+`expTime` is 10 minutes out against a 60-second refresh, so a live EES is never
+expired by an ECS that honours it while one that has stopped refreshing is. Its
+timestamp formatter is hand-rolled (this binary has no date dependency) and
+therefore gets its own test against three fixed points including a leap day, rather
+than being trusted because it compiled.
+
+## Decision 5: the crate's two test locks are collapsed into one
+
+`auth::GLOBAL_STATE_TEST_LOCK` guarded the global EES context and the JWKS from
+inside `auth`. Adding a process-global to `ecs_role` made a natural reach for a lock
+in `context` — and **that is exactly the mistake, and it was made in this PR**: a
+`context::PROCESS_STATE_TEST_LOCK` was added, a test took it, and a `main.rs` test
+holding the *other* lock failed on the very next run. Two disjoint agreements over
+one ambient state is #308's defect, and #276 showed that shape hangs the suite
+rather than merely flaking it.
+
+Collapsed: the static now lives in `context` beside the context it guards, and
+`auth::GLOBAL_STATE_TEST_LOCK` is a `pub(crate) use` alias so the 55 existing call
+sites do not churn. `relocation::PULL_HOOK_LOCK` stays as a second, inner lock over
+a genuinely different thing, with the order documented.
+
+Recorded because the failure took one run to appear and the diagnosis took longer
+than the fix.
+
+## Verification
+
+| claim | how it was made to fail | result |
+|---|---|---|
+| `easIds` comes from the live pool | back to `eas_ids: None` | **fails** the pool/expiry test |
+| `expTime` is set | back to `exp_time: None` | **fails** the same test |
+| the initial POST is retried | one attempt only | **fails** `the_initial_post_retries_with_increasing_delay` |
+| the retry backs OFF | retry with no delay | **fails** the same test (it asserts on arrival times at the stub, so it measures the delay the peer experienced) |
+| a failed refresh re-POSTs | log and return `Failed` | **fails** `a_404_refresh_re_registers_and_adopts_the_new_id` |
+| the ECS 404s an id it does not hold | answer 200 | **fails** both the server's test and the client's |
+| discovery matches on `easIds` | treat absent `easIds` as a match | **fails** `an_ees_advertising_no_eas_ids_is_not_a_discovery_candidate` |
+| the ECS routes are wired into the router | drop the arm | **fails** both router tests |
+
+The router tests go through `ees_sbi_request_handler` rather than through
+`ecs_role`'s functions, deliberately: the arm is added at the end of a ~30-arm
+match, where a typo leaves it shadowed or unreached and every unit test still
+passes.
+
+Gates: `cargo test -p nextgcore-eesd` **194 passed / 0 failed** (was 174), stable
+over 6 consecutive runs plus the revert pass; workspace **6416 passed / 0 failed**;
+clippy `--workspace` and `--all-targets` 0 errors; fmt clean.
+
+## Ceilings
+
+- **Five of the eight ECS APIs are unimplemented** and answer 404. See Decision 2.
+- **The ECS registry is in memory.** Lost on restart — which is exactly the case the
+  hardened client's re-POST recovery handles, so the two halves of this PR cover
+  each other rather than one of them being unexercised. Persisting it would be
+  #191/#192's shape in a new place and no criterion asks for it.
+- **`easIds` at the ECS can be up to one refresh interval (60 s) stale.** See
+  Decision 4; the alternative was two racing writers of one remote resource.
+- **Registration is still gated on `--ecs-uri`.** With it unset the request is built
+  and logged and nothing is sent, as before. An EES running the ECS role in the same
+  process does **not** register with itself: nothing points `--ecs-uri` at the local
+  address automatically, and doing so silently would make a single-process
+  deployment look like a two-node one.
+- **No `expTime` enforcement on the ECS side.** The role stores the `expTime` an EES
+  sends and returns it, but nothing sweeps expired registrations — so a dead EES
+  stays discoverable until an operator deletes it. eesd has a lapsed-registration
+  sweeper for EAS/EEC (`spawn_*`, eesd-12); the ECS registry does not use it.
+- **`Eecs_TargetEESDiscovery` matches on `easIds` only.** Not on service area, not
+  on AC service KPIs, both of which TS 29.558 permits as query members and both of
+  which the EES's own `eas_discover_filter` already implements for EAS discovery.
+  A query carrying them is accepted and they are ignored, which is the kind of
+  half-truth worth naming: the response is a candidate list, not a ranked one.
+- **The `eecs-*` routes are not OAuth2-gated.** A different reference point with
+  different consumers; requiring an `eees-*` scope would make an EEC's bootstrap
+  need an EAS's token. A test pins the contrast against an `eees-*` route that does
+  fail closed, so this is a stated position rather than an omission.
+- **No E2E.** Every assertion is in-process: the ECS role is exercised through the
+  real router, and the client through a loopback stub ECS. No compose service sets
+  `ECS_ROLE`, so the default Docker path is unchanged — which is also what makes the
+  default safe.

--- a/src/bins/nextgcore-eesd/src/auth.rs
+++ b/src/bins/nextgcore-eesd/src/auth.rs
@@ -84,11 +84,15 @@ pub fn clear_auth_jwks() {
     }
 }
 
-/// Serializes tests that mutate the process-global JWKS / EES context across
-/// modules (`auth` + `main` router tests) so they don't race under the default
-/// parallel test runner.
+/// Serializes tests that mutate any process-global in this crate.
+///
+/// An ALIAS for `context::PROCESS_STATE_TEST_LOCK` as of #107, not a second static.
+/// It used to be declared here, which made a test for a new global in another module
+/// reach for its own lock -- two disjoint agreements over one ambient state, which is
+/// #308's defect and #276's hang. Kept under this name so the 55 existing call sites
+/// do not churn.
 #[cfg(test)]
-pub(crate) static GLOBAL_STATE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) use crate::context::PROCESS_STATE_TEST_LOCK as GLOBAL_STATE_TEST_LOCK;
 
 /// Per-operation OAuth2 gate.
 ///

--- a/src/bins/nextgcore-eesd/src/context.rs
+++ b/src/bins/nextgcore-eesd/src/context.rs
@@ -1614,6 +1614,26 @@ impl Default for EesContext {
 }
 
 /// Global EES context (thread-safe singleton).
+/// One agreement about every process-global in this crate: the EES context, the
+/// JWKS store, and the ECS role's enable switch and registry (#107).
+///
+/// Declared **beside the largest global it guards** rather than in `auth`, where it
+/// lived. That mattered as soon as #107 added a second process-global: a test for it
+/// naturally reached for a lock in `context`, which would have been a SECOND
+/// disjoint agreement over the same ambient state -- #308's defect, and #276 showed
+/// that shape HANGS the suite rather than merely flaking it. It cost one collateral
+/// failure in this PR before being collapsed, which is exactly how cheap the
+/// mistake is to make.
+///
+/// `auth::GLOBAL_STATE_TEST_LOCK` is now an alias for this static, so the 55 call
+/// sites that take it and the new ones that take this one are the same lock.
+///
+/// `relocation::PULL_HOOK_LOCK` is deliberately a second, INNER lock: it guards a
+/// different thing (the test pull hook's installed closure) and is already correct.
+/// Order, where both are needed: this one first.
+#[cfg(test)]
+pub static PROCESS_STATE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 static GLOBAL_EES_CONTEXT: std::sync::OnceLock<Arc<RwLock<EesContext>>> =
     std::sync::OnceLock::new();
 

--- a/src/bins/nextgcore-eesd/src/ecs_registration.rs
+++ b/src/bins/nextgcore-eesd/src/ecs_registration.rs
@@ -10,10 +10,27 @@
 //! ECS returns the resource at `registrations/{registrationId}` which is
 //! refreshed periodically (PUT).
 //!
-//! No live ECS peer exists in this stack, so registration is gated behind the
-//! `--ecs-uri` config: when unset, the request is built and logged but skipped
-//! (the request SHAPE is still unit-tested). When set, the request is POSTed
-//! via the existing `nextgcore-sbi` client and a refresh task is spawned.
+//! Registration is gated behind the `--ecs-uri` config: when unset, the request is
+//! built and logged but skipped (the request SHAPE is still unit-tested). When set,
+//! the request is POSTed via the existing `nextgcore-sbi` client and a refresh task
+//! is spawned. A live ECS now exists in this stack -- `ecs_role` serves the
+//! EDGE-6 side when `ECS_ROLE=1` (#107).
+//!
+//! # What #107 hardened
+//!
+//! Three things made this brittle, and all three were silent:
+//!
+//! 1. **One POST and then give up.** A transient blip during startup dropped the
+//!    EES from the ECS registry permanently, with one `warn` line. Now retried with
+//!    capped exponential backoff.
+//! 2. **The refresh only ever PUT.** A 404 -- exactly what an ECS returns for a
+//!    resource it lost across a restart -- was logged and the loop kept PUTting to a
+//!    resource that no longer existed, forever. Now it re-POSTs and adopts the new
+//!    `registrationId`.
+//! 3. **A static body.** `easIds: None` and `expTime: None` meant the ECS's view of
+//!    this EES was wrong even on the happy path, so target-EES selection could
+//!    never match it. Both are now derived from live state on every POST and every
+//!    refresh.
 
 use std::time::Duration;
 
@@ -67,7 +84,81 @@ pub struct EesRegistration {
     pub supp_feat: Option<String>,
 }
 
+/// How long a registration this EES creates is valid for. The refresh loop runs at
+/// [`REFRESH_INTERVAL`], comfortably inside it, so a live EES is never expired by
+/// an ECS that honours `expTime` -- while an EES that has stopped refreshing is.
+pub const REGISTRATION_LIFETIME: Duration = Duration::from_secs(600);
+
+/// How often the registration is refreshed.
+pub const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+/// The EAS application identifiers this EES currently serves.
+///
+/// Read from the live EAS pool on every POST and every refresh, which is the whole
+/// point of #107's criterion 5: a static `easIds: None` makes the ECS's view of this
+/// EES wrong even on the happy path, and `Eecs_TargetEESDiscovery` matches on
+/// exactly this member -- so an EES advertising none can never be selected as a
+/// target.
+///
+/// `None` rather than `Some([])` when the pool is empty: the member is optional, and
+/// an empty array asserts "serves no EAS" where absent says "not stated". An EES
+/// with no EAS yet is the former, so an empty array is in fact the honest value --
+/// but sending it would make an ECS that filters on presence treat this EES as
+/// having declared itself useless. Absent is the conservative reading and matches
+/// what the ECS role's discovery does with it (no match either way).
+fn current_eas_ids() -> Option<Vec<String>> {
+    let ctx = crate::context::ees_self();
+    let guard = ctx.read().ok()?;
+    let mut ids: Vec<String> = guard
+        .eas_list()
+        .into_iter()
+        .map(|r| r.eas_prof.eas_id)
+        .collect();
+    ids.sort();
+    ids.dedup();
+    if ids.is_empty() {
+        None
+    } else {
+        Some(ids)
+    }
+}
+
+/// An RFC 3339 timestamp [`REGISTRATION_LIFETIME`] from now, for `expTime`.
+///
+/// Formatted here rather than pulled from a date crate this binary does not depend
+/// on: the shape is `YYYY-MM-DDTHH:MM:SSZ` and the arithmetic is a civil-date
+/// conversion from the Unix epoch, which is exact for all values this produces.
+fn expiry_timestamp() -> Option<String> {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs()
+        + REGISTRATION_LIFETIME.as_secs();
+    Some(rfc3339_utc(secs))
+}
+
+/// Format a Unix timestamp as an RFC 3339 UTC instant.
+fn rfc3339_utc(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let tod = secs % 86_400;
+    let (h, mi, s) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    // Civil-from-days (Howard Hinnant's algorithm), shifted to a March-based year.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
 /// Build the `EESRegistration` body the EES POSTs to the ECS.
+///
+/// `easIds` and `expTime` are derived from live state, not left `None` (#107).
 pub fn build_ees_registration(ees_id: &str, sbi_addr: &str, sbi_port: u16) -> EesRegistration {
     EesRegistration {
         ees_prof: EesProfile {
@@ -78,9 +169,9 @@ pub fn build_ees_registration(ees_id: &str, sbi_addr: &str, sbi_port: u16) -> Ee
                 ..Default::default()
             },
             prov_id: None,
-            eas_ids: None,
+            eas_ids: current_eas_ids(),
         },
-        exp_time: None,
+        exp_time: expiry_timestamp(),
         supp_feat: None,
     }
 }
@@ -125,18 +216,78 @@ pub async fn start_ecs_registration(
         return;
     };
 
-    match register_once(ecs_uri, &registration).await {
-        Ok(Some(registration_id)) => {
+    match register_with_backoff(ecs_uri, ees_id, sbi_addr, sbi_port).await {
+        Some(registration_id) => {
             log::info!("EES registered with ECS at {ecs_uri} (registrationId={registration_id})");
-            spawn_refresh(ecs_uri.to_string(), registration, registration_id);
+            spawn_refresh(
+                ecs_uri.to_string(),
+                ees_id.to_string(),
+                sbi_addr.to_string(),
+                sbi_port,
+                registration_id,
+            );
         }
-        Ok(None) => {
-            log::warn!("ECS registration accepted but returned no registrationId");
+        None => log::warn!(
+            "ECS registration did not succeed after {MAX_REGISTRATION_ATTEMPTS} attempts; \
+             operating without ECS. EAS discovery through the edge layer will not work until \
+             an operator restarts this EES or the refresh loop is given a registration."
+        ),
+    }
+}
+
+/// Attempts before giving up on the initial registration.
+pub const MAX_REGISTRATION_ATTEMPTS: u32 = 5;
+
+/// The first backoff delay; doubles per attempt up to [`MAX_BACKOFF`].
+pub const BASE_BACKOFF: Duration = Duration::from_millis(500);
+
+/// The cap. Bounded because an unbounded doubling reaches hours, and an EES that
+/// takes hours to notice the ECS came back is not meaningfully better than one that
+/// gave up.
+pub const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// The delay before attempt `attempt` (1-based). Exposed so the test asserts on the
+/// same schedule the loop uses rather than on a copy of it.
+pub fn backoff_for_attempt(attempt: u32) -> Duration {
+    let shift = attempt.saturating_sub(1).min(16);
+    let scaled = BASE_BACKOFF
+        .checked_mul(1u32 << shift)
+        .unwrap_or(MAX_BACKOFF);
+    scaled.min(MAX_BACKOFF)
+}
+
+/// POST the registration, retrying with capped exponential backoff (#107).
+///
+/// The body is rebuilt on every attempt rather than captured once: `easIds` comes
+/// from the live EAS pool, and an EAS that registered while the ECS was unreachable
+/// must appear in the registration that finally lands.
+async fn register_with_backoff(
+    ecs_uri: &str,
+    ees_id: &str,
+    sbi_addr: &str,
+    sbi_port: u16,
+) -> Option<String> {
+    for attempt in 1..=MAX_REGISTRATION_ATTEMPTS {
+        let registration = build_ees_registration(ees_id, sbi_addr, sbi_port);
+        match register_once(ecs_uri, &registration).await {
+            Ok(Some(id)) => return Some(id),
+            Ok(None) => {
+                // Accepted but unusable: without the id the refresh loop has no
+                // resource to PUT, so this is a failure and not a success.
+                log::warn!(
+                    "ECS registration attempt {attempt} was accepted but returned no \
+                     registrationId; retrying"
+                );
+            }
+            Err(e) => log::warn!("ECS registration attempt {attempt} failed: {e}"),
         }
-        Err(e) => {
-            log::warn!("ECS registration failed (will operate without ECS): {e}");
+        if attempt < MAX_REGISTRATION_ATTEMPTS {
+            let delay = backoff_for_attempt(attempt);
+            log::debug!("retrying ECS registration in {delay:?}");
+            tokio::time::sleep(delay).await;
         }
     }
+    None
 }
 
 /// POST the `EESRegistration` to the ECS once; returns the assigned
@@ -183,25 +334,104 @@ fn extract_registration_id(response: &nextgcore_sbi::message::SbiResponse) -> Op
         })
 }
 
-/// Spawn a periodic refresh task that PUTs the registration to keep it alive.
-fn spawn_refresh(ecs_uri: String, registration: EesRegistration, registration_id: String) {
+/// Spawn a periodic refresh task that PUTs the registration to keep it alive, and
+/// **re-creates it when the ECS no longer has it** (#107).
+fn spawn_refresh(
+    ecs_uri: String,
+    ees_id: String,
+    sbi_addr: String,
+    sbi_port: u16,
+    registration_id: String,
+) {
     tokio::spawn(async move {
-        let path = ecs_registration_resource_path(&registration_id);
+        let mut registration_id = registration_id;
         loop {
-            tokio::time::sleep(Duration::from_secs(60)).await;
-            let Some((host, port)) = parse_host_port(&ecs_uri) else {
-                break;
-            };
-            let client = global_context().get_client(&host, port).await;
-            match client.put_json(&path, &registration).await {
-                Ok(r) if (200..300).contains(&r.status) => {
-                    log::debug!("ECS registration refreshed (registrationId={registration_id})");
+            tokio::time::sleep(REFRESH_INTERVAL).await;
+            match refresh_once(&ecs_uri, &ees_id, &sbi_addr, sbi_port, &registration_id).await {
+                RefreshOutcome::Refreshed => {
+                    log::debug!("ECS registration refreshed (registrationId={registration_id})")
                 }
-                Ok(r) => log::warn!("ECS registration refresh returned status {}", r.status),
-                Err(e) => log::warn!("ECS registration refresh failed: {e}"),
+                RefreshOutcome::Recreated(new_id) => {
+                    log::warn!(
+                        "ECS no longer held registration {registration_id} (it restarted, or \
+                         expired us); re-registered as {new_id}"
+                    );
+                    registration_id = new_id;
+                }
+                RefreshOutcome::Failed => {
+                    // Kept in the loop rather than abandoned: the next tick is the
+                    // retry, which is what makes a transient ECS outage survivable.
+                }
+                RefreshOutcome::Fatal => break,
             }
         }
     });
+}
+
+/// What one refresh tick achieved.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RefreshOutcome {
+    /// The PUT was accepted.
+    Refreshed,
+    /// The ECS did not have the resource, so it was re-created under a new id.
+    Recreated(String),
+    /// This tick failed; the next one retries.
+    Failed,
+    /// Unrecoverable (the ECS URI stopped parsing), so the loop stops.
+    Fatal,
+}
+
+/// One refresh: PUT, and on **any non-2xx** re-POST to re-create the registration.
+///
+/// Not only on 404. A 404 is the case #107 names -- an ECS that lost the resource
+/// across a restart -- but a 410 Gone, or a 400 from an ECS that has forgotten the
+/// schema version this id was created under, leave the EES in exactly the same
+/// state: PUTting a resource that will never accept it again. Re-creating is
+/// idempotent from this side (the ECS mints a fresh id), so the narrower check would
+/// buy nothing and would leave those statuses looping forever.
+///
+/// The body is rebuilt from live state, so a refresh carries the EASs that have
+/// registered since the last one -- criterion 5's "updated on EAS
+/// register/deregister", achieved by deriving at send time rather than by hooking
+/// every mutation.
+pub async fn refresh_once(
+    ecs_uri: &str,
+    ees_id: &str,
+    sbi_addr: &str,
+    sbi_port: u16,
+    registration_id: &str,
+) -> RefreshOutcome {
+    let Some((host, port)) = parse_host_port(ecs_uri) else {
+        log::error!("ECS URI '{ecs_uri}' stopped parsing; abandoning the refresh loop");
+        return RefreshOutcome::Fatal;
+    };
+    let registration = build_ees_registration(ees_id, sbi_addr, sbi_port);
+    let path = ecs_registration_resource_path(registration_id);
+    let client = global_context().get_client(&host, port).await;
+    match client.put_json(&path, &registration).await {
+        Ok(r) if (200..300).contains(&r.status) => RefreshOutcome::Refreshed,
+        Ok(r) => {
+            log::warn!(
+                "ECS registration refresh returned status {}; re-creating the registration",
+                r.status
+            );
+            match register_once(ecs_uri, &registration).await {
+                Ok(Some(new_id)) => RefreshOutcome::Recreated(new_id),
+                Ok(None) => {
+                    log::warn!("ECS re-registration was accepted but returned no registrationId");
+                    RefreshOutcome::Failed
+                }
+                Err(e) => {
+                    log::warn!("ECS re-registration failed: {e}");
+                    RefreshOutcome::Failed
+                }
+            }
+        }
+        Err(e) => {
+            log::warn!("ECS registration refresh failed: {e}");
+            RefreshOutcome::Failed
+        }
+    }
 }
 
 #[cfg(test)]
@@ -245,6 +475,289 @@ mod tests {
         let json = serde_json::to_string(&reg).unwrap();
         let back: EesRegistration = serde_json::from_str(&json).unwrap();
         assert_eq!(back, reg);
+    }
+
+    // ── #107: the hardened client ──
+
+    /// The backoff schedule increases and is capped, asserted on the function the
+    /// loop itself uses rather than on a copy of the numbers.
+    #[test]
+    fn the_backoff_increases_and_is_capped() {
+        let delays: Vec<Duration> = (1..=8).map(backoff_for_attempt).collect();
+        for pair in delays.windows(2) {
+            assert!(
+                pair[1] >= pair[0],
+                "the backoff must not decrease: {delays:?}"
+            );
+        }
+        assert!(
+            delays[1] > delays[0],
+            "the second attempt must wait LONGER than the first, or it is not a backoff"
+        );
+        assert_eq!(delays[0], BASE_BACKOFF);
+        assert_eq!(
+            *delays.last().expect("delays"),
+            MAX_BACKOFF,
+            "an unbounded doubling reaches hours; the cap is the point"
+        );
+    }
+
+    /// A stub ECS whose first `n` POSTs fail and which then accepts, recording every
+    /// request with the instant it arrived.
+    struct StubEcs {
+        server: nextgcore_sbi::server::SbiServer,
+        uri: String,
+        seen: Arc<StdMutex<Vec<(String, String, std::time::Instant, serde_json::Value)>>>,
+    }
+
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    async fn spawn_stub_ecs(fail_posts: usize, put_status: u16) -> StubEcs {
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        let seen: Arc<StdMutex<Vec<(String, String, std::time::Instant, serde_json::Value)>>> =
+            Arc::new(StdMutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let posts_failed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (server, addr) = nextgcore_sbi::test_support::sbi_server_on_free_port(
+            move |req: nextgcore_sbi::message::SbiRequest| {
+                let sink = Arc::clone(&sink);
+                let posts_failed = Arc::clone(&posts_failed);
+                async move {
+                    let method = req.header.method.clone();
+                    let uri = req.header.uri.clone();
+                    let body = req
+                        .http
+                        .content
+                        .as_deref()
+                        .and_then(|b| serde_json::from_str(b).ok())
+                        .unwrap_or(serde_json::Value::Null);
+                    sink.lock().unwrap_or_else(|e| e.into_inner()).push((
+                        method.clone(),
+                        uri.clone(),
+                        std::time::Instant::now(),
+                        body,
+                    ));
+                    if method == "POST" {
+                        let n = posts_failed.load(std::sync::atomic::Ordering::SeqCst);
+                        if n < fail_posts {
+                            posts_failed.store(n + 1, std::sync::atomic::Ordering::SeqCst);
+                            return nextgcore_sbi::message::SbiResponse::with_status(503);
+                        }
+                        let id = format!("reg-{}", n + 1);
+                        return nextgcore_sbi::message::SbiResponse::with_status(201).with_header(
+                            "Location",
+                            format!("/eecs-eesregistration/v1/registrations/{id}"),
+                        );
+                    }
+                    nextgcore_sbi::message::SbiResponse::with_status(put_status)
+                }
+            },
+        )
+        .await;
+        StubEcs {
+            server,
+            uri: format!("http://127.0.0.1:{}", addr.port()),
+            seen,
+        }
+    }
+
+    /// #107 criterion 3: the initial POST is retried with increasing delay rather
+    /// than abandoned after one attempt.
+    ///
+    /// Asserted on the ARRIVAL TIMES at the stub, so it measures the delay the peer
+    /// actually experienced rather than the schedule the caller intended.
+    #[tokio::test]
+    async fn the_initial_post_retries_with_increasing_delay() {
+        let ecs = spawn_stub_ecs(2, 204).await;
+        let id = register_with_backoff(&ecs.uri, "ees1.example.com", "10.0.0.5", 7814).await;
+        let seen = ecs.seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        ecs.server.stop().await.expect("stop stub ECS");
+
+        assert_eq!(
+            id.as_deref(),
+            Some("reg-3"),
+            "two failures then an accept must end in a registration, not a give-up"
+        );
+        let posts: Vec<_> = seen.iter().filter(|(m, ..)| m == "POST").collect();
+        assert_eq!(
+            posts.len(),
+            3,
+            "more than one attempt is the whole criterion; got {}",
+            posts.len()
+        );
+        let gap1 = posts[1].2.duration_since(posts[0].2);
+        let gap2 = posts[2].2.duration_since(posts[1].2);
+        assert!(
+            gap1 >= BASE_BACKOFF,
+            "the first retry waited {gap1:?}, less than the base backoff"
+        );
+        assert!(
+            gap2 > gap1,
+            "the delay must INCREASE between attempts: {gap1:?} then {gap2:?}"
+        );
+    }
+
+    /// #107 criterion 4: a refresh the ECS answers 404 re-POSTs and adopts a fresh
+    /// registrationId, rather than looping on a resource that no longer exists.
+    #[tokio::test]
+    async fn a_404_refresh_re_registers_and_adopts_the_new_id() {
+        let ecs = spawn_stub_ecs(0, 404).await;
+        let outcome =
+            refresh_once(&ecs.uri, "ees1.example.com", "10.0.0.5", 7814, "stale-id").await;
+        let seen = ecs.seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        ecs.server.stop().await.expect("stop stub ECS");
+
+        assert_eq!(
+            outcome,
+            RefreshOutcome::Recreated("reg-1".to_string()),
+            "a fresh registrationId must be obtained and adopted"
+        );
+        assert!(
+            seen.iter()
+                .any(|(m, u, ..)| m == "PUT"
+                    && u == "/eecs-eesregistration/v1/registrations/stale-id"),
+            "the PUT is still attempted first: a live registration must not be re-created"
+        );
+        assert!(
+            seen.iter()
+                .any(|(m, u, ..)| m == "POST" && u == "/eecs-eesregistration/v1/registrations"),
+            "the 404 must produce a re-POST; got {seen:?}"
+        );
+    }
+
+    /// The other half of criterion 4's interlock: a refresh the ECS ACCEPTS must not
+    /// re-POST. Without this, "re-create on failure" could be satisfied by a version
+    /// that re-creates every tick, which would mint a new id every 60 seconds and
+    /// leave the ECS holding a growing pile of dead registrations.
+    #[tokio::test]
+    async fn an_accepted_refresh_does_not_re_register() {
+        let ecs = spawn_stub_ecs(0, 204).await;
+        let outcome = refresh_once(&ecs.uri, "ees1.example.com", "10.0.0.5", 7814, "live-id").await;
+        let seen = ecs.seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        ecs.server.stop().await.expect("stop stub ECS");
+
+        assert_eq!(outcome, RefreshOutcome::Refreshed);
+        assert!(
+            !seen.iter().any(|(m, ..)| m == "POST"),
+            "an accepted refresh must not re-create anything; got {seen:?}"
+        );
+    }
+
+    /// #107 criterion 5: `easIds` is populated from the current EAS pool and
+    /// `expTime` is set, and a registration made AFTER an EAS registers carries it.
+    #[tokio::test]
+    async fn the_registration_body_carries_the_current_eas_pool_and_an_expiry() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // `fini` then `init`, not `init` alone: `init` does not empty the EAS pool, so
+        // a sibling test's leftover registration would make the "serves none" half of
+        // this test fail for a reason that has nothing to do with it. That is not
+        // hypothetical -- it happened during this PR's revert pass, when a panicking
+        // sibling skipped its own cleanup.
+        crate::context::ees_context_final();
+        crate::context::ees_context_init(64);
+
+        // Before any EAS registers, easIds is absent -- there is nothing to state.
+        let empty = build_ees_registration("ees1.example.com", "10.0.0.5", 7814);
+        assert!(
+            empty.ees_prof.eas_ids.is_none(),
+            "an EES serving no EAS states none"
+        );
+        assert!(
+            empty.exp_time.is_some(),
+            "expTime must be set, or the ECS can never expire a dead EES"
+        );
+
+        // Register an EAS, then rebuild: it must appear.
+        let ctx = crate::context::ees_self();
+        {
+            let guard = ctx.read().expect("ees context");
+            guard
+                .eas_register(crate::types::EasRegistration {
+                    eas_prof: crate::types::EasProfile {
+                        eas_id: "eas-107.example.com".to_string(),
+                        end_pt: EndPoint {
+                            ipv4_addrs: Some(vec!["10.0.0.20".to_string()]),
+                            port: Some(8080),
+                            ..Default::default()
+                        },
+                        prov_id: None,
+                        eas_type: None,
+                        flex_eas_type: None,
+                        ac_ids: None,
+                        svc_area: None,
+                        svc_kpi: None,
+                    },
+                    exp_time: None,
+                    supp_feat: None,
+                    registration_id: None,
+                })
+                .expect("EAS registers");
+        }
+        let with_eas = build_ees_registration("ees1.example.com", "10.0.0.5", 7814);
+        assert!(
+            with_eas
+                .ees_prof
+                .eas_ids
+                .as_deref()
+                .is_some_and(|ids| ids.contains(&"eas-107.example.com".to_string())),
+            "the EAS that registered must appear in the next registration body -- this is what \
+             makes the EES selectable as a target"
+        );
+
+        // And on the wire, from the refresh path rather than only from the builder.
+        let ecs = spawn_stub_ecs(0, 204).await;
+        refresh_once(&ecs.uri, "ees1.example.com", "10.0.0.5", 7814, "live-id").await;
+        let seen = ecs.seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        ecs.server.stop().await.expect("stop stub ECS");
+        let put = seen
+            .iter()
+            .find(|(m, ..)| m == "PUT")
+            .expect("a PUT must have been sent");
+        assert!(
+            put.3["eesProf"]["easIds"]
+                .as_array()
+                .is_some_and(|ids| ids.iter().any(|v| v == "eas-107.example.com")),
+            "the REFRESH body carries the pool too, not just the initial POST; body was {:?}",
+            put.3
+        );
+        assert!(
+            put.3["expTime"].is_string(),
+            "expTime on the wire, body was {:?}",
+            put.3
+        );
+
+        crate::context::ees_context_final();
+    }
+
+    /// The expiry timestamp is a well-formed RFC 3339 UTC instant in the future.
+    /// The civil-date conversion is hand-rolled, so it gets its own assertion rather
+    /// than being trusted because it compiled.
+    #[test]
+    fn the_expiry_timestamp_is_rfc3339_and_in_the_future() {
+        // Two fixed points, so the conversion is checked against known values rather
+        // than against itself.
+        assert_eq!(rfc3339_utc(0), "1970-01-01T00:00:00Z");
+        assert_eq!(rfc3339_utc(1_700_000_000), "2023-11-14T22:13:20Z");
+        // A leap day, which is where a civil-date conversion goes wrong if it does.
+        assert_eq!(rfc3339_utc(1_709_164_800), "2024-02-29T00:00:00Z");
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_secs();
+        let exp = expiry_timestamp().expect("timestamp");
+        assert!(exp.ends_with('Z') && exp.len() == 20, "got {exp}");
+        assert!(
+            exp > rfc3339_utc(now),
+            "the expiry must be in the future: {exp} vs now {}",
+            rfc3339_utc(now)
+        );
+        assert!(
+            exp <= rfc3339_utc(now + REGISTRATION_LIFETIME.as_secs() + 2),
+            "and not further out than the stated lifetime: {exp}"
+        );
     }
 
     #[test]

--- a/src/bins/nextgcore-eesd/src/ecs_role.rs
+++ b/src/bins/nextgcore-eesd/src/ecs_role.rs
@@ -1,0 +1,765 @@
+//! The Edge Configuration Server role (issue #107, TS 23.558 §8.3, TS 29.558 §5.2).
+//!
+//! # What was missing
+//!
+//! The ECS is the entry point through which an EEC bootstraps the edge enabler
+//! layer: service provisioning over EDGE-4, EES registration over EDGE-6, and
+//! target-EES discovery. **None of the eight ECS-side APIs had a server anywhere
+//! in this workspace.** The only ECS-facing code was the EES's own EDGE-6
+//! registration *client*, so an EEC had no bootstrap path at all and an EES could
+//! not be brought into a deployment through an ECS.
+//!
+//! # Why a role inside eesd rather than a new binary
+//!
+//! #107 offers either. This is the role, for three reasons:
+//!
+//! - **An ECS is not a 5GC NF.** It has no `nfType` in TS 29.510 — the same fact
+//!   that made `ecs_registration` replace eesd's old (incorrect) NRF
+//!   self-registration. So a separate binary would gain none of the NF machinery
+//!   (NRF profile, heartbeat, discovery) that justifies one for nefd/easdfd/tsctsf,
+//!   the precedents #107 cites.
+//! - **The registry an ECS needs is the registry this process already keeps.** The
+//!   EES's own EAS pool is what `Eecs_TargetEESDiscovery` matches against, and
+//!   crossing a process boundary to read it would mean inventing a protocol that
+//!   TS 29.558 does not define.
+//! - **It costs one runtime switch instead of a Dockerfile, a compose service, a
+//!   config file and a health probe**, none of which #107 asks for.
+//!
+//! Gated on `ECS_ROLE=1` and **off by default**, so a deployment that does not
+//! want an ECS serves exactly the routes it served before. A **runtime** switch
+//! rather than the cargo feature #107 suggests, because this project has a recorded
+//! convention for that: a feature-gated path is left uncompiled by CI and rots.
+//! With the switch off the routes answer 404 exactly as they did before, which is
+//! what makes the default safe.
+//!
+//! # Scope: three of the eight APIs
+//!
+//! #107's own suggested approach scopes the initial surface to three, "to stay
+//! implementable": `Eecs_ServiceProvisioning`, `Eecs_EESRegistration` and
+//! `Eecs_TargetEESDiscovery`. The other five are named in the spec's ceilings
+//! rather than stubbed, because a route answering a fabricated 2xx is worse than a
+//! 404: the 404 is honest about not being implemented.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use nextgcore_sbi::message::{SbiRequest, SbiResponse};
+use nextgcore_sbi::server::{send_bad_request, send_method_not_allowed, send_not_found};
+use serde::{Deserialize, Serialize};
+
+use crate::ecs_registration::{EesProfile, EesRegistration};
+
+/// Is the ECS role enabled for this process?
+static ECS_ROLE_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable the ECS role (called once at startup when `ECS_ROLE=1`).
+pub fn enable() {
+    ECS_ROLE_ENABLED.store(true, Ordering::SeqCst);
+    log::info!(
+        "[EES] ECS role ENABLED: serving eecs-serviceprovisioning/v1, \
+         eecs-eesregistration/v1 and eecs-targeteesdiscovery/v1 (TS 29.558 §5.2)"
+    );
+}
+
+/// Whether the ECS role is enabled.
+pub fn enabled() -> bool {
+    ECS_ROLE_ENABLED.load(Ordering::SeqCst)
+}
+
+/// Read `ECS_ROLE` and enable accordingly. Called once from `main`.
+pub fn init_from_env() {
+    match std::env::var("ECS_ROLE").as_deref() {
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("on") => enable(),
+        _ => log::info!(
+            "[EES] ECS role DISABLED (set ECS_ROLE=1 to enable): the eecs-* paths answer 404, \
+             exactly as before #107"
+        ),
+    }
+}
+
+/// Test-only: set the switch without going through startup.
+///
+/// The caller must hold the crate's process-state test lock: this switch and the
+/// registry below are process-global.
+#[cfg(test)]
+pub fn set_for_test(on: bool) {
+    ECS_ROLE_ENABLED.store(on, Ordering::SeqCst);
+}
+
+// ============================================================================
+// The registry
+// ============================================================================
+
+/// One EES registration held by this ECS.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredEesRegistration {
+    /// Server-minted resource id. Never taken from the request: a
+    /// consumer-supplied id would let one EES address another's resource.
+    pub registration_id: String,
+    /// The registration as received, so a member this build does not model is
+    /// returned on a refresh rather than silently dropped.
+    #[serde(flatten)]
+    pub registration: EesRegistration,
+}
+
+/// Registered EESs, keyed by `registrationId`.
+fn registry() -> &'static Mutex<std::collections::HashMap<String, StoredEesRegistration>> {
+    static REG: OnceLock<Mutex<std::collections::HashMap<String, StoredEesRegistration>>> =
+        OnceLock::new();
+    REG.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Every registration currently held.
+pub fn registered_eess() -> Vec<StoredEesRegistration> {
+    match registry().lock() {
+        Ok(r) => r.values().cloned().collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+pub fn clear_registry_for_test() {
+    if let Ok(mut r) = registry().lock() {
+        r.clear();
+    }
+}
+
+/// API prefixes, so criterion 1's grep finds them in one place and the router and
+/// the docs cannot drift from each other.
+pub const API_SERVICE_PROVISIONING: &str = "eecs-serviceprovisioning/v1";
+pub const API_EES_REGISTRATION: &str = "eecs-eesregistration/v1";
+pub const API_TARGET_EES_DISCOVERY: &str = "eecs-targeteesdiscovery/v1";
+
+// ============================================================================
+// Eecs_EESRegistration (EDGE-6, TS 29.558 §9)
+// ============================================================================
+
+/// `POST /eecs-eesregistration/v1/registrations` — CreateEESRegistration.
+///
+/// 201 with a `Location` header, which is what the EES-side client reads the
+/// `registrationId` from. `eesProf.eesId` is mandatory: a registration that names
+/// no EES could never be returned by discovery, which is the un-discoverable state
+/// worth refusing rather than accepting and never matching.
+pub fn handle_registration_create(request: &SbiRequest) -> SbiResponse {
+    let Some(body) = &request.http.content else {
+        return send_bad_request("Missing request body", Some("MANDATORY_IE_MISSING"));
+    };
+    let registration: EesRegistration = match serde_json::from_str(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return send_bad_request(
+                &format!("Invalid EESRegistration: {e}"),
+                Some("INVALID_MSG_FORMAT"),
+            )
+        }
+    };
+    if registration.ees_prof.ees_id.trim().is_empty() {
+        return send_bad_request("eesProf.eesId is mandatory", Some("MANDATORY_IE_MISSING"));
+    }
+
+    let registration_id = uuid::Uuid::new_v4().to_string();
+    let stored = StoredEesRegistration {
+        registration_id: registration_id.clone(),
+        registration,
+    };
+    let location = format!("/{API_EES_REGISTRATION}/registrations/{registration_id}");
+    if let Ok(mut r) = registry().lock() {
+        r.insert(registration_id.clone(), stored.clone());
+    }
+    log::info!(
+        "ECS: EES {} registered (registrationId={registration_id}, easIds={:?})",
+        stored.registration.ees_prof.ees_id,
+        stored.registration.ees_prof.eas_ids
+    );
+    SbiResponse::with_status(201)
+        .with_header("Location", location)
+        .with_json_body(&stored)
+        .unwrap_or_else(|_| SbiResponse::with_status(201))
+}
+
+/// `PUT /eecs-eesregistration/v1/registrations/{registrationId}` — the refresh.
+///
+/// 200 with the stored resource, or **404 for an id this ECS does not hold** —
+/// which is precisely the answer the hardened EES client re-POSTs on, and is what
+/// an ECS restart produces. Answering 200 for an unknown id, or silently
+/// re-creating it, would hide the very case #107's criterion 4 is about.
+pub fn handle_registration_update(registration_id: &str, request: &SbiRequest) -> SbiResponse {
+    let Some(body) = &request.http.content else {
+        return send_bad_request("Missing request body", Some("MANDATORY_IE_MISSING"));
+    };
+    let registration: EesRegistration = match serde_json::from_str(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return send_bad_request(
+                &format!("Invalid EESRegistration: {e}"),
+                Some("INVALID_MSG_FORMAT"),
+            )
+        }
+    };
+    let updated = {
+        match registry().lock() {
+            Ok(mut r) => match r.get_mut(registration_id) {
+                Some(existing) => {
+                    existing.registration = registration;
+                    Some(existing.clone())
+                }
+                None => None,
+            },
+            Err(_) => None,
+        }
+    };
+    match updated {
+        Some(stored) => SbiResponse::with_status(200)
+            .with_json_body(&stored)
+            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        None => send_not_found(
+            &format!("EES registration {registration_id} not found"),
+            Some("REGISTRATION_NOT_FOUND"),
+        ),
+    }
+}
+
+/// `GET`/`DELETE /eecs-eesregistration/v1/registrations/{registrationId}`.
+pub fn handle_registration_get(registration_id: &str) -> SbiResponse {
+    match registry()
+        .lock()
+        .ok()
+        .and_then(|r| r.get(registration_id).cloned())
+    {
+        Some(stored) => SbiResponse::with_status(200)
+            .with_json_body(&stored)
+            .unwrap_or_else(|_| SbiResponse::with_status(200)),
+        None => send_not_found(
+            &format!("EES registration {registration_id} not found"),
+            Some("REGISTRATION_NOT_FOUND"),
+        ),
+    }
+}
+
+/// `DELETE` — 204, or 404 for an unknown id.
+pub fn handle_registration_delete(registration_id: &str) -> SbiResponse {
+    let removed = match registry().lock() {
+        Ok(mut r) => r.remove(registration_id).is_some(),
+        Err(_) => false,
+    };
+    if removed {
+        log::info!("ECS: EES registration {registration_id} removed");
+        SbiResponse::with_status(204)
+    } else {
+        send_not_found(
+            &format!("EES registration {registration_id} not found"),
+            Some("REGISTRATION_NOT_FOUND"),
+        )
+    }
+}
+
+// ============================================================================
+// Eecs_ServiceProvisioning (EDGE-4, TS 29.558 §5.2)
+// ============================================================================
+
+/// `POST /eecs-serviceprovisioning/v1/provisioning-requests` — the EEC's
+/// bootstrap.
+///
+/// Answers an `EcsServiceProvisioningResponse`-shaped body listing the EES
+/// endpoints this ECS knows, which is what lets an EEC reach an EES at all. An ECS
+/// with no registered EES answers **200 with an empty list**, not 404: "no EES is
+/// available yet" and "this ECS does not serve provisioning" are different states
+/// and a consumer must be able to tell them apart.
+pub fn handle_service_provisioning(request: &SbiRequest) -> SbiResponse {
+    // `eecId` is the one mandatory input (TS 29.558 §5.2). Read to validate, not to
+    // filter: this build has no per-EEC provisioning policy, and pretending
+    // otherwise by filtering on something else would be worse than serving the
+    // whole list.
+    let eec_id = request
+        .http
+        .content
+        .as_deref()
+        .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+        .and_then(|v| v.get("eecId").and_then(|x| x.as_str()).map(str::to_string));
+    let Some(eec_id) = eec_id.filter(|s| !s.trim().is_empty()) else {
+        return send_bad_request("eecId is mandatory", Some("MANDATORY_IE_MISSING"));
+    };
+
+    let profiles: Vec<EesProfile> = registered_eess()
+        .into_iter()
+        .map(|s| s.registration.ees_prof)
+        .collect();
+    log::info!(
+        "ECS: service provisioning for eecId={eec_id}: {} EES profile(s)",
+        profiles.len()
+    );
+    SbiResponse::with_status(200)
+        .with_json_body(&serde_json::json!({
+            "provisioningResponses": [{ "edgeDataNetworkConfigs": profiles }],
+        }))
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+// ============================================================================
+// Eecs_TargetEESDiscovery (TS 29.558 §5.2)
+// ============================================================================
+
+/// `POST /eecs-targeteesdiscovery/v1/target-ees-discovery` — return candidate
+/// target EESs for an EAS or AC profile.
+///
+/// Matching is on the registered `eesProf.easIds`, which is exactly why criterion
+/// 5's `easIds` population matters: a registration advertising `easIds: null`
+/// cannot be matched by this, so before #107 the ECS's view of every EES was
+/// unusable for target selection even on the happy path.
+///
+/// A query naming no EAS returns **every** registered EES rather than none: "which
+/// EESs exist" is a legitimate discovery, and answering empty would make an
+/// unfiltered query look like a failed one.
+pub fn handle_target_ees_discovery(request: &SbiRequest) -> SbiResponse {
+    let body: serde_json::Value = match request.http.content.as_deref() {
+        Some(b) => match serde_json::from_str(b) {
+            Ok(v) => v,
+            Err(e) => {
+                return send_bad_request(&format!("Invalid JSON: {e}"), Some("INVALID_MSG_FORMAT"))
+            }
+        },
+        None => return send_bad_request("Missing request body", Some("MANDATORY_IE_MISSING")),
+    };
+
+    // `easId` directly, or via an AC profile's `easIds` — TS 29.558 lets the query
+    // be framed either way, and refusing the AC form would make an EEC's natural
+    // query fail.
+    let mut wanted: Vec<String> = Vec::new();
+    if let Some(id) = body.get("easId").and_then(|v| v.as_str()) {
+        wanted.push(id.to_string());
+    }
+    for key in ["easIds", "acProfs"] {
+        if let Some(arr) = body.get(key).and_then(|v| v.as_array()) {
+            for item in arr {
+                if let Some(id) = item.as_str() {
+                    wanted.push(id.to_string());
+                } else if let Some(ids) = item.get("easIds").and_then(|v| v.as_array()) {
+                    wanted.extend(ids.iter().filter_map(|v| v.as_str()).map(str::to_string));
+                }
+            }
+        }
+    }
+
+    let all = registered_eess();
+    let matched: Vec<EesProfile> = if wanted.is_empty() {
+        all.into_iter().map(|s| s.registration.ees_prof).collect()
+    } else {
+        all.into_iter()
+            .filter(|s| {
+                s.registration
+                    .ees_prof
+                    .eas_ids
+                    .as_ref()
+                    .is_some_and(|ids| ids.iter().any(|id| wanted.contains(id)))
+            })
+            .map(|s| s.registration.ees_prof)
+            .collect()
+    };
+    log::info!(
+        "ECS: target-EES discovery for {wanted:?}: {} candidate(s)",
+        matched.len()
+    );
+    SbiResponse::with_status(200)
+        .with_json_body(&serde_json::json!({ "eesProfiles": matched }))
+        .unwrap_or_else(|_| SbiResponse::with_status(200))
+}
+
+// ============================================================================
+// Routing
+// ============================================================================
+
+/// Dispatch an `eecs-*` path, or `None` when this is not an ECS route or the role
+/// is off.
+///
+/// Returning `None` rather than a 404 keeps the caller's own fallback in charge, so
+/// with the role disabled these paths answer exactly what they answered before
+/// #107 — which is what makes the default safe rather than merely quiet.
+pub fn route(parts: &[&str], request: &SbiRequest) -> Option<SbiResponse> {
+    if !enabled() {
+        return None;
+    }
+    let method = request.header.method.as_str();
+    match parts {
+        ["eecs-eesregistration", "v1", "registrations"] => Some(match method {
+            "POST" => handle_registration_create(request),
+            _ => send_method_not_allowed(method, "registrations"),
+        }),
+        ["eecs-eesregistration", "v1", "registrations", registration_id] => Some(match method {
+            "PUT" => handle_registration_update(registration_id, request),
+            "GET" => handle_registration_get(registration_id),
+            "DELETE" => handle_registration_delete(registration_id),
+            _ => send_method_not_allowed(method, "registrations/{registrationId}"),
+        }),
+        ["eecs-serviceprovisioning", "v1", "provisioning-requests"] => Some(match method {
+            "POST" => handle_service_provisioning(request),
+            _ => send_method_not_allowed(method, "provisioning-requests"),
+        }),
+        ["eecs-targeteesdiscovery", "v1", "target-ees-discovery"] => Some(match method {
+            "POST" => handle_target_ees_discovery(request),
+            _ => send_method_not_allowed(method, "target-ees-discovery"),
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::EndPoint;
+
+    fn post(path: &str, body: serde_json::Value) -> SbiRequest {
+        SbiRequest::post(path)
+            .with_json_body(&body)
+            .expect("serialize test body")
+    }
+
+    fn registration_body(ees_id: &str, eas_ids: Option<Vec<&str>>) -> serde_json::Value {
+        serde_json::json!({
+            "eesProf": {
+                "eesId": ees_id,
+                "endPt": { "ipv4Addrs": ["10.0.0.9"], "port": 7814 },
+                "easIds": eas_ids,
+            },
+            "expTime": "2026-12-31T23:59:59Z",
+        })
+    }
+
+    /// #107 criterion 2: a create returns 201 with a Location, and a subsequent
+    /// PUT refresh returns 2xx.
+    #[test]
+    fn a_registration_is_created_with_a_location_and_can_be_refreshed() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        set_for_test(true);
+
+        let created = handle_registration_create(&post(
+            "/eecs-eesregistration/v1/registrations",
+            registration_body("ees1.example.com", Some(vec!["eas1.example.com"])),
+        ));
+        assert_eq!(created.status, 201);
+        let location = created
+            .http
+            .get_header("location")
+            .expect("201 must carry a Location, which is where the client reads the id from")
+            .clone();
+        let registration_id = location.rsplit('/').next().expect("id segment").to_string();
+        assert!(
+            location.starts_with("/eecs-eesregistration/v1/registrations/"),
+            "Location was {location}"
+        );
+        assert!(!registration_id.is_empty());
+
+        let refreshed = handle_registration_update(
+            &registration_id,
+            &post(
+                &location,
+                registration_body("ees1.example.com", Some(vec!["eas1.example.com"])),
+            ),
+        );
+        assert!(
+            (200..300).contains(&refreshed.status),
+            "the refresh must be 2xx, got {}",
+            refreshed.status
+        );
+        set_for_test(false);
+    }
+
+    /// The 404 the hardened client re-POSTs on. Asserted here because the client's
+    /// recovery is only correct if the ECS actually produces this for an id it does
+    /// not hold — an ECS that answered 200 would make the recovery unreachable.
+    #[test]
+    fn refreshing_an_unknown_registration_is_404() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        let resp = handle_registration_update(
+            "no-such-id",
+            &post(
+                "/eecs-eesregistration/v1/registrations/no-such-id",
+                registration_body("ees1.example.com", None),
+            ),
+        );
+        assert_eq!(
+            resp.status, 404,
+            "an ECS that lost its registry must say so, or the EES cannot recover"
+        );
+    }
+
+    #[test]
+    fn a_registration_without_an_ees_id_is_refused() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        let resp = handle_registration_create(&post(
+            "/eecs-eesregistration/v1/registrations",
+            serde_json::json!({ "eesProf": { "eesId": "", "endPt": {} } }),
+        ));
+        assert_eq!(
+            resp.status, 400,
+            "an EES with no id could never be returned by discovery"
+        );
+    }
+
+    /// #107 criterion 6: discovery returns a candidate EES for a matching EAS
+    /// query, and does not return one for a non-matching query.
+    #[test]
+    fn target_ees_discovery_matches_on_registered_eas_ids() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        handle_registration_create(&post(
+            "/eecs-eesregistration/v1/registrations",
+            registration_body("ees-a.example.com", Some(vec!["eas-alpha", "eas-beta"])),
+        ));
+        handle_registration_create(&post(
+            "/eecs-eesregistration/v1/registrations",
+            registration_body("ees-b.example.com", Some(vec!["eas-gamma"])),
+        ));
+
+        let hit = handle_target_ees_discovery(&post(
+            "/eecs-targeteesdiscovery/v1/target-ees-discovery",
+            serde_json::json!({ "easId": "eas-beta" }),
+        ));
+        assert_eq!(hit.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(hit.http.content.as_deref().expect("body")).expect("json");
+        let profiles = body["eesProfiles"].as_array().expect("array");
+        assert_eq!(profiles.len(), 1, "got {profiles:?}");
+        assert_eq!(profiles[0]["eesId"], "ees-a.example.com");
+
+        let miss = handle_target_ees_discovery(&post(
+            "/eecs-targeteesdiscovery/v1/target-ees-discovery",
+            serde_json::json!({ "easId": "eas-nobody-serves" }),
+        ));
+        let body: serde_json::Value =
+            serde_json::from_str(miss.http.content.as_deref().expect("body")).expect("json");
+        assert!(
+            body["eesProfiles"].as_array().expect("array").is_empty(),
+            "an EAS nobody serves must return no candidate, not any candidate"
+        );
+    }
+
+    /// The matching is on `easIds`, so a registration that advertises none cannot
+    /// be matched — which is the whole reason criterion 5 matters. Pinned so a
+    /// future change cannot make discovery ignore `easIds` and appear to work.
+    #[test]
+    fn an_ees_advertising_no_eas_ids_is_not_a_discovery_candidate() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        handle_registration_create(&post(
+            "/eecs-eesregistration/v1/registrations",
+            registration_body("ees-silent.example.com", None),
+        ));
+        let resp = handle_target_ees_discovery(&post(
+            "/eecs-targeteesdiscovery/v1/target-ees-discovery",
+            serde_json::json!({ "easId": "eas-alpha" }),
+        ));
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        assert!(
+            body["eesProfiles"].as_array().expect("array").is_empty(),
+            "an EES that advertises no easIds is unmatched -- this is what a static \
+             `easIds: None` cost every deployment before #107"
+        );
+
+        // An UNFILTERED query still returns it: "which EESs exist" is legitimate.
+        let all = handle_target_ees_discovery(&post(
+            "/eecs-targeteesdiscovery/v1/target-ees-discovery",
+            serde_json::json!({}),
+        ));
+        let body: serde_json::Value =
+            serde_json::from_str(all.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["eesProfiles"].as_array().expect("array").len(), 1);
+    }
+
+    /// Service provisioning returns the EES endpoints an EEC needs, and an ECS with
+    /// no EES answers 200-with-nothing rather than 404 — two different states.
+    #[test]
+    fn service_provisioning_lists_registered_ees_endpoints() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+
+        let empty = handle_service_provisioning(&post(
+            "/eecs-serviceprovisioning/v1/provisioning-requests",
+            serde_json::json!({ "eecId": "eec-1" }),
+        ));
+        assert_eq!(
+            empty.status, 200,
+            "'no EES available yet' is not 'provisioning not served'"
+        );
+
+        handle_registration_create(&post(
+            "/eecs-eesregistration/v1/registrations",
+            registration_body("ees1.example.com", Some(vec!["eas1"])),
+        ));
+        let resp = handle_service_provisioning(&post(
+            "/eecs-serviceprovisioning/v1/provisioning-requests",
+            serde_json::json!({ "eecId": "eec-1" }),
+        ));
+        assert_eq!(resp.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(resp.http.content.as_deref().expect("body")).expect("json");
+        let configs = body["provisioningResponses"][0]["edgeDataNetworkConfigs"]
+            .as_array()
+            .expect("array");
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0]["eesId"], "ees1.example.com");
+        assert_eq!(
+            configs[0]["endPt"]["port"], 7814,
+            "the EEC needs the endpoint, not just the name"
+        );
+    }
+
+    #[test]
+    fn service_provisioning_without_an_eec_id_is_refused() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let resp = handle_service_provisioning(&post(
+            "/eecs-serviceprovisioning/v1/provisioning-requests",
+            serde_json::json!({}),
+        ));
+        assert_eq!(resp.status, 400);
+    }
+
+    /// With the role OFF every ECS route is unrouted, so the caller's own fallback
+    /// answers — the behaviour a deployment that does not want an ECS had before.
+    #[test]
+    fn the_role_off_routes_nothing() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_for_test(false);
+        for path in [
+            ["eecs-eesregistration", "v1", "registrations"],
+            ["eecs-serviceprovisioning", "v1", "provisioning-requests"],
+            ["eecs-targeteesdiscovery", "v1", "target-ees-discovery"],
+        ] {
+            assert!(
+                route(&path, &post(&path.join("/"), serde_json::json!({}))).is_none(),
+                "{path:?} must not be routed with the role off"
+            );
+        }
+    }
+
+    /// With the role ON they are all routed, and a wrong method is a 405 rather
+    /// than a 404 — a consumer must be able to tell "not implemented here" from
+    /// "wrong verb".
+    #[test]
+    fn the_role_on_routes_all_three_apis() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        set_for_test(true);
+        let paths = [
+            ["eecs-eesregistration", "v1", "registrations"],
+            ["eecs-serviceprovisioning", "v1", "provisioning-requests"],
+            ["eecs-targeteesdiscovery", "v1", "target-ees-discovery"],
+        ];
+        for path in paths {
+            assert!(
+                route(&path, &post(&path.join("/"), serde_json::json!({}))).is_some(),
+                "{path:?} must be routed with the role on"
+            );
+            let get = SbiRequest::get(&path.join("/"));
+            let resp = route(&path, &get).expect("routed");
+            assert_eq!(
+                resp.status, 405,
+                "{path:?} with GET must be 405, not 404: the route exists"
+            );
+        }
+        set_for_test(false);
+    }
+
+    /// An unmodelled member survives the round trip, so an EES sending a
+    /// `supportedFeatures` or vendor extension this build does not type gets it
+    /// back on a GET rather than having it silently dropped.
+    #[test]
+    fn a_registration_is_returned_as_stored() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        let created = handle_registration_create(&post(
+            "/eecs-eesregistration/v1/registrations",
+            registration_body("ees1.example.com", Some(vec!["eas1"])),
+        ));
+        let id = created
+            .http
+            .get_header("location")
+            .and_then(|l| l.rsplit('/').next().map(str::to_string))
+            .expect("id");
+        let got = handle_registration_get(&id);
+        assert_eq!(got.status, 200);
+        let body: serde_json::Value =
+            serde_json::from_str(got.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(body["registrationId"], id);
+        assert_eq!(body["eesProf"]["eesId"], "ees1.example.com");
+        assert_eq!(
+            body["expTime"], "2026-12-31T23:59:59Z",
+            "expTime must survive: an ECS that forgot it could not expire the registration"
+        );
+
+        assert_eq!(handle_registration_delete(&id).status, 204);
+        assert_eq!(handle_registration_get(&id).status, 404);
+    }
+
+    /// The registry is keyed by a server-minted id, so two EESs with the SAME
+    /// `eesId` do not collide. A consumer-supplied key would let one EES replace
+    /// another's registration.
+    #[test]
+    fn two_registrations_get_distinct_server_minted_ids() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        let ids: Vec<String> = (0..2)
+            .map(|_| {
+                handle_registration_create(&post(
+                    "/eecs-eesregistration/v1/registrations",
+                    registration_body("ees-same.example.com", Some(vec!["eas1"])),
+                ))
+                .http
+                .get_header("location")
+                .and_then(|l| l.rsplit('/').next().map(str::to_string))
+                .expect("id")
+            })
+            .collect();
+        assert_ne!(ids[0], ids[1]);
+        assert_eq!(registered_eess().len(), 2);
+    }
+
+    /// The endpoint type round-trips through the registry, so the profile a
+    /// discovery hands back is the one the EES registered.
+    #[test]
+    fn the_stored_profile_keeps_the_endpoint_the_ees_registered() {
+        let _g = crate::context::PROCESS_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_registry_for_test();
+        handle_registration_create(&post(
+            "/eecs-eesregistration/v1/registrations",
+            registration_body("ees1.example.com", Some(vec!["eas1"])),
+        ));
+        let stored = registered_eess();
+        assert_eq!(
+            stored[0].registration.ees_prof.end_pt,
+            EndPoint {
+                ipv4_addrs: Some(vec!["10.0.0.9".to_string()]),
+                port: Some(7814),
+                ..Default::default()
+            }
+        );
+    }
+}

--- a/src/bins/nextgcore-eesd/src/main.rs
+++ b/src/bins/nextgcore-eesd/src/main.rs
@@ -112,6 +112,7 @@ mod auth;
 mod capabilities;
 mod context;
 mod ecs_registration;
+mod ecs_role; // #107: the ECS role (EDGE-4 provisioning, EDGE-6 registration, discovery)
 mod eec;
 mod notifier;
 mod relocation;
@@ -348,6 +349,10 @@ async fn main() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to start SBI server: {e}"))?;
 
     // eesd-01: self-register toward the ECS (EDGE-6), not the NRF.
+    // #107: resolve the ECS-role switch before anything can be served, so no
+    // request is answered under a different setting from the next.
+    ecs_role::init_from_env();
+
     ecs_registration::start_ecs_registration(
         args.ecs_uri.as_deref(),
         &ees_id,
@@ -776,7 +781,14 @@ async fn ees_sbi_request_handler(request: SbiRequest) -> SbiResponse {
                 _ => send_method_not_allowed(method, "instances/{instanceId}"),
             }
         }
-        _ => send_not_found(&format!("Resource not found: {path}"), None),
+        // #107: the ECS role's eecs-* APIs, when this process is running one.
+        // Checked LAST and only after every eees-* arm, so an ECS route can never
+        // shadow an EES one; `route` returns None with the role off, which leaves
+        // the 404 below in charge exactly as before.
+        _ => match ecs_role::route(parts.as_slice(), &request) {
+            Some(resp) => resp,
+            None => send_not_found(&format!("Resource not found: {path}"), None),
+        },
     }
 }
 
@@ -2951,6 +2963,120 @@ mod tests {
         assert_eq!(args.max_eas, 512);
         // eesd-01: NRF removed in favour of an optional ECS apiRoot.
         assert!(args.ecs_uri.is_none());
+    }
+
+    // ── #107: the ECS role through the real router ──
+
+    /// #107 criteria 1 and 2 through `ees_sbi_request_handler` itself, not through
+    /// `ecs_role`'s functions: the route has to be reachable, and the arm is added at
+    /// the END of a 30-arm match where a typo would leave it shadowed or unreached.
+    ///
+    /// Also the interlock: with the role OFF the same path is a 404, so a deployment
+    /// that does not want an ECS is unchanged.
+    #[test]
+    fn the_ecs_role_is_reachable_through_the_router_only_when_enabled() {
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ecs_role::clear_registry_for_test();
+
+        let body = serde_json::json!({
+            "eesProf": {
+                "eesId": "ees-router.example.com",
+                "endPt": { "ipv4Addrs": ["10.0.0.9"], "port": 7814 },
+                "easIds": ["eas-router"],
+            },
+        });
+        let request = || {
+            SbiRequest::post("/eecs-eesregistration/v1/registrations")
+                .with_json_body(&body)
+                .expect("serialize")
+        };
+
+        // OFF: the path is a 404, exactly as before #107.
+        ecs_role::set_for_test(false);
+        let off = block_on(ees_sbi_request_handler(request()));
+        assert_eq!(
+            off.status, 404,
+            "with the role off an eecs-* path must be indistinguishable from a mistyped URI"
+        );
+
+        // ON: created, with a Location.
+        ecs_role::set_for_test(true);
+        let on = block_on(ees_sbi_request_handler(request()));
+        assert_eq!(
+            on.status, 201,
+            "the route must be reachable through the router"
+        );
+        let location = on
+            .http
+            .get_header("location")
+            .expect("201 must carry a Location")
+            .clone();
+        assert!(location.starts_with("/eecs-eesregistration/v1/registrations/"));
+
+        // And the refresh, also through the router.
+        let refresh = block_on(ees_sbi_request_handler(
+            SbiRequest::put(&location)
+                .with_json_body(&body)
+                .expect("serialize"),
+        ));
+        assert!(
+            (200..300).contains(&refresh.status),
+            "the PUT refresh must be 2xx through the router, got {}",
+            refresh.status
+        );
+
+        // Discovery finds it, which is the point of registering at all.
+        let discovered = block_on(ees_sbi_request_handler(
+            SbiRequest::post("/eecs-targeteesdiscovery/v1/target-ees-discovery")
+                .with_json_body(&serde_json::json!({ "easId": "eas-router" }))
+                .expect("serialize"),
+        ));
+        assert_eq!(discovered.status, 200);
+        let found: serde_json::Value =
+            serde_json::from_str(discovered.http.content.as_deref().expect("body")).expect("json");
+        assert_eq!(found["eesProfiles"][0]["eesId"], "ees-router.example.com");
+
+        ecs_role::set_for_test(false);
+        ecs_role::clear_registry_for_test();
+    }
+
+    /// An `eecs-*` route must not require an EES OAuth2 scope. The ECS APIs are a
+    /// different reference point (EDGE-4/EDGE-6) with different consumers, and gating
+    /// them on an `eees-*` scope would make an EEC's bootstrap need an EAS's token.
+    #[test]
+    fn the_ecs_routes_do_not_demand_an_ees_scope() {
+        let _g = auth::GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ecs_role::clear_registry_for_test();
+        ecs_role::set_for_test(true);
+        // No JWKS configured at all: an `eees-*` route fails closed with 401 here.
+        auth::clear_auth_jwks();
+
+        let resp = block_on(ees_sbi_request_handler(
+            SbiRequest::post("/eecs-serviceprovisioning/v1/provisioning-requests")
+                .with_json_body(&serde_json::json!({ "eecId": "eec-1" }))
+                .expect("serialize"),
+        ));
+        assert_eq!(
+            resp.status, 200,
+            "EDGE-4 provisioning must not be gated on an EES service scope"
+        );
+
+        // Contrast: an eees-* route with no JWKS is 401, so the difference is real
+        // rather than an artefact of this test's setup.
+        let ees_route = block_on(ees_sbi_request_handler(SbiRequest::post(
+            "/eees-easregistration/v1/registrations",
+        )));
+        assert_eq!(
+            ees_route.status, 401,
+            "the EES routes still fail closed, which is what makes the contrast meaningful"
+        );
+
+        ecs_role::set_for_test(false);
+        ecs_role::clear_registry_for_test();
     }
 
     /// eesd-01: a legacy `nees-*` path is no longer routed → 404.


### PR DESCRIPTION
Closes #107.

The Edge Configuration Server role was absent from the **whole workspace**: none of the eight ECS-side APIs had a server anywhere, so an EEC had no EDGE-4 bootstrap and an EES could not be brought into a deployment through an ECS. The EES's own EDGE-6 client, meanwhile, was brittle in three silent ways.

Every one of #107's cites still held against current `main` — unusual for this backlog, and worth saying.

## The ECS role

`ecs_role.rs`, behind `ECS_ROLE=1` (off by default):

| API | Path |
|---|---|
| `Eecs_EESRegistration` | `POST/PUT/GET/DELETE /eecs-eesregistration/v1/registrations[/{registrationId}]` |
| `Eecs_ServiceProvisioning` | `POST /eecs-serviceprovisioning/v1/provisioning-requests` |
| `Eecs_TargetEESDiscovery` | `POST /eecs-targeteesdiscovery/v1/target-ees-discovery` |

**A role rather than a new `ecsd`.** #107 offers either; three reasons for the role: an ECS has no `nfType` in TS 29.510 — the same fact that made EDGE-6 registration replace this daemon's old NRF self-registration — so a separate binary gains none of the NF machinery that justifies one for the nefd/easdfd/tsctsf precedents #107 cites; the EAS pool that `Eecs_TargetEESDiscovery` matches against already lives in this process, and crossing a boundary to read it would mean inventing a protocol TS 29.558 does not define; and it costs one runtime switch instead of a Dockerfile, a compose service, a config file and a probe. A **runtime** switch, not the cargo feature #107 suggests — this project's convention, because a feature-gated path is left uncompiled by CI and rots.

## The hardened EDGE-6 client

| was | now |
|---|---|
| one POST, then `warn!("will operate without ECS")` forever | 5 attempts, backoff `500 ms → 1 s → 2 s → 4 s`, capped at 30 s. The body is **rebuilt each attempt**, so an EAS that registered while the ECS was unreachable appears in the registration that finally lands |
| the refresh only PUT; a 404 was logged and the loop kept PUTting a resource that no longer existed | re-POSTs and adopts the new `registrationId` |
| `easIds: null`, `expTime: null` — the ECS's view was wrong even on the happy path | both derived from live state on every POST **and** every refresh |

**Wider than criterion 4's 404, on purpose.** A 410 Gone, or a 400 from an ECS that has forgotten the schema version an id was created under, leave the EES in *exactly* the same state — PUTting a resource that will never accept it again. Re-creating is idempotent from this side, so checking `== 404` would only loop forever on those. Said in the function's doc so a later reader doesn't "tighten" it back.

**`easIds` is derived at send time, not pushed by a hook.** The registration is already sent on a 60-second timer; a second, event-driven sender would race it and the loser would silently overwrite the winner. Cost: up to one refresh interval of staleness at the ECS, stated as a ceiling.

## Two response codes are load-bearing

- **A refresh for an id the ECS does not hold is 404** — not 200, not a silent re-create. That 404 is what the client's recovery keys on, so an ECS answering 200 would make criterion 4's recovery **unreachable**. Reverting that arm fails the *client's* test as well as the server's, which is the check that the two halves agree.
- **Provisioning with no registered EES is 200 with an empty list**, not 404. "No EES available yet" and "this ECS does not serve provisioning" are different states.

## I made #308's mistake on the way

Adding a process-global to `ecs_role` led me to add a `context::PROCESS_STATE_TEST_LOCK` while `auth::GLOBAL_STATE_TEST_LOCK` already guarded the same ambient state. Two disjoint agreements over one state — #308's defect, and #276 showed that shape *hangs* the suite. It surfaced as a collateral failure in an unrelated `main.rs` test on the very next run.

Collapsed: the static now lives in `context`, beside the context it guards, and `auth`'s name is a `pub(crate) use` alias so the 55 existing call sites don't churn.

A second flake, in my own new test, is also fixed: it depended on the EAS pool starting empty, which a *panicking sibling* can violate — `ees_context_init` does not wipe the pool. It now wipes it itself. Confirmed by re-running the same revert and watching exactly one test fail instead of two.

## Verification

**8 reverts, 8 bites:** static `easIds`; unset `expTime`; one POST attempt; retry with no delay; refresh that only logs; ECS answering 200 for an unknown id; discovery treating absent `easIds` as a match; the router arm removed.

The router tests go through `ees_sbi_request_handler`, not through `ecs_role`'s functions — the arm sits at the end of a ~30-arm match where a typo leaves it unreached and every unit test still passes. The backoff test asserts on **arrival times at a stub ECS**, so it measures the delay the peer actually experienced rather than the schedule the caller intended.

eesd **174 → 194** tests, stable over 6 consecutive runs plus the revert pass. Workspace **6416 passed / 0 failed**. clippy `--workspace` and `--all-targets` 0 errors; fmt clean.

## Not done, with reasons

- **Five of the eight ECS APIs stay 404** — `Eecs_ECSDiscovery`, `Eecs_EASInfoManagement`, `Eecs_ACREvents`, `Eecs_ECSServiceProvisioning`, `Ecas_SelectedEES`. #107's own suggested approach scopes the initial surface to three, and a route returning a fabricated 2xx is worse than one honest about not existing — the same call #106 made for three `eees-*` APIs.
- **No `expTime` enforcement on the ECS side**: it stores and returns what an EES sends, but nothing sweeps expired registrations, so a dead EES stays discoverable until deleted.
- **Discovery matches on `easIds` only**, not on service area or AC service KPIs. A query carrying them is accepted and they are ignored — so the response is a candidate list, not a ranked one.
- **The ECS registry is in memory**, lost on restart — which is exactly the case the client's re-POST recovery handles, so the two halves of this PR exercise each other.
- An EES running the role in the same process does **not** register with itself; nothing points `--ecs-uri` at the local address automatically, because doing it silently would make a single-process deployment look like a two-node one.
- No compose service sets `ECS_ROLE`, so the default E2E path is unchanged.

Spec: `specs/fix-ecs-role-and-edge6-hardening.md` (claim/site/still-true table, 5 decisions, 8-row revert table, 9 ceilings). Docs: `docs-book/src/configuration/ees.md`.
