### PR TITLE
fix(pfcp,smfd,upfd,pcfd): give 5GS-TSN a wire, and correct 65 IE numbers (#321)

### DIFF
--- a/specs/fix-pfcp-tsc-container-codec.md
+++ b/specs/fix-pfcp-tsc-container-codec.md
@@ -1,0 +1,242 @@
+# fix(pfcp,smfd,upfd,pcfd): the PFCP TSC container codec and the PCF→SMF→UPF hop
+
+Closes #321. Completes #284's criterion 4, which #284 left unmet and named as its
+main ceiling.
+
+## What was missing
+
+The IE *identifiers* existed. Nothing else did.
+
+`rg 'CreateBridgeInfoForTsc|TscManagementInformationSmr' src/` returned the enum
+declarations and nothing more — no struct, no encoder, no decoder, no carriage, no
+consumer. `upfd`'s `tsn_bridge` was initialised to `None` and the only other
+reference was a unit test that hand-built its own bridge.
+
+## Claim / site / still true
+
+Every claim #321 makes, re-verified against `main` at `57a0b05`.
+
+| #321's claim | site | still true? |
+|---|---|---|
+| `PfcpIeType::CreateBridgeInfoForTsc = 194`, no users | `libs/nextgcore-pfcp/src/ie.rs:205` | **YES** — declaration only |
+| `CreatedBridgeInfoForTsc = 195`, no users | `ie.rs:206` | **YES** |
+| `TscManagementInformationSmr/Smrsp/Srr = 199/200/201`, no users | `ie.rs:210-212` | **YES** |
+| `UpFunctionFeatures.tscu` encoded and decoded, never acted on | `types.rs:1626,1693,1778` | **YES** |
+| `PfcpSrRspFlags.tmir` flag only | `types.rs:1564` | **PARTLY** — the flag is on `ReportType` (§8.2.21 bit 5), and `ReportType.tmir` was already correctly encoded/decoded; it had no reader |
+| `upfd`'s `tsn_bridge: Option<TsnBridge>`, `None` at init, one unit-test reference | `bins/nextgcore-upfd/src/context.rs:1204,1223,1851` | **YES** |
+| "a populated `TsnBridge`/`TsnBridgePort`/`TsnGateControlEntry` type set" | `context.rs:472,503,676` | **YES**, but note there are **TWO** `TsnBridge` types: the one #321 means (`context.rs:676`, ports + bridge ID + PTP clock) and a second, unrelated one in `tsn_bridge.rs:121` (VLAN/PCP flow tagging). Only the first is on `UpfSess` |
+| grouped-IE pre-check: can Create PDR / Create URR's helpers carry these? | `types.rs:2463` | **YES** — the mechanism is a plain `encode(&self, buf)` / `decode(buf)` pair over `RawIe::decode`. No fourth grouping mechanism was added |
+
+### Two things #321 got wrong, and one it could not have known
+
+1. **The IE is not called what #321 calls it.** TS 29.244 §8.2.157 is not TSC
+   Management Information; the grouped IEs are §7.5.4.18, §7.5.5.3 and §7.5.8.5, and
+   the containers are §8.2.144 (PMIC) and **§8.2.182 (UMIC)**. #321 (following
+   TS 29.512) calls the second one a "Bridge Management Information Container"; on
+   N4 it is the **User Plane Node Management Information Container**, IE **266**,
+   which was absent from `IeType` entirely. The two specs name the same octet string
+   differently, which is exactly the kind of thing to get from the spec rather than
+   from memory — this build vendors TS 29.244 k00 at
+   `6g_docs/specs/29244-k00.txt`, and every IE number and figure below was read from
+   it.
+2. **`upfd`'s `tsn_bridge` is in an UNREACHABLE store.** `UpfSess` lives in
+   `UpfContext::sess_list`, and **nothing in production calls `sess_add`** — the only
+   callers are that module's own tests. `rule_match.rs` *reads* the store
+   (`upf_sess_find_by_ipv4`), so every lookup there returns `None`. Populating
+   `UpfSess.tsn_bridge` would therefore have been a correct change in a place no wire
+   path runs through, and the resulting test could only have asserted against a
+   session it built itself — which is precisely the existing unit test at
+   `context.rs:1851`, and precisely why #284's criterion 4 stayed unmet. The live
+   store is `PfcpServer::sessions: HashMap<u64, PfcpSessionInfo>`, so **that** is
+   where the bridge now lives. Filed as its own issue; see Ceilings.
+3. **A live wire bug found on the way in.** See the next section.
+
+## The S-NSSAI defect, found while adding IE 199
+
+`smfd`'s `n4_build::pfcp_ie` is a second, hand-maintained copy of TS 29.244
+Table 8.1.2-1, 255 constants long. It **omitted IP Multicast Address (191)**, so
+every constant from 191 down was shifted by one, and further omissions grew the
+shift to seven by IE 202. Concretely:
+
+```
+smfd said                                        TS 29.244 says
+193  TSC_MANAGEMENT_INFORMATION_..._MOD_REQUEST  193  Packet Rate Status
+199  TIME_DOMAIN_NUMBER                          199  TSC Management Information (SMR)
+250  S_NSSAI                                     250  DL Data Packets Size
+```
+
+**64 of the 65 shifted constants had no caller.** The 65th was `S_NSSAI`, and it was
+live: `PfcpMessageBuilder::add_s_nssai` is called from `pfcp_session_establish`, so
+**every 5GC PFCP Session Establishment Request this SMF sent carried the slice
+identity under IE 250, "DL Data Packets Size"**. TS 29.244 §8.2.176 Figure 8.2.176-1
+says `Type = 257`.
+
+Why it went unnoticed, both parts verified: nothing in this tree *reads* S-NSSAI over
+N4 (`rg S_NSSAI` across `upfd`, `sgwud`, `sgwcd` returns nothing), so no peer
+compensated for it and no test could have caught it; and the other 64 were inert.
+Checked before fixing, because a correctness fix is a breaking change to whoever
+compensated for the defect — here, nobody did.
+
+The whole `>= 191` region is corrected, and pinned by
+`test_pfcp_ie_numbers_match_the_authoritative_table`, which compares 24 constants
+against `nextgcore_pfcp::ie::IeType` and asserts S-NSSAI = 257 and the UMIC = 266
+against the spec clause directly. A 250-row hand-maintained wire table cannot be kept
+correct by review. `upfd`, `sgwcd` and `sgwud` have their own copies; all three stop
+before 191 and were checked clean.
+
+## Scope item 4: which hop, and why
+
+**PCF → SMF over `Npcf_SMPolicyControl`, using the members TS 29.512 already
+defines.** `SmPolicyDecision` carries `tsnBridgeManCont`, `tsnPortManContDstt`,
+`tsnPortManContNwtts`, `tscNotifUri` and `tscNotifCorreId` — read from the official
+`TS29512_Npcf_SMPolicyControl.yaml`, lines 696-708 — under **the same names**
+TS 29.514's `AppSessionContextReqData` uses on the inbound PolicyAuthorization leg.
+So the PCF is a **copier, not a translator**: there is no mapping step in which the
+containers could be corrupted, and no member this build had to invent.
+
+The alternative #321 offers — TSCTSF reaching the SMF directly — was declined for
+three reasons: TS 23.502 Annex F.1 puts the PCF in the path; the TSCTSF has no Nsmf
+consumer role in this tree; and it would need a protocol no spec defines. The
+existing `pcf_sbi_send_af_smpolicycontrol_update_notify` already pushes AF-derived
+decisions to the SMF, and `smfd`'s `handle_sm_policy_notify` already applies them —
+so this hop is a new member on an existing message, not new plumbing.
+
+Note the flow direction this settles: a TSCTSF app session **binds by UE IP**, which
+requires the PDU session to exist first. So the containers always arrive on an
+*update* to a live session, never on the create. That is why the Session Modification
+path is the load-bearing one and the establishment path is not.
+
+## The chain, end to end
+
+1. TSCTSF derives PMIC/UMIC (#284) → PCF over `Npcf_PolicyAuthorization` — *existed*
+2. PCF parses the containers, stores them on the bound `PcfSess`, and includes them in
+   the `SmPolicyDecision` it pushes to the SMF — **new**
+3. SMF parses and base64-decodes them, and carries them over N4 in a Session
+   Modification's TSC Management Information IE (199) — **new**, gated on `tscu`
+4. UPF decodes 199, populates `tsn_bridge` from `None`, echoes IE 200 — **new**
+5. UPF may report asynchronously with IE 201 + the TMIR bit; the SMF decodes and
+   records it — **new**
+6. Establishment: a `tscu`-advertising UPF is asked for bridge info (IE 194, BII), and
+   its Created Bridge/Router Info (IE 195) — DS-TT port + Bridge ID — is decoded and
+   held per session — **new**
+
+## Decisions
+
+**One type for IEs 199, 200 and 201.** Tables 7.5.4.18-1, 7.5.5.3-1 and 7.5.8.5-1
+list the *same three members*, so `TscManagementInformation` serves all three and the
+carrier number is the caller's choice. Three structs would have tripled the codec to
+emit identical bytes. The risk this creates is that a copy-paste puts the wrong
+carrier number on a message — and a self-round-trip cannot catch it, because each
+message would happily decode its own output under any number it agreed with itself
+on. So three tests assert the carrier number **on the wire**
+(`top_level_ie_types(&buf).contains(&199)`).
+
+**The DS-TT container is deliberately not sent over N4.** §7.5.4.18 gives the TSC
+Management Information IE an NW-TT Port Number and no DS-TT one, because the
+device-side port's configuration reaches the DS-TT over NAS (TS 24.501 §5.4.5).
+Sending it with an NW-TT port number would tell the UPF to apply device-side
+configuration to a network-side port. It is still parsed and stored, so the NAS leg
+has it when that is built.
+
+**The bridge info request goes out at establishment, gated on `tscu`.** §5.26.2 puts
+Create Bridge/Router Info on the Establishment Request only, and the SMF cannot know
+at that moment whether a TSCTSF will later authorise the session (see the binding
+note above). So a UPF that advertised TSC support is asked once, up front, and the
+answer is held. A UPF that did not advertise it is never asked — §6.2.2 lets a UP
+function reject a request carrying an unsupported feature's IEs, which would fail
+every session establishment against a plain UPF.
+
+**The TSC modification is its own message, not folded into the QER update.** The two
+have different failure meanings — a rejected QER update means the authorised bandwidth
+is not enforced; a rejected TSC update means the bridge is not configured — and
+§7.5.5 gives ONE Cause per message, which cannot express both.
+
+**Containers are transported byte-exact and not interpreted.** §8.2.144 and §8.2.182
+say they carry TS 24.539 clause 8 and 9 messages, and this tree has no TS 24.539
+codec. For the SMF and the PCF, relaying is the *correct* behaviour, not a shortcut.
+For the UPF it is a ceiling, recorded below.
+
+**A PMIC with no NW-TT Port Number is refused, not defaulted.** Port configuration
+with no port is unattributable, and defaulting the number to 0 would silently name
+the port the TSCTSF's own derivation reserves for the network side. The SMF refuses to
+send one; the UPF answers `ConditionalIeMissing` with the NW-TT Port Number as the
+Offending IE, and applies nothing.
+
+## Verification
+
+Whole workspace: **6464 passed, 0 failed** (main: 6433), clippy warnings unchanged at
+74 (all pre-existing, none in the touched files), `cargo fmt --check` clean.
+
+### Reverts, all of which bite
+
+| revert | named test that failed |
+|---|---|
+| UMIC IE number 266 → 267 | `test_tsc_management_information_decodes_hand_built_wire`, `test_tsc_management_information_encodes_expected_ie_numbers` |
+| Session Modification's carrier 199 → 201 | `test_session_modification_request_carries_tsc_under_ie_199` |
+| remove the `tscu` gate (`if false`) | `test_tsc_containers_withheld_from_a_upf_without_tscu` |
+| send the DS-TT container over N4 too | `test_tsc_containers_are_carried_on_a_session_modification` |
+| never apply the containers in the UPF | `test_tsc_management_information_populates_the_tsn_bridge`, `test_tsc_modification_response_echoes_what_was_applied` |
+| accept a PMIC with no port number | `test_tsc_pmic_without_port_number_is_rejected` |
+| `S_NSSAI` 257 → 250 | `test_pfcp_ie_numbers_match_the_authoritative_table`, quoting the clause |
+
+### Criterion 1's tests decode hand-built wire buffers
+
+Not only the encoder's own output. A pure round-trip passes for any self-consistent
+pair of functions, including one that agrees with itself on the wrong IE number —
+which is the mistake worth catching when five IE numbers land at once. `wire_ie()`
+builds headers the way a peer would, without touching the encoder under test.
+
+## Ceilings
+
+- **`UpfSess.tsn_bridge` is still unreachable, and so is the rest of that store.**
+  `UpfContext::sess_add` has no production caller, so `rule_match`'s lookups by UE IP
+  always return `None`. This is a pre-existing defect of the shape #223 describes for
+  `smfd` ("two parallel session models, one dead"), it is wider than #321, and it is
+  filed separately. The live bridge is on `PfcpSessionInfo`.
+- **No TS 24.539 codec**, so the UPF stores the containers rather than acting on
+  their contents. `TsnBridge.port_management_containers` and
+  `user_plane_node_management_container` hold the raw octets; the gate-control lists
+  and VLAN configuration a real bridge would derive from them need that codec.
+- **The UPF's Bridge ID is derived from the SEID**, not read from configuration.
+  §5.26.2 says these identities "may be pre-configured in the UPF based on
+  deployment"; this build has no such configuration surface, so the SEID gives a
+  value that is stable per session and distinct across sessions without inventing a
+  deployment identity.
+- **The SMF does not relay a received IE 201 onward to the PCF.** TS 23.502 Annex F.1
+  says it should (as `SmPolicyUpdateContextData.tsnBridgeInfo` / the containers), and
+  `parse_tsc_containers`' mirror image on the update-context side is not built. The
+  report is decoded and recorded against the SEID, which is what criterion 4 asks
+  for; the onward leg is the next piece.
+- **`tsctsf`'s PMIC is still this build's own TLV encoding, not IEEE 802.1Q clause 12**
+  (#321 scope item 5). Unchanged deliberately: replacing it needs the same TS 24.539 /
+  802.1Q managed-object codec as the item above, and doing it here would have coupled
+  a wire-format change to the plumbing change. The containers now travel end to end,
+  which is what makes that substitution a local edit when the codec exists.
+- **Direct Reporting Information (IE 295)** is not modelled. §7.5.4.18 makes it
+  conditional on the UPF advertising the DRTSC feature, which this build does not.
+- **In-process, not Docker E2E** (criterion 6). Every assertion here is a loopback
+  request or a real UDP round trip inside one test process. The Docker jobs remain
+  `workflow_dispatch`-only and no compose service sets anything TSC-related.
+
+## Criterion table
+
+| # | criterion | status |
+|---|---|---|
+| 1 | pfcp encodes/decodes TSC Management Information + Create/Created Bridge Info, round-trip against a hand-built buffer | **met** |
+| 2 | a Session Modification carries PMIC/UMIC and `upfd` populates `tsn_bridge` from `None`, asserted from the UPF's own state | **met** — asserted from `PfcpServer::sessions`, over a real UDP round trip |
+| 3 | `tscu` gates the carriage; a test covers a UPF with the bit clear | **met** — and the default stand-in has the bit clear, so this is the ordinary case |
+| 4 | a Session Report carrying IE 201 reaches the SMF and is decoded | **met** — recorded in `TSC_REPORTS`, asserted from state |
+| 5 | the PCF → SMF hop is implemented and stated in the PR | **met** — see "Scope item 4" |
+| 6 | #284's criterion 4 satisfiable end to end; say which | **met, in-process** — stated above |
+| 7 | whole-workspace lint and tests pass | **met** |
+
+## References
+
+- TS 29.244 k00 (vendored at `6g_docs/specs/29244-k00.txt`): §5.26.2, §7.5.3.6,
+  §7.5.4.18, §7.5.5.3, §7.5.8.5, §8.2.21, §8.2.140-§8.2.144, §8.2.176, §8.2.182
+- TS 29.512 (`6g_docs/specs/TS29512_Npcf_SMPolicyControl.yaml`): `SmPolicyDecision`
+  lines 696-708, `PortManagementContainer` / `BridgeManagementContainer` lines
+  2361-2379
+- TS 23.501 §5.27-§5.28; TS 23.502 Annex F.1; TS 24.501 §5.4.5
+- #284 (the actuation half), #113 (the control-plane half), #304 (the modification
+  path this rides on), #306 (the accepted-but-not-applied defect class)

--- a/src/bins/nextgcore-pcfd/src/app.rs
+++ b/src/bins/nextgcore-pcfd/src/app.rs
@@ -2608,6 +2608,55 @@ fn parse_asc_req_data(root: &serde_json::Value) -> AscReqData {
         ue_ipv4: opt_str("ueIpv4"),
         ue_ipv6: opt_str("ueIpv6"),
         ue_mac: opt_str("ueMac"),
+        tsc: parse_tsc_containers(root),
+    }
+}
+
+/// Parse one TS 29.514 / TS 29.512 `PortManagementContainer` (#321).
+///
+/// Both members are REQUIRED by the schema, so a value missing either is dropped
+/// rather than defaulted: a `portNum` defaulted to 0 would be indistinguishable
+/// from the NW-TT port, which is the port number the TSCTSF's own derivation
+/// assigns to the network side.
+fn parse_port_management_container(v: &serde_json::Value) -> Option<PortManagementContainer> {
+    let cont = v.get("portManCont")?.as_str()?;
+    let num = v.get("portNum")?.as_u64()?;
+    Some(PortManagementContainer {
+        port_man_cont: cont.to_string(),
+        port_num: num as u32,
+    })
+}
+
+/// Parse the TSC management containers from an `AppSessionContextReqData` (#321,
+/// TS 29.514 Table 5.7.3-1).
+fn parse_tsc_containers(root: &serde_json::Value) -> TscManagementContainers {
+    let opt_str = |key: &str| {
+        root.get(key)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    TscManagementContainers {
+        bridge_man_cont: root
+            .get("tsnBridgeManCont")
+            .and_then(|v| v.get("bridgeManCont"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        port_man_cont_dstt: root
+            .get("tsnPortManContDstt")
+            .and_then(parse_port_management_container),
+        port_man_cont_nwtts: root
+            .get("tsnPortManContNwtts")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(parse_port_management_container)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        notif_uri: opt_str("tscNotifUri"),
+        notif_corre_id: opt_str("tscNotifCorreId"),
     }
 }
 
@@ -2809,6 +2858,35 @@ pub async fn handle_app_session_create(request: &SbiRequest) -> SbiResponse {
     let app_session_id = app.app_session_id.clone();
     let bound_sess = Some(bound_sess);
 
+    // #321: TSC management containers are recorded whether or not the request
+    // carries media components. A TSCTSF time-synchronization authorisation has NO
+    // medComponents at all (its AppSessionContext carries the containers and a UE
+    // address and nothing else), so gating the store on media components would drop
+    // exactly the case this exists for.
+    let carries_tsc = !asc.tsc.is_empty();
+    if carries_tsc {
+        if let Some(ref sess) = bound_sess {
+            if let Ok(context) = ctx.read() {
+                if let Some(mut latest) = context.sess_find_by_id(sess.id) {
+                    // REPLACES rather than merges: the containers are a complete
+                    // statement of the port and bridge configuration, so keeping
+                    // stale ports alongside new ones would tell the SMF to apply a
+                    // configuration the AF has withdrawn.
+                    latest.tsc_containers = asc.tsc.clone();
+                    context.sess_update(&latest);
+                }
+            }
+            log::info!(
+                "App session create recorded TSC containers on sess_id={} (DS-TT: {}, \
+                 NW-TT ports: {}, UMIC: {})",
+                sess.id,
+                asc.tsc.port_man_cont_dstt.is_some(),
+                asc.tsc.port_man_cont_nwtts.len(),
+                asc.tsc.bridge_man_cont.is_some()
+            );
+        }
+    }
+
     if !asc.med_components.is_empty() {
         // AF media components → PCC rules persisted on the bound session and
         // pushed to the SMF in an SM policy update notify (TS 29.514 §4.2.2.2).
@@ -2831,8 +2909,14 @@ pub async fn handle_app_session_create(request: &SbiRequest) -> SbiResponse {
             notify_af_resource_allocation(app.id, installed > 0);
         }
     } else if let Some(ref sess) = bound_sess {
-        // No medComponents: bind + generic notify, as today.
-        pcf_sbi_send_smpolicycontrol_update_notify(sess.id);
+        // No medComponents. The AF-shaped notify is used when TSC containers are
+        // present because that is the one that carries them; otherwise the generic
+        // subscription-derived notify, as before.
+        if carries_tsc {
+            pcf_sbi_send_af_smpolicycontrol_update_notify(sess.id);
+        } else {
+            pcf_sbi_send_smpolicycontrol_update_notify(sess.id);
+        }
     }
 
     log::info!(
@@ -3135,6 +3219,24 @@ pub async fn handle_app_session_modify(app_session_id: &str, request: &SbiReques
 
     match app {
         Some(app) => {
+            // #321: a PATCH carrying TSC containers replaces the stored set, so a
+            // reconfiguration reaches the SMF. Handled before the media-component
+            // branch so a PATCH that carries BOTH pushes one notification holding
+            // both, rather than two notifications each missing half.
+            let carries_tsc = !asc.tsc.is_empty();
+            if carries_tsc {
+                if let Ok(context) = ctx.read() {
+                    if let Some(mut sess) = context.sess_find_by_id(app.sess_id) {
+                        sess.tsc_containers = asc.tsc.clone();
+                        context.sess_update(&sess);
+                    }
+                }
+                log::info!(
+                    "App session modify replaced TSC containers on sess_id={}",
+                    app.sess_id
+                );
+            }
+
             if !asc.med_components.is_empty() {
                 // Re-derive the AF PCC rules and push them to the SMF.
                 let mut installed = 0usize;
@@ -3152,6 +3254,8 @@ pub async fn handle_app_session_modify(app_session_id: &str, request: &SbiReques
                     app.sess_id
                 );
                 notify_af_resource_allocation(app.id, installed > 0);
+            } else if carries_tsc {
+                pcf_sbi_send_af_smpolicycontrol_update_notify(app.sess_id);
             }
 
             let mut resp_body = build_app_session_context(&app.app_session_id, req_root, &asc);

--- a/src/bins/nextgcore-pcfd/src/context.rs
+++ b/src/bins/nextgcore-pcfd/src/context.rs
@@ -521,6 +521,17 @@ pub struct PcfSess {
     /// `access_type`.
     #[serde(default)]
     pub policy_dnn_data: Option<serde_json::Value>,
+    /// The TSC management containers an AF (in practice the TSCTSF) supplied for
+    /// this PDU session over `Npcf_PolicyAuthorization`, held for onward delivery
+    /// to the SMF in the SM policy decision (#321, TS 23.502 Annex F.1).
+    ///
+    /// Stored on the SESSION rather than the app session because that is what the
+    /// SM policy notification is keyed on, and because a later app-session modify
+    /// replacing the containers must replace what the SMF will next be told rather
+    /// than add to it. `#[serde(default)]` for the same snapshot reason as
+    /// `access_type`.
+    #[serde(default)]
+    pub tsc_containers: crate::npcf_handler::TscManagementContainers,
 }
 
 impl PcfSess {
@@ -552,6 +563,7 @@ impl PcfSess {
             af_pcc_rules: Vec::new(),
             access_type: None,
             policy_dnn_data: None,
+            tsc_containers: Default::default(),
         }
     }
 

--- a/src/bins/nextgcore-pcfd/src/npcf_handler.rs
+++ b/src/bins/nextgcore-pcfd/src/npcf_handler.rs
@@ -77,6 +77,106 @@ pub struct AscReqData {
     pub ue_ipv4: Option<String>,
     pub ue_ipv6: Option<String>,
     pub ue_mac: Option<String>,
+    /// The TSC management containers a TSN AF / TSCTSF supplied (#321).
+    pub tsc: TscManagementContainers,
+}
+
+/// One port's management information container (TS 29.512 / TS 29.514
+/// `PortManagementContainer`), #321.
+///
+/// The schema marks BOTH members required, so neither is optional here: a
+/// container with no port number cannot be applied to anything, and a port number
+/// with no container configures nothing.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PortManagementContainer {
+    /// `portManCont` — the PMIC as a TS 29.571 `Bytes`, i.e. base64.
+    ///
+    /// Kept base64 rather than decoded here: this PCF is a RELAY for it (TS 23.502
+    /// Annex F puts the PCF between the TSCTSF and the SMF and gives it nothing to
+    /// decide about the contents), and decoding then re-encoding an opaque octet
+    /// string only adds a way to corrupt it.
+    pub port_man_cont: String,
+    /// `portNum` — TS 29.512 `TsnPortNumber`.
+    pub port_num: u32,
+}
+
+/// The TSC management containers carried between the TSCTSF, the PCF and the SMF
+/// (TS 29.514 `AppSessionContextReqData` → TS 29.512 `SmPolicyDecision`), #321.
+///
+/// The member names are IDENTICAL in both specs, which is why this one type serves
+/// both the inbound parse and the outbound build.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct TscManagementContainers {
+    /// `tsnBridgeManCont.bridgeManCont` — the UMIC. Base64, for the same relay
+    /// reason as `PortManagementContainer::port_man_cont`.
+    pub bridge_man_cont: Option<String>,
+    /// `tsnPortManContDstt` — the device-side (DS-TT) port's PMIC.
+    pub port_man_cont_dstt: Option<PortManagementContainer>,
+    /// `tsnPortManContNwtts` — one per network-side (NW-TT) port. `minItems: 1`
+    /// in the schema, so an empty vector means "absent" and is not serialised.
+    pub port_man_cont_nwtts: Vec<PortManagementContainer>,
+    /// `tscNotifUri` — where TSC management notifications should be sent.
+    pub notif_uri: Option<String>,
+    /// `tscNotifCorreId`.
+    pub notif_corre_id: Option<String>,
+}
+
+impl TscManagementContainers {
+    /// Whether anything TSC-related was supplied at all.
+    ///
+    /// The whole set is optional: the overwhelming majority of app sessions are
+    /// ordinary media authorisations with no TSC members, and those must not
+    /// acquire a TSC leg just because the members are now parsed.
+    pub fn is_empty(&self) -> bool {
+        self.bridge_man_cont.is_none()
+            && self.port_man_cont_dstt.is_none()
+            && self.port_man_cont_nwtts.is_empty()
+    }
+
+    /// Serialise to the TS 29.512 `SmPolicyDecision` fragment carrying these
+    /// containers to the SMF. Returns the members to merge, empty when there is
+    /// nothing to say.
+    pub fn to_decision_fragment(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut out = serde_json::Map::new();
+        if let Some(umic) = &self.bridge_man_cont {
+            out.insert(
+                "tsnBridgeManCont".to_string(),
+                serde_json::json!({ "bridgeManCont": umic }),
+            );
+        }
+        if let Some(dstt) = &self.port_man_cont_dstt {
+            out.insert(
+                "tsnPortManContDstt".to_string(),
+                serde_json::json!({
+                    "portManCont": dstt.port_man_cont,
+                    "portNum": dstt.port_num,
+                }),
+            );
+        }
+        if !self.port_man_cont_nwtts.is_empty() {
+            out.insert(
+                "tsnPortManContNwtts".to_string(),
+                serde_json::Value::Array(
+                    self.port_man_cont_nwtts
+                        .iter()
+                        .map(|p| {
+                            serde_json::json!({
+                                "portManCont": p.port_man_cont,
+                                "portNum": p.port_num,
+                            })
+                        })
+                        .collect(),
+                ),
+            );
+        }
+        if let Some(uri) = &self.notif_uri {
+            out.insert("tscNotifUri".to_string(), serde_json::json!(uri));
+        }
+        if let Some(id) = &self.notif_corre_id {
+            out.insert("tscNotifCorreId".to_string(), serde_json::json!(id));
+        }
+        out
+    }
 }
 
 /// Media Component
@@ -411,14 +511,21 @@ pub fn af_pcc_rules_to_decision(rules: &[AfPccRule]) -> (serde_json::Value, serd
 /// Build the SmPolicyNotification body that pushes the AF-derived PCC rules
 /// stored on a session to the SMF (TS 29.512 §4.2.3.2). Used by the outbound
 /// `pcf_sbi_send_af_smpolicycontrol_update_notify` path.
+///
+/// #321: also carries the TSC management containers, which is the PCF → SMF hop of
+/// 5GS-TSN. TS 29.512's `SmPolicyDecision` defines `tsnBridgeManCont`,
+/// `tsnPortManContDstt` and `tsnPortManContNwtts` under exactly the names
+/// TS 29.514 uses on the inbound PolicyAuthorization leg, so this is a copy and
+/// not a translation — there is no mapping step in which they could be corrupted.
 pub fn build_af_sm_policy_notification(sess: &PcfSess) -> serde_json::Value {
     let (pcc_rules, qos_decs) = af_pcc_rules_to_decision(&sess.af_pcc_rules);
+    let mut decision = serde_json::Map::new();
+    decision.insert("pccRules".to_string(), pcc_rules);
+    decision.insert("qosDecs".to_string(), qos_decs);
+    decision.extend(sess.tsc_containers.to_decision_fragment());
     serde_json::json!({
         "resourceUri": format!("/npcf-smpolicycontrol/v1/sm-policies/{}", sess.sm_policy_id),
-        "smPolicyDecision": {
-            "pccRules": pcc_rules,
-            "qosDecs": qos_decs,
-        },
+        "smPolicyDecision": serde_json::Value::Object(decision),
     })
 }
 
@@ -1079,5 +1186,96 @@ mod tests {
         assert!(is_serving_plmn_vplmn("001", "99"));
         // Absent serving PLMN → home (false), preserving the H-PCF default.
         assert!(!is_serving_plmn_vplmn("", ""));
+    }
+    // ------------------------------------------------------------------
+    // TSC container relay to the SMF (#321)
+    // ------------------------------------------------------------------
+
+    /// Criterion 5's PCF half: the containers a TSN AF supplied reach the SMF in the
+    /// `SmPolicyDecision`, under the TS 29.512 member names.
+    ///
+    /// Asserted on the built JSON, and on the exact member NAMES: TS 29.512 and
+    /// TS 29.514 spell these identically, which is what makes the PCF a copier
+    /// rather than a translator — and a renamed member here would silently produce a
+    /// decision the SMF's parser skips.
+    #[test]
+    fn test_tsc_containers_reach_the_sm_policy_decision() {
+        let mut sess = PcfSess::new(7, 1, 5);
+        sess.tsc_containers = TscManagementContainers {
+            bridge_man_cont: Some("dW1pYw==".to_string()), // "umic"
+            port_man_cont_dstt: Some(PortManagementContainer {
+                port_man_cont: "ZHN0dA==".to_string(), // "dstt"
+                port_num: 1,
+            }),
+            port_man_cont_nwtts: vec![PortManagementContainer {
+                port_man_cont: "bnd0dA==".to_string(), // "nwtt"
+                port_num: 7,
+            }],
+            notif_uri: Some("http://tsctsf.example/notify".to_string()),
+            notif_corre_id: Some("corr-1".to_string()),
+        };
+
+        let body = build_af_sm_policy_notification(&sess);
+        let dec = &body["smPolicyDecision"];
+
+        assert_eq!(
+            dec["tsnBridgeManCont"]["bridgeManCont"], "dW1pYw==",
+            "the UMIC travels under tsnBridgeManCont.bridgeManCont"
+        );
+        assert_eq!(dec["tsnPortManContDstt"]["portManCont"], "ZHN0dA==");
+        assert_eq!(
+            dec["tsnPortManContDstt"]["portNum"], 1,
+            "portNum is REQUIRED alongside portManCont (TS 29.512 PortManagementContainer)"
+        );
+        assert_eq!(dec["tsnPortManContNwtts"][0]["portManCont"], "bnd0dA==");
+        assert_eq!(dec["tsnPortManContNwtts"][0]["portNum"], 7);
+        assert_eq!(dec["tscNotifUri"], "http://tsctsf.example/notify");
+        assert_eq!(dec["tscNotifCorreId"], "corr-1");
+
+        // The PCC-rule half of the same decision is untouched, so a session with
+        // both an AF media authorisation and a TSC one gets ONE notification
+        // carrying both rather than two each missing half.
+        assert!(dec.get("pccRules").is_some());
+        assert!(dec.get("qosDecs").is_some());
+    }
+
+    /// A session with no TSC authorisation produces a decision with NO TSC members,
+    /// so every ordinary AF notification is byte-identical to before #321.
+    #[test]
+    fn test_no_tsc_containers_adds_no_members() {
+        let sess = PcfSess::new(8, 1, 5);
+        let body = build_af_sm_policy_notification(&sess);
+        let dec = &body["smPolicyDecision"];
+        for member in [
+            "tsnBridgeManCont",
+            "tsnPortManContDstt",
+            "tsnPortManContNwtts",
+            "tscNotifUri",
+            "tscNotifCorreId",
+        ] {
+            assert!(
+                dec.get(member).is_none(),
+                "{member} must be absent, not null: TS 29.512 members are optional \
+                 and a null would be a value the SMF has to interpret"
+            );
+        }
+    }
+
+    #[test]
+    fn test_tsc_containers_is_empty_ignores_notification_members_only() {
+        // notifUri alone is not a configuration: a TSCTSF that sent only a callback
+        // has authorised nothing to apply, so this must not count as TSC-carrying or
+        // the SMF would be sent an empty modification.
+        let notif_only = TscManagementContainers {
+            notif_uri: Some("http://x/y".to_string()),
+            ..Default::default()
+        };
+        assert!(notif_only.is_empty());
+
+        let with_umic = TscManagementContainers {
+            bridge_man_cont: Some("dW1pYw==".to_string()),
+            ..Default::default()
+        };
+        assert!(!with_umic.is_empty());
     }
 }

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -1020,6 +1020,52 @@ async fn handle_pfcp_session_report(
         );
     }
 
+    // TSC Management Information Report (TMIR, bit 0x10 — §8.2.21 bit 5), #321.
+    //
+    // The UPF reporting port or user-plane-node management information the SMF did
+    // not ask for in a transaction: an NW-TT port whose configuration changed, or a
+    // bridge-level change. TS 23.502 Annex F.1 has the SMF relay this to the TSN AF
+    // or TSCTSF via the PCF.
+    //
+    // Decoded and RECORDED here; the onward relay to the PCF is a stated ceiling —
+    // see `specs/fix-pfcp-tsc-container-codec.md`. Decoding it is what criterion 4
+    // asks for, and what makes the report attributable rather than an unknown IE.
+    if report_type & 0x10 != 0 {
+        let reports = decode_tsc_from_report(payload);
+        if reports.is_empty() {
+            // TMIR set with no IE 201 is the peer contradicting itself. Said plainly,
+            // because the alternative reading — "a TSC report arrived and we dropped
+            // it" — is the one worth ruling out.
+            log::warn!(
+                "Session Report for SEID=0x{seid:016x} set TMIR but carried no TSC \
+                 Management Information IE (TS 29.244 §7.5.8.5)"
+            );
+        }
+        for tsc in &reports {
+            log::info!(
+                "TSC Management Information Report: SEID=0x{seid:016x}, NW-TT port={:?}, \
+                 PMIC={} byte(s), UMIC={} byte(s)",
+                tsc.nw_tt_port_number,
+                tsc.port_management_container
+                    .as_ref()
+                    .map(|c| c.len())
+                    .unwrap_or(0),
+                tsc.user_plane_node_management_container
+                    .as_ref()
+                    .map(|c| c.len())
+                    .unwrap_or(0),
+            );
+            if !tsc.conditional_holds() {
+                log::warn!(
+                    "TSC report for SEID=0x{seid:016x} carries a PMIC with no NW-TT Port \
+                     Number, so it names no port to attribute the configuration to \
+                     (TS 29.244 Table 7.5.8.5-1)"
+                );
+            }
+        }
+        pfcp_path::record_tsc_report(seid, reports);
+    }
+
     let mut offset = 0;
     while offset + 4 <= payload.len() {
         let ie_type = u16::from_be_bytes([payload[offset], payload[offset + 1]]);
@@ -1914,6 +1960,36 @@ async fn pfcp_session_establish(
     let dl_far_bytes = n4_build::build_create_far(&dl_far);
     builder.add_tlv(pfcp_ie::CREATE_FAR, &dl_far_bytes);
 
+    // Create Bridge/Router Info (IE 194, TS 29.244 §5.26.2), #321.
+    //
+    // Sent when — and only when — the UPF advertised TSCU in its UP Function
+    // Features. Asking a UPF that did not advertise TSC support for a DS-TT port
+    // number is asking for a resource it has no concept of, and §6.2.2 says a UP
+    // function may reject a request carrying an unsupported feature's IEs outright,
+    // which would fail every session establishment against a plain UPF.
+    //
+    // Sent at ESTABLISHMENT rather than when a TSN AF appears, because §5.26.2 puts
+    // this IE on the Establishment Request only, and the SMF cannot know at that
+    // point whether a TSCTSF will later authorise this session — the TSCTSF binds
+    // its app session by UE IP, which requires the session to exist first. So a
+    // TSC-capable UPF is asked once, up front, and the answer is held.
+    let tsc_capable = client
+        .association()
+        .await
+        .up_function_features
+        .map(|f| f.tscu)
+        .unwrap_or(false);
+    if tsc_capable {
+        let mut bridge_buf = bytes::BytesMut::new();
+        nextgcore_pfcp::types::CreateBridgeInfoForTsc::bridge().encode(&mut bridge_buf);
+        builder.add_tlv(pfcp_ie::CREATE_BRIDGE_INFO_FOR_TSC, &bridge_buf);
+        log::debug!(
+            "PFCP Session Establishment: requesting 5GS bridge info (BII) from {} — \
+             it advertised TSCU",
+            client.peer()
+        );
+    }
+
     let payload = builder.build();
 
     // Send through the transaction engine: T1 retransmission up to N1
@@ -1949,6 +2025,9 @@ async fn pfcp_session_establish(
     let mut upf_seid: u64 = 0;
     let mut upf_teid: u32 = 0;
     let mut upf_ip: [u8; 4] = [127, 0, 0, 1];
+    // #321: the DS-TT port number and 5GS User Plane Node ID the UPF allocated,
+    // present only when the BII request above was sent and honoured.
+    let mut bridge_info: Option<nextgcore_pfcp::types::CreatedBridgeInfoForTsc> = None;
 
     let mut offset = 0;
     while offset + 4 <= resp_payload.len() {
@@ -2021,6 +2100,18 @@ async fn pfcp_session_establish(
                     inner_off = inner_end;
                 }
             }
+            // Created Bridge/Router Info (IE 195, TS 29.244 §7.5.3.6), #321.
+            //
+            // Decoded with the library codec rather than hand-parsed inline like the
+            // two IEs above, so the grouped-IE parsing has one implementation and one
+            // set of tests.
+            195 => {
+                let mut data = bytes::Bytes::copy_from_slice(ie_value);
+                match nextgcore_pfcp::types::CreatedBridgeInfoForTsc::decode(&mut data) {
+                    Ok(info) => bridge_info = Some(info),
+                    Err(e) => log::warn!("malformed Created Bridge Info for TSC, ignoring: {e}"),
+                }
+            }
             _ => {}
         }
         offset = ie_end;
@@ -2036,6 +2127,33 @@ async fn pfcp_session_establish(
     }
 
     log::info!("PFCP Session Established: UPF SEID=0x{upf_seid:016x}, UPF TEID=0x{upf_teid:08x}");
+
+    // #321: a TSC-capable UPF answers the BII request with the DS-TT port it
+    // allocated and its own 5GS User Plane Node ID (the Bridge ID). Recorded against
+    // the SMF-side SEID so a later TSC authorisation has the bridge identity to
+    // report to the PCF, and so the NW-TT containers can be applied to a session
+    // whose device-side port is known.
+    if let Some(info) = bridge_info {
+        log::info!(
+            "5GS bridge info from {}: DS-TT port={:?}, bridge ID={:?}",
+            client.peer(),
+            info.port_number,
+            info.user_plane_node_id.and_then(|n| n.node_id)
+        );
+        pfcp_path::record_session_bridge_info(smf_n4_seid, info);
+    } else if tsc_capable {
+        // The UPF advertised TSCU and was asked, but answered nothing. §7.5.3.6
+        // makes both members conditional-mandatory once BII is set, so this is the
+        // peer not honouring its own advertised feature — worth saying, because the
+        // consequence appears much later as a TSC authorisation with no bridge to
+        // apply it to.
+        log::warn!(
+            "{} advertised TSCU but its Session Establishment Response carried no \
+             Created Bridge Info: TSC authorisation for this session will have no \
+             DS-TT port or bridge ID to report (TS 29.244 §7.5.3.6)",
+            client.peer()
+        );
+    }
 
     // Issue #20: remember which UPF this session was established on so
     // modification/deletion keep signalling the same peer. Keyed by the
@@ -3509,6 +3627,140 @@ async fn pfcp_update_session_qer(
         }
         cause => anyhow::bail!("PFCP Session Modification (QoS) rejected: cause={cause:?}"),
     }
+}
+
+/// Carry the PCF-authorised TSC management containers to the UPF in a Session
+/// Modification (IE 199, TS 29.244 §7.5.4.18), #321.
+///
+/// # The `tscu` gate
+///
+/// An SMF must not send TSC containers to a UPF that did not advertise TSC support
+/// in its UP Function Features (§8.2.25's TSCU bit). Two reasons, and the second is
+/// the one that bites: a UPF with no TSC concept has nothing to apply them to, and
+/// §6.2.2 lets a UP function reject a request carrying an unsupported feature's IEs
+/// — so sending them anyway risks failing the whole modification, taking the
+/// unrelated rule changes in the same message down with it.
+///
+/// Returns the number of TSC IEs sent — 0 when the UPF is not TSC-capable or the
+/// decision authorised nothing, which is a successful no-op rather than an error.
+async fn pfcp_send_tsc_containers(
+    smf_n4_seid: u64,
+    upf_seid: u64,
+    tsc: &policy::TscContainers,
+) -> Result<usize> {
+    let ies = tsc.to_n4_ies();
+    if ies.is_empty() {
+        return Ok(0);
+    }
+
+    let client = pfcp_path::client_for_session(smf_n4_seid)
+        .ok_or_else(|| anyhow::anyhow!("PFCP client not initialised"))?;
+
+    let features = client.association().await.up_function_features;
+    if !features.map(|f| f.tscu).unwrap_or(false) {
+        // Declined with the reason named, not dropped quietly: the PCF authorised a
+        // TSC configuration and it is NOT being enforced, which an operator reading
+        // "policy applied" would otherwise never learn.
+        log::warn!(
+            "TSC containers authorised for SEID 0x{smf_n4_seid:016x} but {} did not \
+             advertise TSCU (TS 29.244 §8.2.25): {} IE(s) NOT sent, so the port and \
+             bridge configuration is not enforced",
+            client.peer(),
+            ies.len()
+        );
+        return Ok(0);
+    }
+
+    // A PMIC with no NW-TT port number cannot be applied to anything. Caught here
+    // rather than on the wire, so the UPF is never asked to make sense of it.
+    if let Some(bad) = ies.iter().find(|ie| !ie.conditional_holds()) {
+        anyhow::bail!(
+            "refusing to send a TSC Management Information IE whose PMIC carries no \
+             NW-TT Port Number (TS 29.244 Table 7.5.4.18-1 makes it conditional-\
+             mandatory): {bad:?}"
+        );
+    }
+
+    let sent = ies.len();
+    let params = n4_build::SessionModificationParams {
+        tsc_management_info: ies,
+        ..Default::default()
+    };
+    let payload = n4_build::build_session_modification_request(&params);
+    let (_, resp_body) = client
+        .request(
+            pfcp_path::pfcp_message_type::SESSION_MODIFICATION_REQUEST,
+            Some(upf_seid),
+            &payload,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("PFCP Session Modification (TSC) failed: {e}"))?;
+
+    match pfcp_path::parse_cause(&resp_body) {
+        Some(pfcp_path::pfcp_cause::REQUEST_ACCEPTED) => {
+            // §7.5.5.3: the response may echo what the UPF applied. Decoded so a
+            // mismatch is visible, and because a response carrying IE 200 that
+            // nothing reads is the defect #321 was filed about, one message over.
+            let echoed = decode_tsc_from_response(&resp_body);
+            log::info!(
+                "TSC containers applied on UPF SEID 0x{upf_seid:016x}: {sent} IE(s) sent, \
+                 {} echoed back",
+                echoed.len()
+            );
+            Ok(sent)
+        }
+        Some(cause) if restoration::cause_means_session_gone(cause) => {
+            restoration::reconcile_session_not_found(upf_seid).await;
+            anyhow::bail!("PFCP Session Modification (TSC) rejected: cause={cause}")
+        }
+        cause => anyhow::bail!("PFCP Session Modification (TSC) rejected: cause={cause:?}"),
+    }
+}
+
+/// Decode every TSC Management Information IE at the top level of a PFCP body,
+/// under the carrier IE type given.
+///
+/// Shared by the Session Modification Response (IE 200) and the Session Report
+/// Request (IE 201) readers, because the grouped contents are identical and only
+/// the carrier differs (§7.5.5.3 vs §7.5.8.5).
+fn decode_tsc_ies(
+    body: &[u8],
+    carrier: u16,
+) -> Vec<nextgcore_pfcp::types::TscManagementInformation> {
+    let mut out = Vec::new();
+    let mut offset = 0usize;
+    while offset + 4 <= body.len() {
+        let ie_type = u16::from_be_bytes([body[offset], body[offset + 1]]);
+        let ie_len = u16::from_be_bytes([body[offset + 2], body[offset + 3]]) as usize;
+        let start = offset + 4;
+        let end = start + ie_len;
+        if end > body.len() {
+            break;
+        }
+        if ie_type == carrier {
+            let mut data = bytes::Bytes::copy_from_slice(&body[start..end]);
+            match nextgcore_pfcp::types::TscManagementInformation::decode(&mut data) {
+                Ok(tsc) => out.push(tsc),
+                Err(e) => log::warn!("malformed TSC Management Information IE {carrier}: {e}"),
+            }
+        }
+        offset = end;
+    }
+    out
+}
+
+/// The TSC Management Information IEs a Session Modification Response carried
+/// (IE 200, TS 29.244 §7.5.5.3).
+fn decode_tsc_from_response(body: &[u8]) -> Vec<nextgcore_pfcp::types::TscManagementInformation> {
+    decode_tsc_ies(body, 200)
+}
+
+/// The TSC Management Information IEs a Session Report Request carried
+/// (IE 201, TS 29.244 §7.5.8.5).
+pub(crate) fn decode_tsc_from_report(
+    body: &[u8],
+) -> Vec<nextgcore_pfcp::types::TscManagementInformation> {
+    decode_tsc_ies(body, 201)
 }
 
 /// Deactivate the downlink FAR (back to BUFF) — used when the AN-side
@@ -5339,6 +5591,29 @@ async fn handle_sm_policy_notify(sm_context_ref: &str, request: &SbiRequest) -> 
             log::error!("Failed to apply PCF-updated QoS: {e}");
             return SbiResponse::with_status(504);
         }
+
+        // #321: the TSC leg of the same decision. Sent as its OWN Session
+        // Modification rather than folded into the QER update above, because the two
+        // have different failure meanings: a rejected QER update means the
+        // authorised bandwidth is not enforced, while a rejected TSC update means
+        // the bridge is not configured. Sharing one message would make a single
+        // Cause answer for both, which §7.5.5 cannot express.
+        if !dec.tsc.is_empty() {
+            match pfcp_send_tsc_containers(smf_n4_seid_for(sm_context_ref), seid, &dec.tsc).await {
+                Ok(0) => {}
+                Ok(n) => log::info!(
+                    "Applied PCF-authorised TSC configuration to ref={sm_context_ref}: \
+                     {n} TSC Management Information IE(s)"
+                ),
+                Err(e) => {
+                    // NOT a 504 for the whole notification: the QoS half above was
+                    // applied and reporting failure would have the PCF retry a
+                    // decision that partly landed. The TSC half is reported as the
+                    // error it is and the notification is still accepted.
+                    log::error!("Failed to apply PCF-authorised TSC configuration: {e}");
+                }
+            }
+        }
     }
 
     // Persist the updated AMBR in the binding
@@ -5559,6 +5834,242 @@ async fn handle_amf_status_change(sm_context_ref: &str) -> SbiResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ------------------------------------------------------------------
+    // 5GS TSC container carriage (#321)
+    // ------------------------------------------------------------------
+    //
+    // Every one of these drives the REAL wire path: the SMF's own
+    // `pfcp_send_tsc_containers` against a stand-in UPF that records the bodies it
+    // received. Asserting on the recorded body rather than on a log line is what
+    // makes "the gate held" distinguishable from "the gate is not implemented".
+
+    /// A PMIC/UMIC pair, as a PCF decision would deliver them.
+    #[cfg(test)]
+    fn tsc_fixture() -> policy::TscContainers {
+        policy::TscContainers {
+            bridge_man_cont: Some(vec![0xE1, 0xE2]),
+            port_man_cont_dstt: Some((vec![0xD1], 1)),
+            port_man_cont_nwtts: vec![(vec![0xF1, 0xF2, 0xF3], 7)],
+        }
+    }
+
+    /// Every TSC Management Information IE (199) in a recorded request body.
+    #[cfg(test)]
+    fn tsc_ies_in(body: &[u8]) -> Vec<nextgcore_pfcp::types::TscManagementInformation> {
+        decode_tsc_ies(body, 199)
+    }
+
+    /// Criterion 2 (SMF half): a Session Modification actually carries the
+    /// containers, under IE 199, with the octets the PCF authorised.
+    #[tokio::test]
+    async fn test_tsc_containers_are_carried_on_a_session_modification() {
+        let upf = pfcp_path::stand_in::associated_upf_with_features(
+            nextgcore_pfcp::types::UpFunctionFeatures {
+                ftup: true,
+                tscu: true,
+                ..Default::default()
+            },
+        )
+        .await;
+        pfcp_path::record_session_peer(0xABCD, upf.client.peer());
+
+        let sent = pfcp_send_tsc_containers(0xABCD, upf.upf_seid, &tsc_fixture())
+            .await
+            .expect("a TSC-capable UPF must accept the modification");
+
+        // Two IEs: one NW-TT port PMIC, one bridge-level UMIC. The DS-TT container
+        // is deliberately NOT among them -- see `TscContainers::to_n4_ies`.
+        assert_eq!(sent, 2, "one NW-TT PMIC IE plus one UMIC IE");
+
+        let bodies = upf.modification_bodies();
+        assert_eq!(bodies.len(), 1, "exactly one Session Modification was sent");
+        let ies = tsc_ies_in(&bodies[0]);
+        assert_eq!(
+            ies.len(),
+            2,
+            "both TSC IEs must be on the wire under IE 199"
+        );
+
+        let pmic = ies
+            .iter()
+            .find(|ie| ie.port_management_container.is_some())
+            .expect("a PMIC IE must be present");
+        assert_eq!(
+            pmic.port_management_container.as_deref(),
+            Some(&[0xF1, 0xF2, 0xF3][..]),
+            "the PMIC octets must reach the UPF byte-exact: they are an opaque \
+             TS 24.539 payload the SMF only relays"
+        );
+        assert_eq!(
+            pmic.nw_tt_port_number,
+            Some(7),
+            "the NW-TT port number the PCF named must travel with its container"
+        );
+
+        let umic = ies
+            .iter()
+            .find(|ie| ie.user_plane_node_management_container.is_some())
+            .expect("a UMIC IE must be present");
+        assert_eq!(
+            umic.user_plane_node_management_container.as_deref(),
+            Some(&[0xE1, 0xE2][..])
+        );
+        assert!(
+            umic.nw_tt_port_number.is_none(),
+            "a UMIC is bridge-level and must carry no port identity"
+        );
+
+        // `SESSION_PEERS` is process-global and outlives this test's N4 guard, so the
+        // mapping is removed rather than left pointing at a stand-in that is about to
+        // be dropped. A leaked entry makes `client_for_session` fall back to the
+        // default client for that SEID, which is the kind of cross-test coupling that
+        // only shows up as an order-dependent failure.
+        pfcp_path::forget_session_peer(0xABCD);
+    }
+
+    /// Criterion 3: a UPF that did not advertise TSCU is NOT sent TSC containers.
+    ///
+    /// The default stand-in advertises `ftup` only, so this is the ordinary case.
+    #[tokio::test]
+    async fn test_tsc_containers_withheld_from_a_upf_without_tscu() {
+        let upf = pfcp_path::stand_in::associated_upf().await;
+        assert!(
+            !upf.client
+                .association()
+                .await
+                .up_function_features
+                .unwrap()
+                .tscu,
+            "precondition: the default stand-in must NOT advertise TSCU"
+        );
+        pfcp_path::record_session_peer(0xABCE, upf.client.peer());
+
+        let sent = pfcp_send_tsc_containers(0xABCE, upf.upf_seid, &tsc_fixture())
+            .await
+            .expect("withholding is a successful no-op, not an error");
+
+        assert_eq!(sent, 0, "nothing may be sent to a UPF without TSCU");
+        assert!(
+            upf.modification_bodies().is_empty(),
+            "NO Session Modification at all may be sent: the message exists only to \
+             carry the TSC IEs, so sending an empty one would be traffic that asks \
+             the UPF for nothing"
+        );
+
+        pfcp_path::forget_session_peer(0xABCE);
+    }
+
+    /// An authorisation carrying nothing sends nothing, even to a capable UPF.
+    #[tokio::test]
+    async fn test_empty_tsc_authorisation_sends_no_modification() {
+        let upf = pfcp_path::stand_in::associated_upf_with_features(
+            nextgcore_pfcp::types::UpFunctionFeatures {
+                ftup: true,
+                tscu: true,
+                ..Default::default()
+            },
+        )
+        .await;
+        pfcp_path::record_session_peer(0xABCF, upf.client.peer());
+
+        let sent =
+            pfcp_send_tsc_containers(0xABCF, upf.upf_seid, &policy::TscContainers::default())
+                .await
+                .expect("no containers is a no-op");
+        assert_eq!(sent, 0);
+        assert!(upf.modification_bodies().is_empty());
+
+        pfcp_path::forget_session_peer(0xABCF);
+    }
+
+    /// Criterion 4: a Session Report carrying IE 201 reaches the SMF, is decoded,
+    /// and is observable from the SMF's own state rather than from a log line.
+    #[tokio::test]
+    async fn test_session_report_tsc_management_information_is_decoded() {
+        let _guard = pfcp_path::N4_TEST_LOCK.lock().await;
+        pfcp_path::clear_tsc_reports_for_test();
+
+        let sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+        let seid = 0x0000_0000_0BAD_F00Du64;
+
+        // Body: Report Type with TMIR (bit 5 => 0x10) plus one IE 201 carrying a
+        // PMIC and its NW-TT port. Hand-built, so the test does not depend on the
+        // SMF's own encoder agreeing with itself.
+        let mut tsc_buf = bytes::BytesMut::new();
+        nextgcore_pfcp::types::TscManagementInformation::port(vec![0xAA, 0xBB], 9)
+            .encode(&mut tsc_buf);
+        let mut body = Vec::new();
+        body.extend_from_slice(&[0x00, 39, 0x00, 0x01, 0x10]); // Report Type = TMIR
+        body.extend_from_slice(&[0x00, 201]);
+        body.extend_from_slice(&(tsc_buf.len() as u16).to_be_bytes());
+        body.extend_from_slice(&tsc_buf);
+
+        let pkt = pfcp_path::encode_wire_message(
+            pfcp_path::pfcp_message_type::SESSION_REPORT_REQUEST,
+            Some(seid),
+            42,
+            &body,
+        );
+
+        handle_pfcp_session_report(&sock, &pkt, peer_addr).await;
+
+        let reports = pfcp_path::tsc_reports_for(seid)
+            .expect("the decoded TSC report must be recorded against the SEID");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(
+            reports[0].port_management_container.as_deref(),
+            Some(&[0xAA, 0xBB][..])
+        );
+        assert_eq!(reports[0].nw_tt_port_number, Some(9));
+
+        // And the SMF still answers the report, rather than treating an IE it now
+        // understands as a reason to stop.
+        let mut rbuf = vec![0u8; 512];
+        let (len, _) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), peer.recv_from(&mut rbuf))
+                .await
+                .expect("a Session Report Response must be sent")
+                .unwrap();
+        let h = pfcp_path::parse_wire_header(&rbuf[..len]).unwrap();
+        assert_eq!(
+            h.msg_type,
+            pfcp_path::pfcp_message_type::SESSION_REPORT_RESPONSE
+        );
+
+        pfcp_path::clear_tsc_reports_for_test();
+    }
+
+    /// A TMIR bit with no IE 201 records nothing, and does not invent an empty
+    /// report. The peer contradicted itself; storing `Some(vec![])` would make
+    /// "reported nothing" indistinguishable from "reported an empty container set".
+    #[tokio::test]
+    async fn test_session_report_tmir_without_ie_records_nothing() {
+        let _guard = pfcp_path::N4_TEST_LOCK.lock().await;
+        pfcp_path::clear_tsc_reports_for_test();
+
+        let sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+        let seid = 0x0000_0000_0BAD_BEEFu64;
+
+        let body = vec![0x00, 39, 0x00, 0x01, 0x10]; // TMIR set, no IE 201
+        let pkt = pfcp_path::encode_wire_message(
+            pfcp_path::pfcp_message_type::SESSION_REPORT_REQUEST,
+            Some(seid),
+            43,
+            &body,
+        );
+        handle_pfcp_session_report(&sock, &pkt, peer_addr).await;
+
+        assert!(
+            pfcp_path::tsc_reports_for(seid).is_none(),
+            "TMIR with no TSC IE must record nothing"
+        );
+        pfcp_path::clear_tsc_reports_for_test();
+    }
 
     #[test]
     fn test_smf_config_default() {

--- a/src/bins/nextgcore-smfd/src/n4_build.rs
+++ b/src/bins/nextgcore-smfd/src/n4_build.rs
@@ -288,71 +288,90 @@ pub mod pfcp_ie {
     pub const IP_MULTICAST_ADDRESSING_INFO: u16 = 188;
     pub const JOIN_IP_MULTICAST_INFORMATION: u16 = 189;
     pub const LEAVE_IP_MULTICAST_INFORMATION: u16 = 190;
-    pub const CREATED_BRIDGE_INFO_FOR_TSC: u16 = 191;
-    pub const TSC_MANAGEMENT_INFORMATION: u16 = 192;
-    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST: u16 = 193;
-    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_RESPONSE: u16 = 194;
-    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_REPORT_REQUEST: u16 = 195;
-    pub const CLOCK_DRIFT_CONTROL_INFORMATION: u16 = 196;
-    pub const CLOCK_DRIFT_REPORT: u16 = 197;
-    pub const REQUESTED_CLOCK_DRIFT_INFORMATION: u16 = 198;
-    pub const TIME_DOMAIN_NUMBER: u16 = 199;
-    pub const TIME_OFFSET_THRESHOLD: u16 = 200;
-    pub const CUMULATIVE_RATE_RATIO_THRESHOLD: u16 = 201;
-    pub const TIME_OFFSET_MEASUREMENT: u16 = 202;
-    pub const CUMULATIVE_RATE_RATIO_MEASUREMENT: u16 = 203;
-    pub const REMOVE_SRR: u16 = 204;
-    pub const CREATE_SRR: u16 = 205;
-    pub const UPDATE_SRR: u16 = 206;
-    pub const SESSION_REPORT: u16 = 207;
-    pub const SRR_ID: u16 = 208;
-    pub const ACCESS_AVAILABILITY_CONTROL_INFORMATION: u16 = 209;
-    pub const REQUESTED_ACCESS_AVAILABILITY_INFORMATION: u16 = 210;
-    pub const ACCESS_AVAILABILITY_REPORT: u16 = 211;
-    pub const ACCESS_AVAILABILITY_INFORMATION: u16 = 212;
-    pub const PROVIDE_ATSSS_CONTROL_INFORMATION: u16 = 213;
-    pub const ATSSS_CONTROL_PARAMETERS: u16 = 214;
-    pub const MPTCP_CONTROL_INFORMATION: u16 = 215;
-    pub const ATSSS_LL_CONTROL_INFORMATION: u16 = 216;
-    pub const PMF_CONTROL_INFORMATION: u16 = 217;
-    pub const MPTCP_PARAMETERS: u16 = 218;
-    pub const ATSSS_LL_PARAMETERS: u16 = 219;
-    pub const PMF_PARAMETERS: u16 = 220;
-    pub const MPTCP_ADDRESS_INFORMATION: u16 = 221;
-    pub const UE_LINK_SPECIFIC_IP_ADDRESS: u16 = 222;
-    pub const PMF_ADDRESS_INFORMATION: u16 = 223;
-    pub const ATSSS_LL_INFORMATION: u16 = 224;
-    pub const DATA_NETWORK_ACCESS_IDENTIFIER: u16 = 225;
-    pub const UE_IP_ADDRESS_POOL_INFORMATION: u16 = 226;
-    pub const AVERAGE_PACKET_DELAY: u16 = 227;
-    pub const MINIMUM_PACKET_DELAY: u16 = 228;
-    pub const MAXIMUM_PACKET_DELAY: u16 = 229;
-    pub const QOS_REPORT_TRIGGER: u16 = 230;
-    pub const GTP_U_PATH_QOS_CONTROL_INFORMATION: u16 = 231;
-    pub const GTP_U_PATH_QOS_REPORT: u16 = 232;
-    pub const QOS_INFORMATION_IN_GTP_U_PATH_QOS_REPORT: u16 = 233;
-    pub const GTP_U_PATH_INTERFACE_TYPE: u16 = 234;
-    pub const QOS_MONITORING_PER_QOS_FLOW_CONTROL_INFORMATION: u16 = 235;
-    pub const REQUESTED_QOS_MONITORING: u16 = 236;
-    pub const REPORTING_FREQUENCY: u16 = 237;
-    pub const PACKET_DELAY_THRESHOLDS: u16 = 238;
-    pub const MINIMUM_WAIT_TIME: u16 = 239;
-    pub const QOS_MONITORING_REPORT: u16 = 240;
-    pub const QOS_MONITORING_MEASUREMENT: u16 = 241;
-    pub const MT_EDT_CONTROL_INFORMATION: u16 = 242;
-    pub const DL_DATA_PACKETS_SIZE: u16 = 243;
-    pub const QER_CONTROL_INDICATIONS: u16 = 244;
-    pub const PACKET_RATE_STATUS_REPORT: u16 = 245;
-    pub const NF_INSTANCE_ID: u16 = 246;
-    pub const ETHERNET_CONTEXT_INFORMATION: u16 = 247;
-    pub const REDUNDANT_TRANSMISSION_PARAMETERS: u16 = 248;
-    pub const UPDATED_PDR: u16 = 249;
-    pub const S_NSSAI: u16 = 250;
-    pub const IP_VERSION: u16 = 251;
-    pub const PFCPASREQ_FLAGS: u16 = 252;
-    pub const DATA_STATUS: u16 = 253;
-    pub const PROVIDE_RDS_CONFIGURATION_INFORMATION: u16 = 254;
-    pub const RDS_CONFIGURATION_INFORMATION: u16 = 255;
+    // NOTE (#321): every constant from here down was WRONG before #321. The table
+    // omitted IP Multicast Address (191), so 191 onward was shifted by one, and
+    // further omissions grew the shift to seven by 202 — e.g. TSC Management
+    // Information within a Session Modification Request was declared as 193
+    // (really Packet Rate Status) instead of 199. `S_NSSAI` was the only one of the
+    // 65 with a caller, and it was live: `add_s_nssai` sent every 5GC session's
+    // slice identity as IE 250, "DL Data Packets Size". Nothing in this tree reads
+    // S-NSSAI over N4, which is why it went unnoticed. Pinned against
+    // `nextgcore_pfcp::ie::IeType` by a test at the bottom of this file so it
+    // cannot drift again.
+    pub const IP_MULTICAST_ADDRESS: u16 = 191;
+    pub const SOURCE_IP_ADDRESS: u16 = 192;
+    pub const PACKET_RATE_STATUS: u16 = 193;
+    pub const CREATE_BRIDGE_INFO_FOR_TSC: u16 = 194;
+    pub const CREATED_BRIDGE_INFO_FOR_TSC: u16 = 195;
+    pub const DS_TT_PORT_NUMBER: u16 = 196;
+    pub const NW_TT_PORT_NUMBER: u16 = 197;
+    pub const FIVEGS_USER_PLANE_NODE: u16 = 198;
+    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST: u16 = 199;
+    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_RESPONSE: u16 = 200;
+    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_REPORT_REQUEST: u16 = 201;
+    pub const PORT_MANAGEMENT_INFORMATION_CONTAINER: u16 = 202;
+    pub const CLOCK_DRIFT_CONTROL_INFORMATION: u16 = 203;
+    pub const REQUESTED_CLOCK_DRIFT_INFORMATION: u16 = 204;
+    pub const CLOCK_DRIFT_REPORT: u16 = 205;
+    pub const TIME_DOMAIN_NUMBER: u16 = 206;
+    pub const TIME_OFFSET_THRESHOLD: u16 = 207;
+    pub const CUMULATIVE_RATE_RATIO_THRESHOLD: u16 = 208;
+    pub const TIME_OFFSET_MEASUREMENT: u16 = 209;
+    pub const CUMULATIVE_RATE_RATIO_MEASUREMENT: u16 = 210;
+    pub const REMOVE_SRR: u16 = 211;
+    pub const CREATE_SRR: u16 = 212;
+    pub const UPDATE_SRR: u16 = 213;
+    pub const SESSION_REPORT: u16 = 214;
+    pub const SRR_ID: u16 = 215;
+    pub const ACCESS_AVAILABILITY_CONTROL_INFORMATION: u16 = 216;
+    pub const REQUESTED_ACCESS_AVAILABILITY_INFORMATION: u16 = 217;
+    pub const ACCESS_AVAILABILITY_REPORT: u16 = 218;
+    pub const ACCESS_AVAILABILITY_INFORMATION: u16 = 219;
+    pub const PROVIDE_ATSSS_CONTROL_INFORMATION: u16 = 220;
+    pub const ATSSS_CONTROL_PARAMETERS: u16 = 221;
+    pub const MPTCP_CONTROL_INFORMATION: u16 = 222;
+    pub const ATSSS_LL_CONTROL_INFORMATION: u16 = 223;
+    pub const PMF_CONTROL_INFORMATION: u16 = 224;
+    pub const MPTCP_PARAMETERS: u16 = 225;
+    pub const ATSSS_LL_PARAMETERS: u16 = 226;
+    pub const PMF_PARAMETERS: u16 = 227;
+    pub const MPTCP_ADDRESS_INFORMATION: u16 = 228;
+    pub const UE_LINK_SPECIFIC_IP_ADDRESS: u16 = 229;
+    pub const PMF_ADDRESS_INFORMATION: u16 = 230;
+    pub const ATSSS_LL_INFORMATION: u16 = 231;
+    pub const DATA_NETWORK_ACCESS_IDENTIFIER: u16 = 232;
+    pub const UE_IP_ADDRESS_POOL_INFORMATION: u16 = 233;
+    pub const AVERAGE_PACKET_DELAY: u16 = 234;
+    pub const MINIMUM_PACKET_DELAY: u16 = 235;
+    pub const MAXIMUM_PACKET_DELAY: u16 = 236;
+    pub const QOS_REPORT_TRIGGER: u16 = 237;
+    pub const GTP_U_PATH_QOS_CONTROL_INFORMATION: u16 = 238;
+    pub const GTP_U_PATH_QOS_REPORT: u16 = 239;
+    pub const QOS_INFORMATION_IN_GTP_U_PATH_QOS_REPORT: u16 = 240;
+    pub const GTP_U_PATH_INTERFACE_TYPE: u16 = 241;
+    pub const QOS_MONITORING_PER_QOS_FLOW_CONTROL_INFORMATION: u16 = 242;
+    pub const REQUESTED_QOS_MONITORING: u16 = 243;
+    pub const REPORTING_FREQUENCY: u16 = 244;
+    pub const PACKET_DELAY_THRESHOLDS: u16 = 245;
+    pub const MINIMUM_WAIT_TIME: u16 = 246;
+    pub const QOS_MONITORING_REPORT: u16 = 247;
+    pub const QOS_MONITORING_MEASUREMENT: u16 = 248;
+    pub const MT_EDT_CONTROL_INFORMATION: u16 = 249;
+    pub const DL_DATA_PACKETS_SIZE: u16 = 250;
+    pub const QER_CONTROL_INDICATIONS: u16 = 251;
+    pub const PACKET_RATE_STATUS_REPORT: u16 = 252;
+    pub const NF_INSTANCE_ID: u16 = 253;
+    pub const ETHERNET_CONTEXT_INFORMATION: u16 = 254;
+    pub const REDUNDANT_TRANSMISSION_PARAMETERS: u16 = 255;
+    pub const UPDATED_PDR: u16 = 256;
+    pub const S_NSSAI: u16 = 257;
+    pub const IP_VERSION: u16 = 258;
+    pub const PFCPASREQ_FLAGS: u16 = 259;
+    pub const DATA_STATUS: u16 = 260;
+    pub const PROVIDE_RDS_CONFIGURATION_INFORMATION: u16 = 261;
+    pub const RDS_CONFIGURATION_INFORMATION: u16 = 262;
+    /// TS 29.244 §8.2.182, the UMIC (#321).
+    pub const USER_PLANE_NODE_MANAGEMENT_INFORMATION_CONTAINER: u16 = 266;
 }
 
 // ============================================================================
@@ -1093,6 +1112,13 @@ pub struct SessionModificationParams {
     pub update_urrs: Vec<(UrrParams, u64)>,
     /// URRs to remove
     pub remove_urr_ids: Vec<u32>,
+    /// TSC Management Information IEs (IE 199, TS 29.244 §7.5.4.18), #321.
+    ///
+    /// The codec lives in `nextgcore-pfcp`; this builder emits its bytes under the
+    /// carrier IE type, so there is ONE encoder for the containers even though this
+    /// crate builds its messages with a raw TLV builder rather than the library's
+    /// typed messages.
+    pub tsc_management_info: Vec<nextgcore_pfcp::types::TscManagementInformation>,
 }
 
 /// Build PFCP Session Modification Request
@@ -1186,6 +1212,18 @@ pub fn build_session_modification_request(params: &SessionModificationParams) ->
     for urr_id in &params.remove_urr_ids {
         let urr_bytes = build_remove_urr(*urr_id);
         builder.add_tlv(pfcp_ie::REMOVE_URR, &urr_bytes);
+    }
+
+    // TSC Management Information (IE 199, TS 29.244 §7.5.4.18), #321. The grouped
+    // payload is produced by `nextgcore-pfcp`'s codec rather than assembled here, so
+    // the PMIC/UMIC/NW-TT encoding has exactly one implementation in the tree.
+    for tsc in params.tsc_management_info.iter().filter(|t| !t.is_empty()) {
+        let mut tsc_buf = bytes::BytesMut::new();
+        tsc.encode(&mut tsc_buf);
+        builder.add_tlv(
+            pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST,
+            &tsc_buf,
+        );
     }
 
     builder.build()
@@ -1716,6 +1754,167 @@ pub fn build_create_bar(params: &BarParams) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pin this crate's `pfcp_ie` numbers against `nextgcore_pfcp::ie::IeType`,
+    /// which is the tree's authoritative TS 29.244 Table 8.1.2-1 transcription (#321).
+    ///
+    /// # Why this test exists
+    ///
+    /// Before #321 this table was WRONG from IE 191 down. It omitted IP Multicast
+    /// Address (191), which shifted everything after it, and further omissions grew
+    /// the shift to seven by IE 202 — so `S_NSSAI` was declared as 250 instead of
+    /// 257, and `add_s_nssai` sent every 5GC session's slice identity under
+    /// "DL Data Packets Size". It went unnoticed for two reasons worth naming: no
+    /// peer in this tree reads S-NSSAI over N4, and the other 64 shifted constants
+    /// had no callers at all, so nothing failed. A second, hand-maintained copy of a
+    /// 250-row wire table cannot be kept correct by review; it has to be pinned.
+    ///
+    /// Only the numbers are compared, not the names: this module spells them
+    /// `SCREAMING_SNAKE` and uses some alternative-but-equivalent names (e.g.
+    /// `UPDATE_BAR_RESPONSE` for the library's `UpdateBar`), and those are
+    /// deliberate rather than drift.
+    #[test]
+    fn test_pfcp_ie_numbers_match_the_authoritative_table() {
+        use nextgcore_pfcp::ie::IeType;
+
+        // (this crate's constant, the library's constant) for every IE this module
+        // declares that the library also declares. A mismatch here means one of the
+        // two disagrees with TS 29.244, and the library is the one with the
+        // round-trip tests.
+        let pairs: [(&str, u16, u16); 24] = [
+            (
+                "IpMulticastAddress",
+                pfcp_ie::IP_MULTICAST_ADDRESS,
+                IeType::IpMulticastAddress as u16,
+            ),
+            (
+                "SourceIpAddress",
+                pfcp_ie::SOURCE_IP_ADDRESS,
+                IeType::SourceIpAddress as u16,
+            ),
+            (
+                "PacketRateStatus",
+                pfcp_ie::PACKET_RATE_STATUS,
+                IeType::PacketRateStatus as u16,
+            ),
+            (
+                "CreateBridgeInfoForTsc",
+                pfcp_ie::CREATE_BRIDGE_INFO_FOR_TSC,
+                IeType::CreateBridgeInfoForTsc as u16,
+            ),
+            (
+                "CreatedBridgeInfoForTsc",
+                pfcp_ie::CREATED_BRIDGE_INFO_FOR_TSC,
+                IeType::CreatedBridgeInfoForTsc as u16,
+            ),
+            (
+                "DsTtPortNumber",
+                pfcp_ie::DS_TT_PORT_NUMBER,
+                IeType::DsTtPortNumber as u16,
+            ),
+            (
+                "NwTtPortNumber",
+                pfcp_ie::NW_TT_PORT_NUMBER,
+                IeType::NwTtPortNumber as u16,
+            ),
+            (
+                "FivegsUserPlaneNode",
+                pfcp_ie::FIVEGS_USER_PLANE_NODE,
+                IeType::FivegsUserPlaneNode as u16,
+            ),
+            (
+                "TscManagementInformationSmr",
+                pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST,
+                IeType::TscManagementInformationSmr as u16,
+            ),
+            (
+                "TscManagementInformationSmrsp",
+                pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_RESPONSE,
+                IeType::TscManagementInformationSmrsp as u16,
+            ),
+            (
+                "TscManagementInformationSrr",
+                pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_REPORT_REQUEST,
+                IeType::TscManagementInformationSrr as u16,
+            ),
+            (
+                "PortManagementInformationContainer",
+                pfcp_ie::PORT_MANAGEMENT_INFORMATION_CONTAINER,
+                IeType::PortManagementInformationContainer as u16,
+            ),
+            (
+                "ClockDriftControlInformation",
+                pfcp_ie::CLOCK_DRIFT_CONTROL_INFORMATION,
+                IeType::ClockDriftControlInformation as u16,
+            ),
+            (
+                "RequestedClockDriftInformation",
+                pfcp_ie::REQUESTED_CLOCK_DRIFT_INFORMATION,
+                IeType::RequestedClockDriftInformation as u16,
+            ),
+            (
+                "ClockDriftReport",
+                pfcp_ie::CLOCK_DRIFT_REPORT,
+                IeType::ClockDriftReport as u16,
+            ),
+            (
+                "TimeDomainNumber",
+                pfcp_ie::TIME_DOMAIN_NUMBER,
+                IeType::TimeDomainNumber as u16,
+            ),
+            ("RemoveSrr", pfcp_ie::REMOVE_SRR, IeType::RemoveSrr as u16),
+            ("CreateSrr", pfcp_ie::CREATE_SRR, IeType::CreateSrr as u16),
+            (
+                "SessionReport",
+                pfcp_ie::SESSION_REPORT,
+                IeType::SessionReport as u16,
+            ),
+            ("SrrId", pfcp_ie::SRR_ID, IeType::SrrId as u16),
+            (
+                "AtsssControlParameters",
+                pfcp_ie::ATSSS_CONTROL_PARAMETERS,
+                IeType::AtsssControlParameters as u16,
+            ),
+            (
+                "QosMonitoringReport",
+                pfcp_ie::QOS_MONITORING_REPORT,
+                IeType::QosMonitoringReport as u16,
+            ),
+            (
+                "NfInstanceId",
+                pfcp_ie::NF_INSTANCE_ID,
+                IeType::NfInstanceId as u16,
+            ),
+            (
+                "RedundantTransmissionParameters",
+                pfcp_ie::REDUNDANT_TRANSMISSION_PARAMETERS,
+                IeType::RedundantTransmissionParameters as u16,
+            ),
+        ];
+        for (name, ours, theirs) in pairs {
+            assert_eq!(
+                ours, theirs,
+                "{name}: smfd's pfcp_ie says {ours}, nextgcore-pfcp's IeType says \
+                 {theirs} — one of them disagrees with TS 29.244 Table 8.1.2-1"
+            );
+        }
+
+        // S-NSSAI is past the library table's range (it stops at 255 and resumes at
+        // 290), so it is pinned against the spec directly. TS 29.244 §8.2.176
+        // Figure 8.2.176-1: "Type = 257 (decimal)". This is the one that was live and
+        // wrong, so it gets its own assertion with the clause cited.
+        assert_eq!(
+            pfcp_ie::S_NSSAI,
+            257,
+            "S-NSSAI is IE 257 (TS 29.244 §8.2.176); 250 is DL Data Packets Size"
+        );
+        // The UMIC, likewise past the library's contiguous range (§8.2.182).
+        assert_eq!(
+            pfcp_ie::USER_PLANE_NODE_MANAGEMENT_INFORMATION_CONTAINER,
+            266,
+            "User Plane Node Management Information Container is IE 266 (§8.2.182)"
+        );
+    }
 
     #[test]
     fn test_pfcp_cause_from_u8() {

--- a/src/bins/nextgcore-smfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-smfd/src/pfcp_path.rs
@@ -376,6 +376,105 @@ pub fn forget_session_peer(smf_n4_seid: u64) {
     if let Ok(mut map) = session_peers().write() {
         map.remove(&smf_n4_seid);
     }
+    forget_session_bridge_info(smf_n4_seid);
+}
+
+/// The 5GS bridge info a TSC-capable UPF reported per session (#321), keyed by the
+/// SMF-side N4 SEID for the same collision reason as [`SESSION_PEERS`].
+static SESSION_BRIDGE_INFO: OnceLock<
+    std::sync::RwLock<HashMap<u64, nextgcore_pfcp::types::CreatedBridgeInfoForTsc>>,
+> = OnceLock::new();
+
+fn session_bridge_info(
+) -> &'static std::sync::RwLock<HashMap<u64, nextgcore_pfcp::types::CreatedBridgeInfoForTsc>> {
+    SESSION_BRIDGE_INFO.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+/// Record the DS-TT port number and 5GS User Plane Node ID a UPF allocated for a
+/// session (TS 29.244 §7.5.3.6).
+pub fn record_session_bridge_info(
+    smf_n4_seid: u64,
+    info: nextgcore_pfcp::types::CreatedBridgeInfoForTsc,
+) {
+    if let Ok(mut map) = session_bridge_info().write() {
+        map.insert(smf_n4_seid, info);
+    }
+}
+
+/// The recorded bridge info for a session, if the UPF supplied any.
+pub fn session_bridge_info_for(
+    smf_n4_seid: u64,
+) -> Option<nextgcore_pfcp::types::CreatedBridgeInfoForTsc> {
+    session_bridge_info()
+        .read()
+        .ok()
+        .and_then(|map| map.get(&smf_n4_seid).copied())
+}
+
+/// Drop a session's bridge info. Called from [`forget_session_peer`] rather than
+/// separately, so the two maps cannot diverge into a bridge record for a session
+/// whose UPF binding is gone.
+fn forget_session_bridge_info(smf_n4_seid: u64) {
+    if let Ok(mut map) = session_bridge_info().write() {
+        map.remove(&smf_n4_seid);
+    }
+}
+
+/// The most recent TSC Management Information a UPF reported per UPF SEID (#321).
+///
+/// Keyed by the UPF SEID, unlike the two maps above: a Session Report Request
+/// arrives addressed to the SMF with the UPF's own SEID in the header, and that is
+/// the only key available at the point the report is decoded.
+///
+/// Holds the LATEST report rather than a history: a TSC report is a statement of
+/// current port configuration, so an older one is superseded rather than additional.
+static TSC_REPORTS: OnceLock<
+    std::sync::RwLock<HashMap<u64, Vec<nextgcore_pfcp::types::TscManagementInformation>>>,
+> = OnceLock::new();
+
+fn tsc_reports(
+) -> &'static std::sync::RwLock<HashMap<u64, Vec<nextgcore_pfcp::types::TscManagementInformation>>>
+{
+    TSC_REPORTS.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+/// Record the TSC Management Information a Session Report carried.
+///
+/// An EMPTY report list is not stored: it would be indistinguishable from a decoded
+/// report that happened to carry nothing, and the caller already logs the
+/// TMIR-without-IE case as the peer contradiction it is.
+pub fn record_tsc_report(
+    upf_seid: u64,
+    reports: Vec<nextgcore_pfcp::types::TscManagementInformation>,
+) {
+    if reports.is_empty() {
+        return;
+    }
+    if let Ok(mut map) = tsc_reports().write() {
+        map.insert(upf_seid, reports);
+    }
+}
+
+/// The TSC Management Information last reported for a UPF SEID.
+pub fn tsc_reports_for(
+    upf_seid: u64,
+) -> Option<Vec<nextgcore_pfcp::types::TscManagementInformation>> {
+    tsc_reports()
+        .read()
+        .ok()
+        .and_then(|map| map.get(&upf_seid).cloned())
+}
+
+/// Clear the recorded TSC reports.
+///
+/// Test-only, and declared BESIDE the map rather than in a `mod tests`: the map is
+/// process-global, so a test that mutates it races every sibling that reads it, and
+/// a lock declared elsewhere is a second agreement rather than one.
+#[cfg(test)]
+pub fn clear_tsc_reports_for_test() {
+    if let Ok(mut map) = tsc_reports().write() {
+        map.clear();
+    }
 }
 
 /// Resolve the PFCP client serving an EXISTING session by the SMF-side N4
@@ -989,6 +1088,14 @@ pub(crate) mod stand_in {
         /// lets one drive the SMF's cause-65 reconciliation over a real round trip
         /// rather than by calling the reconciler directly.
         session_cause: Arc<std::sync::atomic::AtomicU8>,
+        /// Bodies of the Session Modification Requests this stand-in received, in
+        /// order (#321).
+        ///
+        /// `seen` records message TYPES, which cannot answer "did the SMF send the
+        /// TSC IE, and with which containers" — the question the `tscu` gate turns
+        /// on. A gate test asserting only that a modification was or was not sent
+        /// would pass for a modification that carried the wrong IE.
+        pub(crate) modification_bodies: Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
         /// Serialises every N4 test against every other; released with this value.
         _n4_guard: tokio::sync::MutexGuard<'static, ()>,
     }
@@ -1010,6 +1117,19 @@ pub(crate) mod stand_in {
         /// Forget the recorded traffic, so a test asserts only about its own.
         pub(crate) fn clear_seen(&self) {
             self.seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+            self.modification_bodies
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
+        }
+
+        /// Bodies of the Session Modification Requests received since the last
+        /// [`Self::clear_seen`] (#321).
+        pub(crate) fn modification_bodies(&self) -> Vec<Vec<u8>> {
+            self.modification_bodies
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
         }
 
         /// Answer the next Session Modification / Deletion with `cause` (#193).
@@ -1090,14 +1210,32 @@ pub(crate) mod stand_in {
     ///
     /// Not associated yet — [`associated_upf`] adds the handshake.
     pub(crate) async fn install_stand_in_upf() -> StandInUpf {
+        install_stand_in_upf_with_features(UpFunctionFeatures {
+            ftup: true,
+            ..Default::default()
+        })
+        .await
+    }
+
+    /// Install a stand-in UPF advertising exactly `features` (#321).
+    ///
+    /// The features have to be chosen at INSTALL time, not later: they are baked
+    /// into the Association Setup Response, and the SMF reads them from the stored
+    /// `AssociationState` afterwards. A setter would only take effect on a
+    /// re-association, which is a different test.
+    pub(crate) async fn install_stand_in_upf_with_features(
+        features: UpFunctionFeatures,
+    ) -> StandInUpf {
         let n4_guard = N4_TEST_LOCK.lock().await;
         let (client, upf_sock) = client_with_silent_peer().await;
         let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let modification_bodies = Arc::new(std::sync::Mutex::new(Vec::new()));
         let upf_seid = 0x0000_0000_dead_beef_u64;
         let upf_teid = 0x0000_1289_u32;
         let upf_ip = [127, 0, 0, 4];
 
         let recorded = seen.clone();
+        let recorded_bodies = modification_bodies.clone();
         let session_cause = Arc::new(std::sync::atomic::AtomicU8::new(
             pfcp_cause::REQUEST_ACCEPTED,
         ));
@@ -1116,6 +1254,12 @@ pub(crate) mod stand_in {
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .push(h.msg_type);
+                if h.msg_type == pfcp_message_type::SESSION_MODIFICATION_REQUEST {
+                    recorded_bodies
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push(buf[h.body_offset..len].to_vec());
+                }
 
                 let reply = match h.msg_type {
                     pfcp_message_type::ASSOCIATION_SETUP_REQUEST => {
@@ -1124,10 +1268,7 @@ pub(crate) mod stand_in {
                             nextgcore_pfcp::types::PfcpCause::RequestAccepted,
                             rts,
                         );
-                        resp.up_function_features = Some(UpFunctionFeatures {
-                            ftup: true,
-                            ..Default::default()
-                        });
+                        resp.up_function_features = Some(features);
                         Some(Vec::from(build_message(
                             &PfcpMessage::AssociationSetupResponse(resp),
                             h.sequence_number,
@@ -1194,6 +1335,7 @@ pub(crate) mod stand_in {
             upf_teid,
             upf_ip,
             session_cause,
+            modification_bodies,
             _n4_guard: n4_guard,
         }
     }
@@ -1202,6 +1344,22 @@ pub(crate) mod stand_in {
     /// success path.
     pub(crate) async fn associated_upf() -> StandInUpf {
         let upf = install_stand_in_upf().await;
+        upf.client
+            .associate()
+            .await
+            .expect("the stand-in UPF must accept the association");
+        upf.clear_seen();
+        upf
+    }
+
+    /// An associated stand-in UPF advertising exactly `features` (#321).
+    ///
+    /// Note what the DEFAULT stand-in advertises: `ftup` only, so `tscu` is CLEAR.
+    /// That makes "a UPF that did not advertise TSC support" the default case rather
+    /// than something a test has to arrange, and the TSC-capable case the one that
+    /// states itself explicitly.
+    pub(crate) async fn associated_upf_with_features(features: UpFunctionFeatures) -> StandInUpf {
+        let upf = install_stand_in_upf_with_features(features).await;
         upf.client
             .associate()
             .await

--- a/src/bins/nextgcore-smfd/src/policy.rs
+++ b/src/bins/nextgcore-smfd/src/policy.rs
@@ -89,6 +89,106 @@ pub struct PolicyDecision {
     /// True when this decision is the documented config-default fallback
     /// (no PCF configured), not an authorized PCF decision.
     pub is_config_default: bool,
+    /// TSC management containers the PCF authorised for this session (#321,
+    /// TS 29.512 `SmPolicyDecision.tsnBridgeManCont` / `tsnPortManContDstt` /
+    /// `tsnPortManContNwtts`), decoded from base64 ready for N4.
+    pub tsc: TscContainers,
+}
+
+/// The TSC management containers a PCF decision carries, decoded (#321).
+///
+/// Base64 on the SBI (TS 29.571 `Bytes`), raw octets on N4 (TS 29.244 §8.2.144 and
+/// §8.2.182), so the decode happens exactly once, here, at the boundary between
+/// the two — rather than in the N4 builder where a decode failure would be
+/// discovered with a half-built message in hand.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TscContainers {
+    /// The UMIC — bridge-level, no port identity.
+    pub bridge_man_cont: Option<Vec<u8>>,
+    /// The DS-TT port's PMIC, with its port number.
+    pub port_man_cont_dstt: Option<(Vec<u8>, u32)>,
+    /// One PMIC per NW-TT port, with its port number.
+    pub port_man_cont_nwtts: Vec<(Vec<u8>, u32)>,
+}
+
+impl TscContainers {
+    /// Whether the decision authorised any TSC configuration at all.
+    pub fn is_empty(&self) -> bool {
+        self.bridge_man_cont.is_none()
+            && self.port_man_cont_dstt.is_none()
+            && self.port_man_cont_nwtts.is_empty()
+    }
+
+    /// The TSC Management Information IEs these containers become on N4.
+    ///
+    /// One IE per NW-TT port carrying its PMIC and port number, plus one carrying
+    /// the UMIC alone — which is the split TS 29.244 §7.5.4.18's own note
+    /// prescribes ("several instances ... containing a Port Management Information
+    /// Container together with a NW-TT Port Number, and only one instance ...
+    /// containing a User Plane Node Management Information Container").
+    ///
+    /// The DS-TT container is deliberately NOT sent: §7.5.4.18 gives the TSC
+    /// Management Information IE an NW-TT Port Number and no DS-TT one, because the
+    /// device-side port's configuration travels to the DS-TT over NAS
+    /// (TS 24.501 §5.4.5), not over N4. Sending it here with an NW-TT port number
+    /// would tell the UPF to apply device-side configuration to a network-side port.
+    pub fn to_n4_ies(&self) -> Vec<nextgcore_pfcp::types::TscManagementInformation> {
+        use nextgcore_pfcp::types::TscManagementInformation;
+        let mut out = Vec::new();
+        for (cont, port) in &self.port_man_cont_nwtts {
+            out.push(TscManagementInformation::port(cont.clone(), *port));
+        }
+        if let Some(umic) = &self.bridge_man_cont {
+            out.push(TscManagementInformation::user_plane_node(umic.clone()));
+        }
+        out
+    }
+}
+
+/// Decode a TS 29.571 `Bytes` (base64) member, or `None` when absent or malformed.
+///
+/// A malformed container is dropped WITH A WARNING rather than passed through: the
+/// N4 IE is an octet string, so anything would encode, and a UPF would then apply
+/// (or reject) configuration the PCF never sent. Logging it is what makes the gap
+/// attributable to the PCF rather than to the UPF.
+fn decode_container(v: Option<&serde_json::Value>, what: &str) -> Option<Vec<u8>> {
+    use base64::Engine;
+    let s = v?.as_str()?;
+    match base64::engine::general_purpose::STANDARD.decode(s) {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            log::warn!("SmPolicyDecision {what} is not valid base64, ignoring: {e}");
+            None
+        }
+    }
+}
+
+/// Parse one TS 29.512 `PortManagementContainer`. Both members are required by the
+/// schema, so a value missing either is dropped rather than defaulted — a `portNum`
+/// defaulted to 0 would name the NW-TT port the TSCTSF's derivation reserves.
+fn parse_port_container(v: &serde_json::Value) -> Option<(Vec<u8>, u32)> {
+    let cont = decode_container(v.get("portManCont"), "portManCont")?;
+    let num = v.get("portNum")?.as_u64()?;
+    Some((cont, num as u32))
+}
+
+/// Parse the TSC containers out of an `SmPolicyDecision` (#321).
+pub fn parse_tsc_containers(json: &serde_json::Value) -> TscContainers {
+    TscContainers {
+        bridge_man_cont: decode_container(
+            json.get("tsnBridgeManCont")
+                .and_then(|v| v.get("bridgeManCont")),
+            "tsnBridgeManCont.bridgeManCont",
+        ),
+        port_man_cont_dstt: json
+            .get("tsnPortManContDstt")
+            .and_then(parse_port_container),
+        port_man_cont_nwtts: json
+            .get("tsnPortManContNwtts")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(parse_port_container).collect())
+            .unwrap_or_default(),
+    }
 }
 
 impl PolicyDecision {
@@ -132,6 +232,10 @@ impl PolicyDecision {
             pcc_rules: Vec::new(),
             triggers: Vec::new(),
             is_config_default: true,
+            // No PCF means no TSC authorisation. There is deliberately no local
+            // default here: TSC configuration comes from a TSN AF via the PCF, and
+            // inventing one would have the SMF configure a bridge nobody asked for.
+            tsc: TscContainers::default(),
         }
     }
 
@@ -686,6 +790,7 @@ pub fn parse_sm_policy_decision(sm_policy_id: &str, json: &serde_json::Value) ->
         ..PolicyDecision::config_default()
     };
     dec.is_config_default = false;
+    dec.tsc = parse_tsc_containers(json);
 
     // Session rules: authorized session AMBR + default QoS
     if let Some(rules) = json.get("sessRules").and_then(|v| v.as_object()) {
@@ -2059,5 +2164,115 @@ mod tests {
             port: 7777,
         };
         let _ = ep.client();
+    }
+    // ------------------------------------------------------------------
+    // TSC containers in an SmPolicyDecision (#321)
+    // ------------------------------------------------------------------
+
+    /// The SMF half of criterion 5: the containers the PCF authorised are parsed out
+    /// of the decision and base64-DECODED, so what reaches N4 is the octet string the
+    /// TSN AF built.
+    #[test]
+    fn test_tsc_containers_parsed_and_base64_decoded_from_a_decision() {
+        // "umic" / "dstt" / "nwtt" in base64.
+        let json = serde_json::json!({
+            "tsnBridgeManCont": { "bridgeManCont": "dW1pYw==" },
+            "tsnPortManContDstt": { "portManCont": "ZHN0dA==", "portNum": 1 },
+            "tsnPortManContNwtts": [
+                { "portManCont": "bnd0dA==", "portNum": 7 },
+                { "portManCont": "bnd0dA==", "portNum": 8 }
+            ],
+        });
+        let dec = parse_sm_policy_decision("pol-1", &json);
+
+        assert_eq!(
+            dec.tsc.bridge_man_cont.as_deref(),
+            Some(&b"umic"[..]),
+            "the UMIC must arrive as raw octets: N4 carries an octet string, not base64"
+        );
+        assert_eq!(
+            dec.tsc.port_man_cont_dstt,
+            Some((b"dstt".to_vec(), 1)),
+            "the DS-TT container keeps its port number even though it is not sent over N4"
+        );
+        assert_eq!(dec.tsc.port_man_cont_nwtts.len(), 2);
+        assert_eq!(dec.tsc.port_man_cont_nwtts[0], (b"nwtt".to_vec(), 7));
+        assert_eq!(dec.tsc.port_man_cont_nwtts[1], (b"nwtt".to_vec(), 8));
+        assert!(!dec.tsc.is_empty());
+    }
+
+    /// A decision with no TSC members yields no TSC configuration, so the ordinary
+    /// PCF path is unchanged.
+    #[test]
+    fn test_decision_without_tsc_members_authorises_no_tsc() {
+        let json = serde_json::json!({ "sessRules": {} });
+        let dec = parse_sm_policy_decision("pol-2", &json);
+        assert!(dec.tsc.is_empty());
+        assert!(dec.tsc.to_n4_ies().is_empty());
+    }
+
+    /// A container that is not valid base64 is DROPPED, not passed through.
+    ///
+    /// The N4 IE is an octet string, so any bytes would encode and the UPF would
+    /// then apply — or reject — configuration the PCF never sent. Dropping makes the
+    /// gap attributable to the PCF.
+    #[test]
+    fn test_malformed_base64_container_is_dropped() {
+        let json = serde_json::json!({
+            "tsnBridgeManCont": { "bridgeManCont": "not!valid!base64!" },
+            "tsnPortManContNwtts": [{ "portManCont": "bnd0dA==", "portNum": 7 }],
+        });
+        let dec = parse_sm_policy_decision("pol-3", &json);
+        assert!(
+            dec.tsc.bridge_man_cont.is_none(),
+            "a malformed UMIC must not become a container of garbage bytes"
+        );
+        assert_eq!(
+            dec.tsc.port_man_cont_nwtts.len(),
+            1,
+            "and the well-formed siblings in the same decision must survive it"
+        );
+    }
+
+    /// A `PortManagementContainer` missing `portNum` is dropped rather than
+    /// defaulted to 0 — which is the port number the TSCTSF's own derivation
+    /// reserves for the NW-TT side, so a default would silently name a real port.
+    #[test]
+    fn test_port_container_without_port_num_is_dropped() {
+        let json = serde_json::json!({
+            "tsnPortManContNwtts": [
+                { "portManCont": "bnd0dA==" },
+                { "portManCont": "bnd0dA==", "portNum": 7 }
+            ],
+        });
+        let dec = parse_sm_policy_decision("pol-4", &json);
+        assert_eq!(dec.tsc.port_man_cont_nwtts, vec![(b"nwtt".to_vec(), 7)]);
+    }
+
+    /// `to_n4_ies` produces one IE per NW-TT port plus one for the UMIC, and
+    /// deliberately omits the DS-TT container.
+    ///
+    /// TS 29.244 §7.5.4.18 gives the TSC Management Information IE an NW-TT Port
+    /// Number and no DS-TT one: the device-side port's configuration travels to the
+    /// DS-TT over NAS, not over N4. Sending it here would attribute device-side
+    /// configuration to a network-side port.
+    #[test]
+    fn test_to_n4_ies_omits_the_dstt_container() {
+        let tsc = TscContainers {
+            bridge_man_cont: Some(b"umic".to_vec()),
+            port_man_cont_dstt: Some((b"dstt".to_vec(), 1)),
+            port_man_cont_nwtts: vec![(b"nwtt".to_vec(), 7)],
+        };
+        let ies = tsc.to_n4_ies();
+        assert_eq!(ies.len(), 2, "one NW-TT PMIC and one UMIC");
+        assert!(
+            !ies.iter()
+                .any(|ie| ie.port_management_container.as_deref() == Some(&b"dstt"[..])),
+            "the DS-TT container must NOT go over N4"
+        );
+        assert!(
+            ies.iter().all(|ie| ie.conditional_holds()),
+            "every emitted IE must satisfy the NW-TT-port conditional"
+        );
     }
 }

--- a/src/bins/nextgcore-upfd/src/context.rs
+++ b/src/bins/nextgcore-upfd/src/context.rs
@@ -686,6 +686,18 @@ pub struct TsnBridge {
     pub time_aware_scheduling_enabled: bool,
     /// Cycle time for time-aware scheduling (nanoseconds)
     pub cycle_time_ns: u64,
+    /// Port Management Information Containers received over N4, keyed by the NW-TT
+    /// port number they were sent with (#321, TS 29.244 §8.2.144).
+    ///
+    /// Held as RAW OCTETS and not interpreted: §8.2.144 says the container encodes a
+    /// Port management message from clause 8 of TS 24.539, and this tree has no
+    /// TS 24.539 codec. Storing them is what makes the configuration the SMF sent
+    /// observable and reportable; acting on their contents needs that codec and is a
+    /// stated ceiling.
+    pub port_management_containers: HashMap<u32, Vec<u8>>,
+    /// The User Plane Node Management Information Container (the UMIC) last received
+    /// over N4 (§8.2.182). Bridge-level, so there is one, not one per port.
+    pub user_plane_node_management_container: Option<Vec<u8>>,
 }
 
 impl TsnBridge {
@@ -699,7 +711,84 @@ impl TsnBridge {
             cnc_interface: None,
             time_aware_scheduling_enabled: false,
             cycle_time_ns: 1_000_000, // Default 1ms cycle
+            port_management_containers: HashMap::new(),
+            user_plane_node_management_container: None,
         }
+    }
+
+    /// Apply one TSC Management Information IE received over N4 (#321,
+    /// TS 29.244 §7.5.4.18).
+    ///
+    /// Returns whether anything was applied. A PMIC with no NW-TT Port Number is
+    /// REJECTED rather than stored under a default port: §7.5.4.18 makes the port
+    /// number conditional-mandatory when a PMIC is present precisely because port
+    /// configuration with no port is unattributable, and defaulting it to 0 would
+    /// silently attribute it to whichever port happens to be numbered 0.
+    pub fn apply_tsc_management_information(
+        &mut self,
+        tsc: &nextgcore_pfcp::types::TscManagementInformation,
+    ) -> bool {
+        let mut applied = false;
+
+        match (&tsc.port_management_container, tsc.nw_tt_port_number) {
+            (Some(pmic), Some(port)) => {
+                // A port the bridge has no entry for gets one: the SMF naming a port
+                // in a PMIC is how the UPF learns the NW-TT side exists at all, and
+                // dropping the container until some other message creates the port
+                // would make the order of unrelated messages decide whether TSC works.
+                self.ports
+                    .entry(port as u16)
+                    .or_insert_with(|| TsnBridgePort {
+                        port_id: port as u16,
+                        vlan_id: 0,
+                        priority: 0,
+                        is_trunk: false,
+                        allowed_vlans: Vec::new(),
+                        port_type: TsnPortType::NetworkSideTt,
+                        time_aware_shaper_enabled: false,
+                        gate_control_list: Vec::new(),
+                    });
+                self.port_management_containers.insert(port, pmic.clone());
+                applied = true;
+            }
+            (Some(_), None) => {
+                log::warn!(
+                    "[TSN Bridge] TSC Management Information carries a PMIC with no NW-TT \
+                     Port Number — not applied (TS 29.244 Table 7.5.4.18-1)"
+                );
+            }
+            (None, _) => {}
+        }
+
+        if let Some(umic) = &tsc.user_plane_node_management_container {
+            self.user_plane_node_management_container = Some(umic.clone());
+            applied = true;
+        }
+
+        applied
+    }
+
+    /// What this bridge would report back in a TSC Management Information IE
+    /// (§7.5.5.3): the containers it holds, per port, plus the bridge-level one.
+    ///
+    /// This is an echo of what was applied, which is what makes the SMF's
+    /// "N sent, M echoed" comparison meaningful rather than a guess.
+    pub fn tsc_management_information(
+        &self,
+    ) -> Vec<nextgcore_pfcp::types::TscManagementInformation> {
+        use nextgcore_pfcp::types::TscManagementInformation;
+        let mut out: Vec<_> = self
+            .port_management_containers
+            .iter()
+            .map(|(port, cont)| TscManagementInformation::port(cont.clone(), *port))
+            .collect();
+        // Deterministic order: a HashMap iteration order would make the response
+        // bytes differ run to run for identical state, which no test can pin.
+        out.sort_by_key(|ie| ie.nw_tt_port_number);
+        if let Some(umic) = &self.user_plane_node_management_container {
+            out.push(TscManagementInformation::user_plane_node(umic.clone()));
+        }
+        out
     }
 
     /// Add a bridge port

--- a/src/bins/nextgcore-upfd/src/n4_build.rs
+++ b/src/bins/nextgcore-upfd/src/n4_build.rs
@@ -171,6 +171,17 @@ pub mod pfcp_ie {
     pub const UR_SEQN: u16 = 104;
     /// Suggested Buffering Packets Count (TS 29.244 8.2.103)
     pub const SUGGESTED_BUFFERING_PACKETS_COUNT: u16 = 140;
+    /// NW-TT Port Number (TS 29.244 §8.2.142), #321.
+    pub const NW_TT_PORT_NUMBER: u16 = 197;
+    /// TSC Management Information within a Session Modification Request
+    /// (TS 29.244 §7.5.4.18), #321.
+    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST: u16 = 199;
+    /// TSC Management Information within a Session Modification Response
+    /// (TS 29.244 §7.5.5.3), #321.
+    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_RESPONSE: u16 = 200;
+    /// TSC Management Information within a Session Report Request
+    /// (TS 29.244 §7.5.8.5), #321.
+    pub const TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_REPORT_REQUEST: u16 = 201;
 }
 
 /// PFCPSMReq-Flags bit values (TS 29.244 8.2.50)
@@ -769,6 +780,21 @@ pub fn build_session_modification_response_with_reports(
     created_pdrs: &[CreatedPdr],
     usage_reports: &[UsageReport],
 ) -> Vec<u8> {
+    build_session_modification_response_full(msg_type, created_pdrs, usage_reports, &[])
+}
+
+/// Build Session Modification Response, also carrying the TSC Management
+/// Information the UP function applied (IE 200, TS 29.244 §7.5.5.3), #321.
+///
+/// The echo is what lets the CP function tell "applied" from "accepted": a bare
+/// `RequestAccepted` for a TSC modification says the message was well-formed, not
+/// that any port configuration landed.
+pub fn build_session_modification_response_full(
+    msg_type: u8,
+    created_pdrs: &[CreatedPdr],
+    usage_reports: &[UsageReport],
+    tsc_management_info: &[nextgcore_pfcp::types::TscManagementInformation],
+) -> Vec<u8> {
     let mut builder = PfcpMessageBuilder::new();
 
     // Cause - Request Accepted
@@ -781,6 +807,16 @@ pub fn build_session_modification_response_with_reports(
 
     for report in usage_reports {
         builder.add_usage_report(report, pfcp_ie::USAGE_REPORT_SMR);
+    }
+
+    // TSC Management Information (IE 200), encoded by the library codec.
+    for tsc in tsc_management_info.iter().filter(|t| !t.is_empty()) {
+        let mut tsc_buf = BytesMut::new();
+        tsc.encode(&mut tsc_buf);
+        builder.add_tlv(
+            pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_RESPONSE,
+            &tsc_buf,
+        );
     }
 
     let _ = msg_type;

--- a/src/bins/nextgcore-upfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-upfd/src/pfcp_path.rs
@@ -6,12 +6,12 @@ use crate::n4_build::{
     build_association_release_response, build_association_setup_response, build_failure_response,
     build_heartbeat_response, build_session_deletion_response,
     build_session_establishment_response, build_session_modification_response,
-    build_session_modification_response_with_reports, build_session_report_request,
-    parse_create_bar, parse_create_far, parse_create_pdr, parse_create_qer, parse_create_urr,
-    parse_pfcpsmreq_flags, parse_recovery_time_stamp, pfcp_ie, pfcp_type, pfcpsmreq_flags,
-    CreatedPdr, DownlinkDataReport, DownlinkDataServiceInfo, ErrorIndicationReport, FSeid, FTeid,
-    NodeId, ParsedCreateBar, ParsedCreateFar, ParsedCreatePdr, ParsedCreateQer, ParsedCreateUrr,
-    ParsedFSeid, ParsedIe, ParsedPfcpHeader, PfcpCause, ReportType, UserPlaneReport,
+    build_session_modification_response_full, build_session_report_request, parse_create_bar,
+    parse_create_far, parse_create_pdr, parse_create_qer, parse_create_urr, parse_pfcpsmreq_flags,
+    parse_recovery_time_stamp, pfcp_ie, pfcp_type, pfcpsmreq_flags, CreatedPdr, DownlinkDataReport,
+    DownlinkDataServiceInfo, ErrorIndicationReport, FSeid, FTeid, NodeId, ParsedCreateBar,
+    ParsedCreateFar, ParsedCreatePdr, ParsedCreateQer, ParsedCreateUrr, ParsedFSeid, ParsedIe,
+    ParsedPfcpHeader, PfcpCause, ReportType, UserPlaneReport,
 };
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
@@ -631,6 +631,24 @@ pub struct PfcpSessionInfo {
     /// the same order the CP function sent the requests, so they are the only
     /// race-free answer to "does this rule exist" at response-building time.
     pub rules: SessionRuleIds,
+    /// The 5GS TSN bridge this session is part of, once the SMF has configured one
+    /// over N4 (#321, TS 23.501 §5.28).
+    ///
+    /// `None` until a Session Modification carries TSC management information —
+    /// which is the transition #284's criterion 4 asks to be demonstrated.
+    ///
+    /// # Why here and not on `context::UpfSess`
+    ///
+    /// `UpfSess` also has a `tsn_bridge` field, and it is UNREACHABLE: nothing in
+    /// production calls `UpfContext::sess_add`, so that session store is never
+    /// populated (`rule_match` reads it and therefore always finds nothing).
+    /// Populating it would be a correct change in a place no wire path runs through,
+    /// and a test for it could only assert against a session it had hand-built
+    /// itself — which is exactly the unit test that already exists and is exactly
+    /// why #284's criterion 4 stayed unmet. THIS map is the store the N4 handler
+    /// writes, so it is the one where "the UPF's own state" means something. The
+    /// parallel-store defect is filed as its own issue rather than fixed here.
+    pub tsn_bridge: Option<crate::context::TsnBridge>,
 }
 
 /// The rule ids a session holds, by kind (TS 29.244 §7.5.4, #306).
@@ -1426,6 +1444,11 @@ impl PfcpServer {
                 qer_ids: parsed_qers.iter().map(|q| q.qer_id).collect(),
                 urr_ids: parsed_urrs.iter().map(|u| u.urr_id).collect(),
             },
+            // #321: no bridge until the SMF configures one. An establishment
+            // deliberately does not create an empty one — `Some(empty bridge)` and
+            // `None` would then both mean "not configured", and the transition
+            // #284's criterion 4 asks about would no longer be observable.
+            tsn_bridge: None,
         };
 
         {
@@ -1601,6 +1624,45 @@ impl PfcpServer {
             }
         }
 
+        // TSC Management Information (IE 199, TS 29.244 §7.5.4.18), #321. Parsed
+        // here with the rest of the message so a malformed instance is reported
+        // through the same `failure` channel as every other rule operation, rather
+        // than being answered `RequestAccepted` and dropped — the defect #306 fixed
+        // for the rule IEs and this issue fixes for the TSC ones.
+        let mut tsc_ies: Vec<nextgcore_pfcp::types::TscManagementInformation> = Vec::new();
+        for ie in ParsedIe::find_all_ies(
+            &ies,
+            pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST,
+        ) {
+            let mut data = bytes::Bytes::copy_from_slice(&ie.value);
+            match nextgcore_pfcp::types::TscManagementInformation::decode(&mut data) {
+                Ok(tsc) if tsc.conditional_holds() => tsc_ies.push(tsc),
+                Ok(_) => {
+                    // A PMIC with no NW-TT Port Number names no port to apply it to.
+                    // Answered with the Conditional-IE-missing cause rather than
+                    // accepted, because accepting it would report success for
+                    // configuration the UPF cannot attribute.
+                    log::warn!(
+                        "TSC Management Information carries a PMIC with no NW-TT Port \
+                         Number (TS 29.244 Table 7.5.4.18-1)"
+                    );
+                    note_first_failure(
+                        &mut failure,
+                        PfcpCause::ConditionalIeMissing,
+                        pfcp_ie::NW_TT_PORT_NUMBER,
+                    );
+                }
+                Err(e) => {
+                    log::warn!("malformed TSC Management Information IE: {e}");
+                    note_first_failure(
+                        &mut failure,
+                        PfcpCause::MandatoryIeIncorrect,
+                        pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST,
+                    );
+                }
+            }
+        }
+
         // PFCPSMReq-Flags (TS 29.244 8.2.50): SNDEM → emit End Marker on the
         // old DL tunnel; DROBU → discard buffered DL packets; QAURR → report every
         // URR immediately in this response. QAURR was declared as a constant and
@@ -1728,12 +1790,48 @@ impl PfcpServer {
                     }
                 }
 
-                Some((session.smf_seid, old_tunnel))
+                // #321: apply the TSC containers in the SAME critical section as the
+                // rule bookkeeping, so the response's echo (IE 200) describes state
+                // that is already committed rather than state a concurrent
+                // modification could still change.
+                if !tsc_ies.is_empty() {
+                    let bridge = session.tsn_bridge.get_or_insert_with(|| {
+                        // The bridge ID is the UPF's own 5GS User Plane Node ID. The
+                        // SEID is used as its basis so it is stable per session and
+                        // distinct across sessions; a real deployment reads it from
+                        // configuration (TS 29.244 §5.26.2 says these identities "may
+                        // be pre-configured in the UPF based on deployment"), which is
+                        // a recorded ceiling rather than something to invent here.
+                        crate::context::TsnBridge::new(upf_seid.to_be_bytes())
+                    });
+                    let mut applied = 0usize;
+                    for tsc in &tsc_ies {
+                        if bridge.apply_tsc_management_information(tsc) {
+                            applied += 1;
+                        }
+                    }
+                    log::info!(
+                        "TSC management information applied to SEID {upf_seid:#x}: \
+                         {applied}/{} IE(s), bridge now holds {} port(s)",
+                        tsc_ies.len(),
+                        bridge.port_count()
+                    );
+                }
+
+                Some((
+                    session.smf_seid,
+                    old_tunnel,
+                    session
+                        .tsn_bridge
+                        .as_ref()
+                        .map(|b| b.tsc_management_information())
+                        .unwrap_or_default(),
+                ))
             } else {
                 None
             }
         };
-        let (smf_seid, old_dl_tunnel) = match lookup {
+        let (smf_seid, old_dl_tunnel, tsc_echo) = match lookup {
             Some(v) => v,
             None => {
                 log::warn!("Session Modification for unknown SEID {upf_seid:#x} — rejecting");
@@ -1797,10 +1895,14 @@ impl PfcpServer {
                 );
                 build_failure_response(cause, Some(offending_ie))
             }
-            None => build_session_modification_response_with_reports(
+            None => build_session_modification_response_full(
                 pfcp_type::SESSION_MODIFICATION_RESPONSE,
                 &[], // No created PDRs for modification
                 &usage_reports,
+                // #321: echo the TSC configuration this session now holds, so the SMF
+                // can tell an applied modification from a merely accepted one. Empty
+                // for every non-TSC session, so no existing response changes.
+                &tsc_echo,
             ),
         };
 
@@ -3055,6 +3157,221 @@ mod tests {
         assert_eq!(updated_urrs[0].volume_threshold_total, Some(8888));
     }
 
+    // ------------------------------------------------------------------
+    // 5GS TSC bridge configuration over N4 (#321)
+    // ------------------------------------------------------------------
+
+    /// Build a TSC Management Information IE payload (#321). Uses the library
+    /// codec, which is the encoder a real SMF uses, so the test exercises the same
+    /// bytes rather than a test-local approximation.
+    fn tsc_ie(pmic: Option<(&[u8], u32)>, umic: Option<&[u8]>) -> Vec<u8> {
+        let tsc = nextgcore_pfcp::types::TscManagementInformation {
+            port_management_container: pmic.map(|(c, _)| c.to_vec()),
+            nw_tt_port_number: pmic.map(|(_, p)| p),
+            user_plane_node_management_container: umic.map(|c| c.to_vec()),
+        };
+        let mut buf = bytes::BytesMut::new();
+        tsc.encode(&mut buf);
+        buf.to_vec()
+    }
+
+    /// #284's criterion 4, which is what #321 exists to make satisfiable: a Session
+    /// Modification carrying a PMIC/UMIC takes `tsn_bridge` from `None` to
+    /// populated.
+    ///
+    /// Asserted from `PfcpServer::sessions` — the store the N4 wire path writes —
+    /// and NOT from a log line, and not from a hand-built session either. The
+    /// session here was established over the socket by the fixture.
+    #[tokio::test]
+    async fn test_tsc_management_information_populates_the_tsn_bridge() {
+        let (server, smf, addr, _rx, _dp, upf_seid) = established_session().await;
+
+        // The precondition #284's criterion 4 is stated against.
+        assert!(
+            server
+                .sessions
+                .read()
+                .await
+                .get(&upf_seid)
+                .expect("session")
+                .tsn_bridge
+                .is_none(),
+            "precondition: an established session has NO TSN bridge until the SMF \
+             configures one"
+        );
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(
+            pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST,
+            &tsc_ie(Some((&[0x11, 0x22, 0x33], 7)), None),
+        );
+        b.add_tlv(
+            pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST,
+            &tsc_ie(None, Some(&[0xAB, 0xCD])),
+        );
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 9, &b.build())).await;
+        assert_eq!(
+            response_cause(&resp),
+            PfcpCause::RequestAccepted as u8,
+            "a well-formed TSC modification must be accepted"
+        );
+
+        let sessions = server.sessions.read().await;
+        let bridge = sessions
+            .get(&upf_seid)
+            .expect("session")
+            .tsn_bridge
+            .as_ref()
+            .expect("the TSN bridge must exist after a TSC modification");
+
+        assert_eq!(
+            bridge
+                .port_management_containers
+                .get(&7)
+                .map(|c| c.as_slice()),
+            Some(&[0x11, 0x22, 0x33][..]),
+            "the PMIC must be stored against the NW-TT port number it arrived with, \
+             byte-exact (it is an opaque TS 24.539 payload)"
+        );
+        assert_eq!(
+            bridge.user_plane_node_management_container.as_deref(),
+            Some(&[0xAB, 0xCD][..]),
+            "the UMIC is bridge-level, so it is stored once and not per port"
+        );
+        assert_eq!(
+            bridge.port_count(),
+            1,
+            "the PMIC's port must exist as a bridge port: naming it in a PMIC is how \
+             the UPF learns the NW-TT side exists"
+        );
+        assert_eq!(
+            bridge.ports.get(&7).map(|p| p.port_type),
+            Some(crate::context::TsnPortType::NetworkSideTt),
+            "a port learned from a TSC Management Information IE is network-side: the \
+             IE carries an NW-TT Port Number and no DS-TT one"
+        );
+    }
+
+    /// The response echoes what was applied (IE 200, TS 29.244 §7.5.5.3), so the
+    /// SMF can tell an APPLIED modification from a merely accepted one.
+    #[tokio::test]
+    async fn test_tsc_modification_response_echoes_what_was_applied() {
+        let (_server, smf, addr, _rx, _dp, upf_seid) = established_session().await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(
+            pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST,
+            &tsc_ie(Some((&[0x55], 3)), None),
+        );
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 10, &b.build())).await;
+
+        let (_h, payload) = ParsedPfcpHeader::parse(&resp).unwrap();
+        let ies = ParsedIe::parse_all(payload);
+        let echoed = ParsedIe::find_all_ies(
+            &ies,
+            pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_RESPONSE,
+        );
+        assert_eq!(
+            echoed.len(),
+            1,
+            "the response must carry the applied TSC configuration under IE 200"
+        );
+        let mut data = bytes::Bytes::copy_from_slice(&echoed[0].value);
+        let decoded = nextgcore_pfcp::types::TscManagementInformation::decode(&mut data).unwrap();
+        assert_eq!(decoded.nw_tt_port_number, Some(3));
+        assert_eq!(
+            decoded.port_management_container.as_deref(),
+            Some(&[0x55][..])
+        );
+    }
+
+    /// A PMIC with no NW-TT Port Number is REJECTED with the conditional-IE cause,
+    /// not accepted and dropped.
+    ///
+    /// This is the shape §7.5.4.18's conditional exists to forbid: port
+    /// configuration with no port to attribute it to. Accepting it would report
+    /// success for something the UPF cannot apply — the defect class #306 fixed for
+    /// the rule IEs.
+    #[tokio::test]
+    async fn test_tsc_pmic_without_port_number_is_rejected() {
+        let (server, smf, addr, _rx, _dp, upf_seid) = established_session().await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(
+            pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_REQUEST,
+            // PMIC present, NW-TT Port Number absent.
+            &tsc_ie_pmic_only(&[0x99]),
+        );
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 11, &b.build())).await;
+
+        assert_eq!(
+            response_cause(&resp),
+            PfcpCause::ConditionalIeMissing as u8,
+            "a PMIC with no NW-TT Port Number must be refused, not silently dropped"
+        );
+        assert!(
+            server
+                .sessions
+                .read()
+                .await
+                .get(&upf_seid)
+                .expect("session")
+                .tsn_bridge
+                .is_none(),
+            "a refused modification must apply NOTHING: a bridge created from a \
+             rejected message is the divergence the Cause exists to prevent"
+        );
+    }
+
+    /// A PMIC with no port number, built directly rather than through the codec's
+    /// `port()` constructor (which requires one).
+    fn tsc_ie_pmic_only(pmic: &[u8]) -> Vec<u8> {
+        let tsc = nextgcore_pfcp::types::TscManagementInformation {
+            port_management_container: Some(pmic.to_vec()),
+            nw_tt_port_number: None,
+            user_plane_node_management_container: None,
+        };
+        let mut buf = bytes::BytesMut::new();
+        tsc.encode(&mut buf);
+        buf.to_vec()
+    }
+
+    /// A modification with no TSC IE leaves `tsn_bridge` alone, so no existing
+    /// session acquires a bridge as a side effect of this feature.
+    #[tokio::test]
+    async fn test_non_tsc_modification_leaves_the_bridge_absent() {
+        let (server, smf, addr, mut rx, dp, upf_seid) = established_session().await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_tlv(pfcp_ie::UPDATE_QER, &qer_body(1, 6));
+        let resp = exchange(&smf, addr, &encode_pfcp(52, Some(upf_seid), 12, &b.build())).await;
+        assert_eq!(response_cause(&resp), PfcpCause::RequestAccepted as u8);
+        apply_next(&mut rx, &dp).await;
+
+        assert!(
+            server
+                .sessions
+                .read()
+                .await
+                .get(&upf_seid)
+                .expect("session")
+                .tsn_bridge
+                .is_none(),
+            "an ordinary modification must not create a TSN bridge"
+        );
+
+        let (_h, payload) = ParsedPfcpHeader::parse(&resp).unwrap();
+        let ies = ParsedIe::parse_all(payload);
+        assert!(
+            ParsedIe::find_all_ies(
+                &ies,
+                pfcp_ie::TSC_MANAGEMENT_INFORMATION_WITHIN_SESSION_MODIFICATION_RESPONSE,
+            )
+            .is_empty(),
+            "and its response must carry no TSC IE"
+        );
+    }
+
     #[tokio::test]
     async fn test_session_modification_unknown_seid_rejected() {
         let (_server, smf, addr, _rx) = spawn_test_server().await;
@@ -3482,6 +3799,7 @@ mod tests {
                 dl_teid: 0x200,
                 gnb_addr: Some(Ipv4Addr::new(127, 0, 0, 1)),
                 rules: SessionRuleIds::default(),
+                tsn_bridge: None,
             })
             .await;
         (server, smf, upf_seid, smf_seid)

--- a/src/libs/nextgcore-pfcp/src/ie.rs
+++ b/src/libs/nextgcore-pfcp/src/ie.rs
@@ -202,8 +202,16 @@ pub enum IeType {
     IpMulticastAddress = 191,
     SourceIpAddress = 192,
     PacketRateStatus = 193,
+    /// TS 29.244 §8.2.140. Renamed "Create Bridge/Router Info" in Rel-18 when
+    /// DetNet was added (the RII flag beside BII); the Rel-17 spelling is kept
+    /// because it is what every 5GS-TSN caller in this tree means by it.
     CreateBridgeInfoForTsc = 194,
+    /// TS 29.244 §7.5.3.6, "Created Bridge/Router Info" from Rel-18 on.
     CreatedBridgeInfoForTsc = 195,
+    /// TS 29.244 §8.2.141. The spec calls this bare "Port Number" from Rel-18 on,
+    /// because for DetNet it is the PDU session's port rather than a DS-TT one.
+    /// For TSN (BII set) it IS the DS-TT port, which is the only case this tree
+    /// drives.
     DsTtPortNumber = 196,
     NwTtPortNumber = 197,
     FivegsUserPlaneNode = 198,
@@ -264,6 +272,11 @@ pub enum IeType {
     NfInstanceId = 253,
     EthernetContextInformation = 254,
     RedundantTransmissionParameters = 255,
+    /// TS 29.244 §8.2.182, the UMIC. The N4 counterpart of TS 29.512's
+    /// `BridgeManagementContainer` — the two specs name the same octet string
+    /// differently, which is why the SBI-side member is `tsnBridgeManCont` while
+    /// the IE is "User Plane Node Management Information Container".
+    UserPlaneNodeManagementInformationContainer = 266,
     PfcpSessionChangeInfo = 290,
     GroupId = 291,
     CpIpAddress = 292,

--- a/src/libs/nextgcore-pfcp/src/lib.rs
+++ b/src/libs/nextgcore-pfcp/src/lib.rs
@@ -51,11 +51,12 @@ pub mod prelude {
         SessionModificationResponse, SessionReportRequest, SessionReportResponse,
     };
     pub use crate::types::{
-        ApplyAction, Bitrate, CpFunctionFeatures, CreateBar, CreateFar, CreatePdr, CreateQer,
-        CreateUrr, DestinationInterface, DownlinkDataReport, FSeid, FTeid, ForwardingParameters,
-        GateStatus, MeasurementMethod, NodeId, NodeIdType, OuterHeaderCreation, OuterHeaderRemoval,
-        Pdi, PfcpCause, RemoveFar, RemovePdr, RemoveQer, RemoveUrr, ReportType, ReportingTriggers,
-        SourceInterface, UeIpAddress, UpFunctionFeatures, UpdateFar, UpdatePdr, UpdateQer,
-        UpdateUrr, UsageReportSrr, VolumeMeasurement, VolumeThreshold,
+        ApplyAction, Bitrate, CpFunctionFeatures, CreateBar, CreateBridgeInfoForTsc, CreateFar,
+        CreatePdr, CreateQer, CreateUrr, CreatedBridgeInfoForTsc, DestinationInterface,
+        DownlinkDataReport, FSeid, FTeid, FiveGsUserPlaneNodeId, ForwardingParameters, GateStatus,
+        MeasurementMethod, NodeId, NodeIdType, OuterHeaderCreation, OuterHeaderRemoval, Pdi,
+        PfcpCause, RemoveFar, RemovePdr, RemoveQer, RemoveUrr, ReportType, ReportingTriggers,
+        SourceInterface, TscManagementInformation, UeIpAddress, UpFunctionFeatures, UpdateFar,
+        UpdatePdr, UpdateQer, UpdateUrr, UsageReportSrr, VolumeMeasurement, VolumeThreshold,
     };
 }

--- a/src/libs/nextgcore-pfcp/src/message.rs
+++ b/src/libs/nextgcore-pfcp/src/message.rs
@@ -6,10 +6,11 @@ use crate::error::{PfcpError, PfcpResult};
 use crate::header::{PfcpHeader, PfcpMessageType};
 use crate::ie::{encode_u16_ie, encode_u32_ie, encode_u8_ie, IeHeader, IeType, RawIe};
 use crate::types::{
-    ApplicationIdsPfds, CpFunctionFeatures, CreateBar, CreateFar, CreatePdr, CreateQer, CreateUrr,
-    DownlinkDataReport, FSeid, FqCsid, GracefulReleasePeriod, LoadControlInformation, NodeId,
-    NodeReportType, PfcpAssociationReleaseRequest, PfcpCause, PfcpSessionChangeInfo,
-    PfdPartialFailureInformation, RemoveFar, RemovePdr, RemoveQer, RemoveUrr, ReportType,
+    ApplicationIdsPfds, CpFunctionFeatures, CreateBar, CreateBridgeInfoForTsc, CreateFar,
+    CreatePdr, CreateQer, CreateUrr, CreatedBridgeInfoForTsc, DownlinkDataReport, FSeid, FqCsid,
+    GracefulReleasePeriod, LoadControlInformation, NodeId, NodeReportType,
+    PfcpAssociationReleaseRequest, PfcpCause, PfcpSessionChangeInfo, PfdPartialFailureInformation,
+    RemoveFar, RemovePdr, RemoveQer, RemoveUrr, ReportType, TscManagementInformation,
     UpFunctionFeatures, UpdateFar, UpdatePdr, UpdateQer, UpdateUrr, UsageReportSrr,
     UserPlanePathFailureReport,
 };
@@ -406,6 +407,10 @@ pub struct SessionEstablishmentRequest {
     pub create_qers: Vec<CreateQer>,
     pub create_urrs: Vec<CreateUrr>,
     pub create_bar: Option<CreateBar>,
+    /// Create Bridge/Router Info (IE 194, TS 29.244 §5.26.2), #321. Present when
+    /// the session is for TSC and the SMF wants the UP function to allocate a port
+    /// number and report its 5GS User Plane Node ID.
+    pub create_bridge_info: Option<CreateBridgeInfoForTsc>,
 }
 
 impl SessionEstablishmentRequest {
@@ -418,6 +423,7 @@ impl SessionEstablishmentRequest {
             create_qers: Vec::new(),
             create_urrs: Vec::new(),
             create_bar: None,
+            create_bridge_info: None,
         }
     }
 
@@ -480,6 +486,18 @@ impl SessionEstablishmentRequest {
             header.encode(buf);
             buf.put_slice(&bar_buf);
         }
+
+        // Create Bridge/Router Info (IE 194)
+        if let Some(bridge) = &self.create_bridge_info {
+            let mut bridge_buf = BytesMut::new();
+            bridge.encode(&mut bridge_buf);
+            let header = IeHeader::new(
+                IeType::CreateBridgeInfoForTsc as u16,
+                bridge_buf.len() as u16,
+            );
+            header.encode(buf);
+            buf.put_slice(&bridge_buf);
+        }
     }
 
     pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
@@ -490,6 +508,7 @@ impl SessionEstablishmentRequest {
         let mut create_qers = Vec::new();
         let mut create_urrs = Vec::new();
         let mut create_bar = None;
+        let mut create_bridge_info = None;
 
         while buf.remaining() >= IeHeader::LEN {
             let ie = RawIe::decode(buf)?;
@@ -522,6 +541,9 @@ impl SessionEstablishmentRequest {
                     let mut data = ie.data;
                     create_bar = Some(CreateBar::decode(&mut data)?);
                 }
+                t if t == IeType::CreateBridgeInfoForTsc as u16 => {
+                    create_bridge_info = Some(CreateBridgeInfoForTsc::decode(&ie.data)?);
+                }
                 _ => {}
             }
         }
@@ -539,6 +561,7 @@ impl SessionEstablishmentRequest {
             create_qers,
             create_urrs,
             create_bar,
+            create_bridge_info,
         })
     }
 }
