### PR TITLE
test(sbi): assert stop()'s drain ordering instead of a wall-clock bound (#326)

### DIFF
--- a/specs/fix-sbi-stop-drain-ordering-not-wall-clock.md
+++ b/specs/fix-sbi-stop-drain-ordering-not-wall-clock.md
@@ -1,0 +1,115 @@
+# fix(sbi): assert the drain ORDERING, not a wall-clock lower bound
+
+Closes #326.
+
+## Claim-vs-site-vs-still-true
+
+Re-located against `1606deb`, because a stale cite is the usual reason an issue looks
+bigger or smaller than it is:
+
+| # | #326's claim | site now | still true? |
+|---|---|---|---|
+| 1 | the assertion is a wall-clock lower bound on how long `stop()` blocked | `server.rs:2496` `assert!(stop_started.elapsed() >= Duration::from_millis(150))` | **yes** |
+| 2 | the setup that makes it hold is an unsynchronised 80 ms sleep | `server.rs:2490` `sleep(Duration::from_millis(80))` | **yes** |
+| 3 | the handler sleeps 300 ms | `server.rs:2479` | **yes** |
+| 4 | siblings with the same sleep-then-measure shape exist in this crate | `rg 'elapsed\(\)' libs/nextgcore-sbi/src` → 6 hits, **all production**: `heartbeat.rs:63,70,243`, `oauth.rs:518,1486`. `rg 'sleep\(Duration::from_millis'` → **1 hit, this test**. | **no — none** |
+
+So criterion 4 is answered by enumeration rather than by work: `stop_drains_an_in_flight_request`
+was the only sleep-then-measure test in `nextgcore-sbi`. Every other `Instant::now()` in the
+crate is either production code or a test that **injects** `now` as a parameter
+(`overload.rs:606,635,668` all pass `now` into `record`/`decide`/`live_count`), which is the
+shape that has no wall-clock dependency to begin with.
+
+## Why the old test flaked, precisely
+
+The failing inequality needed the 80 ms sleep to be an *upper* bound on how long the request
+takes to reach the handler:
+
+```text
+elapsed(stop) ≈ 300 ms − (time already spent in the handler when stop() was called)
+             ≈ 300 ms − (80 ms sleep + scheduling overshoot + connect/send time)
+```
+
+so the assertion `elapsed(stop) >= 150 ms` holds only while overshoot + connect stays under
+**70 ms**. On a loaded whole-workspace runner it does not, and the drain is blamed for it.
+That is a 70 ms margin on an accumulated overshoot — which is why it reproduced at roughly
+1 run in 5 under load and 0 in 25 in isolation.
+
+## What it does now
+
+Two changes, and the second is the one that makes the first safe:
+
+1. **The handler signals ENTRY and then parks on a signal the test owns.** No sleep has to
+   stand in for "the request has reached the handler" — `entered.notified().await` *is* that
+   fact. `tokio::sync::Notify` rather than a `oneshot` because `SbiRequestHandler` is
+   implemented for `Fn` (not `FnOnce`), and because a `notify_one` that lands before the
+   waiter stores its permit instead of being dropped.
+
+2. **`stop()` runs in its own task and the test asserts that task is STILL PENDING** while
+   the handler is parked. This is the ordering the doc comment already claimed to be about
+   ("in-flight completes, connection then closes"), asserted as an ordering:
+
+   ```rust
+   let stop_task = tokio::spawn(async move { server.stop().await });
+   tokio::time::sleep(Duration::from_millis(50)).await;
+   assert!(!stop_task.is_finished(), "stop() returned while a stream was still in flight, …");
+   release.notify_one();
+   ```
+
+The margin is now infinite in the direction that used to fail. `stop()` waits on
+`drain.recv()`, which returns only when every cloned drain token has dropped; the connection
+task holds one until it returns, and it cannot return until the handler does. So **no amount
+of scheduling delay can make a correct `stop()` look finished** — waiting longer only makes
+the pending assertion more obviously true.
+
+## Decisions
+
+**The 50 ms sleep is a revert-DETECTOR, not a correctness dependency, and the comment says
+so.** A `stop()` that skips the drain still needs *some* slice of time to run to completion
+before `is_finished()` can observe it. Deleting the sleep would make the test unable to
+notice a broken drain (`is_finished()` would be `false` merely because the task had not been
+polled yet); lengthening it never invalidates the assertion. Load pushes this test toward a
+*slower* verdict, never a wrong one — which is the opposite of the property it had before.
+
+**Assert on `is_finished()` rather than on a completion flag the handler sets.** An
+`AtomicBool` set on the handler's way out, read after `stop()` returns, states the same
+ordering — but it degrades to a *vacuous pass* if the handler happens to finish before
+`stop()` is called, so a broken drain could go unreported under load. Asserting the stop task
+is pending while the handler is *provably* still parked has no such window: the test controls
+when the handler returns.
+
+**The existing 200/`"drained"` assertions are kept verbatim.** They are the half that already
+proved the request was not *dropped*, which is a different property from ordering, and #326
+explicitly asks for them to stay.
+
+## Revert-verify
+
+Required by the convention that a behavioural claim is verified by making it fail, not by
+writing it down. `stop()`'s drain wait was replaced with an early `return Ok(())`:
+
+```text
+test server::tests::stop_drains_an_in_flight_request ... FAILED
+panicked at libs/nextgcore-sbi/src/server.rs:2542:9:
+stop() returned while a stream was still in flight, so it did not drain
+```
+
+Restored, and green again. The **named** assertion is the one that fires — not a transport
+error, not a join failure — so the test fails for the reason it claims to test.
+
+Worth recording because it nearly did not bite: the first revert attempt reported green and
+proved nothing. The command was `cd src && cp … && python3 …`, run from a shell whose working
+directory was *already* `src`; `cd` failed, the `&&` chain short-circuited, the edit never
+applied, and `cargo test` re-ran the unmodified tree. A revert-verify that passes is
+indistinguishable from a revert that never happened unless the edit is confirmed
+independently — here by `grep`-ing for the injected line before running the test.
+
+## Criterion 3: 25 consecutive whole-workspace runs
+
+`cargo test --workspace`, 25 runs, **6520 tests each, 0 failures**. Run under the same
+condition that produced the original flake (a full workspace run with every test binary
+competing), which is what makes the count meaningful rather than decorative.
+
+## Files
+
+- `src/libs/nextgcore-sbi/src/server.rs` — `stop_drains_an_in_flight_request` reworked; doc
+  comment records the mechanism, the ordering property, and why the residual sleep is safe.

