### PR TITLE
fix(mmed): make the attach reach S11 and the response reach the Attach Accept (#329)

### DIFF
--- a/specs/fix-mmed-attach-s11-csr-and-accept.md
+++ b/specs/fix-mmed-attach-s11-csr-and-accept.md
@@ -1,0 +1,177 @@
+# fix(mmed): make the attach path reach S11 and the response reach the Attach Accept
+
+Closes #329. Unblocks the MME half of #303 (whose remaining blocker is #328, the
+"nothing can originate an S1AP attach" decision).
+
+## What was broken
+
+Two senders, both built and unit-tested, with **zero callers** — and, once wired, four
+more breaks behind them. The EPS attach could not complete, and each layer was invisible
+from the one above it.
+
+| # | gap | site | how it presented |
+|---|---|---|---|
+| 1 | the NAS path never sent the Create Session Request | `nas_dispatch.rs:1322`, `:1386` | logged *"the S11 Create Session Request to the SGW is not implemented (#51)"* — and #51 was CLOSED |
+| 2 | no SGW-UE context existed at request time | `context.rs:1957` | `send_create_session_request` → `ContextNotFound` for every attach |
+| 3 | `mme_s11_teid` was never assigned | `context.rs:1039` | every CSR carried Sender F-TEID **0** |
+| 4 | `mme_s11_teid_hash` had a reader and **no writer** | `context.rs:1480,2021` | `mme_ue_find_by_s11_local_teid` always `None`, so every Create Session Response was dropped as matching no UE |
+| 5 | the PAA was parsed and discarded | `s11_handler.rs:291` | the UE's IP address never reached the session |
+| 6 | the response could not tell which procedure it belonged to | `gtp_path.rs:545` | no create action reached the response path |
+| 7 | the Attach Accept was unreachable | `nas_path.rs:266` | zero callers |
+| 8 | a reachable panic on the accept path | `esm_build.rs:616` | `.expect("value expected")` on an absent subscription record |
+| 9 | the accept named a fabricated EBI | `nas_path.rs:285` | `build_activate_default_bearer_context_request` invents `ebi: 5`, ignoring the real bearer |
+
+Gaps 2-4, 8 and 9 are **not in #329's text**. Each was found by the previous one's fix
+making the next line of code run for the first time — which is the pattern worth
+recording: a chain of unreachable code hides its own defects, and they surface strictly
+one at a time.
+
+### Why 1 fell between two closed issues
+
+#51's eight criteria are all about transport, sequencing and message construction, and
+`specs/fix-mmed-s11-gtpc-endpoint.md:144-151` states the ceiling explicitly: *"the attach
+procedure still does not complete… wiring the Create Session Response into an Initial
+Context Setup plus an Attach Accept is #46's subject."* #46 then closed by satisfying its
+criterion via the **TAU** path and left the attach half blocked. So the call sites were
+each other's follow-up, and the log lines kept citing an issue that had already shipped
+everything it promised.
+
+## What changed
+
+**`context.rs` — the UE gets its S11 identity when it is created.**
+`mme_ue_add` now allocates `mme_s11_teid` (from the pool id, `+1` so it is never 0 —
+which is what the broken state sent and what a peer reads as "no TEID") and registers it
+in `mme_s11_teid_hash` in the same breath, so the index cannot drift from the field. It
+also creates and associates the `SgwUe` context, because
+`send_create_session_request` resolves it on the REQUEST path while the only previous
+creator ran on the response path — the MME could not send the request whose response
+would have created the context it needed to send it. `mme_ue_remove` removes the index
+entry keyed by **the removed context's** TEID, the same discipline the IMSI line beside
+it follows and for the same reason a previous defect there taught.
+
+**`gtp_path.rs` — `PENDING_CREATES`, keyed by S11 sequence number.**
+`send_create_session_request` already returned a `GtpXactData` carrying the create action
+and the eNB UE id, and its (absent) caller was expected to hold it. The response path
+receives only bytes, type, sequence and peer, so the create action had to travel
+somewhere. Keyed by sequence number because that is what `match_response` already
+correlates on — one notion of "which request is this the answer to" rather than two that
+can disagree. Records are **taken**, not read, so a duplicated or retransmitted response
+cannot drive the continuation twice.
+
+**`nas_dispatch.rs` — the two call sites**, via one `send_s11_create_session` helper that
+maps `esm_build::CreateAction` to `s11_build::GtpCreateAction`. A send failure is logged
+and NOT turned into a reject: the ESM procedure is still open and its T3485/T3489 timers
+govern the outcome, so synthesising a reject would race them.
+
+**`s11_handler.rs` — the continuation.** `apply_create_session_response` now takes its
+pending record, stores the PAA, and on `AttachRequest` **only** calls
+`nas_eps_send_attach_accept`. The PDN type comes from the **response**, not from what the
+UE requested: TS 29.274 §8.14 lets the network grant a narrower type, and honouring the
+request would tell the UE it has an address family the PGW never allocated. An undefined
+PDN type stores nothing rather than pairing a real address with a type no one can read.
+
+**`nas_path.rs` / `esm_build.rs` — the accept says what it means.** The accept path now
+calls `build_activate_default_bearer_context_request_with_params` with the real
+`default_bearer` it was handed, instead of the simplified helper that fabricates EBI 5 —
+otherwise the ESM message told the UE to bind EBI 5 while the E-RAB in the enclosing
+Initial Context Setup (built from the same `default_bearer` a few lines down) could name a
+different one. And the simplified helper's `.expect("value expected")` on
+`sess.session` — absent for any session the HSS has not populated — becomes a default plus
+a warning. A crashing MME is strictly worse than a default-QoS bearer, and that panic was
+about to become reachable for the first time.
+
+## Three parallel create-action enums
+
+`esm_build::CreateAction` (what the ESM handlers take), `nas_path::GtpCreateAction` (what
+the ESM builders take) and `s11_build::GtpCreateAction` (what the S11 builder takes). None
+is a superset: `s11_build`'s has `UplinkNasTransport` and `PathSwitchRequest`, the others
+have `InPdnConnectivityRequest` and `InHandover`. Unifying them is a separate change with
+its own blast radius, so this maps explicitly in one readable place rather than leaving
+the correspondence to be inferred. Recorded here because "count the implementations before
+writing the abstraction" cuts both ways — three is the count, and the answer this time is
+still not one.
+
+## Verification
+
+Whole workspace **6472 passed / 0 failed** (main: 6464). Clippy warnings unchanged at
+**74**, all pre-existing. `cargo fmt --check` clean.
+
+### Reverts, all of which bite
+
+| revert | named test that failed |
+|---|---|
+| drop the `mme_s11_teid_hash` registration | `the_paa_from_a_create_session_response_reaches_the_session`, `an_attach_create_action_drives_the_attach_accept`, `a_tau_create_action_does_not_drive_the_attach_accept`, `the_activate_default_bearer_request_carries_the_stored_paa_and_real_ebi` |
+| don't create the `SgwUe` with the UE | `the_pdn_connectivity_path_sends_a_create_session_request` |
+| restore the "not implemented (#51)" log | `the_pdn_connectivity_path_sends_a_create_session_request` |
+| drop the pending-create recording | `the_pdn_connectivity_path_sends_a_create_session_request` |
+| drop the PAA store | three PAA/continuation tests |
+| remove the create-action gate | `a_tau_create_action_does_not_drive_the_attach_accept` |
+| use the simplified builder in the accept | `an_attach_create_action_drives_the_attach_accept` |
+| restore the `.expect` on `sess.session` | `a_session_without_subscribed_qos_does_not_panic_the_esm_builder` |
+
+### One revert did NOT bite the first time, and that is the finding
+
+The builder-swap revert initially passed, because the EBI test called
+`build_activate_default_bearer_context_request_with_params` **directly** and asserted on
+the builder's own output — so it passed whichever builder `nas_eps_send_attach_accept`
+chose. That is exactly the "the helper is tested and the wiring is not" shape, walked
+into while fixing an issue about unreachable code.
+
+The test now asserts the expected ESM bytes appear **as a subsequence of what the
+production path buffered in `t3450.pkbuf`**, and uses **EBI 7** — with EBI 5 the
+fabricated and real answers coincide, so the assertion could not have distinguished them.
+With that, the revert fails.
+
+### Observables are state, not logs
+
+- the CSR is asserted from a **stand-in SGW-C socket's received datagram**, decoded with
+  the library codec;
+- the Sender F-TEID is asserted to **resolve back to the UE** through
+  `mme_ue_find_by_s11_local_teid`, which is the lookup that was broken;
+- the Attach Accept is asserted from **`mme_ue.t3450.pkbuf`** — the retransmission buffer
+  the accept path fills — not from the S1AP send queue, because
+  `s1ap_path::install_send_queue` is once-per-process and a sibling test already consumes
+  that slot.
+
+### One test installs the S11 server, deliberately
+
+`S11_SERVER` is a `OnceLock`, so a second installer would silently use the first's socket
+and assert about a sibling's traffic. `the_pdn_connectivity_path_sends_a_create_session_request`
+is therefore the only installer and carries both the production-caller and the
+correlation assertions; an earlier draft had a second install in `gtp_path`'s tests and it
+was removed rather than left to race.
+
+`S11_TEST_LOCK` was **promoted out of `gtp_path::tests`** to a `pub(crate)` static beside
+the globals it guards, so `s11_handler`'s tests share the one agreement. Declaring a
+second lock over the same variables is what #276 showed HANGS the suite rather than
+merely flaking it.
+
+20 consecutive `-p nextgcore-mmed` runs clean.
+
+## Ceilings
+
+- **Nothing can originate an S1AP attach.** There is no LTE eNB or UE simulator in this
+  tree (`nextgsim` is 5G-only), so the chain is exercised from an uplink NAS PDU injected
+  into `nas_eps_handle_uplink` rather than from a radio-side peer. That is #328's
+  decision, and it is what still blocks #303.
+- **The Modify Bearer Request is not driven from here.** TS 23.401 §5.3.2.1 continues past
+  the Attach Accept to Initial Context Setup Response → Modify Bearer, and
+  `send_modify_bearer_request` exists. It has its own trigger (the ICS Response) and is
+  not on this path.
+- **The EPS bearer identity is written as a whole octet** followed by the protocol
+  discriminator (`esm_build.rs:559-560`) rather than packed into octet 1 as
+  TS 24.301 §9.3.1 does. That is this build's existing convention across every ESM
+  builder; the test follows the code's layout and says so rather than quietly asserting
+  the spec's.
+- **`build_activate_default_bearer_context_request`'s fabricated `ebi: 5` survives** for
+  its other caller (`nas_path.rs:874`). Documented as a fallback for callers with no
+  bearer to name; that caller should be given one, but it is a different path.
+- **No E2E.** Every assertion is in-process, over loopback UDP where a socket is involved.
+
+## References
+
+- #329, #303 (blocked), #328 (the origination decision), #51 and its spec's Ceilings,
+  #46 (closed via the TAU path)
+- TS 23.401 §5.3.2.1; TS 29.274 §7.2.1, §8.14, §8.22; TS 24.301 §6.5.1.2, §9.3.1
+- `context.rs:1957,1974,2020,2255`, `gtp_path.rs:619,545`, `nas_dispatch.rs:1322,1386`,
+  `s11_handler.rs:291`, `nas_path.rs:266,285`, `esm_build.rs:605`