@@ -552,6 +575,10 @@ pub struct SessionEstablishmentResponse {
     /// Created PDR(s) carrying the UP-allocated local F-TEID(s); present when
     /// the request is accepted (§7.5.3.2).
     pub created_pdrs: Vec<CreatedPdr>,
+    /// Created Bridge/Router Info (IE 195, TS 29.244 §7.5.3.6), #321. The UP
+    /// function's answer to a `create_bridge_info` on the request: the allocated
+    /// port number and the 5GS User Plane Node ID.
+    pub created_bridge_info: Option<CreatedBridgeInfoForTsc>,
 }
 
 impl SessionEstablishmentResponse {
@@ -561,6 +588,7 @@ impl SessionEstablishmentResponse {
             cause,
             up_f_seid: None,
             created_pdrs: Vec::new(),
+            created_bridge_info: None,
         }
     }
 
@@ -594,6 +622,18 @@ impl SessionEstablishmentResponse {
             header.encode(buf);
             buf.put_slice(&cpdr_buf);
         }
+
+        // Created Bridge/Router Info (IE 195)
+        if let Some(bridge) = &self.created_bridge_info {
+            let mut bridge_buf = BytesMut::new();
+            bridge.encode(&mut bridge_buf);
+            let header = IeHeader::new(
+                IeType::CreatedBridgeInfoForTsc as u16,
+                bridge_buf.len() as u16,
+            );
+            header.encode(buf);
+            buf.put_slice(&bridge_buf);
+        }
     }
 
     pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