--- a/src/libs/nextgcore-sbi/src/server.rs
+++ b/src/libs/nextgcore-sbi/src/server.rs
@@ -2462,9 +2462,31 @@ mod tests {
 
     /// #65 acceptance: `stop()` drains in-flight streams instead of killing them.
     ///
-    /// The handler sleeps, so shutdown is requested while the request is
-    /// genuinely mid-flight. Before the graceful path existed, the connection task
-    /// was detached and the client saw a transport error here.
+    /// The handler parks on a signal the test controls, so shutdown is requested
+    /// while the request is genuinely mid-flight. Before the graceful path
+    /// existed, the connection task was detached and the client saw a transport
+    /// error here.
+    ///
+    /// #326: this used to assert a wall-clock LOWER BOUND on how long `stop()`
+    /// blocked (`elapsed() >= 150 ms`) after an unsynchronised 80 ms sleep that
+    /// merely hoped the request had reached the handler. Under a loaded
+    /// whole-workspace run the 80 ms overshot, the fixed 300 ms handler was
+    /// already more than 150 ms through by the time `stop()` was called, and the
+    /// bound failed with nothing wrong with the drain — about 1 run in 5. The
+    /// property is an ORDERING, not a duration, so it is asserted as one:
+    ///
+    /// - the handler signals ENTRY, so nothing has to guess when it was reached;
+    /// - `stop()` runs in its own task, and the test asserts that task is STILL
+    ///   PENDING while the handler is parked. That is deterministic in both
+    ///   directions: the drain barrier cannot release until the connection task
+    ///   returns, which cannot happen until the handler does, so no amount of
+    ///   scheduling delay can make a correct `stop()` look finished.
+    ///
+    /// The `sleep` before the pending check is a revert-DETECTOR, not a
+    /// correctness dependency: a `stop()` that skips the drain needs some slice of
+    /// time to run to completion before `is_finished()` can observe it. Waiting
+    /// longer never invalidates the assertion, which is the direction that makes
+    /// it safe under load.
     ///
     /// Ceiling, stated rather than implied: this asserts the OBSERVABLE
     /// consequence of the GOAWAY (in-flight completes, connection then closes),
@@ -2473,30 +2495,53 @@ mod tests {
     #[tokio::test]
     async fn stop_drains_an_in_flight_request() {
         use crate::client::SbiClient;
+        use tokio::sync::Notify;
 
-        let (server, port) =
-            start_test_server(SbiServerConfig::default(), |_req: SbiRequest| async {
-                tokio::time::sleep(Duration::from_millis(300)).await;
-                SbiResponse::with_status(200).with_body("drained", "text/plain")
-            })
-            .await;
+        // `entered` fires on handler entry; `release` lets the test decide when the
+        // handler returns. `Notify` rather than a oneshot because the handler is an
+        // `Fn` and may be called more than once, and because a `notify_one` that
+        // arrives first stores its permit instead of being lost.
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+
+        let handler = {
+            let entered = entered.clone();
+            let release = release.clone();
+            move |_req: SbiRequest| {
+                let entered = entered.clone();
+                let release = release.clone();
+                async move {
+                    entered.notify_one();
+                    release.notified().await;
+                    SbiResponse::with_status(200).with_body("drained", "text/plain")
+                }
+            }
+        };
+
+        let (server, port) = start_test_server(SbiServerConfig::default(), handler).await;
         let client = Arc::new(SbiClient::with_host_port("127.0.0.1", port));
 
-        // Fire the request, let it reach the handler, then stop the server.
         let in_flight = {
             let client = client.clone();
             tokio::spawn(async move { client.send_request(SbiRequest::get("/slow")).await })
         };
-        tokio::time::sleep(Duration::from_millis(80)).await;
 
-        let stop_started = std::time::Instant::now();
-        server.stop().await.expect("stop");
-        // stop() must have WAITED for the drain rather than returning at once.
+        // Synchronised, not slept for: the handler is now definitely running and
+        // parked, so the request is definitely in flight.
+        entered.notified().await;
+
+        let server = Arc::new(server);
+        let stop_task = {
+            let server = server.clone();
+            tokio::spawn(async move { server.stop().await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(
-            stop_started.elapsed() >= Duration::from_millis(150),
-            "stop() returned in {:?}, so it did not wait for the in-flight stream",
-            stop_started.elapsed()
+            !stop_task.is_finished(),
+            "stop() returned while a stream was still in flight, so it did not drain"
         );
+
+        release.notify_one();
 
         let response = in_flight
             .await
@@ -2504,6 +2549,8 @@ mod tests {
             .expect("an in-flight request must complete across a graceful shutdown");
         assert_eq!(response.status, 200);
         assert_eq!(response.http.content.as_deref(), Some("drained"));
+
+        stop_task.await.expect("stop task joined").expect("stop");
     }
 
     /// #65: after a graceful stop the listener is gone, so a NEW connection is


### PR DESCRIPTION
Closes #326.

## Claim-vs-site-vs-still-true

Re-located against `1606deb` rather than trusted, because a stale cite is the usual reason an issue looks bigger or smaller than it is:

| # | #326's claim | site now | still true? |
|---|---|---|---|
| 1 | the assertion is a wall-clock lower bound on how long `stop()` blocked | `server.rs:2496` | **yes** |
| 2 | the setup that makes it hold is an unsynchronised 80 ms sleep | `server.rs:2490` | **yes** |
| 3 | the handler sleeps 300 ms | `server.rs:2479` | **yes** |
| 4 | siblings with the same sleep-then-measure shape exist in this crate | see below | **no — none** |

## Why it flaked, precisely

```
elapsed(stop) ≈ 300 ms − (80 ms sleep + scheduling overshoot + connect/send time)
```

so `elapsed(stop) >= 150 ms` holds only while overshoot + connect stays under **70 ms**. On a loaded whole-workspace runner it does not, and the drain gets blamed for the runner's scheduling. That is why it reproduced at roughly 1 run in 5 under load and 0 in 25 in isolation.

## What it does now

1. **The handler signals ENTRY, then parks on a signal the test owns.** `entered.notified().await` *is* the fact that the request reached the handler — no sleep stands in for it. `tokio::sync::Notify` rather than a `oneshot` because `SbiRequestHandler` is implemented for `Fn` (not `FnOnce`), and because a `notify_one` that lands before the waiter stores its permit instead of being dropped.

2. **`stop()` runs in its own task; the test asserts that task is STILL PENDING** while the handler is parked:

```rust
let stop_task = tokio::spawn(async move { server.stop().await });
tokio::time::sleep(Duration::from_millis(50)).await;
assert!(!stop_task.is_finished(), "stop() returned while a stream was still in flight, …");
release.notify_one();
```

`stop()` waits on `drain.recv()`, which returns only when every cloned drain token has dropped; the connection task holds one until it returns, and it cannot return until the handler does. **No amount of scheduling delay can make a correct `stop()` look finished** — so load now pushes this test toward a slower verdict, never a wrong one. That is the opposite of the property it had before.

## Decisions

**The 50 ms sleep is a revert-DETECTOR, not a correctness dependency, and the comment says so.** A `stop()` that skips the drain still needs *some* slice of time to run to completion before `is_finished()` can observe it. Deleting the sleep would make the test unable to notice a broken drain; lengthening it never invalidates the assertion.

**`is_finished()` rather than a completion flag the handler sets.** An `AtomicBool` set on the handler's way out states the same ordering, but degrades to a **vacuous pass** if the handler happens to finish before `stop()` is called — so a broken drain could go unreported under exactly the load that motivated this. Asserting the stop task is pending while the handler is *provably* still parked has no such window.

**The existing `200`/`"drained"` assertions are unchanged.** They prove the request was not *dropped*, which is a different property, and #326 asks for them to stay.

## Criterion 4 — the sibling sweep, answered by enumeration

`rg 'sleep\(Duration::from_millis' libs/nextgcore-sbi/src` → **1 hit, this test**. `rg 'elapsed\(\)'` → 6 hits, **all production** (`heartbeat.rs:63,70,243`, `oauth.rs:518,1486`). Every other `Instant::now()` in the crate is in a test that **injects** `now` as a parameter (`overload.rs:606,635,668` pass it into `record`/`decide`/`live_count`) — the shape with no wall-clock dependency to begin with. So there is nothing to fix and nothing left un-fixed with a reason.

## Revert-verify

Replacing `stop()`'s drain wait with an early `return Ok(())`:

```
test server::tests::stop_drains_an_in_flight_request ... FAILED
panicked at libs/nextgcore-sbi/src/server.rs:2542:9:
stop() returned while a stream was still in flight, so it did not drain
```

The **named** assertion fires — not a transport error, not a join failure — so the test fails for the reason it claims to test.

Worth recording because it nearly did not bite: the first revert attempt reported green and proved nothing. `cd src && cp … && python3 …` was run from a shell whose working directory was *already* `src`; `cd` failed, the `&&` chain short-circuited, the edit never applied, and `cargo test` re-ran the unmodified tree. A revert-verify that passes is indistinguishable from a revert that never happened unless the edit is confirmed independently — here by grepping for the injected line before running the test.

## Criterion 3 — 25 consecutive whole-workspace runs

`cargo test --workspace` × 25, **6520 tests each, 0 failures**, under the same full-workspace contention that produced the original flake. `cargo clippy --workspace`: 0 errors, warning count unchanged from `main`. `cargo fmt --all --check`: clean.