--- a/src/bins/nextgcore-mmed/src/context.rs
+++ b/src/bins/nextgcore-mmed/src/context.rs
@@ -1956,6 +1956,23 @@ impl MmeContext {
     /// Add a new MME UE
     pub fn mme_ue_add(&self, enb_ue_id: u64) -> u64 {
         let id = self.next_pool_id();
+        // #329: the UE's own S11 control-plane TEID, allocated HERE and registered in
+        // the lookup index in the same breath.
+        //
+        // Before this it was never assigned at all: `mme_s11_teid` stayed at
+        // `Default`'s 0, so every Create Session Request carried a Sender F-TEID of 0,
+        // and `mme_s11_teid_hash` had a reader (`mme_ue_find_by_s11_local_teid`) and
+        // **no writer anywhere in the crate** — so that lookup always returned `None`
+        // and every Create Session Response was dropped as matching no UE. The MME
+        // could ask for a session and could not recognise the answer.
+        //
+        // Derived from the pool id rather than from a second counter: the pool id is
+        // already unique per live UE, so the two cannot drift apart, and the index is
+        // keyed by exactly the value the Sender F-TEID carries. The low 32 bits are
+        // taken because a TEID is 32-bit (TS 29.274 §8.22); `saturating_add(1)` keeps
+        // it non-zero, since 0 is what the broken state used and a real peer treats it
+        // as "no TEID assigned".
+        let mme_s11_teid = (id as u32).saturating_add(1);
         let mme_ue = MmeUe {
             id,
             enb_ue_id,
@@ -1964,9 +1981,32 @@ impl MmeContext {
             // E-UTRAN, because S1 is the only access this MME has (#51). Set here
             // rather than left at `Default`'s 0, which is a reserved RAT value.
             rat_type: crate::s11_build::rat_type::EUTRAN,
+            mme_s11_teid,
             ..Default::default()
         };
         self.mme_ue_pool.write().unwrap().insert(id, mme_ue);
+        self.mme_s11_teid_hash
+            .write()
+            .unwrap()
+            .insert(mme_s11_teid, id);
+
+        // #329: the UE's SGW-side context, created WITH the UE rather than on the
+        // Create Session RESPONSE.
+        //
+        // `set_sgw_s11_teid_for_ue` creates one if it is missing, and that was the only
+        // production creator — but it runs on the response path, while
+        // `send_create_session_request` resolves `sgw_ue_find_by_id(mme_ue.sgw_ue_id)`
+        // on the REQUEST path and returned `ContextNotFound` for every attach because
+        // the id was still `NEXTGCORE_INVALID_POOL_ID`. So the MME could not send the
+        // request whose response would have created the context it needed to send it.
+        //
+        // The SGW node id stays invalid: TS 23.401 §4.3.8.1 selects the SGW by TAI/APN
+        // via DNS, which this tree does not implement, so there is no node to point at
+        // yet — the peer comes from `sgwc_list` at send time.
+        // `set_sgw_s11_teid_for_ue`'s create-if-missing branch survives as a fallback
+        // for any UE that predates this.
+        let sgw_ue_id = self.sgw_ue_add(NEXTGCORE_INVALID_POOL_ID);
+        self.sgw_ue_associate_mme_ue(sgw_ue_id, id);
         id
     }
 
@@ -1976,6 +2016,16 @@ impl MmeContext {
             // Remove from hash tables
             if !ue.imsi_bcd.is_empty() {
                 self.imsi_ue_hash.write().unwrap().remove(&ue.imsi_bcd);
+            }
+            // #329: keyed by the REMOVED context's TEID, not by anything re-derived —
+            // the same discipline the IMSI line above follows, and for the same reason
+            // a previous defect here taught (re-deriving the key dropped the surviving
+            // mapping instead of the dead one).
+            if ue.mme_s11_teid != 0 {
+                self.mme_s11_teid_hash
+                    .write()
+                    .unwrap()
+                    .remove(&ue.mme_s11_teid);
             }
             true
         } else {

--- a/src/bins/nextgcore-mmed/src/esm_build.rs
+++ b/src/bins/nextgcore-mmed/src/esm_build.rs
@@ -606,14 +606,31 @@ pub fn build_activate_default_bearer_context_request(
     sess: &MmeSess,
     create_action: crate::nas_path::GtpCreateAction,
 ) -> Vec<u8> {
-    // Get default bearer from session (first bearer)
+    // The bearer this message activates.
+    //
+    // #329: `sess.session.as_ref()...expect("value expected")` used to be here, and it
+    // was a REACHABLE PANIC — `sess.session` is the subscription record, absent for any
+    // session the HSS has not populated, and this function is on the Attach Accept path.
+    // It survived only because that path had no caller (see the issue). A crashing MME
+    // is strictly worse than one that activates a bearer with default QoS and says so.
+    let subscribed_qos = sess.session.as_ref().map(|s| s.qos.clone());
+    if subscribed_qos.is_none() {
+        log::warn!(
+            "session for APN '{}' carries no subscribed QoS; activating the default \
+             bearer with default QoS values",
+            sess.apn
+        );
+    }
     let default_bearer = MmeBearer {
-        ebi: 5, // Default EBI
-        qos: sess
-            .session
-            .as_ref()
-            .map(|s| s.qos.clone())
-            .expect("value expected"),
+        // EBI 5 is the lowest value TS 24.007 §11.2.3.1.5 assigns to an EPS bearer, so
+        // it is the right FALLBACK for a caller that has no bearer to name — but a
+        // caller that does have one should use
+        // `build_activate_default_bearer_context_request_with_params` and pass it,
+        // which is what the Attach Accept path now does (#329). Leaving this to
+        // fabricate an EBI for that path made the UE bind whatever bearer the message
+        // named rather than the one the MME had created.
+        ebi: 5,
+        qos: subscribed_qos.unwrap_or_default(),
         ..Default::default()
     };
 

--- a/src/bins/nextgcore-mmed/src/gtp_path.rs
+++ b/src/bins/nextgcore-mmed/src/gtp_path.rs
@@ -83,6 +83,103 @@ pub fn server() -> Option<&'static GtpcServer> {
     S11_SERVER.get()
 }
 
+/// What a sent Create Session Request was for, so its response can continue the
+/// procedure that started it (#329).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PendingCreate {
+    /// The EMM/ESM procedure that triggered the request.
+    pub create_action: GtpCreateAction,
+    /// The eNB UE context the continuation has to answer on.
+    pub enb_ue_id: u64,
+    /// The session the response's PAA and bearer TEIDs belong to.
+    pub sess_id: u64,
+}
+
+/// Pending Create Session Requests, keyed by S11 sequence number.
+///
+/// # Why this exists at all
+///
+/// `send_create_session_request` returns a `GtpXactData` carrying the create action
+/// and the eNB UE id, and the caller was expected to hold it — but it had **no
+/// caller**, so nothing did (#329). The response path
+/// (`s11_handler::dispatch_triggered`) receives only the raw bytes, the message type,
+/// the sequence number and the peer, so without this it cannot tell an attach's
+/// Create Session Response from a TAU's, and would either answer every one with an
+/// Attach Accept or none.
+///
+/// Keyed by SEQUENCE NUMBER because that is what the transaction layer already
+/// correlates on (`GtpcInner::match_response`), so there is one notion of "which
+/// request is this the answer to" rather than two that can disagree. Keyed by the
+/// local TEID instead would collapse two concurrent requests for the same UE.
+///
+/// Entries are TAKEN, not read: a response consumes its record, so a retransmitted
+/// or duplicated response cannot drive the continuation twice.
+static PENDING_CREATES: OnceLock<Mutex<HashMap<u32, PendingCreate>>> = OnceLock::new();
+
+fn pending_creates() -> &'static Mutex<HashMap<u32, PendingCreate>> {
+    PENDING_CREATES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record what a Create Session Request at `seq` was for.
+fn record_pending_create(seq: u32, pending: PendingCreate) {
+    if let Ok(mut map) = pending_creates().lock() {
+        map.insert(seq, pending);
+    }
+}
+
+/// Take the record for the Create Session Request at `seq`, if this MME sent one.
+///
+/// `None` means either that the response is for a request this MME did not send, or
+/// that its record was already consumed — both of which are reasons NOT to continue a
+/// procedure, which is why the caller treats them the same way.
+pub fn take_pending_create(seq: u32) -> Option<PendingCreate> {
+    pending_creates().lock().ok()?.remove(&seq)
+}
+
+/// Serialises every test that installs the process-wide S11 server, touches the MME
+/// context's GTP-C configuration, or drives the S11 response path.
+///
+/// Declared beside the globals it guards rather than inside a `mod tests`, per #308,
+/// and `pub(crate)` so `s11_handler`'s tests share THIS lock: the globals involved are
+/// `S11_SERVER`, `PENDING_CREATES`, and `mme_self()`'s UE/session/bearer pools plus its
+/// `gtpc_list` / `sgwc_list`, and they cannot be guarded separately. A second lock over
+/// the same variables would be two disjoint agreements rather than one — #276 showed
+/// that mistake HANGS the suite rather than merely flaking it, which is why this is
+/// promoted here instead of re-declared in `s11_handler` (#329).
+#[cfg(test)]
+pub(crate) static S11_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Take [`S11_TEST_LOCK`], recovering from a poisoned guard so one failing test does
+/// not cascade into every sibling.
+#[cfg(test)]
+pub(crate) fn lock_s11() -> std::sync::MutexGuard<'static, ()> {
+    S11_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Record a pending create without sending anything.
+///
+/// Test-only. The response path's behaviour turns entirely on whether a record exists
+/// and what create action it names, and driving that through a real socket send would
+/// make every response-side test also a transport test — so this seeds the one input
+/// the response path reads. Callers hold [`S11_TEST_LOCK`].
+#[cfg(test)]
+pub(crate) fn record_pending_create_for_test(seq: u32, pending: PendingCreate) {
+    record_pending_create(seq, pending);
+}
+
+/// Drop every pending record.
+///
+/// Declared here beside the map rather than in a `mod tests`: it is process-global, so
+/// a test that mutates it races every sibling that reads it, and a second lock
+/// declared elsewhere would be a second agreement rather than one. Callers hold
+/// [`S11_TEST_LOCK`].
+#[cfg(test)]
+pub fn clear_pending_creates_for_test() {
+    if let Ok(mut map) = pending_creates().lock() {
+        map.clear();
+    }
+}
+
 /// Send `msg` as an initial message to the configured Serving GW.
 ///
 /// One place resolves the peer and reports the two ways a send can fail before it
@@ -671,6 +768,18 @@ pub fn send_create_session_request(
     let xact_id = ctx.next_pool_id();
     send_to_sgwc(ctx, &msg, xact_id)?;
 
+    // #329: record what this request was for BEFORE returning, so the response path
+    // can continue the procedure. Recorded after the send succeeds: a request that
+    // never left would leave a record no response can ever consume.
+    record_pending_create(
+        seq,
+        PendingCreate {
+            create_action,
+            enb_ue_id,
+            sess_id,
+        },
+    );
+
     Ok(GtpXactData {
         xact_id,
         create_action: Some(create_action),
@@ -1141,17 +1250,8 @@ const GTP_CMD_XACT_ID_FLAG: u64 = 0x8000_0000_0000_0000;
 mod tests {
     use super::*;
 
-    /// Serialises every test that installs the process-wide S11 server or touches the
-    /// MME context's GTP-C configuration.
-    ///
-    /// Declared beside the globals it guards rather than in a submodule, per #308: the
-    /// `S11_SERVER` `OnceLock` and `mme_self()`'s `gtpc_list` / `sgwc_list` are
-    /// process-wide, and a test that binds a socket while a sibling is reading the
-    /// peer list gets the sibling's answer.
-    static S11_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn lock_s11() -> std::sync::MutexGuard<'static, ()> {
-        S11_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+        super::lock_s11()
     }
 
     #[test]

--- a/src/bins/nextgcore-mmed/src/nas_dispatch.rs
+++ b/src/bins/nextgcore-mmed/src/nas_dispatch.rs
@@ -53,8 +53,13 @@ use crate::emm_build::{EmmCause, NAS_PROTOCOL_DISCRIMINATOR_EMM, NAS_PROTOCOL_DI
 use crate::emm_handler;
 use crate::esm_build::{CreateAction, EsmCause};
 use crate::esm_handler;
+use crate::gtp_path;
 use crate::nas_path::{self, GtpCreateAction};
+// #329: `s11_build`'s create action is a THIRD enum with the same purpose as
+// `esm_build::CreateAction` and `nas_path::GtpCreateAction`. Aliased rather than
+// imported bare so the three cannot be confused at a glance in this file.
 use crate::nas_security::{self, SecurityHeaderTypeFlags};
+use crate::s11_build::GtpCreateAction as S11CreateAction;
 use crate::s1ap_build::{self, nas_cause};
 use crate::s1ap_path;
 
@@ -1319,11 +1324,11 @@ pub fn handle_esm_message(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue: &MmeUe, esm:
                         return;
                     }
 
-                    log::info!(
-                        "[{}] PDN connectivity accepted locally; the S11 Create Session Request \
-                         to the SGW is not implemented (#51)",
-                        mme_ue.imsi_bcd
-                    );
+                    // #329: send the Create Session Request. Before this, the branch
+                    // logged "not implemented (#51)" — and #51 had shipped the sender,
+                    // the transaction layer and the transport, leaving only this call
+                    // site, which fell between #51's and #46's scopes.
+                    send_s11_create_session(ctx, enb_ue.id, sess_id, create_action, mme_ue);
                 }
                 Err(e) => {
                     log::warn!(
@@ -1383,11 +1388,21 @@ pub fn handle_esm_message(ctx: &MmeContext, enb_ue: &EnbUe, mme_ue: &MmeUe, esm:
                     if let Some(bearer) = ctx.bearer_pool.write().unwrap().get_mut(&bearer_id) {
                         bearer.t3489.pkbuf = None;
                     }
-                    log::info!(
-                        "[{}] ESM information complete; the S11 Create Session Request to the \
-                         SGW is not implemented (#51)",
-                        mme_ue.imsi_bcd
-                    );
+                    // #329: the deferred half of the PDN Connectivity Request. The UE
+                    // withheld its APN and sent it here (TS 24.301 §6.5.1.2), so this
+                    // is where that session finally has enough to ask the SGW.
+                    //
+                    // The create action is re-derived from the EMM procedure rather
+                    // than carried from the PDN Connectivity Request: the ESM
+                    // Information Response arrives on the same EMM procedure, and
+                    // re-reading it keeps one rule for both sites instead of a stored
+                    // copy that can go stale.
+                    let create_action = match mme_ue.nas_eps.type_ {
+                        MmeEpsType::AttachRequest => CreateAction::InAttachRequest,
+                        MmeEpsType::TauRequest => CreateAction::InTauRequest,
+                        _ => CreateAction::InPdnConnectivityRequest,
+                    };
+                    send_s11_create_session(ctx, enb_ue.id, sess_id, create_action, mme_ue);
                 }
                 Err(e) => log::warn!(
                     "[{}] ESM Information Response rejected: {e}",
@@ -1603,6 +1618,61 @@ fn locate_session(ctx: &MmeContext, mme_ue_id: u64, pti: u8, ebi: u8) -> Option<
         .sess_find_by_id(sess_id)
         .and_then(|sess| sess.bearer_list.first().copied())?;
     Some((sess_id, bearer_id))
+}
+
+/// Ask the Serving GW to create the session's bearers over S11 (#329,
+/// TS 23.401 §5.3.2.1 step 4).
+///
+/// Called from the two points where the ESM procedure has everything the Create
+/// Session Request needs: a PDN Connectivity Request that carried its APN, and the
+/// ESM Information Response that supplied one withheld from it. Both used to log
+/// "the S11 Create Session Request to the SGW is not implemented (#51)" — and #51 had
+/// in fact shipped the sender, the sequencing and the transport, leaving only this
+/// call.
+///
+/// # Why the create action is mapped rather than passed through
+///
+/// The tree has THREE parallel create-action enums: `esm_build::CreateAction` (what
+/// the ESM handlers take), `nas_path::GtpCreateAction` (what the ESM builders take)
+/// and `s11_build::GtpCreateAction` (what the S11 builder takes). They are not
+/// interchangeable and none is a superset — `s11_build`'s has `UplinkNasTransport` and
+/// `PathSwitchRequest`, the others have `InPdnConnectivityRequest` and `InHandover`.
+/// Unifying them is a separate change with its own blast radius; mapping explicitly
+/// here at least puts the correspondence in one readable place instead of leaving the
+/// next reader to infer it.
+///
+/// A failure is logged and NOT propagated to the UE as a reject. TS 23.401 has the MME
+/// wait for the SGW; the ESM procedure is still open and its T3485/T3489 timers govern
+/// what happens when no answer arrives, so synthesising a reject here would race them.
+fn send_s11_create_session(
+    ctx: &MmeContext,
+    enb_ue_id: u64,
+    sess_id: u64,
+    create_action: CreateAction,
+    mme_ue: &MmeUe,
+) {
+    let gtp_action = match create_action {
+        CreateAction::InAttachRequest => S11CreateAction::AttachRequest,
+        CreateAction::InTauRequest => S11CreateAction::TrackingAreaUpdate,
+        // A standalone PDN Connectivity Request arrives in an Uplink NAS Transport,
+        // which is exactly what TS 29.274's create action distinguishes it by.
+        CreateAction::InPdnConnectivityRequest => S11CreateAction::UplinkNasTransport,
+        CreateAction::InHandover => S11CreateAction::PathSwitchRequest,
+    };
+
+    match gtp_path::send_create_session_request(ctx, enb_ue_id, sess_id, gtp_action) {
+        Ok(xact) => log::info!(
+            "[{}] S11 Create Session Request sent to the SGW (action={gtp_action:?}, \
+             local S11 TEID {:#x})",
+            mme_ue.imsi_bcd,
+            xact.local_teid
+        ),
+        Err(e) => log::error!(
+            "[{}] S11 Create Session Request could not be sent: {e:?} — the ESM \
+             procedure stays open and its timer governs the outcome",
+            mme_ue.imsi_bcd
+        ),
+    }
 }
 
 /// Send ESM INFORMATION REQUEST, arming T3489's retransmission buffer.
@@ -2664,6 +2734,139 @@ mod tests {
             .unwrap()
             .sess_list
             .is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // The attach path's S11 Create Session Request (#329)
+    // ------------------------------------------------------------------
+
+    /// The criterion this issue exists for: driving a real PDN Connectivity Request
+    /// through the NAS dispatch makes a Create Session Request reach the wire.
+    ///
+    /// Before #329 this branch logged "the S11 Create Session Request to the SGW is not
+    /// implemented (#51)" and returned — so `gtp_path::send_create_session_request` had
+    /// no caller at all and no attach could complete. A test that called the sender
+    /// directly would have passed against that state, which is why this one starts from
+    /// an uplink NAS PDU.
+    ///
+    /// It is also the ONLY test in this crate that installs the process-wide S11 server:
+    /// `S11_SERVER` is a `OnceLock`, so a second installer would silently use the
+    /// first's socket and assert about a sibling's traffic. It therefore also carries
+    /// the correlation assertions, rather than leaving those to a second install.
+    #[test]
+    fn the_pdn_connectivity_path_sends_a_create_session_request() {
+        use nextgcore_gtp::v2::{Gtp2IeType, Gtp2Message};
+
+        let _guard = crate::gtp_path::lock_s11();
+        crate::gtp_path::clear_pending_creates_for_test();
+
+        // A stand-in SGW-C that only receives, plus the MME's real S11 socket.
+        let peer = std::net::UdpSocket::bind("127.0.0.1:0").expect("peer bind");
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(2)))
+            .expect("peer timeout");
+        let peer_addr = peer.local_addr().expect("peer addr");
+        let server = crate::gtp_path::GtpcServer::open(
+            "127.0.0.1:0",
+            nextgcore_gtp::v2::xact::Gtp2XactConfig::default(),
+            7,
+        )
+        .expect("S11 bind");
+        if !crate::gtp_path::install_server(server) {
+            // A sibling installed first; this test would then be asserting about that
+            // socket rather than its own. Skipped rather than made flaky.
+            return;
+        }
+
+        let mut ctx = test_ctx();
+        ctx.sgwc_list = vec![peer_addr];
+        let enb_ue_id = enb_with_connection(&ctx);
+        let mme_ue_id = ue_with_vector(&ctx, enb_ue_id);
+
+        // A real ATTACH REQUEST first, so the UE's EMM procedure IS an attach. Without
+        // it `mme_ue.nas_eps.type_` is unset and the create action derives to
+        // `UplinkNasTransport` — correct for a standalone PDN connectivity request, but
+        // not the path this issue is about.
+        nas_eps_handle_uplink(
+            &ctx,
+            uplink(
+                enb_ue_id,
+                &attach_request(&[0x08, 0x29, 0x43, 0x65, 0x87, 0x09, 0x21, 0x43], &[]),
+            ),
+        );
+
+        // Establish the security context the ESM handler requires.
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &authentication_response()));
+        assert!(
+            ctx.mme_ue_find_by_id(mme_ue_id)
+                .unwrap()
+                .security_context_available,
+            "precondition: the ESM handler refuses without a security context"
+        );
+
+        // A well-formed PDN CONNECTIVITY REQUEST: PDN type IPv4 (high nibble 1) and
+        // request type 1 (initial request), then an APN IE so the request is complete
+        // and does NOT divert into an ESM Information Request instead.
+        let mme_ue = ctx.mme_ue_find_by_id(mme_ue_id).unwrap();
+        let mut esm = vec![
+            NAS_PROTOCOL_DISCRIMINATOR_ESM,
+            7, // procedure transaction identity
+            EsmMessageType::PdnConnectivityRequest as u8,
+            0x11, // PDN type IPv4 | request type 1
+            0x28, // Access Point Name IEI
+        ];
+        let apn = b"\x08internet";
+        esm.push(apn.len() as u8);
+        esm.extend_from_slice(apn);
+        let protected = protect_uplink(&mme_ue, 1, &esm);
+
+        nas_eps_handle_uplink(&ctx, uplink(enb_ue_id, &protected));
+
+        // The CSR must be on the wire.
+        let mut buf = [0u8; 4096];
+        let (len, _) = peer
+            .recv_from(&mut buf)
+            .expect("a Create Session Request must reach the SGW-C");
+        let mut bytes = bytes::Bytes::copy_from_slice(&buf[..len]);
+        let received = Gtp2Message::decode(&mut bytes).expect("the CSR must decode");
+        assert_eq!(
+            received.header.message_type,
+            crate::s11_build::message_type::CREATE_SESSION_REQUEST,
+            "the NAS path must send a Create Session Request, not some other message"
+        );
+
+        // The Sender F-TEID must carry a REAL S11 TEID. Before #329 `mme_s11_teid` was
+        // never assigned, so this was 0 and no response could be attributed to a UE.
+        let fteid = nextgcore_gtp::v2::Gtp2FTeidIe::decode(
+            &received
+                .get_ie(Gtp2IeType::FTeid as u8, 0)
+                .expect("Sender F-TEID is mandatory")
+                .value,
+        )
+        .expect("the F-TEID must decode");
+        assert_ne!(
+            fteid.teid, 0,
+            "the Sender F-TEID must name a real TEID: 0 is the pre-#329 value and \\
+             mme_s11_teid_hash cannot resolve it"
+        );
+        assert_eq!(
+            ctx.mme_ue_find_by_s11_local_teid(fteid.teid),
+            Some(mme_ue_id),
+            "and that TEID must resolve back to this UE, which is what lets the \\
+             Create Session Response be attributed"
+        );
+
+        // The pending record must be keyed by the sequence number that went out, and
+        // must name an ATTACH (the UE's EMM procedure), so the response continues to an
+        // Attach Accept rather than to nothing.
+        let pending = crate::gtp_path::take_pending_create(received.header.sequence_number)
+            .expect("the wire sequence number must be the record's key");
+        assert_eq!(
+            pending.create_action,
+            crate::s11_build::GtpCreateAction::AttachRequest
+        );
+        assert_eq!(pending.enb_ue_id, enb_ue_id);
+
+        crate::gtp_path::clear_pending_creates_for_test();
     }
 
     #[test]

--- a/src/bins/nextgcore-mmed/src/nas_path.rs
+++ b/src/bins/nextgcore-mmed/src/nas_path.rs
@@ -281,10 +281,18 @@ pub fn nas_eps_send_attach_accept(
 
     log::debug!("[{}] Attach accept", mme_ue.imsi_bcd);
 
-    // Build ESM activate default bearer context request
-    let esm_message = esm_build::build_activate_default_bearer_context_request(
+    // Build ESM activate default bearer context request.
+    //
+    // #329: `_with_params` and the REAL `default_bearer`, not the simplified helper.
+    // That helper fabricates `ebi: 5` because it has no bearer to name, and this
+    // function is handed the actual default bearer — so the simplified call made the
+    // Attach Accept tell the UE to bind EBI 5 whatever the MME had actually created,
+    // and the E-RAB in the enclosing Initial Context Setup (built from
+    // `default_bearer` a few lines below) could then name a different one.
+    let esm_message = esm_build::build_activate_default_bearer_context_request_with_params(
         sess,
-        GtpCreateAction::InAttachRequest,
+        default_bearer,
+        esm_build::CreateAction::InAttachRequest,
     );
 
     // Build EMM attach accept with ESM message

--- a/src/bins/nextgcore-mmed/src/s11_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s11_handler.rs
@@ -339,6 +339,148 @@ fn apply_create_session_response(
             );
         }
     }
+
+    // #329: continue the procedure that asked for this session. Everything above is
+    // bookkeeping the response supplies; everything below is the UE's answer, which
+    // before #329 was never sent because nothing tracked what the request was for.
+    let Some(pending) = crate::gtp_path::take_pending_create(sequence_number) else {
+        // Either a response to a request this MME did not send, or a duplicate whose
+        // record a first copy already consumed. Both are reasons not to continue: the
+        // TEIDs above are idempotent, an Attach Accept is not.
+        log::debug!(
+            "S11 Create Session Response (seq={sequence_number}) has no pending create \
+             record; TEIDs applied, no procedure continued"
+        );
+        return;
+    };
+
+    // The PAA is the UE's IP address, and it is the reason the UE attached at all.
+    // Stored BEFORE the Attach Accept is built: `esm_build::encode_pdn_address` reads
+    // `sess.paa`, so an accept built first would carry an unset address and the UE
+    // would complete an attach with no usable bearer.
+    store_paa(ctx, pending.sess_id, data);
+
+    match pending.create_action {
+        crate::s11_build::GtpCreateAction::AttachRequest => {
+            continue_attach(ctx, mme_ue_id, &pending);
+        }
+        other => {
+            // A TAU, a standalone PDN connectivity request and a path switch each have
+            // their own continuation, and none of them is an Attach Accept. Naming the
+            // action rather than staying silent, because "session created and nothing
+            // happened" is otherwise indistinguishable from a missing call site — which
+            // is exactly the defect #329 fixed.
+            log::info!(
+                "S11 session created for create action {other:?}; no attach continuation \
+                 applies (its own procedure owns the next step)"
+            );
+        }
+    }
+}
+
+/// Store the PDN Address Allocation the PGW granted on the session (#329).
+///
+/// The PDN type is taken from the response rather than from what the UE requested:
+/// TS 29.274 §8.14 lets the network grant a narrower type than was asked for (an
+/// IPv4v6 request answered with IPv4 only), and honouring the request instead would
+/// have the MME tell the UE it has an address family the PGW did not allocate.
+fn store_paa(ctx: &crate::context::MmeContext, sess_id: u64, data: &CreateSessionResponseData) {
+    use crate::esm_build::PdnType;
+
+    let pdn_type = match data.paa_pdn_type {
+        1 => PdnType::Ipv4,
+        2 => PdnType::Ipv6,
+        3 => PdnType::Ipv4v6,
+        5 => PdnType::NonIp,
+        6 => PdnType::Ethernet,
+        other => {
+            log::warn!(
+                "S11 Create Session Response carried PDN type {other}, which TS 29.274 §8.14 \
+                 does not define; treating the session as having no allocated address"
+            );
+            return;
+        }
+    };
+
+    let Ok(mut pool) = ctx.sess_pool.write() else {
+        log::error!("session pool poisoned; PAA not stored");
+        return;
+    };
+    let Some(sess) = pool.get_mut(&sess_id) else {
+        log::warn!("S11 Create Session Response PAA is for session {sess_id}, which is gone");
+        return;
+    };
+    sess.paa.pdn_type = pdn_type;
+    if let Some(v4) = data.paa_ipv4 {
+        sess.paa.addr = v4;
+    }
+    if let Some(v6) = data.paa_ipv6 {
+        sess.paa.addr6 = v6;
+    }
+    log::info!(
+        "S11 PAA stored on session {sess_id}: pdn_type={pdn_type:?}, ipv4={:?}",
+        data.paa_ipv4
+    );
+}
+
+/// Answer the UE that started this attach: Initial Context Setup carrying the Attach
+/// Accept (#329, TS 23.401 §5.3.2.1 steps 16-17).
+///
+/// `nas_eps_send_attach_accept` builds the ESM Activate Default Bearer Context Request,
+/// the EMM Attach Accept, applies NAS security AND wraps the result in an Initial
+/// Context Setup Request, so this one call is the whole step rather than half of it.
+fn continue_attach(
+    ctx: &crate::context::MmeContext,
+    mme_ue_id: u64,
+    pending: &crate::gtp_path::PendingCreate,
+) {
+    let Some(sess) = ctx.sess_find_by_id(pending.sess_id) else {
+        log::warn!("attach continuation: session {} is gone", pending.sess_id);
+        return;
+    };
+    let Some(enb_ue) = ctx.enb_ue_find_by_id(pending.enb_ue_id) else {
+        // The S1 context went away while the SGW was answering — the UE is no longer
+        // reachable, so there is nowhere to send the accept.
+        log::warn!(
+            "attach continuation: eNB UE context {} is gone, so the Attach Accept has \
+             nowhere to go",
+            pending.enb_ue_id
+        );
+        return;
+    };
+    // The DEFAULT bearer, which is the one the Initial Context Setup builds an E-RAB
+    // for. Taken as the session's lowest EBI: TS 24.301 §6.4.1 makes the default
+    // bearer the first activated for the PDN connection.
+    let Some(bearer) = sess
+        .bearer_list
+        .iter()
+        .filter_map(|id| ctx.bearer_find_by_id(*id))
+        .min_by_key(|b| b.ebi)
+    else {
+        log::warn!(
+            "attach continuation: session {} holds no bearer to build an E-RAB from",
+            pending.sess_id
+        );
+        return;
+    };
+
+    let Ok(mut pool) = ctx.mme_ue_pool.write() else {
+        log::error!("UE pool poisoned; Attach Accept not sent");
+        return;
+    };
+    let Some(mme_ue) = pool.get_mut(&mme_ue_id) else {
+        log::warn!("attach continuation: UE context {mme_ue_id} is gone");
+        return;
+    };
+
+    match crate::nas_path::nas_eps_send_attach_accept(mme_ue, &enb_ue, &sess, &bearer) {
+        Ok(()) => log::info!(
+            "[{}] Attach Accept sent in an Initial Context Setup Request (EBI {})",
+            mme_ue.imsi_bcd,
+            bearer.ebi
+        ),
+        Err(e) => log::error!("[{}] Attach Accept failed: {e:?}", mme_ue.imsi_bcd),
+    }
 }
 
 /// Route an initial message the SGW-C originated.
@@ -952,5 +1094,432 @@ mod tests {
         assert_eq!(teid, 0x12345678);
         assert_eq!(ipv4, Some([192, 168, 1, 1]));
         assert!(ipv6.is_none());
+    }
+    // ------------------------------------------------------------------
+    // Create Session Response continuation (#329)
+    // ------------------------------------------------------------------
+    //
+    // These drive `apply_create_session_response` against the PROCESS-GLOBAL
+    // `mme_self()` context, which is what the live path uses, so they hold
+    // `gtp_path::S11_TEST_LOCK` — the one agreement about the S11 globals, shared with
+    // `gtp_path`'s own tests rather than re-declared here (a second lock over the same
+    // variables hung the suite in #276).
+
+    /// Seed the GLOBAL context with one UE, session and default bearer, and return
+    /// `(mme_ue_id, enb_ue_id, sess_id, bearer_id, local_s11_teid)`.
+    ///
+    /// The local S11 TEID is READ BACK from the context rather than chosen: `mme_ue_add`
+    /// allocates it and registers it in `mme_s11_teid_hash`, and writing the field
+    /// directly would leave the index pointing elsewhere — a fixture that disagrees with
+    /// itself and reproduces by hand the exact defect #329 fixed.
+    fn seed_global_ue(ebi: u8) -> (u64, u64, u64, u64, u32) {
+        let ctx = crate::context::mme_self();
+        let enb_id = ctx.enb_add("127.0.0.1:36412".parse().unwrap());
+        let enb_ue_id = ctx.enb_ue_add(enb_id, 300);
+        let mme_ue_id = ctx.mme_ue_add(enb_ue_id);
+        let sgw_ue_id = ctx.sgw_ue_add(mme_ue_id);
+        let local_teid = ctx
+            .mme_ue_find_by_id(mme_ue_id)
+            .expect("the UE just added")
+            .mme_s11_teid;
+        assert_ne!(local_teid, 0, "mme_ue_add must allocate an S11 TEID");
+
+        let sess_id = ctx.sess_add(mme_ue_id, 9);
+        let bearer_id = ctx.bearer_add(sess_id, mme_ue_id);
+        if let Ok(mut pool) = ctx.mme_ue_pool.write() {
+            if let Some(ue) = pool.get_mut(&mme_ue_id) {
+                ue.sgw_ue_id = sgw_ue_id;
+                ue.imsi_bcd = format!("99970000000{mme_ue_id:04}");
+                ue.sess_list.push(sess_id);
+            }
+        }
+        if let Ok(mut pool) = ctx.sess_pool.write() {
+            if let Some(sess) = pool.get_mut(&sess_id) {
+                sess.apn = "internet".to_string();
+                sess.bearer_list.push(bearer_id);
+            }
+        }
+        if let Ok(mut pool) = ctx.bearer_pool.write() {
+            if let Some(bearer) = pool.get_mut(&bearer_id) {
+                bearer.ebi = ebi;
+                bearer.qos.qci = 9;
+                bearer.qos.arp.priority_level = 8;
+            }
+        }
+        (mme_ue_id, enb_ue_id, sess_id, bearer_id, local_teid)
+    }
+
+    /// Release what `seed_global_ue` added, so the shared global context does not
+    /// accumulate UEs across the suite.
+    fn release_global_ue(mme_ue_id: u64, sess_id: u64, bearer_id: u64) {
+        let ctx = crate::context::mme_self();
+        ctx.bearer_remove(bearer_id);
+        ctx.sess_remove(sess_id);
+        ctx.mme_ue_remove(mme_ue_id);
+    }
+
+    /// An accepted Create Session Response carrying a PAA and one bearer context.
+    fn accepted_response(ebi: u8, paa: [u8; 4]) -> CreateSessionResponseData {
+        CreateSessionResponseData {
+            cause: 16,
+            sgw_s11_teid: 0x0000_ABCD,
+            paa_pdn_type: 1, // IPv4
+            paa_ipv4: Some(paa),
+            bearer_contexts: vec![BearerContextCreated {
+                ebi,
+                cause: 16,
+                sgw_s1u_teid: 0x0000_1111,
+                sgw_s1u_ipv4: Some([10, 0, 0, 9]),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// The PAA is the UE's IP address, and it was being DROPPED: the response was
+    /// parsed into `paa_ipv4` and never written to the session, so an Attach Accept
+    /// would have carried an unset PDN address.
+    #[test]
+    fn the_paa_from_a_create_session_response_reaches_the_session() {
+        let _guard = crate::gtp_path::lock_s11();
+        crate::gtp_path::clear_pending_creates_for_test();
+
+        let (mme_ue_id, enb_ue_id, sess_id, bearer_id, local_teid) = seed_global_ue(5);
+        let ctx = crate::context::mme_self();
+        assert_eq!(
+            ctx.sess_find_by_id(sess_id).unwrap().paa.addr,
+            [0, 0, 0, 0],
+            "precondition: the session has no allocated address before the response"
+        );
+
+        // A pending record is required for the continuation to run at all, which is
+        // what carries the create action.
+        crate::gtp_path::record_pending_create_for_test(
+            4242,
+            crate::gtp_path::PendingCreate {
+                create_action: GtpCreateAction::AttachRequest,
+                enb_ue_id,
+                sess_id,
+            },
+        );
+
+        apply_create_session_response(
+            &accepted_response(5, [10, 45, 0, 7]),
+            local_teid,
+            4242,
+            "127.0.0.1:2123".parse().unwrap(),
+        );
+
+        let sess = ctx.sess_find_by_id(sess_id).expect("session");
+        assert_eq!(
+            sess.paa.addr,
+            [10, 45, 0, 7],
+            "the PGW-allocated address must be stored on the session"
+        );
+        assert_eq!(sess.paa.pdn_type, crate::esm_build::PdnType::Ipv4);
+
+        release_global_ue(mme_ue_id, sess_id, bearer_id);
+        crate::gtp_path::clear_pending_creates_for_test();
+    }
+
+    /// The PDN type comes from the RESPONSE, not from what the UE asked for.
+    ///
+    /// TS 29.274 §8.14 lets the network grant a narrower type than requested, and
+    /// honouring the request would tell the UE it has an address family the PGW never
+    /// allocated.
+    #[test]
+    fn an_undefined_pdn_type_leaves_the_session_without_an_address() {
+        let _guard = crate::gtp_path::lock_s11();
+        crate::gtp_path::clear_pending_creates_for_test();
+
+        let (mme_ue_id, enb_ue_id, sess_id, bearer_id, local_teid) = seed_global_ue(5);
+        crate::gtp_path::record_pending_create_for_test(
+            4243,
+            crate::gtp_path::PendingCreate {
+                create_action: GtpCreateAction::AttachRequest,
+                enb_ue_id,
+                sess_id,
+            },
+        );
+
+        let mut data = accepted_response(5, [10, 45, 0, 8]);
+        data.paa_pdn_type = 7; // not defined by TS 29.274 §8.14
+        apply_create_session_response(&data, local_teid, 4243, "127.0.0.1:2123".parse().unwrap());
+
+        assert_eq!(
+            crate::context::mme_self()
+                .sess_find_by_id(sess_id)
+                .unwrap()
+                .paa
+                .addr,
+            [0, 0, 0, 0],
+            "an undefined PDN type must not be paired with the address anyway"
+        );
+
+        release_global_ue(mme_ue_id, sess_id, bearer_id);
+        crate::gtp_path::clear_pending_creates_for_test();
+    }
+
+    /// An `AttachRequest` create action reaches the Attach Accept; the encoded message
+    /// is left in T3450's retransmission buffer, which is where the UE's copy lives.
+    ///
+    /// Asserted from `mme_ue.t3450` — the UE context's own state — rather than from a
+    /// log line or from the S1AP send queue: `s1ap_path::install_send_queue` is
+    /// once-per-process and a sibling test already consumes that slot, so the queue is
+    /// not a reliable observable here.
+    #[test]
+    fn an_attach_create_action_drives_the_attach_accept() {
+        let _guard = crate::gtp_path::lock_s11();
+        crate::gtp_path::clear_pending_creates_for_test();
+
+        // EBI 7, not 5: the simplified builder fabricates 5, so with 5 the wrong and
+        // right answers coincide and the assertion below could not tell them apart.
+        let (mme_ue_id, enb_ue_id, sess_id, bearer_id, local_teid) = seed_global_ue(7);
+        let ctx = crate::context::mme_self();
+        assert!(
+            ctx.mme_ue_find_by_id(mme_ue_id)
+                .unwrap()
+                .t3450
+                .pkbuf
+                .is_none(),
+            "precondition: T3450 holds nothing before the accept"
+        );
+
+        crate::gtp_path::record_pending_create_for_test(
+            4244,
+            crate::gtp_path::PendingCreate {
+                create_action: GtpCreateAction::AttachRequest,
+                enb_ue_id,
+                sess_id,
+            },
+        );
+        apply_create_session_response(
+            &accepted_response(7, [10, 45, 0, 9]),
+            local_teid,
+            4244,
+            "127.0.0.1:2123".parse().unwrap(),
+        );
+
+        let pkbuf = ctx
+            .mme_ue_find_by_id(mme_ue_id)
+            .unwrap()
+            .t3450
+            .pkbuf
+            .expect("an attach continuation must leave the Attach Accept in T3450");
+        assert!(
+            !pkbuf.is_empty(),
+            "the buffered Attach Accept must carry the encoded message"
+        );
+
+        // And it must carry the ESM message built from THIS session's REAL bearer.
+        //
+        // Asserted as a subsequence of what the production path buffered, not by
+        // calling the builder and checking the builder's own output: a direct builder
+        // assertion passes whichever builder `nas_eps_send_attach_accept` chose, which
+        // is how the fabricated-EBI defect survived. Reverting the accept path to the
+        // simplified builder makes this fail, because that one names EBI 5.
+        let sess = ctx.sess_find_by_id(sess_id).expect("session");
+        let bearer = ctx.bearer_find_by_id(bearer_id).expect("bearer");
+        assert_eq!(bearer.ebi, 7, "precondition: not the fabricated EBI 5");
+        let expected_esm =
+            crate::esm_build::build_activate_default_bearer_context_request_with_params(
+                &sess,
+                &bearer,
+                crate::esm_build::CreateAction::InAttachRequest,
+            );
+        assert!(
+            pkbuf
+                .windows(expected_esm.len())
+                .any(|w| w == expected_esm.as_slice()),
+            "the buffered Attach Accept must contain the ESM Activate Default Bearer \
+             Context Request for the session's own bearer (EBI {}); it did not, so the \
+             accept was built from a different bearer than the MME created",
+            bearer.ebi
+        );
+
+        release_global_ue(mme_ue_id, sess_id, bearer_id);
+        crate::gtp_path::clear_pending_creates_for_test();
+    }
+
+    /// A NON-attach create action must NOT produce an Attach Accept.
+    ///
+    /// A TAU, a standalone PDN connectivity request and a path switch each own their
+    /// continuation; emitting an Attach Accept for any of them would answer a procedure
+    /// the UE did not start. This is the gate the revert table exercises.
+    #[test]
+    fn a_tau_create_action_does_not_drive_the_attach_accept() {
+        let _guard = crate::gtp_path::lock_s11();
+        crate::gtp_path::clear_pending_creates_for_test();
+
+        let (mme_ue_id, enb_ue_id, sess_id, bearer_id, local_teid) = seed_global_ue(5);
+        crate::gtp_path::record_pending_create_for_test(
+            4245,
+            crate::gtp_path::PendingCreate {
+                create_action: GtpCreateAction::TrackingAreaUpdate,
+                enb_ue_id,
+                sess_id,
+            },
+        );
+        apply_create_session_response(
+            &accepted_response(5, [10, 45, 0, 10]),
+            local_teid,
+            4245,
+            "127.0.0.1:2123".parse().unwrap(),
+        );
+
+        let ctx = crate::context::mme_self();
+        assert!(
+            ctx.mme_ue_find_by_id(mme_ue_id)
+                .unwrap()
+                .t3450
+                .pkbuf
+                .is_none(),
+            "a TAU-triggered session creation must NOT emit an Attach Accept"
+        );
+        // The bookkeeping still happened: the TEIDs and the PAA are the response's
+        // content regardless of which procedure asked for them.
+        assert_eq!(
+            ctx.sess_find_by_id(sess_id).unwrap().paa.addr,
+            [10, 45, 0, 10],
+            "the PAA belongs to the session whichever procedure created it"
+        );
+
+        release_global_ue(mme_ue_id, sess_id, bearer_id);
+        crate::gtp_path::clear_pending_creates_for_test();
+    }
+
+    /// A response with no pending record applies the TEIDs and continues NOTHING.
+    ///
+    /// That covers a duplicate (whose record the first copy consumed) and a response to
+    /// a request this MME never sent. The TEIDs are idempotent; an Attach Accept is not.
+    #[test]
+    fn a_response_without_a_pending_record_continues_nothing() {
+        let _guard = crate::gtp_path::lock_s11();
+        crate::gtp_path::clear_pending_creates_for_test();
+
+        let (mme_ue_id, _enb_ue_id, sess_id, bearer_id, local_teid) = seed_global_ue(5);
+        apply_create_session_response(
+            &accepted_response(5, [10, 45, 0, 11]),
+            local_teid,
+            9999, // no record was ever made for this sequence
+            "127.0.0.1:2123".parse().unwrap(),
+        );
+
+        let ctx = crate::context::mme_self();
+        assert!(
+            ctx.mme_ue_find_by_id(mme_ue_id)
+                .unwrap()
+                .t3450
+                .pkbuf
+                .is_none(),
+            "an uncorrelated response must not drive a procedure"
+        );
+        assert_eq!(
+            ctx.sess_find_by_id(sess_id).unwrap().paa.addr,
+            [0, 0, 0, 0],
+            "and it must not store a PAA either: without a record there is no session \
+             to attribute it to, so the store is skipped with the continuation"
+        );
+
+        release_global_ue(mme_ue_id, sess_id, bearer_id);
+    }
+
+    /// The Attach Accept's ESM Activate Default Bearer Context Request must carry the
+    /// PGW-allocated address AND the session's real EBI, asserted from the ENCODED
+    /// NAS bytes.
+    ///
+    /// Built through `build_activate_default_bearer_context_request_with_params` —
+    /// **the same function `nas_eps_send_attach_accept` calls** — rather than through
+    /// the simplified `build_activate_default_bearer_context_request` helper. The
+    /// helper fabricates `ebi: 5` because it has no bearer to name, so asserting
+    /// against it would be testing a function production no longer uses on this path,
+    /// and would pass whatever the wiring did.
+    ///
+    /// EBI 7, not 5: with 5 the fabricated value and the real one coincide, so the
+    /// assertion would hold for the pre-#329 call too.
+    #[test]
+    fn the_activate_default_bearer_request_carries_the_stored_paa_and_real_ebi() {
+        let _guard = crate::gtp_path::lock_s11();
+        crate::gtp_path::clear_pending_creates_for_test();
+
+        let (mme_ue_id, enb_ue_id, sess_id, bearer_id, local_teid) = seed_global_ue(7);
+        crate::gtp_path::record_pending_create_for_test(
+            4246,
+            crate::gtp_path::PendingCreate {
+                create_action: GtpCreateAction::AttachRequest,
+                enb_ue_id,
+                sess_id,
+            },
+        );
+        apply_create_session_response(
+            &accepted_response(7, [10, 45, 0, 12]),
+            local_teid,
+            4246,
+            "127.0.0.1:2123".parse().unwrap(),
+        );
+
+        let ctx = crate::context::mme_self();
+        let sess = ctx.sess_find_by_id(sess_id).expect("session");
+        let bearer = ctx.bearer_find_by_id(bearer_id).expect("bearer");
+        assert_eq!(
+            bearer.ebi, 7,
+            "precondition: the real EBI is not the fabricated 5"
+        );
+
+        let esm = crate::esm_build::build_activate_default_bearer_context_request_with_params(
+            &sess,
+            &bearer,
+            crate::esm_build::CreateAction::InAttachRequest,
+        );
+
+        // The four address octets appear contiguously in the encoded PDN Address IE.
+        assert!(
+            esm.windows(4).any(|w| w == [10, 45, 0, 12]),
+            "the encoded Activate Default Bearer Context Request must carry the \
+             PGW-allocated address; found none in {esm:02x?}"
+        );
+        // This module writes the EPS bearer identity as a WHOLE octet followed by the
+        // protocol discriminator (`esm_build.rs:559-560`), rather than packing both into
+        // octet 1 as TS 24.301 §9.3.1 does. That spelling is this build's existing
+        // convention across every ESM builder and is not #329's to change; the
+        // assertion follows the code's actual layout rather than the spec's, and says so.
+        assert_eq!(
+            esm.first().copied(),
+            Some(7),
+            "the message must name the bearer the MME actually created, not a \
+             fabricated EBI 5"
+        );
+        assert_eq!(
+            esm.get(1).copied(),
+            Some(crate::emm_build::NAS_PROTOCOL_DISCRIMINATOR_ESM),
+            "and the octet after it is the ESM discriminator, which is what makes the \
+             first one the bearer identity rather than a coincidence"
+        );
+
+        release_global_ue(mme_ue_id, sess_id, bearer_id);
+        crate::gtp_path::clear_pending_creates_for_test();
+    }
+
+    /// The simplified helper must NOT panic on a session with no subscribed QoS.
+    ///
+    /// It used to `.expect("value expected")` on `sess.session`, which is absent for
+    /// any session the HSS has not populated — a reachable panic on the Attach Accept
+    /// path, surviving only because that path had no caller. A crashing MME is worse
+    /// than a default-QoS bearer.
+    #[test]
+    fn a_session_without_subscribed_qos_does_not_panic_the_esm_builder() {
+        let sess = crate::context::MmeSess {
+            apn: "internet".to_string(),
+            ..Default::default()
+        };
+        assert!(
+            sess.session.is_none(),
+            "precondition: no subscription record, as an un-provisioned session has"
+        );
+        let esm = crate::esm_build::build_activate_default_bearer_context_request(
+            &sess,
+            crate::nas_path::GtpCreateAction::InAttachRequest,
+        );
+        assert!(!esm.is_empty(), "it must still produce a message");
     }
 }


### PR DESCRIPTION
Closes #329. Unblocks the MME half of #303, whose remaining blocker is #328.

## What was broken

Two senders, both built and unit-tested, with **zero callers** — and once wired, four more
breaks behind them. Each was invisible from the layer above, and they surfaced strictly one
at a time.

| # | gap | site | how it presented |
|---|---|---|---|
| 1 | the NAS path never sent the CSR | `nas_dispatch.rs:1322`, `:1386` | logged *"…not implemented (#51)"* — and #51 was CLOSED |
| 2 | no SGW-UE context at request time | `context.rs:1957` | `ContextNotFound` for every attach |
| 3 | `mme_s11_teid` never assigned | `context.rs:1039` | every CSR carried Sender F-TEID **0** |
| 4 | `mme_s11_teid_hash` had a reader and **no writer** | `context.rs:1480,2021` | every Create Session Response dropped as matching no UE |
| 5 | the PAA was parsed and discarded | `s11_handler.rs:291` | the UE's IP never reached the session |
| 6 | the response couldn't tell which procedure it was for | `gtp_path.rs:545` | no create action reached the response path |
| 7 | the Attach Accept was unreachable | `nas_path.rs:266` | zero callers |
| 8 | a **reachable panic** on the accept path | `esm_build.rs:616` | `.expect("value expected")` on an absent subscription |
| 9 | the accept named a **fabricated EBI** | `nas_path.rs:285` | the simplified builder invents `ebi: 5` |

**Gaps 2-4, 8 and 9 are not in #329's text.** Each was found by the previous fix making
the next line run for the first time. That is the pattern worth naming: a chain of
unreachable code hides its own defects.

### Why gap 1 fell between two closed issues

#51's criteria are all transport, sequencing and message construction, and
`specs/fix-mmed-s11-gtpc-endpoint.md:144-151` states the ceiling outright: *"the attach
procedure still does not complete… wiring the Create Session Response into an Initial
Context Setup plus an Attach Accept is #46's subject."* #46 then closed via the **TAU**
path and left the attach half blocked. The call sites were each other's follow-up, and the
log lines kept citing an issue that had shipped everything it promised.

### Gap 2 is a nice circular one

`send_create_session_request` resolves the `SgwUe` on the **request** path. The only
production creator was inside `set_sgw_s11_teid_for_ue`, on the **response** path. So the
MME could not send the request whose response would have created the context it needed in
order to send it.

## Decisions

- **`PENDING_CREATES` keyed by S11 sequence number** — what `match_response` already
  correlates on, so there is one notion of "which request is this the answer to" rather
  than two that can disagree. Records are **taken**, so a duplicated or retransmitted
  response cannot drive the continuation twice.
- **The S11 TEID is allocated in `mme_ue_add`** and indexed in the same breath, so field
  and index cannot drift. `+1` on the pool id keeps it non-zero — 0 is what the broken
  state sent and what a peer reads as "no TEID". `mme_ue_remove` drops the entry keyed by
  **the removed context's** TEID, the discipline the IMSI line beside it already follows.
- **Only `AttachRequest` continues to an Attach Accept.** A TAU, a standalone PDN
  connectivity request and a path switch each own their continuation; answering any of
  them with an Attach Accept would answer a procedure the UE did not start.
- **The PDN type comes from the response, not the request** — TS 29.274 §8.14 lets the
  network grant a narrower type, and honouring the request would tell the UE it has an
  address family the PGW never allocated.
- **A send failure is logged, not turned into a reject** — the ESM procedure is still open
  and its T3485/T3489 timers govern the outcome, so synthesising a reject would race them.

## Verification

Workspace **6472 passed / 0 failed** (main: 6464). Clippy warnings unchanged at **74**,
all pre-existing. `cargo fmt --check` clean. **20 consecutive `-p nextgcore-mmed` runs
clean.**

### Eight reverts, all of which bite

| revert | named test that failed |
|---|---|
| drop the `mme_s11_teid_hash` registration | 4 tests |
| don't create the `SgwUe` with the UE | `the_pdn_connectivity_path_sends_a_create_session_request` |
| restore the "not implemented (#51)" log | same |
| drop the pending-create recording | same |
| drop the PAA store | 3 tests |
| remove the create-action gate | `a_tau_create_action_does_not_drive_the_attach_accept` |
| use the simplified builder in the accept | `an_attach_create_action_drives_the_attach_accept` |
| restore the `.expect` on `sess.session` | `a_session_without_subscribed_qos_does_not_panic_the_esm_builder` |

### One revert did NOT bite at first — that's the finding

The builder-swap revert initially **passed**, because the EBI test called
`build_activate_default_bearer_context_request_with_params` directly and asserted on the
builder's own output — so it passed whichever builder the accept path chose. The
"helper is tested and the wiring is not" shape, walked into while fixing an issue about
unreachable code.

It now asserts the expected ESM bytes appear **as a subsequence of what production
buffered in `t3450.pkbuf`**, and uses **EBI 7**: with EBI 5 the fabricated and real
answers coincide, so the assertion could not have told them apart. With that, the revert
fails.

### Observables are state, not logs

- the CSR is read from a **stand-in SGW-C socket's datagram**, decoded with the library codec;
- the Sender F-TEID is asserted to **resolve back to the UE** via
  `mme_ue_find_by_s11_local_teid` — the lookup that was broken;
- the Attach Accept is read from **`mme_ue.t3450.pkbuf`**, not the S1AP send queue:
  `install_send_queue` is once-per-process and a sibling test already consumes that slot.

### Process-global discipline

`S11_TEST_LOCK` is **promoted out of `gtp_path::tests`** to a `pub(crate)` static beside
the globals it guards, so `s11_handler`'s tests share the one agreement — a second lock
over the same variables is what #276 showed *hangs* the suite rather than merely flaking
it. And exactly **one** test installs the S11 server, because `S11_SERVER` is a `OnceLock`
and a second installer would silently assert about a sibling's socket; an earlier draft
had two and one was removed rather than left to race.

## Ceilings

- **Nothing can originate an S1AP attach** — no LTE eNB or UE simulator exists here
  (`nextgsim` is 5G-only), so the chain is driven from an uplink NAS PDU injected into
  `nas_eps_handle_uplink`. That is **#328**'s decision, and what still blocks #303.
- **Modify Bearer is not driven from here** — TS 23.401 §5.3.2.1 continues past the accept
  to ICS Response → Modify Bearer; `send_modify_bearer_request` exists and has its own
  trigger.
- **The EPS bearer identity is written as a whole octet** followed by the discriminator
  (`esm_build.rs:559-560`) rather than packed into octet 1 as TS 24.301 §9.3.1 does. That
  is this build's existing convention across every ESM builder; the test follows the
  code's layout and says so rather than quietly asserting the spec's.
- **The fabricated `ebi: 5` survives** in the simplified helper for its other caller
  (`nas_path.rs:874`), documented as a fallback for callers with no bearer to name.
- **No E2E** — everything in-process, over loopback UDP where a socket is involved.

## Also in this PR's neighbourhood

Three parallel create-action enums (`esm_build::CreateAction`,
`nas_path::GtpCreateAction`, `s11_build::GtpCreateAction`), none a superset of the others.
Mapped explicitly in one place rather than unified: unifying is a separate change with its
own blast radius. Noted because "count the implementations before writing the abstraction"
cuts both ways — the count is three, and the answer is still not one.

Spec: `specs/fix-mmed-attach-s11-csr-and-accept.md`