@@ -602,6 +642,7 @@ impl SessionEstablishmentResponse {
         let mut cause: Option<PfcpCause> = None;
         let mut up_f_seid = None;
         let mut created_pdrs = Vec::new();
+        let mut created_bridge_info = None;
 
         while buf.remaining() >= IeHeader::LEN {
             let ie = RawIe::decode(buf)?;
@@ -623,6 +664,10 @@ impl SessionEstablishmentResponse {
                     let mut data = ie.data;
                     created_pdrs.push(CreatedPdr::decode(&mut data)?);
                 }
+                t if t == IeType::CreatedBridgeInfoForTsc as u16 => {
+                    let mut data = ie.data;
+                    created_bridge_info = Some(CreatedBridgeInfoForTsc::decode(&mut data)?);
+                }
                 _ => {}
             }
         }
@@ -643,6 +688,7 @@ impl SessionEstablishmentResponse {
             cause,
             up_f_seid,
             created_pdrs,
+            created_bridge_info,
         })
     }
 }
@@ -723,6 +769,13 @@ pub struct SessionModificationRequest {
     /// the session measured on a rule the CP function believes is gone.
     pub remove_urrs: Vec<RemoveUrr>,
     pub pfcp_smreq_flags: Option<u8>,
+    /// TSC Management Information (IE 199, TS 29.244 §7.5.4.18), #321.
+    ///
+    /// A LIST, not an option: §7.5.4.18's own note says that for multiple ports
+    /// there may be several instances carrying a PMIC with its NW-TT Port Number,
+    /// and only one carrying a UMIC. Modelling it as a single value would silently
+    /// drop every port after the first.
+    pub tsc_management_info: Vec<TscManagementInformation>,
 }
 
 impl Default for SessionModificationRequest {
@@ -749,6 +802,7 @@ impl SessionModificationRequest {
             remove_qers: Vec::new(),
             remove_urrs: Vec::new(),
             pfcp_smreq_flags: None,
+            tsc_management_info: Vec::new(),
         }
     }
 
