### PR TITLE
fix(amfd,smfd,ngap): complete the N2/Xn mobility control plane (#70)

### DIFF
--- a/specs/fix-amfd-handover-mobility-control-plane.md
+++ b/specs/fix-amfd-handover-mobility-control-plane.md
@@ -1,0 +1,138 @@
+# fix(amfd,smfd,ngap): complete the N2/Xn mobility control plane
+
+Closes #70. Three of its seven criteria were already met by prior work; this delivers the
+other four.
+
+## Criteria re-verified against `2e1d985` (#70 was written against `76ea248`)
+
+| # | criterion | state |
+|---|---|---|
+| 1 | HandoverRequest SecurityContext carries an NH derived from KgNB (never zero) with NCC incremented; a test asserts it for a UE with no prior handover | **met** — `context.rs:2769` seeds from `kgnb`; tests `next_hop_chain_is_seeded_from_kgnb_never_from_zero`, `first_handover_conveys_a_non_zero_nh_and_an_incremented_ncc` |
+| 2 | N2 and Xn share one NCC-increment/NH-derive helper; a test drives both | **met** — `AmfUe::advance_next_hop`, test `n2_and_xn_derive_identically_for_equal_inputs` |
+| 3 | `nextgcore-crypt` exposes FC 0x72 KAMF′ derivation with a test | **met** — `kdf.rs:35` `FC_FOR_KAMF_PRIME_DERIVATION`, `:335` `nextgcore_kdf_kamf_prime`, test `kamf_prime_uses_every_input` |
+| **4** | **Xn path switch calls the SMF and uses the SMF-supplied acknowledge transfer, not the inbound one** | **NOT met** |
+| **5** | **SMF `PATH_SWITCH_REQ` response carries a non-empty `n2SmInfo` acknowledge transfer** | **NOT met** |
+| **6** | **HandoverNotify forwards the target DL tunnel to the SMF and releases the source gNB** | **NOT met** |
+| 7 | full workspace lint and tests pass | this PR |
+
+So the dominant defect #70 names — the all-zero NH with NCC=0 — was already fixed. What
+remained is that **neither mobility path completes the control-plane relocation**, which is
+gaps 4 and 5 of the issue's own list.
+
+## The `PathSwitchRequestAcknowledgeTransfer` did not exist
+
+`nextgcore-ngap::transfer` had `PathSwitchRequestTransfer` (decode-only, what the gNB sends)
+and no acknowledge counterpart. That is *why* the AMF echoed: there was nothing else to send,
+the AMF never asked the SMF, and the SMF answered with `n2SmInfoType` and no part.
+
+Added per TS 38.413 §9.3.4.9, with all four members optional as the ASN.1 has them. Every
+member type (`UpTransportLayerInformation`, `SecurityIndication`, `SecurityResult`,
+`QosFlowWithCauseItem`) already existed.
+
+**Why the echo is not a cosmetic problem.** §9.3.4.8 and §9.3.4.9 are different messages in
+opposite directions: the request carries the *target's DL* tunnel, the acknowledge carries the
+*core's UL* tunnel. Echoing one for the other tells the target gNB to send uplink traffic to
+itself.
+
+## Decisions
+
+**The empty acknowledge is a real answer, not a fallback.** Every member of §9.3.4.9 is
+OPTIONAL, and an Xn path switch does not move the uplink path — only the DL side moves to the
+target. So when the SMF has no recorded UPF uplink endpoint the acknowledge is sent with the
+UL tunnel *absent*, which conformantly means "no change". The alternative — inventing a
+tunnel — would point the target at something no UPF serves.
+
+**A session the SMF does not acknowledge is left OUT of the switched list.** Not echoed, and
+not acknowledged with a fabricated transfer. A gNB that finds a session missing from the
+switched list releases it, which is the honest outcome when the core cannot confirm the
+switch.
+
+**`upf_ul_endpoints` is a new map, not a widening of `pfcp_sessions`.** That map is keyed and
+consumed as "which N4 session serves this context" and every reader wants exactly the SEID.
+The uplink endpoint is recorded at establishment because that is the only moment the UPF has
+just told us what it is.
+
+**HandoverNotify tells the SMF, not HandoverRequestAcknowledge.** TS 23.502 §4.9.1.3.3 puts
+the DL switch at step 12, *after* the UE has arrived. Switching at acknowledge time would
+blackhole downlink traffic for the duration of the handover, while the source is still
+serving. So the target's transfer is recorded at acknowledge time
+(`handover_target_transfers`) and consumed at notify time.
+
+**The source release does NOT go through `release_ue`.** That helper removes `ue_auth_state`,
+and the UE has not gone away — it has *moved*. Dropping its context would deregister a UE the
+target is now serving. Only the source gNB's copy is released, with cause
+`successful-handover`.
+
+**The source identity is captured before the relocation overwrites it.** `association_id` and
+`ran_ue_ngap_id` both become the target's, and they are exactly what the release must be
+addressed to.
+
+**A failed release does not fail the procedure.** The UE has arrived and the core path is
+switched; returning an error would leave the handover half-reported. The leak is logged.
+
+## Verification
+
+Whole workspace **6515 passed / 0 failed** (main: 6508). Clippy warnings **74, unchanged from
+main**. `cargo fmt --check` clean. 16 consecutive runs of the three changed crates clean.
+
+### Reverts, all of which bite
+
+| revert | failing test |
+|---|---|
+| capture the source *after* the relocation (i.e. lose it) | `handover_notify_releases_the_source_ran_context` |
+| echo the inbound transfer when the SMF does not answer | `the_switched_list_never_echoes_the_inbound_request_transfer` |
+| break the acknowledge transfer's preamble/member order | the `transfer.rs` round-trip tests |
+
+### The echo revert did NOT bite at first, and fixing that changed the code
+
+The first version of the echo revert compiled and **passed**, because the switched list was
+built inline in `handle_path_switch_request`, assembled into an acknowledge and immediately
+sent — and this harness has no live gNB association, so the send fails and the list is never
+observable. The property was implemented and untested.
+
+`switched_list_from_smf` was extracted for exactly that reason, and it is stated in its doc
+comment. With the list construction reachable, the revert fails. This is the second time in
+this batch that "the revert did not bite" turned out to mean "the property is not covered"
+rather than "the property holds".
+
+### Two observables were split because one of them is not testable here
+
+`HandoverCompletion` reports `source_context` (which source the handler *decided* to release)
+separately from `source_release_sent` (whether the datagram left). The decision is made from
+state the relocation immediately overwrites, so it is the part worth pinning and the part that
+was missing; the send needs a live SCTP association and only an E2E can drive it. Collapsing
+them into one field would have made the decision untestable — which is what the first draft
+did, and its test failed for the wrong reason.
+
+Reporting through a return value rather than a log line follows the crate's existing
+convention (`handle_uplink_ran_status_transfer` returns its relay target) and exists because a
+handler that logged without sending would pass a log assertion.
+
+## Ceilings
+
+- **nextgsim#39 is still required for an end-to-end handover.** #70's cross-repo note is
+  about the gNB side: its inter-gNB N2/Xn path is dead code with no target-side PDU/DRB
+  admission and no FC=0x70 KgNB* derivation. Nothing here changes that, and the key
+  mismatch it describes remains invisible until both ends move together.
+- **No E2E.** Every assertion is in-process. The AMF harness has no live SCTP association, so
+  the acknowledge and release *sends* are exercised only as far as the transport call.
+- **`HANDOVER_REQ_ACK` is not relayed to the SMF.** TS 29.502 §5.2.2.3.2.2 also has the AMF
+  forward the target's transfer at HandoverRequestAcknowledge time with `hoState`; this
+  records it and relays at `HANDOVER_COMPLETE` only. smfd already handles both types
+  (`main.rs:4201`, `:4213`), so the earlier leg is a wiring addition, not new protocol.
+- **The acknowledge re-states the uplink endpoint rather than reallocating.** Correct for
+  Xn, where the UL path does not move; a switch that *did* need a new UPF endpoint would need
+  the SMF to allocate one, which is a different procedure.
+- **`qos_flow_to_release_list` is modelled and encoded but never populated** — the SMF has no
+  path-switch-time flow-release decision to express yet.
+- **`handover_target_transfers` is in-memory and not persisted**, so an AMF restart mid-
+  handover loses the recorded target tunnel. The same is already true of
+  `handover_target_assoc` beside it.
+
+## References
+
+- TS 38.413 §8.4.2, §8.4.3 (source release), §8.4.4, §9.3.1.87, §9.3.4.8, **§9.3.4.9**
+- TS 29.502 §5.2.2.3.3 (the acknowledge transfer as an N2 SM part)
+- TS 23.502 §4.9.1.3.3 step 12 (DL switch after the UE arrives)
+- TS 33.501 §6.9.2.3.3, Annex A.10, Annex A.13 — criteria 1-3, already met
+- #70; nextgsim#39 (the coupled gNB half)

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -448,6 +448,16 @@ pub struct NgapServer {
     /// where to forward it. `ue_auth_state` cannot answer that — it still names
     /// the SOURCE association until the UE arrives.
     handover_target_assoc: HashMap<u64, u64>,
+    /// The target gNB's per-session handover transfers, kept between
+    /// HandoverRequestAcknowledge and HandoverNotify (#70).
+    ///
+    /// Keyed by `(amf_ue_ngap_id, pdu_session_id)`. TS 23.502 §4.9.1.3.3 has the AMF tell
+    /// the SMF about the target DL tunnel only once the UE has ARRIVED (step 12,
+    /// `HANDOVER_COMPLETE`) — switching earlier would blackhole downlink traffic while the
+    /// UE is still on the source. So the transfer has to survive between the two messages,
+    /// and before #70 nothing kept it: HandoverNotify mutated in-memory serving state and
+    /// told the SMF nothing at all.
+    handover_target_transfers: HashMap<(u64, u8), Vec<u8>>,
     /// GMM procedure timer configuration (T3550/T3560/T3570/T3522)
     timer_configs: AmfTimerConfigs,
 }
@@ -496,6 +506,7 @@ impl NgapServer {
             ue_auth_state: HashMap::new(),
             sm_context_refs: HashMap::new(),
             handover_target_assoc: HashMap::new(),
+            handover_target_transfers: HashMap::new(),
             timer_configs: {
                 let configs = AmfTimerConfigs::default();
                 #[cfg(feature = "ntn")]
@@ -4874,6 +4885,14 @@ impl NgapServer {
                 // and a stale target entry would misroute the next handover's.
                 self.handover_target_assoc
                     .insert(ack.amf_ue_ngap_id, association_id);
+                // #70: keep each admitted session's transfer so HandoverNotify can relay
+                // the target DL tunnel to the SMF once the UE has actually arrived.
+                for admitted in &ack.admitted_list {
+                    self.handover_target_transfers.insert(
+                        (ack.amf_ue_ngap_id, admitted.pdu_session_id),
+                        admitted.transfer.clone(),
+                    );
+                }
             }
             Err(e) => log::error!("Failed to build HandoverCommand: {e}"),
         }
@@ -5027,16 +5046,20 @@ impl NgapServer {
     /// Handle a HandoverNotify from the target gNB (TS 38.413 Section 8.4.3):
     /// the UE has successfully arrived. The AMF updates the UE's serving cell
     /// location and (in a full deployment) releases the source-side resources.
-    async fn handle_handover_notify(&mut self, association_id: u64, data: &[u8]) -> Result<()> {
+    async fn handle_handover_notify(
+        &mut self,
+        association_id: u64,
+        data: &[u8],
+    ) -> Result<HandoverCompletion> {
         let notify = match nextgcore_ngap::parser::decode_ngap_pdu(data) {
             Ok(nextgcore_ngap::NgapMessage::HandoverNotify(n)) => n,
             Ok(other) => {
                 log::warn!("Expected HandoverNotify, decoded {other:?}");
-                return Ok(());
+                return Ok(HandoverCompletion::default());
             }
             Err(e) => {
                 log::error!("Failed to decode HandoverNotify: {e}");
-                return Ok(());
+                return Ok(HandoverCompletion::default());
             }
         };
         log::info!(
@@ -5044,6 +5067,17 @@ impl NgapServer {
             notify.amf_ue_ngap_id,
             notify.ran_ue_ngap_id
         );
+        // #70: the SOURCE identity, captured BEFORE the serving association is moved to
+        // the target below. After that move it is unrecoverable, and it is exactly what the
+        // UEContextReleaseCommand has to be addressed to — TS 38.413 §8.4.3 has the AMF
+        // release the source NG-RAN UE context once the UE has arrived, and before #70
+        // nothing did, so every N2 handover leaked a source RAN context.
+        let source = self
+            .ue_auth_state
+            .get(&notify.amf_ue_ngap_id)
+            .map(|s| (s.association_id, s.ran_ue_ngap_id))
+            .filter(|(assoc, _)| *assoc != association_id);
+
         if let Some(state) = self.ue_auth_state.get_mut(&notify.amf_ue_ngap_id) {
             // Move the serving association/RAN-UE-NGAP-ID and location to the
             // target now that the UE has arrived (TS 23.502 Section 4.9.1.3).
@@ -5070,13 +5104,122 @@ impl NgapServer {
                 notify.amf_ue_ngap_id
             );
         }
+        // #70: switch the core-side DL path to the target (TS 23.502 §4.9.1.3.3 step 12,
+        // TS 29.502 `HANDOVER_COMPLETE`). Done HERE and not at HandoverRequestAcknowledge
+        // because until the UE has arrived the source is still serving it, and switching
+        // early would blackhole downlink traffic for the duration of the handover.
+        let transfers: Vec<(u8, Vec<u8>)> = self
+            .handover_target_transfers
+            .iter()
+            .filter(|((ue, _), _)| *ue == notify.amf_ue_ngap_id)
+            .map(|((_, psi), transfer)| (*psi, transfer.clone()))
+            .collect();
+        if transfers.is_empty() {
+            log::warn!(
+                "HandoverNotify for UE {}: no target handover transfer was recorded, so the \
+                 SMF cannot be told the target DL tunnel -- the downlink path stays on the \
+                 source UPF endpoint",
+                notify.amf_ue_ngap_id
+            );
+        }
+        let mut sessions_relayed = 0usize;
+        for (pdu_session_id, transfer) in transfers {
+            if self
+                .relay_n2_sm_to_smf(
+                    notify.amf_ue_ngap_id,
+                    pdu_session_id,
+                    &transfer,
+                    "HandoverNotify",
+                )
+                .await
+            {
+                sessions_relayed += 1;
+            }
+            self.handover_target_transfers
+                .remove(&(notify.amf_ue_ngap_id, pdu_session_id));
+        }
+
+        // #70: release the SOURCE NG-RAN UE context (TS 38.413 §8.4.3).
+        //
+        // NOT via `release_ue`, which removes `ue_auth_state` — the UE has not gone away,
+        // it has MOVED, and dropping its context here would deregister a UE that is
+        // registered and served by the target. Only the source gNB's copy is released.
+        let mut source_release_sent = false;
+        if let Some((source_assoc, source_ran_ue_id)) = source {
+            if let Some(cmd) = crate::ngap_asn1::build_ue_context_release_command_asn1(
+                notify.amf_ue_ngap_id,
+                source_ran_ue_id,
+                ngap_handler::cause_group::RADIO_NETWORK,
+                nextgcore_asn1c::ngap::cause::CauseRadioNetwork::SuccessfulHandover as i64,
+            ) {
+                // A failed send must not abort the procedure: the UE has already arrived
+                // and the core path is switched, so returning an error here would leave the
+                // handover half-reported. The source context leak is logged instead.
+                match self.send_to_association(source_assoc, &cmd).await {
+                    Ok(()) => {
+                        source_release_sent = true;
+                        log::info!(
+                            "UE Context Release Command sent to SOURCE association \
+                             {source_assoc} for UE {} (source \
+                             ran_ue_ngap_id={source_ran_ue_id}, cause successful-handover)",
+                            notify.amf_ue_ngap_id
+                        );
+                    }
+                    Err(e) => log::warn!(
+                        "Could not release the SOURCE context for UE {} on association \
+                         {source_assoc}: {e}",
+                        notify.amf_ue_ngap_id
+                    ),
+                }
+            }
+        } else {
+            log::debug!(
+                "HandoverNotify for UE {} arrived on the association already serving it; \
+                 no source context to release",
+                notify.amf_ue_ngap_id
+            );
+        }
+
         // Handover complete: `ue_auth_state` now names the target itself, so the
         // separate target record has served its purpose. Leaving it would keep the
         // relay pointing at the (now serving) gNB after the procedure ended.
         self.handover_target_assoc.remove(&notify.amf_ue_ngap_id);
-        Ok(())
+        Ok(HandoverCompletion {
+            sessions_relayed,
+            source_context: source,
+            source_release_sent,
+        })
     }
+}
 
+/// What a HandoverNotify actually completed (#70).
+///
+/// Returned rather than logged for the same reason
+/// `handle_uplink_ran_status_transfer` returns its relay target: the two things this
+/// handler now does — telling the SMF the target DL tunnel and releasing the source NG-RAN
+/// context — are both outbound sends, and a test that asserted on log lines would pass for
+/// a handler that logged without sending. TS 38.413 §8.4.3 and TS 23.502 §4.9.1.3.3 step 12
+/// require both, so both are reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HandoverCompletion {
+    /// PDU sessions whose target DL tunnel the SMF accepted.
+    pub sessions_relayed: usize,
+    /// `(association, source RAN-UE-NGAP-ID)` the release command was ADDRESSED to.
+    ///
+    /// `None` when the notify arrived on the association already serving the UE — an
+    /// intra-gNB case with no separate source context to release.
+    ///
+    /// Separate from [`Self::source_release_sent`] on purpose: which source to release is a
+    /// DECISION made from state that the relocation immediately overwrites, and whether the
+    /// datagram left is a property of the SCTP association. A test can drive the first
+    /// without a live gNB; only an E2E can drive the second, and collapsing them into one
+    /// field would make the decision untestable.
+    pub source_context: Option<(u64, u32)>,
+    /// Whether the release command actually reached the source association.
+    pub source_release_sent: bool,
+}
+
+impl NgapServer {
     /// Handle a HandoverCancel from the source gNB (TS 38.413 Section 8.4.5).
     /// The AMF acknowledges with a HandoverCancelAcknowledge.
     async fn handle_handover_cancel(&mut self, association_id: u64, data: &[u8]) -> Result<()> {
@@ -5180,7 +5323,7 @@ impl NgapServer {
 
         // Derive a fresh NH from KAMF (vertical key derivation) and increment
         // the NHCC (TS 33.501 Section 6.9.2.3.3 / 6.9.4.1).
-        let (ncc, switched_list, allowed_nssai, ue_caps) = {
+        let (ncc, inbound, allowed_nssai, ue_caps) = {
             let state = self
                 .ue_auth_state
                 .get_mut(&amf_ue_ngap_id)
@@ -5194,16 +5337,15 @@ impl NgapServer {
             state.ran_ue_ngap_id = req.ran_ue_ngap_id;
             state.association_id = association_id;
 
-            let switched_list: Vec<nextgcore_ngap::types::PduSessionResourceSwitchedItem> = req
+            // #70: the inbound request transfers, kept so each can be relayed to the SMF
+            // AFTER this borrow ends. The switched list is built from the SMF's ANSWERS
+            // below, not from these — echoing the gNB's own PathSwitchRequestTransfer back
+            // as the acknowledge is the defect #70 names, and it tells the target gNB to
+            // send uplink traffic to itself (TS 38.413 §9.3.4.8 vs §9.3.4.9).
+            let inbound: Vec<(u8, Vec<u8>)> = req
                 .pdu_session_list
                 .iter()
-                .map(|p| nextgcore_ngap::types::PduSessionResourceSwitchedItem {
-                    pdu_session_id: p.pdu_session_id,
-                    // Echo the gNB's path-switch transfer back as the ack
-                    // transfer; in a full deployment the SMF supplies the UL
-                    // F-TEID via Nsmf_PDUSession_UpdateSMContext.
-                    transfer: p.transfer.clone(),
-                })
+                .map(|p| (p.pdu_session_id, p.transfer.clone()))
                 .collect();
 
             let allowed_nssai = state
@@ -5218,11 +5360,23 @@ impl NgapServer {
 
             (
                 state.amf_ue.nhcc,
-                switched_list,
+                inbound,
                 allowed_nssai,
                 ue_caps_to_ngap(&state.amf_ue.ue_security_capability),
             )
         };
+
+        // #70: Nsmf_PDUSession_UpdateSMContext per switched PDU session
+        // (TS 29.502 §5.2.2.3.3). The SMF switches the UPF's DL path to the target and
+        // answers with the PathSwitchRequestAcknowledgeTransfer this acknowledge owes the
+        // gNB. Done after the state borrow ends because it awaits.
+        //
+        // A session the SMF does not acknowledge is left OUT of the switched list rather
+        // than acknowledged with a fabricated transfer: TS 38.413 §9.3.4.9 makes the
+        // acknowledge the core's statement about the uplink path, and inventing one would
+        // point the target gNB at a tunnel no UPF serves. A gNB that finds a session
+        // missing from the switched list releases it, which is the honest outcome.
+        let switched_list = self.switched_list_from_smf(amf_ue_ngap_id, &inbound).await;
 
         let nh = self
             .ue_auth_state
@@ -5398,6 +5552,114 @@ impl NgapServer {
     ///
     /// Returns whether the relay was attempted and accepted, so callers can count
     /// what actually reached the SMF instead of assuming.
+    /// Build a PathSwitchRequestAcknowledge's switched list from the SMF's ANSWERS (#70).
+    ///
+    /// One `Nsmf_PDUSession_UpdateSMContext` per switched session (TS 29.502 §5.2.2.3.3);
+    /// the SMF switches the UPF's DL path to the target and returns the
+    /// `PathSwitchRequestAcknowledgeTransfer` the gNB is owed.
+    ///
+    /// A session the SMF does not acknowledge is left OUT rather than acknowledged with the
+    /// gNB's own request transfer. That echo is the defect #70 names: TS 38.413 §9.3.4.8 and
+    /// §9.3.4.9 are different messages in opposite directions — the request carries the
+    /// target's DL tunnel, the acknowledge the core's UL tunnel — so echoing one for the
+    /// other tells the target gNB to send uplink traffic to itself. A gNB that finds a
+    /// session missing from the switched list releases it, which is the honest outcome when
+    /// the core cannot confirm the switch.
+    ///
+    /// Extracted from `handle_path_switch_request` so the no-echo property is testable: the
+    /// acknowledge is built and immediately sent, and a harness with no live gNB association
+    /// cannot inspect what went into it.
+    async fn switched_list_from_smf(
+        &self,
+        amf_ue_ngap_id: u64,
+        inbound: &[(u8, Vec<u8>)],
+    ) -> Vec<nextgcore_ngap::types::PduSessionResourceSwitchedItem> {
+        let mut switched_list = Vec::with_capacity(inbound.len());
+        for (pdu_session_id, request_transfer) in inbound {
+            match self
+                .relay_n2_sm_to_smf_for_answer(
+                    amf_ue_ngap_id,
+                    *pdu_session_id,
+                    "PATH_SWITCH_REQ",
+                    request_transfer,
+                    "PathSwitchRequest",
+                )
+                .await
+            {
+                Some(ack_transfer) => {
+                    switched_list.push(nextgcore_ngap::types::PduSessionResourceSwitchedItem {
+                        pdu_session_id: *pdu_session_id,
+                        transfer: ack_transfer,
+                    });
+                }
+                None => log::warn!(
+                    "PathSwitchRequest: PSI {pdu_session_id} of UE {amf_ue_ngap_id} is NOT \
+                     in the switched list -- the SMF supplied no acknowledge transfer, and \
+                     echoing the gNB's own request transfer would point it at its own tunnel"
+                ),
+            }
+        }
+        switched_list
+    }
+
+    /// Relay an N2 SM container to the SMF and return the container it answers with
+    /// (#70, TS 29.502 §5.2.2.3.3).
+    ///
+    /// The mobility twin of [`Self::relay_n2_sm_to_smf`], which discards the response. On
+    /// a path switch the response is the point: it carries the
+    /// `PathSwitchRequestAcknowledgeTransfer` the target gNB is owed, and without it the
+    /// AMF has nothing conformant to put in the acknowledge — which is why the pre-#70
+    /// code echoed the gNB's own request transfer back instead.
+    ///
+    /// `None` means the relay failed or the SMF answered with no N2 SM part, and the caller
+    /// must decide what to do about it rather than substituting something.
+    async fn relay_n2_sm_to_smf_for_answer(
+        &self,
+        amf_ue_ngap_id: u64,
+        pdu_session_id: u8,
+        n2_sm_info_type: &str,
+        transfer: &[u8],
+        context: &str,
+    ) -> Option<Vec<u8>> {
+        let sm_context_ref = self
+            .sm_context_refs
+            .get(&(amf_ue_ngap_id, pdu_session_id))
+            .cloned()?;
+        let (host, port) = Self::smf_sbi_target();
+        match crate::sbi_path::call_smf_update_sm_context_n2(
+            &host,
+            port,
+            &sm_context_ref,
+            n2_sm_info_type,
+            transfer,
+        )
+        .await
+        {
+            Ok(resp) if !resp.n2_sm_info.is_empty() => {
+                log::info!(
+                    "{context}: SMF ref={sm_context_ref} answered with {} N2 SM bytes for \
+                     UE {amf_ue_ngap_id} PSI {pdu_session_id}",
+                    resp.n2_sm_info.len()
+                );
+                Some(resp.n2_sm_info)
+            }
+            Ok(_) => {
+                log::warn!(
+                    "{context}: SMF ref={sm_context_ref} accepted the update but returned \
+                     no N2 SM information for UE {amf_ue_ngap_id} PSI {pdu_session_id}"
+                );
+                None
+            }
+            Err(e) => {
+                log::warn!(
+                    "{context}: SMF update failed for UE {amf_ue_ngap_id} PSI \
+                     {pdu_session_id} (ref={sm_context_ref}): {e}"
+                );
+                None
+            }
+        }
+    }
+
     async fn relay_n2_sm_to_smf(
         &self,
         amf_ue_ngap_id: u64,
@@ -9373,6 +9635,254 @@ mod tests {
             mbs::MULTICAST_SESSION_ACTIVATION,
             68,
             "68 is id-BroadcastSessionSetup, a different elementary procedure"
+        );
+    }
+
+    /// #70's criterion 4, asserted where it can be: the switched list is built from the
+    /// SMF's answers, so an unanswered session is ABSENT rather than echoed.
+    ///
+    /// Driving `switched_list_from_smf` directly is what makes this testable — the
+    /// acknowledge is built and immediately sent, and this harness has no gNB association to
+    /// send to, so the assembled list is otherwise unobservable. Reverting the `None` arm to
+    /// push `request_transfer` makes this fail; before the extraction, nothing did.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_switched_list_never_echoes_the_inbound_request_transfer() {
+        let server = test_ngap_server().await;
+        let amf_ue_ngap_id = 78_005u64;
+        let inbound_bytes = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        // No `sm_context_refs` entry, so the SMF cannot be addressed — the same arm a
+        // failed or empty answer takes.
+        assert!(server.sm_context_refs.is_empty());
+
+        let list = server
+            .switched_list_from_smf(amf_ue_ngap_id, &[(1u8, inbound_bytes.clone())])
+            .await;
+
+        assert!(
+            list.is_empty(),
+            "an unacknowledged session must be ABSENT from the switched list; it contained \
+             {list:?}"
+        );
+        assert!(
+            !list.iter().any(|i| i.transfer == inbound_bytes),
+            "and above all it must never carry the gNB's own request transfer back"
+        );
+    }
+
+    // ---- #70: HandoverNotify completes the relocation ----
+
+    fn handover_notify_pdu(amf_ue_ngap_id: u64, ran_ue_ngap_id: u32) -> Vec<u8> {
+        nextgcore_ngap::builder::build_handover_notify(&nextgcore_ngap::types::HandoverNotify {
+            amf_ue_ngap_id,
+            ran_ue_ngap_id,
+            user_location_info: nextgcore_ngap::types::UserLocationInformation::Nr {
+                nr_cgi_plmn: plmn_id_to_ngap_bytes(&PlmnId::new("001", "01")),
+                nr_cell_identity: 0x0000_0042,
+                tai_plmn: plmn_id_to_ngap_bytes(&PlmnId::new("001", "01")),
+                tai_tac: [0x00, 0x00, 0x01],
+            },
+        })
+        .expect("build HandoverNotify")
+    }
+
+    /// TS 38.413 §8.4.3: after HandoverNotify the AMF releases the SOURCE NG-RAN UE
+    /// context. Before #70 it released nothing, so every N2 handover leaked one.
+    ///
+    /// Asserted from the handler's report rather than a log line: the release is an
+    /// outbound send, and a handler that logged without sending would pass a log assertion.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handover_notify_releases_the_source_ran_context() {
+        let mut server = test_ngap_server().await;
+        let (source, target) = (9301u64, 9302u64);
+        let amf_ue_ngap_id = 78_001u64;
+        let source_ran_ue_id = 11u32;
+        seed_gnb_session(&server, source).await;
+        seed_gnb_session(&server, target).await;
+
+        // The UE is served by the SOURCE when the notify arrives from the TARGET.
+        let mut state = UeNasContext::new(amf_ue_ngap_id, source_ran_ue_id, source, false);
+        state.amf_ue.supi = Some("imsi-001010000000001".to_string());
+        server.ue_auth_state.insert(amf_ue_ngap_id, state);
+
+        let report = server
+            .handle_handover_notify(target, &handover_notify_pdu(amf_ue_ngap_id, 22))
+            .await
+            .expect("handled");
+
+        assert_eq!(
+            report.source_context,
+            Some((source, source_ran_ue_id)),
+            "the release must be addressed to the SOURCE association and the SOURCE \
+             RAN-UE-NGAP-ID, both of which are overwritten by the relocation and so must be \
+             captured before it"
+        );
+        // `source_release_sent` is deliberately NOT asserted: this harness has no live SCTP
+        // association, so the send cannot succeed. What is testable here is the decision,
+        // and that is what was missing before #70 — the handler released nothing at all.
+
+        // The UE context SURVIVES: the UE moved, it did not go away. Releasing it here
+        // would deregister a UE the target is now serving.
+        let moved = server
+            .ue_auth_state
+            .get(&amf_ue_ngap_id)
+            .expect("the UE context must survive its own handover");
+        assert_eq!(moved.association_id, target, "serving association moved");
+        assert_eq!(moved.ran_ue_ngap_id, 22, "serving RAN-UE-NGAP-ID moved");
+    }
+
+    /// An intra-gNB notify — arriving on the association already serving the UE — has no
+    /// separate source context, so nothing is released.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_intra_gnb_handover_notify_releases_nothing() {
+        let mut server = test_ngap_server().await;
+        let assoc = 9303u64;
+        let amf_ue_ngap_id = 78_002u64;
+        seed_gnb_session(&server, assoc).await;
+        server.ue_auth_state.insert(
+            amf_ue_ngap_id,
+            UeNasContext::new(amf_ue_ngap_id, 33, assoc, false),
+        );
+
+        let report = server
+            .handle_handover_notify(assoc, &handover_notify_pdu(amf_ue_ngap_id, 33))
+            .await
+            .expect("handled");
+        assert_eq!(
+            report.source_context, None,
+            "there is no source context distinct from the serving one"
+        );
+        assert!(!report.source_release_sent);
+    }
+
+    /// The target's handover transfer is kept between HandoverRequestAcknowledge and
+    /// HandoverNotify, and CONSUMED by the notify.
+    ///
+    /// The relay itself needs a live SMF, which this harness has none of — so
+    /// `sessions_relayed` is 0 here and the observable is the drain: the notify attempted
+    /// the relay for the recorded session and did not leave the transfer behind to be
+    /// re-sent on a later handover.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handover_notify_consumes_the_recorded_target_transfer() {
+        let mut server = test_ngap_server().await;
+        let (source, target) = (9304u64, 9305u64);
+        let amf_ue_ngap_id = 78_003u64;
+        seed_gnb_session(&server, source).await;
+        seed_gnb_session(&server, target).await;
+        server.ue_auth_state.insert(
+            amf_ue_ngap_id,
+            UeNasContext::new(amf_ue_ngap_id, 44, source, false),
+        );
+        server
+            .handover_target_transfers
+            .insert((amf_ue_ngap_id, 1), vec![0xAA, 0xBB, 0xCC]);
+        // A transfer for a DIFFERENT UE must be left alone.
+        server
+            .handover_target_transfers
+            .insert((amf_ue_ngap_id + 1, 1), vec![0xDD]);
+
+        server
+            .handle_handover_notify(target, &handover_notify_pdu(amf_ue_ngap_id, 55))
+            .await
+            .expect("handled");
+
+        assert!(
+            !server
+                .handover_target_transfers
+                .contains_key(&(amf_ue_ngap_id, 1)),
+            "the notify must consume this UE's recorded transfer, or a later handover would \
+             re-send a stale target tunnel to the SMF"
+        );
+        assert!(
+            server
+                .handover_target_transfers
+                .contains_key(&(amf_ue_ngap_id + 1, 1)),
+            "and must not touch another UE's"
+        );
+    }
+
+    /// #70's criterion 4, at the level this harness can reach: the switched list is built
+    /// from the SMF's ANSWERS, so with no SMF reachable it is EMPTY — the inbound request
+    /// transfer is never echoed into it.
+    ///
+    /// That is the defect stated as a test. Before #70 the same conditions produced a
+    /// switched list containing the gNB's own `PathSwitchRequestTransfer`, which tells the
+    /// target to send uplink traffic to itself. An empty list makes the gNB release the
+    /// session, which is the honest outcome when the core cannot confirm the switch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_path_switch_with_no_smf_answer_switches_nothing_rather_than_echoing() {
+        let mut server = test_ngap_server().await;
+        let assoc = 9306u64;
+        let amf_ue_ngap_id = 78_004u64;
+        seed_gnb_session(&server, assoc).await;
+        server.ue_auth_state.insert(
+            amf_ue_ngap_id,
+            UeNasContext::new(amf_ue_ngap_id, 66, assoc, false),
+        );
+        // No `sm_context_refs` entry, so `relay_n2_sm_to_smf_for_answer` cannot even
+        // address the SMF — the same code path a failed or empty answer takes.
+        assert!(server.sm_context_refs.is_empty());
+
+        let request_transfer = nextgcore_ngap::transfer::PathSwitchRequestTransfer {
+            dl_ngu_up_tnl_information:
+                nextgcore_ngap::transfer::UpTransportLayerInformation::GtpTunnel(
+                    nextgcore_ngap::transfer::GtpTunnel {
+                        transport_layer_address:
+                            nextgcore_ngap::transfer::TransportLayerAddress::from_ipv4([
+                                10, 45, 0, 9,
+                            ]),
+                        gtp_teid: [0x00, 0x00, 0xBE, 0xEF],
+                    },
+                ),
+            qos_flow_accepted_list: vec![1],
+        };
+        // The gNB's own transfer, which must NOT come back in the acknowledge.
+        let inbound_bytes = {
+            // No encoder exists for the request transfer (it is decode-only in this tree),
+            // so an opaque non-empty byte string stands in: the assertion is that WHATEVER
+            // came in is not what goes out.
+            let _ = &request_transfer;
+            vec![0x11, 0x22, 0x33, 0x44]
+        };
+
+        let psr = nextgcore_ngap::types::PathSwitchRequest {
+            ran_ue_ngap_id: 67,
+            source_amf_ue_ngap_id: amf_ue_ngap_id,
+            user_location_info: nextgcore_ngap::types::UserLocationInformation::Nr {
+                nr_cgi_plmn: plmn_id_to_ngap_bytes(&PlmnId::new("001", "01")),
+                nr_cell_identity: 7,
+                tai_plmn: plmn_id_to_ngap_bytes(&PlmnId::new("001", "01")),
+                tai_tac: [0, 0, 1],
+            },
+            ue_security_capabilities: nextgcore_ngap::types::UeSecurityCapabilities {
+                nr_encryption_algorithms: 0xF000,
+                nr_integrity_algorithms: 0xF000,
+                eutra_encryption_algorithms: 0,
+                eutra_integrity_algorithms: 0,
+            },
+            pdu_session_list: vec![nextgcore_ngap::types::PduSessionResourceSwitchItem {
+                pdu_session_id: 1,
+                transfer: inbound_bytes.clone(),
+            }],
+            failed_list: None,
+        };
+        let pdu = nextgcore_ngap::builder::build_path_switch_request(&psr)
+            .expect("build PathSwitchRequest");
+
+        // The acknowledge SEND fails here — this harness has no live SCTP association — so
+        // the error is tolerated. What is asserted is everything the handler did BEFORE the
+        // send, which is where the defect was.
+        let _ = server.handle_path_switch_request(assoc, &pdu).await;
+
+        // The UE's NCC advanced (the pre-existing forward-security behaviour) and the
+        // relocation happened, so the handler ran to completion rather than bailing early.
+        let state = server.ue_auth_state.get(&amf_ue_ngap_id).expect("UE");
+        assert_eq!(
+            state.ran_ue_ngap_id, 67,
+            "the handler completed the relocation"
+        );
+        assert!(
+            state.amf_ue.nh.iter().any(|b| *b != 0) || state.amf_ue.nhcc != 0,
+            "and advanced the NH chain"
         );
     }
 }

--- a/src/bins/nextgcore-amfd/src/sbi_path.rs
+++ b/src/bins/nextgcore-amfd/src/sbi_path.rs
@@ -1073,6 +1073,79 @@ pub struct SmContextUpdateResponse {
 
 /// Call SMF to update SM context with N1 SM info (UE-initiated modification)
 ///
+/// Call the SMF with an N2 SM transfer and return what it answers (#70).
+///
+/// Generalises [`call_smf_update_sm_context`], which hardcodes
+/// `n2SmInfoType: "PDU_RES_SETUP_RSP"` and DISCARDS the response body. Both are wrong for
+/// mobility: a path switch is `PATH_SWITCH_REQ`, and the whole point of the exchange is the
+/// `PathSwitchRequestAcknowledgeTransfer` the SMF puts in its answer
+/// (TS 29.502 §5.2.2.3.3). Before #70 the AMF never made this call at all and echoed the
+/// gNB's own request transfer back to it instead.
+///
+/// Returns the response's `n2SmInfo` binary part, empty when the SMF sent none — which is
+/// the caller's cue that it has nothing conformant to put in the acknowledge.
+pub async fn call_smf_update_sm_context_n2(
+    smf_host: &str,
+    smf_port: u16,
+    sm_context_ref: &str,
+    n2_sm_info_type: &str,
+    n2_sm_info: &[u8],
+) -> SbiResult<SmContextUpdateResponse> {
+    log::info!(
+        "Calling SMF SM Context Update ({n2_sm_info_type}): ref={sm_context_ref}, \
+         n2_len={}",
+        n2_sm_info.len()
+    );
+
+    let client = crate::attach_oauth2(
+        SbiClient::for_peer(smf_host, smf_port),
+        nextgcore_sbi::types::NfType::Smf,
+    );
+
+    let body = serde_json::json!({
+        "n2SmInfo": { "contentId": "n2SmInfo" },
+        "n2SmInfoType": n2_sm_info_type,
+    });
+
+    let path = format!("/nsmf-pdusession/v1/sm-contexts/{sm_context_ref}/modify");
+    let request = SbiRequest::post(&path)
+        .with_body(body.to_string(), content_type::APPLICATION_JSON)
+        .with_part(SbiPart::with_content(
+            "n2SmInfo",
+            content_type::APPLICATION_NGAP,
+            bytes::Bytes::copy_from_slice(n2_sm_info),
+        ));
+    let response = client
+        .send_request(request)
+        .await
+        .map_err(|e| SbiError::RequestFailed(format!("SMF update failed: {e}")))?;
+
+    if !response.is_success() {
+        return Err(SbiError::RequestFailed(format!(
+            "SMF update ({n2_sm_info_type}) returned status {}",
+            response.status
+        )));
+    }
+
+    let response_body: serde_json::Value = response
+        .http
+        .content
+        .as_deref()
+        .and_then(|c| serde_json::from_str(c).ok())
+        .unwrap_or(serde_json::Value::Null);
+    let n2_sm_info = extract_binary_ref(&response, &response_body, "n2SmInfo").unwrap_or_default();
+
+    log::info!(
+        "SMF SM Context Updated ({n2_sm_info_type}): ref={sm_context_ref}, \
+         answered n2_len={}",
+        n2_sm_info.len()
+    );
+    Ok(SmContextUpdateResponse {
+        n1_sm_msg: Vec::new(),
+        n2_sm_info,
+    })
+}
+
 /// Sends POST /nsmf-pdusession/v1/sm-contexts/{ref}/modify with N1 SM info
 /// from UE's PDU Session Modification Request. Returns updated N1+N2 from SMF.
 pub async fn call_smf_update_sm_context_with_n1(

--- a/src/bins/nextgcore-smfd/src/context.rs
+++ b/src/bins/nextgcore-smfd/src/context.rs
@@ -1699,6 +1699,22 @@ pub struct SmfContext {
     /// cross-test contamination from a process-wide singleton.
     pub pfcp_sessions: RwLock<HashMap<String, u64>>,
 
+    /// The UPF's N3 uplink endpoint per SM context: `sm_context_ref -> (TEID, IPv4)`
+    /// (#70).
+    ///
+    /// Recorded at establishment, when the UPF's Created PDR names it, so the
+    /// `PATH_SWITCH_REQ` handler can put it in the
+    /// `PathSwitchRequestAcknowledgeTransfer` it owes the target gNB
+    /// (TS 38.413 §9.3.4.9). Before #70 nothing kept it past establishment, so the only
+    /// acknowledge the SMF could have built would have carried no UL tunnel at all — and
+    /// the AMF echoed the gNB's own request transfer back instead, telling the target to
+    /// send uplink traffic to itself.
+    ///
+    /// Separate from `pfcp_sessions` rather than widened into it: that map is keyed and
+    /// consumed as "which N4 session serves this context", and every one of its readers
+    /// wants exactly the SEID.
+    pub upf_ul_endpoints: RwLock<HashMap<String, (u32, [u8; 4])>>,
+
     /// SM policy bindings: sm_context_ref -> PCF policy association + GSM FSM
     pub policy_bindings: RwLock<HashMap<String, PolicyBinding>>,
 
@@ -1820,6 +1836,7 @@ impl SmfContext {
                 .unwrap_or(std::net::Ipv4Addr::new(127, 0, 0, 1)),
             initialized: AtomicBool::new(false),
             pfcp_sessions: RwLock::new(HashMap::new()),
+            upf_ul_endpoints: RwLock::new(HashMap::new()),
             unrestorable_sessions: RwLock::new(Vec::new()),
             policy_bindings: RwLock::new(HashMap::new()),
             upf_recovery_time_stamps: RwLock::new(HashMap::new()),

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -3285,6 +3285,16 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
                     if let Ok(mut sessions) = ctx.pfcp_sessions.write() {
                         sessions.insert(sm_context_ref.to_string(), result.upf_seid);
                     }
+                    // #70: keep the UPF's uplink endpoint too. The PATH_SWITCH_REQ
+                    // handler owes the target gNB a PathSwitchRequestAcknowledgeTransfer
+                    // naming it (TS 38.413 §9.3.4.9), and this is the only point at which
+                    // the UPF has just told us what it is.
+                    if let Ok(mut endpoints) = ctx.upf_ul_endpoints.write() {
+                        endpoints.insert(
+                            sm_context_ref.to_string(),
+                            (result.upf_teid, result.upf_addr),
+                        );
+                    }
                     // Issue #191: after the write guard drops -- `persist` takes a
                     // read lock on this same map and RwLock is not reentrant.
                     ctx.persist();
@@ -3575,6 +3585,16 @@ fn lookup_upf_seid(sm_context_ref: &str) -> Option<u64> {
             .read()
             .ok()
             .and_then(|sessions| sessions.get(sm_context_ref).copied())
+    })
+}
+
+/// The UPF's N3 uplink endpoint for an SM context, if establishment recorded one (#70).
+fn lookup_upf_ul_endpoint(sm_context_ref: &str) -> Option<(u32, [u8; 4])> {
+    smf_self().read().ok().and_then(|ctx| {
+        ctx.upf_ul_endpoints
+            .read()
+            .ok()
+            .and_then(|endpoints| endpoints.get(sm_context_ref).copied())
     })
 }
 
@@ -3909,8 +3929,73 @@ async fn handle_sm_context_update(sm_context_ref: &str, request: &SbiRequest) ->
 
             let mut response_body = serde_json::json!({ "upCnxState": "ACTIVATED" });
             if n2_sm_info_type == "PATH_SWITCH_REQ" {
-                // Echo the (unchanged) UL tunnel back to the target gNB
-                response_body["n2SmInfoType"] = serde_json::json!("PATH_SWITCH_REQ_ACK");
+                // #70: the acknowledge TRANSFER, not just the type. TS 29.502 §5.2.2.3.3
+                // makes the Path Switch Request Acknowledge Transfer an N2 SM information
+                // part of this response, and TS 38.413 §9.3.4.9 makes it a different
+                // message from the request the gNB sent — the request carries the
+                // target's DL tunnel, the acknowledge carries the core's UL tunnel.
+                // Before #70 this branch answered with the type and no part at all, and
+                // the AMF filled the gap by echoing the gNB's own request transfer back,
+                // which tells the target to send uplink traffic to itself.
+                //
+                // The UL endpoint is unchanged by an Xn path switch (only the DL side
+                // moves), so this re-states it rather than allocating anything. When
+                // establishment recorded no endpoint the transfer is sent with the UL
+                // tunnel ABSENT, which §9.3.4.9 permits and which honestly means "no
+                // change" — better than inventing a tunnel the UPF does not serve.
+                let ack = match lookup_upf_ul_endpoint(sm_context_ref) {
+                    Some((teid, addr)) => {
+                        use nextgcore_ngap::transfer::{
+                            GtpTunnel, PathSwitchRequestAcknowledgeTransfer, TransportLayerAddress,
+                            UpTransportLayerInformation,
+                        };
+                        PathSwitchRequestAcknowledgeTransfer {
+                            ul_ngu_up_tnl_information: Some(
+                                UpTransportLayerInformation::GtpTunnel(GtpTunnel {
+                                    transport_layer_address: TransportLayerAddress::from_ipv4(addr),
+                                    gtp_teid: teid.to_be_bytes(),
+                                }),
+                            ),
+                            ..Default::default()
+                        }
+                    }
+                    None => {
+                        log::warn!(
+                            "PATH_SWITCH_REQ for ref={sm_context_ref}: no recorded UPF uplink \
+                             endpoint, so the acknowledge carries no UL tunnel (TS 38.413 \
+                             §9.3.4.9 permits its absence, and it means the UL path is \
+                             unchanged)"
+                        );
+                        nextgcore_ngap::transfer::PathSwitchRequestAcknowledgeTransfer::default()
+                    }
+                };
+                use nextgcore_sbi::constants::content_type;
+                match ack.encode() {
+                    Ok(bytes) => {
+                        response_body["n2SmInfoType"] = serde_json::json!("PATH_SWITCH_REQ_ACK");
+                        response_body["n2SmInfo"] = serde_json::json!({ "contentId": "n2SmInfo" });
+                        return SbiResponse::with_status(200)
+                            .with_body(response_body.to_string(), content_type::APPLICATION_JSON)
+                            .with_part(nextgcore_sbi::message::SbiPart::with_content(
+                                "n2SmInfo",
+                                content_type::APPLICATION_NGAP,
+                                bytes::Bytes::from(bytes),
+                            ));
+                    }
+                    Err(e) => {
+                        // The user plane is already switched at this point, so the switch
+                        // itself succeeded; what failed is telling the gNB about it.
+                        // Answering 500 lets the AMF fail the PathSwitchRequest rather
+                        // than acknowledge one whose transfer is missing.
+                        log::error!(
+                            "Failed to encode PathSwitchRequestAcknowledgeTransfer for \
+                             ref={sm_context_ref}: {e:?}"
+                        );
+                        return nextgcore_sbi::server::send_internal_error(
+                            "could not build the Path Switch Request Acknowledge Transfer",
+                        );
+                    }
+                }
             }
             SbiResponse::with_status(200).with_body(response_body.to_string(), "application/json")
         }
@@ -9918,5 +10003,107 @@ mod oauth2_h8_tests {
         assert_ne!(resp.status, 401, "valid token must not be 401");
         assert_ne!(resp.status, 403, "valid token must not be 403");
         server.stop().await.expect("stop");
+    }
+}
+
+/// #70: the Path Switch Request Acknowledge Transfer the SMF owes the target gNB.
+#[cfg(test)]
+mod path_switch_ack_tests {
+    use super::*;
+
+    // ---- #70: the PATH_SWITCH_REQ acknowledge transfer ----
+
+    /// TS 29.502 §5.2.2.3.3: the `PATH_SWITCH_REQ` response carries the Path Switch Request
+    /// Acknowledge Transfer as an N2 SM information part, not just the type.
+    ///
+    /// Before #70 this branch answered `{upCnxState, n2SmInfoType}` with no part at all,
+    /// which is why the AMF had nothing to put in the acknowledge and echoed the gNB's own
+    /// request transfer back instead.
+    ///
+    /// Asserted by DECODING the bytes as a `PathSwitchRequestAcknowledgeTransfer`, because
+    /// "a non-empty part is present" would pass for any bytes at all — including a copy of
+    /// the request transfer, which is precisely the defect.
+    #[test]
+    fn the_path_switch_acknowledge_transfer_carries_the_recorded_uplink_endpoint() {
+        use nextgcore_ngap::transfer::{
+            PathSwitchRequestAcknowledgeTransfer, UpTransportLayerInformation,
+        };
+
+        // The shape the handler builds when establishment recorded an endpoint.
+        let ack = PathSwitchRequestAcknowledgeTransfer {
+            ul_ngu_up_tnl_information: Some(UpTransportLayerInformation::GtpTunnel(
+                nextgcore_ngap::transfer::GtpTunnel {
+                    transport_layer_address:
+                        nextgcore_ngap::transfer::TransportLayerAddress::from_ipv4([10, 45, 0, 1]),
+                    gtp_teid: 0x0001_0001u32.to_be_bytes(),
+                },
+            )),
+            ..Default::default()
+        };
+        let bytes = ack
+            .encode()
+            .expect("the handler must be able to encode this");
+        assert!(!bytes.is_empty(), "the n2SmInfo part must be non-empty");
+
+        let decoded =
+            PathSwitchRequestAcknowledgeTransfer::decode(&bytes).expect("decode as the ack type");
+        match decoded.ul_ngu_up_tnl_information {
+            Some(UpTransportLayerInformation::GtpTunnel(t)) => {
+                assert_eq!(
+                    t.gtp_teid,
+                    0x0001_0001u32.to_be_bytes(),
+                    "the UPF uplink TEID must survive: it is what the target gNB sends to"
+                );
+            }
+            other => panic!("expected a GTP tunnel, got {other:?}"),
+        }
+    }
+
+    /// The absent-endpoint fallback is a VALID transfer meaning "the uplink path is
+    /// unchanged" (TS 38.413 §9.3.4.9 makes every member optional), not an error and not an
+    /// invented tunnel.
+    #[test]
+    fn an_acknowledge_without_a_recorded_endpoint_is_still_a_valid_transfer() {
+        use nextgcore_ngap::transfer::PathSwitchRequestAcknowledgeTransfer;
+        let bytes = PathSwitchRequestAcknowledgeTransfer::default()
+            .encode()
+            .expect("encode");
+        assert!(
+            !bytes.is_empty(),
+            "even the no-change form has a preamble, so the n2SmInfo part is non-empty"
+        );
+        let decoded = PathSwitchRequestAcknowledgeTransfer::decode(&bytes).expect("decode");
+        assert!(
+            decoded.ul_ngu_up_tnl_information.is_none(),
+            "and it says 'no uplink change' rather than naming a tunnel the UPF does not serve"
+        );
+    }
+
+    /// The UPF uplink endpoint recorded at establishment is what the acknowledge reads.
+    ///
+    /// This is the store #70 added; without it the handler could only ever send the
+    /// no-change form.
+    #[test]
+    fn the_upf_uplink_endpoint_is_recorded_and_looked_up_by_context_ref() {
+        let ctx = context::SmfContext::new();
+        {
+            let mut endpoints = ctx.upf_ul_endpoints.write().expect("write");
+            endpoints.insert("ref-1".to_string(), (0x0001_0002, [10, 45, 0, 3]));
+        }
+        let got = ctx
+            .upf_ul_endpoints
+            .read()
+            .expect("read")
+            .get("ref-1")
+            .copied();
+        assert_eq!(got, Some((0x0001_0002, [10, 45, 0, 3])));
+        assert!(
+            ctx.upf_ul_endpoints
+                .read()
+                .expect("read")
+                .get("ref-2")
+                .is_none(),
+            "an unrelated context ref must not resolve to another session's tunnel"
+        );
     }
 }

--- a/src/libs/nextgcore-ngap/src/transfer.rs
+++ b/src/libs/nextgcore-ngap/src/transfer.rs
@@ -1759,6 +1759,120 @@ impl PathSwitchRequestTransfer {
     }
 }
 
+// ============================================================================
+// Path Switch Request Acknowledge Transfer (TS 38.413 Section 9.3.4.9)
+// ============================================================================
+
+/// PathSwitchRequestAcknowledgeTransfer - built by the SMF, consumed by the target gNB.
+///
+/// The SMF's answer to a [`PathSwitchRequestTransfer`]: it tells the target gNB the UL
+/// NG-U endpoint to send on, and optionally re-states the user-plane security policy and
+/// its result.
+///
+/// # Why this exists (#70)
+///
+/// Before #70 the AMF echoed the gNB's own `PathSwitchRequestTransfer` back to it as the
+/// acknowledge transfer, because there was nothing else to send: this type did not exist,
+/// the AMF never asked the SMF, and the SMF's `PATH_SWITCH_REQ` branch answered with no
+/// `n2SmInfo` at all. TS 38.413 §9.3.4.9 makes these two different transfers with
+/// different contents and opposite directions — the request carries the target's DL
+/// tunnel, the acknowledge carries the core's UL tunnel — so echoing one for the other
+/// tells the target gNB to send uplink traffic to itself.
+///
+/// # Optionality
+///
+/// Every member is OPTIONAL in the ASN.1, so an empty acknowledge is legal and means "no
+/// change". That is deliberately representable: `Default` gives exactly that, and it is
+/// the honest encoding for a path switch where the UL tunnel did not move.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct PathSwitchRequestAcknowledgeTransfer {
+    /// UL NG-U UP TNL information - the UPF N3 endpoint the target gNB sends uplink to.
+    pub ul_ngu_up_tnl_information: Option<UpTransportLayerInformation>,
+    /// User-plane security policy for the switched session.
+    pub security_indication: Option<SecurityIndication>,
+    /// The security result actually applied.
+    pub new_security_result: Option<SecurityResult>,
+    /// QoS flows the core is releasing as part of the switch.
+    pub qos_flow_to_release_list: Vec<QosFlowWithCauseItem>,
+}
+
+impl PathSwitchRequestAcknowledgeTransfer {
+    pub fn encode(&self) -> NgapResult<Vec<u8>> {
+        let mut encoder = AperEncoder::new();
+        // SEQUENCE preamble: extension marker, then one present-bit per OPTIONAL member
+        // in declaration order (uL-NGU-UP-TNLInformation, securityIndication,
+        // newSecurityResult, qosFlowToReleaseList, iE-Extensions).
+        encoder.write_bit(false); // extension marker
+        encoder.write_bit(self.ul_ngu_up_tnl_information.is_some());
+        encoder.write_bit(self.security_indication.is_some());
+        encoder.write_bit(self.new_security_result.is_some());
+        encoder.write_bit(!self.qos_flow_to_release_list.is_empty());
+        encoder.write_bit(false); // no iE-Extensions
+
+        if let Some(tnl) = &self.ul_ngu_up_tnl_information {
+            tnl.encode(&mut encoder)?;
+        }
+        if let Some(si) = &self.security_indication {
+            si.encode(&mut encoder)?;
+        }
+        if let Some(sr) = &self.new_security_result {
+            sr.encode(&mut encoder)?;
+        }
+        if !self.qos_flow_to_release_list.is_empty() {
+            // QosFlowListWithCause ::= SEQUENCE (SIZE(1..64)) OF QosFlowWithCauseItem
+            encoder.encode_constrained_length(self.qos_flow_to_release_list.len(), 1, 64)?;
+            for item in &self.qos_flow_to_release_list {
+                item.encode(&mut encoder)?;
+            }
+        }
+        encoder.align();
+        Ok(encoder.into_bytes().to_vec())
+    }
+
+    pub fn decode(data: &[u8]) -> NgapResult<Self> {
+        let mut decoder = AperDecoder::new(data);
+        let _ext = decoder.read_bit()?;
+        let tnl_present = decoder.read_bit()?;
+        let si_present = decoder.read_bit()?;
+        let sr_present = decoder.read_bit()?;
+        let release_present = decoder.read_bit()?;
+        let _ie_ext = decoder.read_bit()?;
+
+        let ul_ngu_up_tnl_information = if tnl_present {
+            Some(UpTransportLayerInformation::decode(&mut decoder)?)
+        } else {
+            None
+        };
+        let security_indication = if si_present {
+            Some(SecurityIndication::decode(&mut decoder)?)
+        } else {
+            None
+        };
+        let new_security_result = if sr_present {
+            Some(SecurityResult::decode(&mut decoder)?)
+        } else {
+            None
+        };
+        let qos_flow_to_release_list = if release_present {
+            let count = decoder.decode_constrained_length(1, 64)?;
+            let mut list = Vec::with_capacity(count);
+            for _ in 0..count {
+                list.push(QosFlowWithCauseItem::decode(&mut decoder)?);
+            }
+            list
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self {
+            ul_ngu_up_tnl_information,
+            security_indication,
+            new_security_result,
+            qos_flow_to_release_list,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2171,6 +2285,94 @@ mod tests {
             prop_assert_eq!(bytes[0], 0x00);
             let decoded = PduSessionResourceSetupRequestTransfer::decode(&bytes).unwrap();
             prop_assert_eq!(decoded, transfer);
+        }
+    }
+    // ------------------------------------------------------------------
+    // PathSwitchRequestAcknowledgeTransfer (#70, TS 38.413 §9.3.4.9)
+    // ------------------------------------------------------------------
+
+    /// Every member is OPTIONAL, so the empty transfer must round-trip — it is the honest
+    /// encoding for a path switch where the UL tunnel did not move.
+    #[test]
+    fn path_switch_ack_transfer_round_trips_empty() {
+        let empty = PathSwitchRequestAcknowledgeTransfer::default();
+        let bytes = empty.encode().expect("encode");
+        let decoded = PathSwitchRequestAcknowledgeTransfer::decode(&bytes).expect("decode");
+        assert_eq!(decoded, empty);
+        assert!(decoded.ul_ngu_up_tnl_information.is_none());
+        assert!(decoded.qos_flow_to_release_list.is_empty());
+    }
+
+    /// The member that matters: the UL tunnel the target gNB must send uplink to.
+    #[test]
+    fn path_switch_ack_transfer_round_trips_the_ul_tunnel() {
+        let transfer = PathSwitchRequestAcknowledgeTransfer {
+            ul_ngu_up_tnl_information: Some(sample_tunnel()),
+            ..Default::default()
+        };
+        let bytes = transfer.encode().expect("encode");
+        let decoded = PathSwitchRequestAcknowledgeTransfer::decode(&bytes).expect("decode");
+        assert_eq!(decoded, transfer);
+        assert_eq!(
+            decoded.ul_ngu_up_tnl_information,
+            Some(sample_tunnel()),
+            "the UPF endpoint must survive: it is the whole point of the acknowledge"
+        );
+    }
+
+    /// All members together, so the present-bit order in the preamble is exercised.
+    ///
+    /// Order matters and a wrong one is silent: with only one member set, any preamble
+    /// ordering decodes back to the same value, so a permutation would pass. Setting all
+    /// of them is what pins the sequence.
+    #[test]
+    fn path_switch_ack_transfer_round_trips_every_member() {
+        let transfer = PathSwitchRequestAcknowledgeTransfer {
+            ul_ngu_up_tnl_information: Some(sample_tunnel()),
+            security_indication: Some(SecurityIndication {
+                integrity_protection_indication: ProtectionIndication::Required,
+                confidentiality_protection_indication: ProtectionIndication::Preferred,
+                maximum_integrity_protected_data_rate_ul: Some(
+                    MaximumIntegrityProtectedDataRate::Bitrate64kbs,
+                ),
+            }),
+            new_security_result: Some(SecurityResult {
+                integrity_protection_result: ProtectionResult::Performed,
+                confidentiality_protection_result: ProtectionResult::NotPerformed,
+            }),
+            qos_flow_to_release_list: vec![QosFlowWithCauseItem {
+                qos_flow_identifier: 5,
+                cause: Cause::RadioNetwork(CauseRadioNetwork::Unspecified),
+            }],
+        };
+        let bytes = transfer.encode().expect("encode");
+        let decoded = PathSwitchRequestAcknowledgeTransfer::decode(&bytes).expect("decode");
+        assert_eq!(decoded, transfer);
+    }
+
+    /// The acknowledge and the request are DIFFERENT transfers, which is the defect #70
+    /// names: the AMF echoed the request back as the acknowledge.
+    ///
+    /// Decoding an acknowledge's bytes as a request (or the reverse) must not quietly
+    /// succeed with plausible contents — that is what made the echo invisible.
+    #[test]
+    fn an_acknowledge_transfer_is_not_a_request_transfer() {
+        let ack = PathSwitchRequestAcknowledgeTransfer {
+            ul_ngu_up_tnl_information: Some(sample_tunnel()),
+            ..Default::default()
+        };
+        let ack_bytes = ack.encode().expect("encode");
+
+        // The request has a 4-bit preamble and two MANDATORY members; the acknowledge has
+        // a 6-bit preamble and none. They cannot be the same bytes for the same tunnel.
+        match PathSwitchRequestTransfer::decode(&ack_bytes) {
+            Err(_) => {}
+            Ok(req) => assert_ne!(
+                req.dl_ngu_up_tnl_information,
+                sample_tunnel(),
+                "an acknowledge must not decode as a request naming the same tunnel — if it \
+                 did, echoing one for the other would be undetectable on the wire"
+            ),
         }
     }
 }


### PR DESCRIPTION
Closes #70.

## Three criteria were already met — including the defect #70 leads with

#70 was written against `76ea248`. Re-verified at `2e1d985`:

| # | criterion | state |
|---|---|---|
| 1 | HandoverRequest NH derived from KgNB, NCC incremented | **met** — `context.rs:2769`; tests `next_hop_chain_is_seeded_from_kgnb_never_from_zero`, `first_handover_conveys_a_non_zero_nh_and_an_incremented_ncc` |
| 2 | N2 and Xn share one NCC/NH helper | **met** — `AmfUe::advance_next_hop`, test `n2_and_xn_derive_identically_for_equal_inputs` |
| 3 | FC 0x72 KAMF′ in `nextgcore-crypt` | **met** — `kdf.rs:35`, `:335`, test `kamf_prime_uses_every_input` |
| **4** | **Xn calls the SMF and uses its acknowledge transfer** | **NOT met** |
| **5** | **SMF `PATH_SWITCH_REQ` carries a non-empty `n2SmInfo`** | **NOT met** |
| **6** | **HandoverNotify tells the SMF and releases the source** | **NOT met** |

So the all-zero-NH forward-security break is already fixed. What remained is gaps **4 and 5**
of the issue's own list: *neither mobility path completes the control-plane relocation.*

## `PathSwitchRequestAcknowledgeTransfer` did not exist — and that's why the AMF echoed

`nextgcore-ngap::transfer` had `PathSwitchRequestTransfer` (decode-only, what the gNB sends)
and no acknowledge counterpart. There was nothing else to send, the AMF never asked the SMF,
and the SMF answered with `n2SmInfoType` and no part.

**The echo is not cosmetic.** §9.3.4.8 and §9.3.4.9 are different messages in opposite
directions — the request carries the *target's DL* tunnel, the acknowledge the *core's UL*
tunnel. Echoing one for the other tells the target gNB to **send uplink traffic to itself**.

Added per TS 38.413 §9.3.4.9, all four members optional as the ASN.1 has them; every member
type already existed.

## Decisions

- **The empty acknowledge is a real answer.** Every member of §9.3.4.9 is OPTIONAL, and an Xn
  switch does not move the uplink path — only the DL side moves. With no recorded UPF endpoint
  the acknowledge omits the UL tunnel, conformantly meaning "no change". Inventing one would
  point the target at something no UPF serves.
- **An unacknowledged session is left OUT of the switched list**, not echoed and not
  fabricated. A gNB that finds a session missing releases it — the honest outcome when the
  core cannot confirm the switch.
- **`upf_ul_endpoints` is a new map, not a widening of `pfcp_sessions`** — that map is keyed
  and consumed as "which N4 session serves this context" and every reader wants the SEID.
- **The SMF is told at HandoverNotify, not at HandoverRequestAcknowledge.** TS 23.502
  §4.9.1.3.3 puts the DL switch at step 12, *after* the UE arrives; switching earlier would
  blackhole downlink while the source is still serving. So the target's transfer is recorded at
  acknowledge time and consumed at notify time.
- **The source release does not go through `release_ue`**, which removes `ue_auth_state`. The
  UE has not gone away — it has **moved** — and dropping its context would deregister a UE the
  target is now serving. Only the source gNB's copy is released, cause `successful-handover`.
- **The source identity is captured before the relocation overwrites it** — `association_id`
  and `ran_ue_ngap_id` both become the target's, and they are exactly what the release must be
  addressed to.
- **A failed release does not fail the procedure** — the UE has arrived and the path is
  switched; erroring would leave the handover half-reported.

## Verification

Workspace **6520 passed / 0 failed** (main: 6508). Clippy **74 warnings, unchanged from main**.
`cargo fmt --check` clean. **16 consecutive runs of the three changed crates clean.**

### Reverts, all of which bite

| revert | failing test |
|---|---|
| capture the source *after* the relocation | `handover_notify_releases_the_source_ran_context` |
| echo the inbound transfer when the SMF doesn't answer | `the_switched_list_never_echoes_the_inbound_request_transfer` |
| break the acknowledge transfer's preamble/member order | the `transfer.rs` round-trip tests |

### The echo revert did NOT bite at first, and fixing that changed the code

The first echo revert compiled and **passed**. The switched list was built inline, assembled
into an acknowledge and immediately sent — and this harness has no live gNB association, so the
send fails and the list is never observable. **The property was implemented and untested.**

`switched_list_from_smf` was extracted for exactly that reason (and says so in its doc
comment). With the construction reachable, the revert fails. This is the **second time in this
batch** that "the revert did not bite" meant "the property isn't covered" rather than "the
property holds".

### Two observables split, because one isn't testable here

`HandoverCompletion` reports `source_context` (which source the handler *decided* to release)
separately from `source_release_sent` (whether the datagram left). The decision comes from
state the relocation immediately overwrites and is the part that was missing; the send needs a
live SCTP association. Collapsing them made the decision untestable — which is what the first
draft did, and its test then failed for the wrong reason.

Reported through a return value rather than a log line, following the crate's existing
convention (`handle_uplink_ran_status_transfer` returns its relay target), because a handler
that logged without sending would pass a log assertion.

## Ceilings

- **nextgsim#39 is still required for an end-to-end handover.** #70's cross-repo note is about
  the gNB side: its inter-gNB N2/Xn path is dead code with no target-side PDU/DRB admission
  and no FC=0x70 KgNB* derivation. Nothing here changes that.
- **No E2E** — all in-process; the AMF harness has no live SCTP association, so the
  acknowledge and release *sends* are exercised only as far as the transport call.
- **`HANDOVER_REQ_ACK` is recorded but not relayed at acknowledge time.** TS 29.502
  §5.2.2.3.2.2 has that leg too; smfd already handles both types (`main.rs:4201`, `:4213`), so
  it is wiring rather than new protocol.
- **The acknowledge re-states the uplink endpoint rather than reallocating** — correct for Xn.
- **`qos_flow_to_release_list` is modelled and encoded but never populated** — the SMF has no
  path-switch-time flow-release decision to express yet.
- **`handover_target_transfers` is in-memory**, so an AMF restart mid-handover loses the
  recorded target tunnel; the same is already true of `handover_target_assoc` beside it.

Spec: `specs/fix-amfd-handover-mobility-control-plane.md`