@@ -870,6 +924,20 @@ impl SessionModificationRequest {
         if let Some(flags) = self.pfcp_smreq_flags {
             encode_u8_ie(buf, IeType::PfcpSmreqFlags, flags);
         }
+
+        // TSC Management Information (IE 199). An empty instance is skipped rather
+        // than emitted: a four-octet IE with no members asks the UP function for
+        // nothing while looking like a request.
+        for tsc in self.tsc_management_info.iter().filter(|t| !t.is_empty()) {
+            let mut tsc_buf = BytesMut::new();
+            tsc.encode(&mut tsc_buf);
+            let header = IeHeader::new(
+                IeType::TscManagementInformationSmr as u16,
+                tsc_buf.len() as u16,
+            );
+            header.encode(buf);
+            buf.put_slice(&tsc_buf);
+        }
     }
 
     pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
@@ -939,6 +1007,12 @@ impl SessionModificationRequest {
                         result.pfcp_smreq_flags = Some(ie.data[0]);
                     }
                 }
+                t if t == IeType::TscManagementInformationSmr as u16 => {
+                    let mut data = ie.data;
+                    result
+                        .tsc_management_info
+                        .push(TscManagementInformation::decode(&mut data)?);
+                }
                 _ => {}
             }
         }
@@ -953,6 +1027,9 @@ pub struct SessionModificationResponse {
     pub cause: PfcpCause,
     pub offending_ie: Option<u16>,
     pub created_pdrs: Vec<CreatedPdr>,
+    /// TSC Management Information (IE 200, TS 29.244 §7.5.5.3), #321. What the UP
+    /// function actually applied, reported back on the same transaction.
+    pub tsc_management_info: Vec<TscManagementInformation>,
 }
 
 impl SessionModificationResponse {
@@ -961,6 +1038,7 @@ impl SessionModificationResponse {
             cause,
             offending_ie: None,
             created_pdrs: Vec::new(),
+            tsc_management_info: Vec::new(),
         }
     }
 
@@ -980,6 +1058,18 @@ impl SessionModificationResponse {
             header.encode(buf);
             buf.put_slice(&cpdr_buf);
         }
+
+        // TSC Management Information (IE 200)
+        for tsc in self.tsc_management_info.iter().filter(|t| !t.is_empty()) {
+            let mut tsc_buf = BytesMut::new();
+            tsc.encode(&mut tsc_buf);
+            let header = IeHeader::new(
+                IeType::TscManagementInformationSmrsp as u16,
+                tsc_buf.len() as u16,
+            );
+            header.encode(buf);
+            buf.put_slice(&tsc_buf);
+        }
     }
 
     pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
@@ -987,6 +1077,7 @@ impl SessionModificationResponse {
         let mut cause: Option<PfcpCause> = None;
         let mut offending_ie = None;
         let mut created_pdrs = Vec::new();
+        let mut tsc_management_info = Vec::new();
 
         while buf.remaining() >= IeHeader::LEN {
             let ie = RawIe::decode(buf)?;
@@ -1006,6 +1097,10 @@ impl SessionModificationResponse {
                     let mut data = ie.data;
                     created_pdrs.push(CreatedPdr::decode(&mut data)?);
                 }
+                t if t == IeType::TscManagementInformationSmrsp as u16 => {
+                    let mut data = ie.data;
+                    tsc_management_info.push(TscManagementInformation::decode(&mut data)?);
+                }
                 _ => {}
             }
         }
@@ -1015,6 +1110,7 @@ impl SessionModificationResponse {
             cause,
             offending_ie,
             created_pdrs,
+            tsc_management_info,
         })
     }
 }
@@ -1082,6 +1178,11 @@ pub struct SessionReportRequest {
     pub report_type: ReportType,
     pub downlink_data_report: Option<DownlinkDataReport>,
     pub usage_reports: Vec<UsageReportSrr>,
+    /// TSC Management Information (IE 201, TS 29.244 §7.5.8.5), #321. The UP
+    /// function reporting port or user-plane-node management information the
+    /// SMF did not ask for in a transaction — an NW-TT port whose configuration
+    /// changed, for instance. Accompanied by the `tmir` bit in the Report Type.
+    pub tsc_management_info: Vec<TscManagementInformation>,
 }
 
 impl SessionReportRequest {
@@ -1090,6 +1191,7 @@ impl SessionReportRequest {
             report_type,
             downlink_data_report: None,
             usage_reports: Vec::new(),
+            tsc_management_info: Vec::new(),
         }
     }
 
@@ -1111,12 +1213,25 @@ impl SessionReportRequest {
             header.encode(buf);
             buf.put_slice(&ur_buf);
         }
+
+        // TSC Management Information (IE 201)
+        for tsc in self.tsc_management_info.iter().filter(|t| !t.is_empty()) {
+            let mut tsc_buf = BytesMut::new();
+            tsc.encode(&mut tsc_buf);
+            let header = IeHeader::new(
+                IeType::TscManagementInformationSrr as u16,
+                tsc_buf.len() as u16,
+            );
+            header.encode(buf);
+            buf.put_slice(&tsc_buf);
+        }
     }
 
     pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
         let mut report_type = ReportType::default();
         let mut downlink_data_report = None;
         let mut usage_reports = Vec::new();
+        let mut tsc_management_info = Vec::new();
 
         while buf.remaining() >= IeHeader::LEN {
             let ie = RawIe::decode(buf)?;
@@ -1134,6 +1249,10 @@ impl SessionReportRequest {
                     let mut data = ie.data;
                     usage_reports.push(UsageReportSrr::decode(&mut data)?);
                 }
+                t if t == IeType::TscManagementInformationSrr as u16 => {
+                    let mut data = ie.data;
+                    tsc_management_info.push(TscManagementInformation::decode(&mut data)?);
+                }
                 _ => {}
             }
         }
@@ -1142,6 +1261,7 @@ impl SessionReportRequest {
             report_type,
             downlink_data_report,
             usage_reports,
+            tsc_management_info,
         })
     }
 }
@@ -3139,5 +3259,129 @@ mod tests {
             SessionEstablishmentResponse::decode(&mut buf.freeze()),
             Err(PfcpError::MissingMandatoryIe(_))
         ));
+    }
+
+    // ========================================================================
+    // 5GS TSC carriage (#321)
+    // ========================================================================
+    //
+    // One `TscManagementInformation` type serves IE 199, 200 and 201, so the ONLY
+    // thing that distinguishes the three carriers is the number each message
+    // encodes it under. That is exactly what a copy-paste between the three arms
+    // gets wrong, and what a self-round-trip cannot detect — each message would
+    // decode its own output happily under any number, as long as it agreed with
+    // itself. So these assert the carrier number ON THE WIRE.
+
+    /// The IE type numbers present at the top level of an encoded body.
+    fn top_level_ie_types(body: &[u8]) -> Vec<u16> {
+        let mut out = Vec::new();
+        let mut buf = Bytes::copy_from_slice(body);
+        while buf.remaining() >= IeHeader::LEN {
+            match RawIe::decode(&mut buf) {
+                Ok(ie) => out.push(ie.ie_type),
+                Err(_) => break,
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn test_session_modification_request_carries_tsc_under_ie_199() {
+        let mut req = SessionModificationRequest::new();
+        req.tsc_management_info
+            .push(TscManagementInformation::port(vec![0x01, 0x02], 3));
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+
+        assert!(
+            top_level_ie_types(&buf).contains(&199),
+            "a Session Modification Request must carry TSC Management Information as IE 199 \
+             (TS 29.244 §7.5.4.18), not 200 or 201"
+        );
+        let decoded = SessionModificationRequest::decode(&mut buf.freeze()).unwrap();
+        assert_eq!(decoded.tsc_management_info.len(), 1);
+        assert_eq!(decoded.tsc_management_info[0].nw_tt_port_number, Some(3));
+    }
+
+    #[test]
+    fn test_session_modification_response_carries_tsc_under_ie_200() {
+        let mut resp = SessionModificationResponse::new(PfcpCause::RequestAccepted);
+        resp.tsc_management_info
+            .push(TscManagementInformation::user_plane_node(vec![0xAB]));
+        let mut buf = BytesMut::new();
+        resp.encode(&mut buf);
+
+        assert!(
+            top_level_ie_types(&buf).contains(&200),
+            "a Session Modification Response must carry it as IE 200 (§7.5.5.3)"
+        );
+        let decoded = SessionModificationResponse::decode(&mut buf.freeze()).unwrap();
+        assert_eq!(
+            decoded.tsc_management_info[0]
+                .user_plane_node_management_container
+                .as_deref(),
+            Some(&[0xAB][..])
+        );
+    }
+
+    #[test]
+    fn test_session_report_request_carries_tsc_under_ie_201() {
+        let mut rt = ReportType::default();
+        rt.tmir = true;
+        let mut req = SessionReportRequest::new(rt);
+        req.tsc_management_info
+            .push(TscManagementInformation::port(vec![0x09], 11));
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+
+        assert!(
+            top_level_ie_types(&buf).contains(&201),
+            "a Session Report Request must carry it as IE 201 (§7.5.8.5)"
+        );
+        let decoded = SessionReportRequest::decode(&mut buf.freeze()).unwrap();
+        assert!(
+            decoded.report_type.tmir,
+            "the TMIR bit is what tells the SMF a TSC report is present at all"
+        );
+        assert_eq!(decoded.tsc_management_info[0].nw_tt_port_number, Some(11));
+    }
+
+    #[test]
+    fn test_session_establishment_carries_create_and_created_bridge_info() {
+        let mut req = SessionEstablishmentRequest::new(
+            NodeId::new_ipv4([10, 45, 0, 1]),
+            FSeid::new_ipv4(1, [10, 45, 0, 1]),
+        );
+        req.create_bridge_info = Some(CreateBridgeInfoForTsc::bridge());
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        assert!(
+            top_level_ie_types(&buf).contains(&194),
+            "Create Bridge/Router Info is IE 194"
+        );
+        let decoded = SessionEstablishmentRequest::decode(&mut buf.freeze()).unwrap();
+        assert_eq!(
+            decoded.create_bridge_info.map(|b| b.bii),
+            Some(true),
+            "the BII bit must survive the round trip: it is what asks the UPF to allocate"
+        );
+
+        let mut resp = SessionEstablishmentResponse::new(PfcpCause::RequestAccepted);
+        resp.node_id = Some(NodeId::new_ipv4([10, 45, 0, 2]));
+        resp.up_f_seid = Some(FSeid::new_ipv4(2, [10, 45, 0, 2]));
+        resp.created_bridge_info = Some(CreatedBridgeInfoForTsc {
+            port_number: Some(4),
+            user_plane_node_id: Some(FiveGsUserPlaneNodeId::new(0xBEEF)),
+        });
+        let mut rbuf = BytesMut::new();
+        resp.encode(&mut rbuf);
+        assert!(
+            top_level_ie_types(&rbuf).contains(&195),
+            "Created Bridge/Router Info is IE 195"
+        );
+        let rdecoded = SessionEstablishmentResponse::decode(&mut rbuf.freeze()).unwrap();
+        let created = rdecoded.created_bridge_info.unwrap();
+        assert_eq!(created.port_number, Some(4));
+        assert_eq!(created.user_plane_node_id.unwrap().node_id, Some(0xBEEF));
     }
 }

--- a/src/libs/nextgcore-pfcp/src/types.rs
+++ b/src/libs/nextgcore-pfcp/src/types.rs
@@ -4267,6 +4267,294 @@ impl PfcpSessionChangeInfo {
     }
 }
 
+// ============================================================================
+// 5GS TSC bridge management (TS 29.244 §5.26, issue #321)
+// ============================================================================
+//
+// The SMF-to-UPF half of 5GS-TSN. The IE *identifiers* for all of this were
+// already declared in `ie.rs` with zero users; what follows is the codec, and
+// `message.rs` carries it on the four messages TS 29.244 puts it on.
+//
+// The three "TSC Management Information" IEs (199 within a Session Modification
+// Request, 200 within its Response, 201 within a Session Report Request) have
+// BYTE-IDENTICAL contents — Tables 7.5.4.18-1, 7.5.5.3-1 and 7.5.8.5-1 list the
+// same three members — so one type serves all three and the carrier IE type is
+// the caller's choice, not the type's. Modelling them as three structs would
+// triple the codec to encode the same bytes.
+
+/// Create Bridge/Router Info (TS 29.244 §8.2.140, IE 194).
+///
+/// One flags octet, sent on a Session Establishment Request to ask the UP
+/// function to allocate a port number and report its 5GS User Plane Node ID.
+///
+/// `bii` requests IEEE TSN bridge information; `rii` requests IETF DetNet router
+/// information. They are independent bits, so both, either or neither can be set
+/// — and "neither" is a real request that asks for nothing, which is why this is
+/// not modelled as an enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CreateBridgeInfoForTsc {
+    /// BII (bit 1): Bridge Information Indication — a DS-TT port number and the
+    /// related 5GS User Plane Node ID are requested.
+    pub bii: bool,
+    /// RII (bit 2): Router Information Indication — a PDU-session port number and
+    /// the related 5GS User Plane Node ID are requested (DetNet).
+    pub rii: bool,
+}
+
+impl CreateBridgeInfoForTsc {
+    /// Request IEEE TSN bridge information.
+    pub fn bridge() -> Self {
+        Self {
+            bii: true,
+            rii: false,
+        }
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u8((self.bii as u8) | ((self.rii as u8) << 1));
+    }
+
+    /// Decode from the IE payload.
+    ///
+    /// An EMPTY payload decodes to "neither flag set" rather than an error: the
+    /// figure's octet 5 is the only defined octet and a zero-length IE carries no
+    /// request, which is the same thing. Erroring would reject a message whose
+    /// meaning is unambiguous.
+    pub fn decode(data: &[u8]) -> PfcpResult<Self> {
+        let flags = data.first().copied().unwrap_or(0);
+        Ok(Self {
+            bii: flags & 0x01 != 0,
+            rii: flags & 0x02 != 0,
+        })
+    }
+}
+
+/// 5GS User Plane Node ID (TS 29.244 §8.2.143, IE 198).
+///
+/// A flags octet whose BID bit says whether the 8-octet node-ID value follows.
+/// For IEEE TSN the value is the Bridge ID of IEEE 802.1Q clause 14.2.5.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FiveGsUserPlaneNodeId {
+    /// The node ID, present iff the BID flag was set.
+    ///
+    /// `Option` rather than a bool plus a value, so a BID flag set with no value
+    /// (or a value with the flag clear) cannot be represented and then mis-sent.
+    pub node_id: Option<u64>,
+}
+
+impl FiveGsUserPlaneNodeId {
+    pub fn new(node_id: u64) -> Self {
+        Self {
+            node_id: Some(node_id),
+        }
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u8(u8::from(self.node_id.is_some()));
+        if let Some(id) = self.node_id {
+            buf.put_u64(id);
+        }
+    }
+
+    /// Decode from the IE payload.
+    ///
+    /// The value is read only when BID is set AND eight octets are actually
+    /// present. A BID flag with a short value yields `None` rather than a
+    /// zero-padded node ID: a bridge ID that is wrong is worse than one that is
+    /// missing, because the SMF reports it to the PCF as the bridge's identity.
+    pub fn decode(data: &[u8]) -> PfcpResult<Self> {
+        let flags = data.first().copied().unwrap_or(0);
+        let node_id = if flags & 0x01 != 0 && data.len() >= 9 {
+            Some(u64::from_be_bytes([
+                data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8],
+            ]))
+        } else {
+            None
+        };
+        Ok(Self { node_id })
+    }
+}
+
+/// Created Bridge/Router Info (TS 29.244 §7.5.3.6, IE 195) — grouped.
+///
+/// The UP function's answer to a `CreateBridgeInfoForTsc`: the port number it
+/// allocated for the PDU session, and its own 5GS User Plane Node ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CreatedBridgeInfoForTsc {
+    /// Port Number (IE 196). For TSN this is the DS-TT port number.
+    pub port_number: Option<u32>,
+    /// 5GS User Plane Node ID (IE 198).
+    pub user_plane_node_id: Option<FiveGsUserPlaneNodeId>,
+}
+
+impl CreatedBridgeInfoForTsc {
+    pub fn encode(&self, buf: &mut BytesMut) {
+        use crate::ie::{IeHeader, IeType};
+
+        if let Some(port) = self.port_number {
+            // §8.2.141: Length = 4, and for TSN the value is an Unsigned16 in
+            // octets 7-8 with 5-6 zero. Encoding the whole u32 big-endian gives
+            // exactly that for any port that fits in 16 bits, and stays correct
+            // for a DetNet Unsigned32 port.
+            let header = IeHeader::new(IeType::DsTtPortNumber as u16, 4);
+            header.encode(buf);
+            buf.put_u32(port);
+        }
+        if let Some(node) = &self.user_plane_node_id {
+            let mut node_buf = BytesMut::new();
+            node.encode(&mut node_buf);
+            let header = IeHeader::new(IeType::FivegsUserPlaneNode as u16, node_buf.len() as u16);
+            header.encode(buf);
+            buf.put_slice(&node_buf);
+        }
+    }
+
+    pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
+        use crate::ie::{IeHeader, IeType, RawIe};
+
+        let mut port_number = None;
+        let mut user_plane_node_id = None;
+
+        while buf.remaining() >= IeHeader::LEN {
+            let ie = RawIe::decode(buf)?;
+            match ie.ie_type {
+                t if t == IeType::DsTtPortNumber as u16 => {
+                    if ie.data.len() >= 4 {
+                        let mut data = ie.data;
+                        port_number = Some(data.get_u32());
+                    }
+                }
+                t if t == IeType::FivegsUserPlaneNode as u16 => {
+                    user_plane_node_id = Some(FiveGsUserPlaneNodeId::decode(&ie.data)?);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            port_number,
+            user_plane_node_id,
+        })
+    }
+}
+
+/// TSC Management Information (TS 29.244 §7.5.4.18 / §7.5.5.3 / §7.5.8.5) —
+/// grouped, carried as IE 199, 200 or 201 depending on the message.
+///
+/// Both containers are OPAQUE octet strings: §8.2.144 and §8.2.182 say they carry
+/// a Port management message and a User plane node management message defined in
+/// clauses 8 and 9 of TS 24.539. **This tree has no TS 24.539 codec**, so the
+/// containers are transported byte-exact and not interpreted — which is the
+/// correct behaviour for the SMF (a pure relay between the PCF and the UPF) and a
+/// stated ceiling for the UPF.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TscManagementInformation {
+    /// Port Management Information Container (IE 202) — the PMIC.
+    pub port_management_container: Option<Vec<u8>>,
+    /// User Plane Node Management Information Container (IE 266) — the UMIC.
+    pub user_plane_node_management_container: Option<Vec<u8>>,
+    /// NW-TT Port Number (IE 197). Conditional: the tables require it when a PMIC
+    /// is present, because a port container without a port is unattributable.
+    pub nw_tt_port_number: Option<u32>,
+}
+
+impl TscManagementInformation {
+    /// A PMIC for one NW-TT port. The port number is not optional here, since
+    /// that is exactly the condition the tables state.
+    pub fn port(container: Vec<u8>, nw_tt_port_number: u32) -> Self {
+        Self {
+            port_management_container: Some(container),
+            user_plane_node_management_container: None,
+            nw_tt_port_number: Some(nw_tt_port_number),
+        }
+    }
+
+    /// A UMIC, which is bridge-level and carries no port identity.
+    pub fn user_plane_node(container: Vec<u8>) -> Self {
+        Self {
+            port_management_container: None,
+            user_plane_node_management_container: Some(container),
+            nw_tt_port_number: None,
+        }
+    }
+
+    /// Whether this carries anything at all.
+    ///
+    /// An empty TSC Management Information IE is legal to decode (every member is
+    /// O or C) but pointless to send, so senders check this rather than emitting a
+    /// four-octet IE that says nothing.
+    pub fn is_empty(&self) -> bool {
+        self.port_management_container.is_none()
+            && self.user_plane_node_management_container.is_none()
+            && self.nw_tt_port_number.is_none()
+    }
+
+    /// Whether the conditional in Tables 7.5.4.18-1/7.5.5.3-1/7.5.8.5-1 holds:
+    /// "When PMIC IE is present, this IE shall contain the related NW-TT Port
+    /// Number."
+    ///
+    /// A PMIC with no port number is the one shape a receiver cannot act on — it
+    /// has port configuration and nothing to apply it to — so it is reported
+    /// rather than silently accepted.
+    pub fn conditional_holds(&self) -> bool {
+        self.port_management_container.is_none() || self.nw_tt_port_number.is_some()
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        use crate::ie::{encode_bytes_ie, IeHeader, IeType};
+
+        if let Some(pmic) = &self.port_management_container {
+            encode_bytes_ie(buf, IeType::PortManagementInformationContainer, pmic);
+        }
+        if let Some(umic) = &self.user_plane_node_management_container {
+            encode_bytes_ie(
+                buf,
+                IeType::UserPlaneNodeManagementInformationContainer,
+                umic,
+            );
+        }
+        if let Some(port) = self.nw_tt_port_number {
+            // §8.2.142: Length = 4, TSN value an Unsigned16 in octets 7-8.
+            let header = IeHeader::new(IeType::NwTtPortNumber as u16, 4);
+            header.encode(buf);
+            buf.put_u32(port);
+        }
+    }
+
+    pub fn decode(buf: &mut Bytes) -> PfcpResult<Self> {
+        use crate::ie::{IeHeader, IeType, RawIe};
+
+        let mut port_management_container = None;
+        let mut user_plane_node_management_container = None;
+        let mut nw_tt_port_number = None;
+
+        while buf.remaining() >= IeHeader::LEN {
+            let ie = RawIe::decode(buf)?;
+            match ie.ie_type {
+                t if t == IeType::PortManagementInformationContainer as u16 => {
+                    port_management_container = Some(ie.data.to_vec());
+                }
+                t if t == IeType::UserPlaneNodeManagementInformationContainer as u16 => {
+                    user_plane_node_management_container = Some(ie.data.to_vec());
+                }
+                t if t == IeType::NwTtPortNumber as u16 => {
+                    if ie.data.len() >= 4 {
+                        let mut data = ie.data;
+                        nw_tt_port_number = Some(data.get_u32());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            port_management_container,
+            user_plane_node_management_container,
+            nw_tt_port_number,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5104,5 +5392,188 @@ mod tests {
         let decoded = OuterHeaderCreation::decode(&mut b).unwrap();
         assert!(decoded.description.gtpu_udp_ipv4);
         assert_eq!(decoded.teid, Some(0x1234_5678));
+    }
+
+    // ========================================================================
+    // 5GS TSC bridge management (#321)
+    // ========================================================================
+    //
+    // These decode HAND-BUILT wire buffers, not this module's own encoder output.
+    // A pure round-trip test passes for any self-consistent pair of functions,
+    // including one that agrees with itself on the wrong IE type number — which is
+    // exactly the mistake worth catching when five IE numbers land at once.
+
+    /// Build an IE header plus payload the way a peer would, without going
+    /// anywhere near the encoder under test.
+    fn wire_ie(ie_type: u16, payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&ie_type.to_be_bytes());
+        out.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+        out.extend_from_slice(payload);
+        out
+    }
+
+    #[test]
+    fn test_tsc_management_information_decodes_hand_built_wire() {
+        // TS 29.244 Table 7.5.4.18-1: PMIC (202), UMIC (266), NW-TT Port (197).
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&wire_ie(202, &[0xAA, 0xBB, 0xCC]));
+        wire.extend_from_slice(&wire_ie(266, &[0x01, 0x02]));
+        // §8.2.142: Length 4, TSN port is an Unsigned16 in octets 7-8.
+        wire.extend_from_slice(&wire_ie(197, &[0x00, 0x00, 0x00, 0x07]));
+
+        let mut buf = Bytes::from(wire);
+        let tsc = TscManagementInformation::decode(&mut buf).unwrap();
+
+        assert_eq!(
+            tsc.port_management_container.as_deref(),
+            Some(&[0xAA, 0xBB, 0xCC][..]),
+            "PMIC must survive byte-exact: it is an opaque TS 24.539 payload"
+        );
+        assert_eq!(
+            tsc.user_plane_node_management_container.as_deref(),
+            Some(&[0x01, 0x02][..])
+        );
+        assert_eq!(tsc.nw_tt_port_number, Some(7));
+        assert!(tsc.conditional_holds());
+    }
+
+    #[test]
+    fn test_tsc_management_information_encodes_expected_ie_numbers() {
+        // The golden half: the container IE numbers are 202 and 266, and 266 is
+        // NOT a number this tree could round-trip its way into by accident — it
+        // was absent from `IeType` until #321.
+        let mut buf = BytesMut::new();
+        TscManagementInformation {
+            port_management_container: Some(vec![0x11]),
+            user_plane_node_management_container: Some(vec![0x22, 0x33]),
+            nw_tt_port_number: Some(0x0102),
+        }
+        .encode(&mut buf);
+
+        assert_eq!(
+            buf.to_vec(),
+            vec![
+                0x00, 0xCA, 0x00, 0x01, 0x11, // 202, len 1, PMIC
+                0x01, 0x0A, 0x00, 0x02, 0x22, 0x33, // 266, len 2, UMIC
+                0x00, 0xC5, 0x00, 0x04, 0x00, 0x00, 0x01, 0x02, // 197, len 4, port
+            ],
+            "TSC Management Information must encode PMIC=202, UMIC=266, NW-TT=197"
+        );
+    }
+
+    #[test]
+    fn test_tsc_management_information_pmic_without_port_fails_the_conditional() {
+        // "When PMIC IE is present, this IE shall contain the related NW-TT Port
+        // Number." Port configuration with no port to apply it to is the one shape
+        // a receiver cannot act on, so it must be reportable rather than silently
+        // accepted.
+        let tsc = TscManagementInformation {
+            port_management_container: Some(vec![0x01]),
+            user_plane_node_management_container: None,
+            nw_tt_port_number: None,
+        };
+        assert!(!tsc.conditional_holds());
+
+        // A UMIC alone carries no port identity at all, so the conditional is
+        // vacuously satisfied — not a violation.
+        assert!(TscManagementInformation::user_plane_node(vec![0x01]).conditional_holds());
+    }
+
+    #[test]
+    fn test_tsc_management_information_empty_is_detected() {
+        let mut buf = Bytes::new();
+        let decoded = TscManagementInformation::decode(&mut buf).unwrap();
+        assert!(
+            decoded.is_empty(),
+            "an IE with no members decodes rather than erroring, but must report empty \
+             so senders do not emit it"
+        );
+    }
+
+    #[test]
+    fn test_create_bridge_info_flag_bits_golden() {
+        // TS 29.244 §8.2.140: BII is octet-5 bit 1 (0x01), RII is bit 2 (0x02).
+        let mut buf = BytesMut::new();
+        CreateBridgeInfoForTsc::bridge().encode(&mut buf);
+        assert_eq!(buf.to_vec(), vec![0x01], "BII must be 0x01");
+
+        let mut buf = BytesMut::new();
+        CreateBridgeInfoForTsc {
+            bii: false,
+            rii: true,
+        }
+        .encode(&mut buf);
+        assert_eq!(buf.to_vec(), vec![0x02], "RII must be 0x02");
+
+        // Decoded from a hand-built octet, both bits set.
+        let both = CreateBridgeInfoForTsc::decode(&[0x03]).unwrap();
+        assert!(both.bii && both.rii);
+
+        // An empty payload is "asks for nothing", not an error.
+        let none = CreateBridgeInfoForTsc::decode(&[]).unwrap();
+        assert!(!none.bii && !none.rii);
+    }
+
+    #[test]
+    fn test_five_gs_user_plane_node_id_bid_flag_and_value() {
+        // §8.2.143: octet 5 bit 1 is BID; the value is an Unsigned64 after it.
+        let mut buf = BytesMut::new();
+        FiveGsUserPlaneNodeId::new(0x0011_2233_4455_6677).encode(&mut buf);
+        assert_eq!(
+            buf.to_vec(),
+            vec![0x01, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77],
+            "BID set then the 8-octet bridge ID"
+        );
+
+        let decoded = FiveGsUserPlaneNodeId::decode(&[0x01, 0, 0, 0, 0, 0, 0, 0, 0x2A]).unwrap();
+        assert_eq!(decoded.node_id, Some(42));
+
+        // BID clear: no value, even if octets follow.
+        let clear = FiveGsUserPlaneNodeId::decode(&[0x00, 0xFF, 0xFF]).unwrap();
+        assert_eq!(clear.node_id, None);
+    }
+
+    #[test]
+    fn test_five_gs_user_plane_node_id_short_value_is_absent_not_padded() {
+        // A BID flag with only four octets of value must NOT yield a zero-padded
+        // bridge ID: the SMF reports this to the PCF as the bridge's identity, and
+        // a wrong identity is worse than a missing one.
+        let short = FiveGsUserPlaneNodeId::decode(&[0x01, 0xDE, 0xAD, 0xBE, 0xEF]).unwrap();
+        assert_eq!(short.node_id, None);
+    }
+
+    #[test]
+    fn test_created_bridge_info_decodes_hand_built_wire() {
+        // TS 29.244 Table 7.5.3.6-1: Port Number (196) + 5GS User Plane Node ID (198).
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&wire_ie(196, &[0x00, 0x00, 0x00, 0x05]));
+        wire.extend_from_slice(&wire_ie(198, &[0x01, 0, 0, 0, 0, 0, 0, 0x12, 0x34]));
+
+        let mut buf = Bytes::from(wire);
+        let created = CreatedBridgeInfoForTsc::decode(&mut buf).unwrap();
+
+        assert_eq!(
+            created.port_number,
+            Some(5),
+            "DS-TT port from the UP function"
+        );
+        assert_eq!(
+            created.user_plane_node_id.and_then(|n| n.node_id),
+            Some(0x1234),
+            "bridge ID per IEEE 802.1Q clause 14.2.5"
+        );
+    }
+
+    #[test]
+    fn test_created_bridge_info_round_trip_through_own_encoder() {
+        let original = CreatedBridgeInfoForTsc {
+            port_number: Some(0xABCD),
+            user_plane_node_id: Some(FiveGsUserPlaneNodeId::new(0xFFFF_0000_FFFF_0000)),
+        };
+        let mut buf = BytesMut::new();
+        original.encode(&mut buf);
+        let mut b = buf.freeze();
+        assert_eq!(CreatedBridgeInfoForTsc::decode(&mut b).unwrap(), original);
     }
 }


### PR DESCRIPTION
Closes #321. Completes #284's **criterion 4**, which #284 left unmet and named as its
main ceiling.

## What was missing

The TSC IE *identifiers* existed. Nothing else did — `rg 'CreateBridgeInfoForTsc|TscManagementInformationSmr' src/`
returned the enum declarations and nothing more. `upfd`'s `tsn_bridge` was `None` at
init and its only other reference was a unit test that hand-built its own bridge.

## The chain now

1. TSCTSF derives PMIC/UMIC (#284) → PCF over `Npcf_PolicyAuthorization` — *existed*
2. PCF stores the containers and includes them in the `SmPolicyDecision` — **new**
3. SMF base64-decodes them and carries them over N4 as IE 199 — **new**, gated on `tscu`
4. UPF decodes 199, populates `tsn_bridge` from `None`, echoes IE 200 — **new**
5. UPF may report asynchronously with IE 201 + TMIR; the SMF decodes and records it — **new**
6. Establishment: a `tscu`-advertising UPF is asked for bridge info (194) and its
   Created Bridge/Router Info (195) — DS-TT port + Bridge ID — is held per session — **new**

## Scope item 4: which hop, and why

**PCF → SMF over `Npcf_SMPolicyControl`.** `SmPolicyDecision` already defines
`tsnBridgeManCont`, `tsnPortManContDstt`, `tsnPortManContNwtts`, `tscNotifUri` and
`tscNotifCorreId` (official `TS29512_Npcf_SMPolicyControl.yaml`, lines 696-708), under
**the same names** TS 29.514 uses on the inbound leg. So the PCF is a **copier, not a
translator** — no mapping step in which the opaque containers could be corrupted, and
no member invented.

TSCTSF → SMF directly was declined: TS 23.502 Annex F.1 puts the PCF in the path, the
TSCTSF has no Nsmf consumer role here, and it would need a protocol no spec defines.

Note what settles the shape: a TSCTSF app session **binds by UE IP**, so it requires
the PDU session to already exist. The containers therefore always arrive on an *update*
to a live session, never on the create — which is why the Session Modification path is
the load-bearing one.

## A live wire bug found on the way in

`smfd`'s `n4_build::pfcp_ie` is a second, hand-maintained copy of TS 29.244
Table 8.1.2-1. It **omitted IP Multicast Address (191)**, shifting every constant after
it — 65 in total, growing to a seven-place shift by IE 202:

```
smfd said                                        TS 29.244 says
193  TSC_MANAGEMENT_INFORMATION_..._MOD_REQUEST  193  Packet Rate Status
199  TIME_DOMAIN_NUMBER                          199  TSC Management Information (SMR)
250  S_NSSAI                                     250  DL Data Packets Size
```

**64 were inert. The 65th was live**: `add_s_nssai` is called from
`pfcp_session_establish`, so every 5GC Session Establishment Request carried the slice
identity as IE 250, "DL Data Packets Size". §8.2.176 Figure 8.2.176-1 says `Type = 257`.

Why it hid, both halves verified: nothing in this tree *reads* S-NSSAI over N4
(`rg S_NSSAI` across `upfd`/`sgwud`/`sgwcd` returns nothing), so no peer compensated
for it — checked before fixing, since a correctness fix is a breaking change to whoever
compensated — and the other 64 had no callers. `upfd`, `sgwcd` and `sgwud` keep their
own copies; all three stop before 191 and were checked clean.

Now pinned by `test_pfcp_ie_numbers_match_the_authoritative_table`, which compares 24
constants against `nextgcore_pfcp::ie::IeType` and asserts S-NSSAI = 257 and the
UMIC = 266 against the clause directly. A 255-row hand-maintained wire table cannot be
kept correct by review.

## Two things #321 got wrong

1. **The UMIC is not called what #321 calls it.** On N4 it is the **User Plane Node
   Management Information Container, IE 266** (§8.2.182) — absent from `IeType`
   entirely. #321, following TS 29.512, calls it a "Bridge Management Information
   Container"; the two specs name the same octet string differently. Every IE number
   here was read from the vendored `6g_docs/specs/29244-k00.txt`, not from memory,
   which is the only reason that surfaced.
2. **`UpfSess.tsn_bridge` is in an unreachable store.** `UpfContext::sess_add` has **no
   production caller** — only that module's own tests — so `rule_match`'s UE-IP lookups
   always return `None`. Populating `UpfSess.tsn_bridge` would have been a correct
   change in a place no wire path runs through, and its test could only have asserted
   against a session it built itself. **That is why #284's criterion 4 stayed unmet.**
   The live bridge is on `PfcpSessionInfo`. Filed as #325.

## Decisions

- **One type for IEs 199/200/201** — the three tables list identical members. The risk
  is a copy-paste putting the wrong carrier number on a message, which a self-round-trip
  cannot catch, so three tests assert the carrier number **on the wire**.
- **The DS-TT container is deliberately not sent over N4** — §7.5.4.18 gives the IE an
  NW-TT Port Number and no DS-TT one, because device-side config reaches the DS-TT over
  NAS (TS 24.501 §5.4.5). It is still parsed and stored for when that leg exists.
- **`tscu` gates the carriage** — §6.2.2 lets a UP function reject a request carrying an
  unsupported feature's IEs, which would fail every establishment against a plain UPF.
- **The TSC modification is its own message** — §7.5.5 gives one Cause per message, and
  "bandwidth not enforced" and "bridge not configured" are different failures.
- **A PMIC with no NW-TT Port Number is refused, not defaulted** — 0 is the port number
  the TSCTSF's own derivation reserves for the network side.

## Verification

Workspace **6464 passed / 0 failed** (main: 6433). Clippy warnings unchanged at **74**,
all pre-existing, none in the touched files. `cargo fmt --check` clean.
**14 whole-workspace loops and 22 targeted loops clean** — a first green run proved
nothing last session, so these were looped before trusting them.

Criterion 1's tests decode **hand-built wire buffers**, not the encoder's own output.

### Reverts, all of which bite

| revert | named test that failed |
|---|---|
| UMIC IE 266 → 267 | `test_tsc_management_information_decodes_hand_built_wire`, `..._encodes_expected_ie_numbers` |
| modification carrier 199 → 201 | `test_session_modification_request_carries_tsc_under_ie_199` |
| remove the `tscu` gate | `test_tsc_containers_withheld_from_a_upf_without_tscu` |
| send the DS-TT container over N4 | `test_tsc_containers_are_carried_on_a_session_modification` |
| never apply the containers in the UPF | `test_tsc_management_information_populates_the_tsn_bridge`, `test_tsc_modification_response_echoes_what_was_applied` |
| accept a PMIC with no port number | `test_tsc_pmic_without_port_number_is_rejected` |
| `S_NSSAI` 257 → 250 | `test_pfcp_ie_numbers_match_the_authoritative_table` |

## Criteria

| # | criterion | status |
|---|---|---|
| 1 | codec for TSC Management Information + Create/Created Bridge Info, round-trip vs hand-built buffer | **met** |
| 2 | Session Modification carries PMIC/UMIC, `upfd` populates `tsn_bridge` from `None`, asserted from UPF state | **met** — from `PfcpServer::sessions`, over a real UDP round trip |
| 3 | `tscu` gates carriage; test covers a UPF with the bit clear | **met** — the default stand-in has it clear, so that is the ordinary case |
| 4 | Session Report carrying IE 201 reaches the SMF and is decoded | **met** — recorded and asserted from state |
| 5 | PCF → SMF hop implemented and stated | **met** |
| 6 | #284 criterion 4 satisfiable end to end; say which | **met, in-process** |
| 7 | whole-workspace lint and tests pass | **met** |

## Ceilings (spec has the full list)

- No TS 24.539 codec, so the UPF **stores** the containers rather than acting on them.
- The SMF does not yet relay a received IE 201 onward to the PCF (TS 23.502 Annex F.1).
- `tsctsf`'s PMIC is still this build's own TLV encoding, not IEEE 802.1Q clause 12
  (#321 scope item 5) — it needs the same codec as the item above.
- The UPF's Bridge ID is derived from the SEID; §5.26.2 says it may be pre-configured,
  and this build has no such configuration surface.
- **In-process, not Docker E2E.** The Docker jobs remain `workflow_dispatch`-only.

## Follow-ups filed

- **#325** — `upfd`'s `UpfSess` store has production readers and test-only writers
  (the #223 defect class, in `upfd`); it is what blocked #284's criterion 4.
- **#326** — `nextgcore-sbi::stop_drains_an_in_flight_request` is load-sensitive
  (wall-clock lower bound behind a racy 80 ms sleep). Surfaced in these flake loops,
  1-in-5 under load; **not caused by this change** — that crate is untouched here, and
  it does not reproduce in 25 isolated or 20 crate-level runs.

Spec: `specs/fix-pfcp-tsc-container-codec.md`