### PR TITLE
fix(upfd): delete the dead session model, and repair the load gauge it fed (#325)

### DIFF
--- a/specs/fix-pfcp-tsc-container-codec.md
+++ b/specs/fix-pfcp-tsc-container-codec.md
@@ -188,11 +188,17 @@ builds headers the way a peer would, without touching the encoder under test.
 
 ## Ceilings
 
-- **`UpfSess.tsn_bridge` is still unreachable, and so is the rest of that store.**
-  `UpfContext::sess_add` has no production caller, so `rule_match`'s lookups by UE IP
-  always return `None`. This is a pre-existing defect of the shape #223 describes for
-  `smfd` ("two parallel session models, one dead"), it is wider than #321, and it is
-  filed separately. The live bridge is on `PfcpSessionInfo`.
+- ~~**`UpfSess.tsn_bridge` is still unreachable, and so is the rest of that store.**~~
+  **RESOLVED by #325**, in the direction this note was waiting for: the dead half was
+  deleted rather than populated. `UpfSess`, `UpfContext::sess_list`, the five lookup
+  indices, the two framed-route tries and `rule_match`'s two UE-IP lookups are gone,
+  so there is no longer a `tsn_bridge` field in an unreachable store — the live bridge
+  on `PfcpSessionInfo`, which is where #321 put it and why, is now the only one.
+  #325 also found what the dead store cost in production, which this note did not
+  reach: `UpfContext::sess_count` had a production caller in `get_load`, so the UPF
+  advertised `load: 0` to the NRF and (under `compute-aware-upf`) in the PFCP Load
+  Control IE regardless of how many sessions it held. #223 remains open as the same
+  defect class in `smfd`.
 - **No TS 24.539 codec**, so the UPF stores the containers rather than acting on
   their contents. `TsnBridge.port_management_containers` and
   `user_plane_node_management_container` hold the raw octets; the gate-control lists

--- a/specs/fix-upfd-delete-the-dead-session-model.md
+++ b/specs/fix-upfd-delete-the-dead-session-model.md
@@ -1,0 +1,221 @@
+# fix(upfd): delete the dead session model, and repair the load gauge it was feeding
+
+Closes #325.
+
+## Criterion 1 — what `rule_match`'s callers do with `None` today
+
+#325 asks this first because it decides whether the issue is a latent cleanup or a live
+packet-path defect. The answer is **neither of the two the issue anticipated**, and finding
+that out changes which option is correct.
+
+`rule_match.rs`'s four `sess_find_by_ipv4/6` call sites live inside exactly two functions:
+
+| function | site | its own callers |
+|---|---|---|
+| `upf_sess_find_by_ue_ip_address` | `rule_match.rs:192,223` | `rule_match.rs:560,563,566,570` — **all inside `#[cfg(test)] mod tests`** |
+| `upf_sess_find_by_ue_ip_address_src` | `rule_match.rs:290,304` | **none, anywhere** |
+
+`rg upf_sess_find_by_ue_ip_address bins/ libs/` outside `rule_match.rs` returns nothing. So the
+`None` never reaches production code: the chain is dead at both ends, not just at the write
+end. Nor is the rest of the module load-bearing — `get_ip_version`, `get_ipv4_dst_addr`,
+`get_ipv6_dst_addr` and `IPV4_MIN_HEADER_LEN` have no callers outside it either, and
+`arp_nd.rs` declares its **own** `Ipv6Header` rather than using this one.
+
+**No traffic is affected, because the live data path never asks these functions anything.**
+It has its own UE-IP index: `DataPlaneSessionManager::ue_ip_map`
+(`data_plane.rs:1466`), written by `add_session_from_pfcp` on the N4 establishment path
+(`main.rs:767`) and read by `find_by_ue_ip` for downlink (`data_plane.rs:2474`) and for the
+uplink source-spoofing check (`data_plane.rs:2267`). That index works.
+
+### But the dead store IS reachable, through a path #325 does not mention
+
+`sess_count()` reads `sess_list` (`context.rs:1745`) — and `sess_count` has a **production
+caller**: `get_load()` (`context.rs:1759`), which feeds three live sites.
+
+| consumer | site | what it advertises |
+|---|---|---|
+| NRF heartbeat `NFProfile.load` PATCH | `main.rs:173` | TS 29.510 §5.2.2.3.2 load percentage |
+| NRF registration `NFProfile.load` | `main.rs:529` | same, at registration |
+| PFCP Heartbeat **Load Control Information** | `pfcp_path.rs:1062` | TS 29.244 §5.19.1 metric (behind `compute-aware-upf`) |
+
+So the UPF reports **load = 0 to the NRF and to the SMF no matter how many sessions it is
+serving**, and `get_load`'s own doc comment asserts the opposite: *"an honest occupancy metric
+derived from real session state — the UPF never fabricates a CPU-based load figure"*. It does
+not fabricate a CPU figure; it reports a constant. An SMF doing load-aware UPF selection sees
+every UPF at 0 and cannot balance; a saturated UPF keeps attracting sessions.
+
+**A second, independent defect on the same line.** `max_num_of_sess` is the denominator, and
+it is **always 0**: `UpfContext::init` needs `&mut self`, `upf_self()` hands out
+`&'static UpfContext`, and `upf_context_init` therefore *discards* its argument behind a
+comment saying so (`context.rs:1813-1817`) — while `main.rs:149` dutifully passes
+`--max-sessions` (default 1024). With a zero denominator `get_load` takes its
+`checked_div` → `None` branch and reports the **raw session count** saturated at 100. So even
+with a working count, a UPF at 100 of 1024 sessions would report `load: 100` — fully loaded at
+under 10% occupancy.
+
+Both halves have to be fixed together, because repointing the count is what makes the
+denominator bug observable.
+
+## Criterion 2 — the decision, and why
+
+**Option 1: delete the store.** #325's three options differ in blast radius, and criterion 1's
+answer settles it: option 2 (re-point `rule_match` at `PfcpSessionInfo`) would build a second
+UE-IP index to serve **a caller that does not exist**, and would have to reinvent the
+`ipv4_framed_routes`/`ipv6_framed_routes`/`RouteTrie` support on a type that lacks it — all
+for a lookup no packet ever reaches. Option 3 is worse for the reason #325 gives.
+
+Deleting is also the only option that satisfies criterion 3 as written, since options 2 and 3
+both keep a `UpfSess` alive.
+
+What goes:
+
+- `UpfSess` and its `impl`/`Default` — including `tsn_bridge` (criterion 4) and the
+  `check_framed_routes`/`urr_acc_*` methods that only it had.
+- `UpfContext::sess_list` and all thirteen `sess_*` methods, plus `get_all_sessions`.
+- The five lookup indices that existed only to resolve into `sess_list`:
+  `upf_n4_seid_hash`, `smf_n4_seid_hash`, `smf_n4_f_seid_hash`, `ipv4_hash`, `ipv6_hash`.
+- `RouteTrie` and the two `ipv4_framed_routes`/`ipv6_framed_routes` tries (criterion 4), whose
+  only feeder was the callerless `sess_add_framed_route`.
+- `IpSubnet` and both `NEXTGCORE_MAX_NUM_OF_*` constants, reachable only from the above.
+  `UeIp` is **kept**: it turned out to be a field of `Pdr` (`context.rs:525`), part of a
+  second, unreferenced *rule* model in the same file. That model is a different and milder
+  defect — nothing reads it, so unlike the session store it never reached the wire — and
+  removing it needs a call on the workspace-wide `dead_code = "allow"` that hides it. Filed
+  as **#335** rather than folded in here.
+- `rule_match::upf_sess_find_by_ue_ip_address` and `_src`, and the four assertions that were
+  their only callers.
+- `n4_handler::Pdr::ipv4_framed_routes` / `ipv6_framed_routes` — declared, never assigned,
+  never read. They looked like the surviving half of a framed-route feature whose only sink
+  was `sess_add_framed_route`; leaving them behind would misrepresent the wire decode as
+  present. Removing them is the No-Broken-Windows half of criterion 4.
+
+What stays, and why it is not the same defect: `PfcpSessionInfo` (written by the N4 handlers,
+read by the report and modification paths) and `DataPlaneSession` (written by
+`add_session_from_pfcp`, read by the forwarding path) are both production-written **and**
+production-read.
+
+## What replaces the count
+
+`sess_count()` keeps its name and its callers and changes its source: it now reads a **gauge
+handed to it by the one authoritative N4 store**, `PfcpServer::sessions`.
+
+```rust
+// UpfContext
+session_gauge: RwLock<Option<Arc<AtomicUsize>>>,
+max_num_of_sess: AtomicUsize,
+```
+
+`PfcpServer` owns the `Arc<AtomicUsize>` and `store`s `sessions.len()` inside **every** write
+scope that changes the map's size — establishment insert, deletion remove, and the
+peer-failure clear — and `main.rs` hands the handle to `UpfContext` right after the server is
+constructed.
+
+**Why a gauge and not "populate the second store" (option 3).** The distinction matters
+because a mirrored `usize` sounds like the thing #325 warns against. It is not the same
+failure mode:
+
+- Option 3's failure is a **session** present in one store and absent from the other, so the
+  UE-IP lookup returns a session with no PDRs — #325's words, "actively worse than `None`".
+- This gauge is written **from `sessions.len()`**, never incremented, and always inside the
+  same critical section as the mutation. It cannot hold a value the map never had. A future
+  mutation site that forgot it would leave the gauge *stale until the next write*, which is a
+  wrong number, not a wrong forwarding decision.
+
+`max_num_of_sess` becomes an `AtomicUsize` so `upf_context_init` can actually record
+`--max-sessions`, which turns `get_load`'s percentage branch on. `init` and `fini` take
+`&self` for the same reason — `&mut self` is what made them uncallable from `upf_self()`.
+
+`init` now stores the ceiling **unconditionally** and uses the `initialized` flag only to
+latch liveness. Gating the store on the flag would mean a context something had already
+marked live could never record a ceiling: harmless in production, where `upf_context_init`
+is called exactly once from `main`, but in a test binary the process-global is shared and
+whichever test got there first would decide the ceiling for every other.
+
+Tests that touch the global serialise on `UPF_GLOBAL_TEST_LOCK`, declared beside
+`UPF_CONTEXT` rather than inside a `mod tests` — a lock declared inside one module's test
+block is unreachable from a sibling module's, so the next test that needs one declares a
+second, and two locks are two disjoint agreements about one variable (#308). The async test
+holds the `std::sync::Mutex` guard across awaits with `#[allow(clippy::await_holding_lock)]`
+and a stated reason: the awaits are exactly the window a sibling could interleave in, and a
+second `tokio` lock for the async half would recreate the split the lock prevents.
+
+## Criterion 3 — the test that pins it
+
+`the_load_gauge_follows_the_live_n4_session_store` (in `pfcp_path`, where the N4 path can
+actually be driven) runs Association Setup, Session Establishment and Session Deletion over
+a socket through the real handlers, and asserts `upf_self().sess_count()` after each step.
+**Nothing in it touches a session store directly**, which is what makes it an assertion
+about wiring rather than about arithmetic: it fails if the gauge stays 0, and it fails if
+the gauge is fed by anything other than the store the N4 path writes.
+
+That is the honest reading of "a test pins this". A test cannot assert the *absence* of some
+future parallel store, but it can assert that the store the production reader reads is the
+store the production writer writes — and the violation of exactly that was the bug. The
+deletion assertion is not redundant with the establishment one: a gauge that only ever
+counted up would pass the first and still be wrong.
+
+The old `test_get_load_gauge` is the counter-example that motivates the split. It drove the
+count with `ctx.sess_add(...)` — a writer that exists only in tests — so it proved 20% for
+2-of-10 and **passed**, while the shipped binary reported 0 for every deployment. It
+survives, rewritten, as a test of the **arithmetic only** (now also pinning that a
+percentage cannot exceed 100), with the wiring assertion moved to where the wiring is.
+
+`the_session_ceiling_reaches_the_global_context` covers the denominator half through the
+process-global, because that is the trip the ceiling did not survive.
+
+## Revert-verify
+
+Both new properties were made to fail before being trusted, and each revert was confirmed
+applied by grep before the test was run:
+
+- Removing `publish_session_count` from the establishment path:
+  `the_load_gauge_follows_the_live_n4_session_store` fails on the named assertion, *"an
+  established N4 session must be visible to the load gauge; 0 here is the shipped defect, a
+  UPF advertising load 0 while serving a session"*.
+- Removing the ceiling `store` from `UpfContext::init`:
+  `the_session_ceiling_reaches_the_global_context` fails with `left: 50, right: 25` —
+  reproducing the shipped behaviour exactly, a raw count where a percentage belongs.
+
+The second revert was **narrowed** on purpose. Reverting `upf_context_init` to its old
+discard-the-argument body also stopped `initialized` being set, so the test failed on its
+liveness assertion instead of its ceiling assertion — a signal that could not distinguish
+"init never ran" from "the ceiling was dropped". Reverting only the `store` isolates the
+property under test.
+
+## Ceilings, stated rather than implied
+
+- **`add_session_from_pfcp` is gated on `ue_ipv4.is_some()`** (`main.rs:755`), so an
+  IPv6-only session never enters the data plane's `seid_map`. That is why the load gauge is
+  taken from `PfcpServer::sessions` (which every established session enters) and not from
+  `DataPlaneSessionManager::session_count()`. The IPv6-only gap in the data-plane store is a
+  separate defect and is not touched here.
+- **`#321`'s note in `specs/fix-pfcp-tsc-container-codec.md` is updated** (criterion 4): its
+  "`UpfSess` also has a `tsn_bridge` field, and it is UNREACHABLE" reasoning described a type
+  that no longer exists, so the note now records that the duplication was resolved by deleting
+  the dead half — which is the outcome that note was waiting for.
+- **`#223` is the same defect class in `smfd`** and is deliberately not touched: it is
+  `decision`-labelled and its `SmfSess` has far more production readers than `UpfSess` had.
+- **`dead_code = "allow"` is the ambient condition that let this rot** (`Cargo.toml:210`,
+  commented "Future-use code for Rel-17/18/20 features"). It is why a store with production
+  readers and test-only writers raised nothing for as long as it did. Narrowing it is a
+  workspace-wide change with its own blast radius and belongs to #335.
+
+## Verification
+
+- Workspace **6520 → 6513** tests, 0 failures: 9 tests removed with the types they
+  exercised, 2 added. `cargo clippy --workspace` 0 errors, and `nextgcore-upfd` is at **0
+  warnings** — the pre-existing `unused import: Bytes` in `pfcp_path`'s tests went with it,
+  a one-line broken window in a file this change already touches. `cargo fmt` clean.
+- **8 consecutive `nextgcore-upfd` runs**, 297 passed each. Required rather than optional:
+  the two new tests share a process-global, and one green run of a test that serialises on a
+  lock proves nothing about the lock.
+
+## Files
+
+- `src/bins/nextgcore-upfd/src/context.rs` — dead model removed; `sess_count` repointed;
+  `max_num_of_sess` made settable.
+- `src/bins/nextgcore-upfd/src/rule_match.rs` — the two UE-IP lookups and their tests removed.
+- `src/bins/nextgcore-upfd/src/pfcp_path.rs` — session gauge maintained beside `sessions`.
+- `src/bins/nextgcore-upfd/src/n4_handler.rs` — dead `Pdr` framed-route fields removed.
+- `src/bins/nextgcore-upfd/src/main.rs` — gauge handed to `UpfContext`.
+- `specs/fix-pfcp-tsc-container-codec.md` — #321's note updated.

--- a/src/bins/nextgcore-upfd/src/context.rs
+++ b/src/bins/nextgcore-upfd/src/context.rs
@@ -1,93 +1,30 @@
 //! UPF Context Management
 //!
-//! Port of src/upf/context.c, src/upf/context.h - UPF context with session management,
-//! hash tables for SEID/IP lookups, route tries, and URR accounting
+//! Port of src/upf/context.c, src/upf/context.h.
+//!
+//! # What this module is NOT, since it used to claim otherwise (#325)
+//!
+//! It used to carry a whole second session model — `UpfSess`, a `sess_list`, five
+//! lookup indices and two framed-route tries — whose writers were all inside
+//! `mod tests`. Nothing on the N4 wire path ever created a `UpfSess`, so the
+//! UE-IP lookups built on it (`rule_match::upf_sess_find_by_ue_ip_address` and
+//! its `_src` sibling) searched a permanently empty map. Those lookups had no
+//! production caller either, so no packet was ever misrouted by it — but
+//! [`UpfContext::sess_count`] DID have one, [`UpfContext::get_load`], and that is
+//! how a dead store reached the wire: as a `load: 0` advertised to the NRF and to
+//! the SMF by a UPF serving any number of sessions.
+//!
+//! The live session stores are `pfcp_path::PfcpServer::sessions` (the N4 census,
+//! written by the establishment/deletion handlers) and
+//! `data_plane::DataPlaneSessionManager` (the forwarding tables, including the UE-IP
+//! index the data path actually uses). This module holds neither. It holds the TSN
+//! bridge model that `PfcpSessionInfo` points at, the PFCP rule types, and the
+//! process-global context whose only live business is the load gauge.
 
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::RwLock;
-use std::time::Instant;
-
-// ============================================================================
-// Constants
-// ============================================================================
-
-/// Maximum number of URRs per session
-pub const NEXTGCORE_MAX_NUM_OF_URR: usize = 8;
-/// Maximum number of framed routes in PDI
-pub const NEXTGCORE_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI: usize = 8;
-
-// ============================================================================
-// IP Subnet
-// ============================================================================
-
-/// IP subnet for framed routes
-#[derive(Debug, Clone, Default)]
-pub struct IpSubnet {
-    /// Address family (AF_INET or AF_INET6)
-    pub family: u16,
-    /// Subnet address (4 u32s for IPv6, 1 for IPv4)
-    pub sub: [u32; 4],
-    /// Subnet mask
-    pub mask: [u32; 4],
-}
-
-impl IpSubnet {
-    /// Create IPv4 subnet
-    pub fn new_ipv4(addr: u32, prefix_len: u8) -> Self {
-        let mask = if prefix_len >= 32 {
-            0xFFFFFFFF
-        } else {
-            !((1u32 << (32 - prefix_len)) - 1)
-        };
-        Self {
-            family: libc::AF_INET as u16,
-            sub: [addr & mask, 0, 0, 0],
-            mask: [mask, 0, 0, 0],
-        }
-    }
-
-    /// Create IPv6 subnet
-    pub fn new_ipv6(addr: [u32; 4], prefix_len: u8) -> Self {
-        let mut mask = [0u32; 4];
-        let mut remaining = prefix_len as i32;
-        for i in 0..4 {
-            if remaining >= 32 {
-                mask[i] = 0xFFFFFFFF;
-                remaining -= 32;
-            } else if remaining > 0 {
-                mask[i] = !((1u32 << (32 - remaining)) - 1);
-                remaining = 0;
-            }
-        }
-        Self {
-            family: libc::AF_INET6 as u16,
-            sub: [
-                addr[0] & mask[0],
-                addr[1] & mask[1],
-                addr[2] & mask[2],
-                addr[3] & mask[3],
-            ],
-            mask,
-        }
-    }
-
-    /// Check if address matches this subnet
-    pub fn matches(&self, addr: &[u32; 4]) -> bool {
-        if self.family == 0 {
-            return false;
-        }
-        if self.family == libc::AF_INET as u16 {
-            self.sub[0] == (addr[0] & self.mask[0])
-        } else {
-            self.sub[0] == (addr[0] & self.mask[0])
-                && self.sub[1] == (addr[1] & self.mask[1])
-                && self.sub[2] == (addr[2] & self.mask[2])
-                && self.sub[3] == (addr[3] & self.mask[3])
-        }
-    }
-}
+use std::sync::{Arc, RwLock};
 
 // ============================================================================
 // UE IP Address
@@ -123,343 +60,6 @@ impl UeIp {
             ],
             subnet_id: None,
         }
-    }
-}
-
-// ============================================================================
-// Route Trie Node
-// ============================================================================
-
-/// Trie node for IP framed routes mapping to sessions
-#[derive(Debug, Default)]
-pub struct RouteTrie {
-    /// Left child (0 bit)
-    left: Option<Box<RouteTrie>>,
-    /// Right child (1 bit)
-    right: Option<Box<RouteTrie>>,
-    /// Session ID if this node represents a route endpoint
-    sess_id: Option<u64>,
-}
-
-impl RouteTrie {
-    /// Create a new empty trie
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Insert a route into the trie
-    pub fn insert(&mut self, addr: &[u32; 4], prefix_len: u8, sess_id: u64, is_ipv6: bool) {
-        let total_bits = if is_ipv6 { 128 } else { 32 };
-        let bits_to_use = prefix_len.min(total_bits);
-
-        let mut node = self;
-        for bit_idx in 0..bits_to_use {
-            let word_idx = (bit_idx / 32) as usize;
-            let bit_pos = 31 - (bit_idx % 32);
-            let bit = (addr[word_idx] >> bit_pos) & 1;
-
-            if bit == 0 {
-                node = node.left.get_or_insert_with(|| Box::new(RouteTrie::new()));
-            } else {
-                node = node.right.get_or_insert_with(|| Box::new(RouteTrie::new()));
-            }
-        }
-        node.sess_id = Some(sess_id);
-    }
-
-    /// Remove a route from the trie
-    pub fn remove(&mut self, addr: &[u32; 4], prefix_len: u8, is_ipv6: bool) -> bool {
-        let total_bits = if is_ipv6 { 128 } else { 32 };
-        let bits_to_use = prefix_len.min(total_bits);
-
-        let mut node = self;
-        for bit_idx in 0..bits_to_use {
-            let word_idx = (bit_idx / 32) as usize;
-            let bit_pos = 31 - (bit_idx % 32);
-            let bit = (addr[word_idx] >> bit_pos) & 1;
-
-            let next = if bit == 0 {
-                node.left.as_mut()
-            } else {
-                node.right.as_mut()
-            };
-
-            match next {
-                Some(n) => node = n,
-                None => return false,
-            }
-        }
-
-        if node.sess_id.is_some() {
-            node.sess_id = None;
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Find session by IP address (longest prefix match)
-    pub fn find(&self, addr: &[u32; 4], is_ipv6: bool) -> Option<u64> {
-        let total_bits = if is_ipv6 { 128 } else { 32 };
-
-        let mut node = self;
-        let mut last_match = node.sess_id;
-
-        for bit_idx in 0..total_bits {
-            let word_idx = (bit_idx / 32) as usize;
-            let bit_pos = 31 - (bit_idx % 32);
-            let bit = (addr[word_idx] >> bit_pos) & 1;
-
-            let next = if bit == 0 {
-                node.left.as_ref()
-            } else {
-                node.right.as_ref()
-            };
-
-            match next {
-                Some(n) => {
-                    node = n;
-                    if node.sess_id.is_some() {
-                        last_match = node.sess_id;
-                    }
-                }
-                None => break,
-            }
-        }
-
-        last_match
-    }
-}
-
-// ============================================================================
-// URR Accounting
-// ============================================================================
-
-/// URR (Usage Reporting Rule) accounting data
-/// Port of upf_sess_urr_acc_t from context.h
-#[derive(Debug, Clone, Default)]
-pub struct UrrAccounting {
-    /// Reporting enabled
-    pub reporting_enabled: bool,
-    /// Report sequence number
-    pub report_seqn: u32,
-    /// Total octets
-    pub total_octets: u64,
-    /// Uplink octets
-    pub ul_octets: u64,
-    /// Downlink octets
-    pub dl_octets: u64,
-    /// Total packets
-    pub total_pkts: u64,
-    /// Uplink packets
-    pub ul_pkts: u64,
-    /// Downlink packets
-    pub dl_pkts: u64,
-    /// Time of first packet
-    pub time_of_first_packet: Option<Instant>,
-    /// Time of last packet
-    pub time_of_last_packet: Option<Instant>,
-    /// Time when timers started
-    pub time_start: Option<Instant>,
-    /// Last report snapshot
-    pub last_report: UrrAccountingSnapshot,
-    /// Per-QoS-flow accounting (QFI -> flow accounting)
-    pub qos_flow_acc: HashMap<u8, QosFlowAccounting>,
-    /// Combined threshold: volume (bytes) + time (seconds)
-    pub volume_threshold: Option<u64>,
-    /// Time threshold in seconds
-    pub time_threshold_secs: Option<u64>,
-    /// Volume quota remaining (bytes); when 0, traffic is blocked
-    pub volume_quota: Option<u64>,
-    /// Time quota remaining (seconds)
-    pub time_quota_secs: Option<u64>,
-    /// Whether this URR has triggered (threshold exceeded)
-    pub triggered: bool,
-}
-
-/// Per-QoS-flow accounting (Rel-18 enhanced usage reporting)
-#[derive(Debug, Clone, Default)]
-pub struct QosFlowAccounting {
-    /// QoS Flow Identifier
-    pub qfi: u8,
-    /// Total octets for this flow
-    pub total_octets: u64,
-    /// Uplink octets
-    pub ul_octets: u64,
-    /// Downlink octets
-    pub dl_octets: u64,
-    /// Total packets
-    pub total_pkts: u64,
-    /// Time of first packet
-    pub time_of_first_packet: Option<Instant>,
-    /// Time of last packet
-    pub time_of_last_packet: Option<Instant>,
-}
-
-/// Snapshot of URR accounting for last report
-#[derive(Debug, Clone, Default)]
-pub struct UrrAccountingSnapshot {
-    pub total_octets: u64,
-    pub ul_octets: u64,
-    pub dl_octets: u64,
-    pub total_pkts: u64,
-    pub ul_pkts: u64,
-    pub dl_pkts: u64,
-    pub timestamp: Option<Instant>,
-}
-
-/// Reason for a usage report trigger
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UrrTriggerReason {
-    /// Volume threshold exceeded
-    VolumeThreshold,
-    /// Time threshold exceeded
-    TimeThreshold,
-    /// Volume quota exhausted
-    VolumeQuotaExhausted,
-    /// Time quota exhausted
-    TimeQuotaExhausted,
-    /// Periodic reporting
-    Periodic,
-    /// Immediate report requested
-    ImmediateReport,
-}
-
-impl UrrAccounting {
-    /// Add traffic to accounting
-    pub fn add(&mut self, size: usize, is_uplink: bool) {
-        let now = Instant::now();
-
-        if self.time_of_first_packet.is_none() {
-            self.time_of_first_packet = Some(now);
-        }
-        self.time_of_last_packet = Some(now);
-
-        self.total_octets += size as u64;
-        self.total_pkts += 1;
-
-        if is_uplink {
-            self.ul_octets += size as u64;
-            self.ul_pkts += 1;
-        } else {
-            self.dl_octets += size as u64;
-            self.dl_pkts += 1;
-        }
-    }
-
-    /// Add traffic with QoS flow identifier (Rel-18 per-QoS-flow accounting)
-    pub fn add_with_qfi(&mut self, size: usize, is_uplink: bool, qfi: u8) {
-        self.add(size, is_uplink);
-
-        let now = Instant::now();
-        let flow = self
-            .qos_flow_acc
-            .entry(qfi)
-            .or_insert_with(|| QosFlowAccounting {
-                qfi,
-                ..Default::default()
-            });
-        flow.total_octets += size as u64;
-        flow.total_pkts += 1;
-        if is_uplink {
-            flow.ul_octets += size as u64;
-        } else {
-            flow.dl_octets += size as u64;
-        }
-        if flow.time_of_first_packet.is_none() {
-            flow.time_of_first_packet = Some(now);
-        }
-        flow.time_of_last_packet = Some(now);
-    }
-
-    /// Consume volume quota. Returns false if quota exhausted.
-    pub fn consume_quota(&mut self, size: usize) -> bool {
-        if let Some(ref mut quota) = self.volume_quota {
-            let bytes = size as u64;
-            if *quota >= bytes {
-                *quota -= bytes;
-                true
-            } else {
-                *quota = 0;
-                self.triggered = true;
-                false
-            }
-        } else {
-            true // no quota configured
-        }
-    }
-
-    /// Check if any threshold is exceeded and return the reason.
-    pub fn check_thresholds(&mut self) -> Option<UrrTriggerReason> {
-        // Volume threshold
-        if let Some(thresh) = self.volume_threshold {
-            let (delta, _, _) = self.delta_since_last_report();
-            if delta >= thresh {
-                self.triggered = true;
-                return Some(UrrTriggerReason::VolumeThreshold);
-            }
-        }
-        // Time threshold
-        if let Some(thresh_secs) = self.time_threshold_secs {
-            if let Some(start) = self.time_start {
-                let elapsed = start.elapsed().as_secs();
-                if elapsed >= thresh_secs {
-                    self.triggered = true;
-                    return Some(UrrTriggerReason::TimeThreshold);
-                }
-            }
-        }
-        // Volume quota exhausted
-        if let Some(quota) = self.volume_quota {
-            if quota == 0 {
-                self.triggered = true;
-                return Some(UrrTriggerReason::VolumeQuotaExhausted);
-            }
-        }
-        // Time quota exhausted
-        if let (Some(tq), Some(start)) = (self.time_quota_secs, self.time_start) {
-            if start.elapsed().as_secs() >= tq {
-                self.triggered = true;
-                return Some(UrrTriggerReason::TimeQuotaExhausted);
-            }
-        }
-        None
-    }
-
-    /// Get per-QoS-flow accounting for a specific QFI
-    pub fn flow_accounting(&self, qfi: u8) -> Option<&QosFlowAccounting> {
-        self.qos_flow_acc.get(&qfi)
-    }
-
-    /// Number of tracked QoS flows
-    pub fn tracked_flow_count(&self) -> usize {
-        self.qos_flow_acc.len()
-    }
-
-    /// Take a snapshot for reporting
-    pub fn snapshot(&mut self) {
-        self.last_report = UrrAccountingSnapshot {
-            total_octets: self.total_octets,
-            ul_octets: self.ul_octets,
-            dl_octets: self.dl_octets,
-            total_pkts: self.total_pkts,
-            ul_pkts: self.ul_pkts,
-            dl_pkts: self.dl_pkts,
-            timestamp: Some(Instant::now()),
-        };
-        self.report_seqn += 1;
-        self.triggered = false;
-        // Reset time start for next measurement period
-        self.time_start = Some(Instant::now());
-    }
-
-    /// Get delta since last report
-    pub fn delta_since_last_report(&self) -> (u64, u64, u64) {
-        (
-            self.total_octets - self.last_report.total_octets,
-            self.ul_octets - self.last_report.ul_octets,
-            self.dl_octets - self.last_report.dl_octets,
-        )
     }
 }
 
@@ -1204,226 +804,28 @@ impl Clone for RateLimiter {
 }
 
 // ============================================================================
-// PFCP Session (simplified)
-// ============================================================================
-
-/// PFCP session data (simplified from nextgcore_pfcp_sess_t)
-#[derive(Debug, Clone, Default)]
-pub struct PfcpSess {
-    /// PDR list IDs
-    pub pdr_ids: Vec<u64>,
-    /// FAR list IDs
-    pub far_ids: Vec<u64>,
-    /// URR list IDs
-    pub urr_ids: Vec<u64>,
-    /// QER list IDs
-    pub qer_ids: Vec<u64>,
-    /// BAR list IDs
-    pub bar_ids: Vec<u64>,
-}
-
-// ============================================================================
-// F-SEID (Fully qualified SEID)
-// ============================================================================
-
-/// F-SEID structure
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
-pub struct FSeid {
-    /// SEID value
-    pub seid: u64,
-    /// IPv4 address (if present)
-    pub ipv4: Option<Ipv4Addr>,
-    /// IPv6 address (if present)
-    pub ipv6: Option<Ipv6Addr>,
-}
-
-impl FSeid {
-    /// Create F-SEID with IPv4
-    pub fn with_ipv4(seid: u64, ipv4: Ipv4Addr) -> Self {
-        Self {
-            seid,
-            ipv4: Some(ipv4),
-            ipv6: None,
-        }
-    }
-
-    /// Create F-SEID with IPv6
-    pub fn with_ipv6(seid: u64, ipv6: Ipv6Addr) -> Self {
-        Self {
-            seid,
-            ipv4: None,
-            ipv6: Some(ipv6),
-        }
-    }
-}
-
-// ============================================================================
-// UPF Session
-// ============================================================================
-
-/// UPF Session context
-/// Port of upf_sess_t from context.h
-#[derive(Debug, Clone)]
-pub struct UpfSess {
-    /// Session ID (pool ID)
-    pub id: u64,
-    /// PFCP session data
-    pub pfcp: PfcpSess,
-    /// UPF N4 SEID (derived from node)
-    pub upf_n4_seid: u64,
-    /// SMF N4 F-SEID (received from peer)
-    pub smf_n4_f_seid: FSeid,
-    /// IPv4 UE address
-    pub ipv4: Option<UeIp>,
-    /// IPv6 UE address
-    pub ipv6: Option<UeIp>,
-    /// IPv4 framed routes
-    pub ipv4_framed_routes: Option<Vec<IpSubnet>>,
-    /// IPv6 framed routes
-    pub ipv6_framed_routes: Option<Vec<IpSubnet>>,
-    /// Gx Session ID
-    pub gx_sid: Option<String>,
-    /// PFCP node ID
-    pub pfcp_node_id: Option<u64>,
-    /// URR accounting data
-    pub urr_acc: [UrrAccounting; NEXTGCORE_MAX_NUM_OF_URR],
-    /// APN/DNN
-    pub apn_dnn: Option<String>,
-    /// TSN bridge (Rel-18)
-    pub tsn_bridge: Option<TsnBridge>,
-}
-
-impl UpfSess {
-    /// Create a new UPF session
-    pub fn new(id: u64, upf_n4_seid: u64) -> Self {
-        Self {
-            id,
-            pfcp: PfcpSess::default(),
-            upf_n4_seid,
-            smf_n4_f_seid: FSeid::default(),
-            ipv4: None,
-            ipv6: None,
-            ipv4_framed_routes: None,
-            ipv6_framed_routes: None,
-            gx_sid: None,
-            pfcp_node_id: None,
-            urr_acc: Default::default(),
-            apn_dnn: None,
-            tsn_bridge: None,
-        }
-    }
-
-    /// Set UE IPv4 address
-    pub fn set_ipv4(&mut self, addr: Ipv4Addr) {
-        self.ipv4 = Some(UeIp::from_ipv4(addr));
-    }
-
-    /// Set UE IPv6 address
-    pub fn set_ipv6(&mut self, addr: Ipv6Addr) {
-        self.ipv6 = Some(UeIp::from_ipv6(addr));
-    }
-
-    /// Add IPv4 framed route
-    pub fn add_ipv4_framed_route(&mut self, subnet: IpSubnet) {
-        if self.ipv4_framed_routes.is_none() {
-            self.ipv4_framed_routes = Some(Vec::new());
-        }
-        if let Some(routes) = &mut self.ipv4_framed_routes {
-            if routes.len() < NEXTGCORE_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI {
-                routes.push(subnet);
-            }
-        }
-    }
-
-    /// Add IPv6 framed route
-    pub fn add_ipv6_framed_route(&mut self, subnet: IpSubnet) {
-        if self.ipv6_framed_routes.is_none() {
-            self.ipv6_framed_routes = Some(Vec::new());
-        }
-        if let Some(routes) = &mut self.ipv6_framed_routes {
-            if routes.len() < NEXTGCORE_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI {
-                routes.push(subnet);
-            }
-        }
-    }
-
-    /// Check if address matches framed routes
-    pub fn check_framed_routes(&self, addr: &[u32; 4], is_ipv6: bool) -> bool {
-        let routes = if is_ipv6 {
-            &self.ipv6_framed_routes
-        } else {
-            &self.ipv4_framed_routes
-        };
-
-        if let Some(routes) = routes {
-            for route in routes {
-                if route.matches(addr) {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
-    /// Add URR accounting
-    pub fn urr_acc_add(&mut self, urr_idx: usize, size: usize, is_uplink: bool) {
-        if urr_idx < NEXTGCORE_MAX_NUM_OF_URR {
-            self.urr_acc[urr_idx].add(size, is_uplink);
-        }
-    }
-
-    /// Take URR accounting snapshot
-    pub fn urr_acc_snapshot(&mut self, urr_idx: usize) {
-        if urr_idx < NEXTGCORE_MAX_NUM_OF_URR {
-            self.urr_acc[urr_idx].snapshot();
-        }
-    }
-}
-
-impl Default for UpfSess {
-    fn default() -> Self {
-        Self::new(0, 0)
-    }
-}
-
-// ============================================================================
 // UPF Context
 // ============================================================================
 
 /// UPF Context - main context structure for UPF
 /// Port of upf_context_t from context.h
 pub struct UpfContext {
-    // Hash tables
-    /// UPF N4 SEID -> Session ID hash
-    upf_n4_seid_hash: RwLock<HashMap<u64, u64>>,
-    /// SMF N4 SEID -> Session ID hash
-    smf_n4_seid_hash: RwLock<HashMap<u64, u64>>,
-    /// SMF N4 F-SEID -> Session ID hash
-    smf_n4_f_seid_hash: RwLock<HashMap<FSeid, u64>>,
-    /// IPv4 address -> Session ID hash
-    ipv4_hash: RwLock<HashMap<u32, u64>>,
-    /// IPv6 address -> Session ID hash (using first 64 bits as key)
-    ipv6_hash: RwLock<HashMap<[u32; 2], u64>>,
+    /// Read handle on the live N4 session count, published by
+    /// `pfcp_path::PfcpServer` (see [`UpfContext::set_session_gauge`]).
+    ///
+    /// `None` until the PFCP server is constructed, which is why
+    /// [`UpfContext::sess_count`] reports 0 before then: at that point the UPF
+    /// genuinely has no sessions.
+    session_gauge: RwLock<Option<Arc<AtomicUsize>>>,
 
-    // Route tries
-    /// IPv4 framed routes trie
-    ipv4_framed_routes: RwLock<RouteTrie>,
-    /// IPv6 framed routes trie
-    ipv6_framed_routes: RwLock<RouteTrie>,
-
-    // Session list
-    /// Session list (by pool ID)
-    sess_list: RwLock<HashMap<u64, UpfSess>>,
-
-    // ID generators
-    /// Next session ID
-    next_sess_id: AtomicUsize,
-    /// N4 SEID generator
-    n4_seid_generator: AtomicU64,
-
-    // Pool limits
-    /// Maximum number of sessions
-    max_num_of_sess: usize,
+    /// Session ceiling from `--max-sessions`; 0 means "no ceiling configured".
+    ///
+    /// Atomic because `upf_self()` hands out `&'static UpfContext`, so there is no
+    /// `&mut` moment after start-up in which to record it. It used to be a plain
+    /// `usize` set by a `&mut self` `init` that the global could never call, so the
+    /// operator's `--max-sessions` was silently discarded and `get_load`'s
+    /// percentage branch was unreachable (#325).
+    max_num_of_sess: AtomicUsize,
 
     /// Context initialized flag
     initialized: AtomicBool,
@@ -1433,43 +835,39 @@ impl UpfContext {
     /// Create a new UPF context
     pub fn new() -> Self {
         Self {
-            upf_n4_seid_hash: RwLock::new(HashMap::new()),
-            smf_n4_seid_hash: RwLock::new(HashMap::new()),
-            smf_n4_f_seid_hash: RwLock::new(HashMap::new()),
-            ipv4_hash: RwLock::new(HashMap::new()),
-            ipv6_hash: RwLock::new(HashMap::new()),
-            ipv4_framed_routes: RwLock::new(RouteTrie::new()),
-            ipv6_framed_routes: RwLock::new(RouteTrie::new()),
-            sess_list: RwLock::new(HashMap::new()),
-            next_sess_id: AtomicUsize::new(1),
-            n4_seid_generator: AtomicU64::new(1),
-            max_num_of_sess: 0,
+            session_gauge: RwLock::new(None),
+            max_num_of_sess: AtomicUsize::new(0),
             initialized: AtomicBool::new(false),
         }
     }
 
-    /// Initialize the UPF context
-    pub fn init(&mut self, max_sess: usize) {
-        if self.initialized.load(Ordering::SeqCst) {
+    /// Record the session ceiling and mark the context live.
+    ///
+    /// Takes `&self`, not `&mut self`: the only caller reaches this through
+    /// `upf_self()`, which is a `&'static`. The `&mut self` version could not be
+    /// called from there at all, so `--max-sessions` never arrived (#325).
+    pub fn init(&self, max_sess: usize) {
+        // The ceiling is stored UNCONDITIONALLY and the flag only latches liveness.
+        // Gating the store on the flag would mean a context something had already
+        // marked live could never record a ceiling -- harmless in production, where
+        // `upf_context_init` is called exactly once from `main`, but in a test
+        // binary the process-global is shared and whichever test got there first
+        // would decide the ceiling for every other.
+        self.max_num_of_sess.store(max_sess, Ordering::SeqCst);
+        if self.initialized.swap(true, Ordering::SeqCst) {
             return;
         }
-
-        self.max_num_of_sess = max_sess;
-        self.initialized.store(true, Ordering::SeqCst);
-
-        log::info!(
-            "UPF context initialized with max {} sessions",
-            self.max_num_of_sess
-        );
+        log::info!("UPF context initialized with max {max_sess} sessions");
     }
 
-    /// Finalize the UPF context
-    pub fn fini(&mut self) {
+    /// Release the context's own state. The session stores belong to the PFCP
+    /// server and the data plane and are torn down with them.
+    pub fn fini(&self) {
         if !self.initialized.load(Ordering::SeqCst) {
             return;
         }
 
-        self.sess_remove_all();
+        *self.session_gauge.write().unwrap() = None;
         self.initialized.store(false, Ordering::SeqCst);
         log::info!("UPF context finalized");
     }
@@ -1479,314 +877,60 @@ impl UpfContext {
         self.initialized.load(Ordering::SeqCst)
     }
 
-    /// Generate next N4 SEID
-    fn next_n4_seid(&self) -> u64 {
-        self.n4_seid_generator.fetch_add(1, Ordering::SeqCst)
+    /// Publish the live N4 session count so [`UpfContext::get_load`] can read it.
+    ///
+    /// The handle is owned by `pfcp_path::PfcpServer`, which stores
+    /// `sessions.len()` into it inside every write scope that changes the map's
+    /// size. It is deliberately a READ HANDLE on one store and not a second store:
+    /// the value is always assigned from a `len()` and never incremented, so it
+    /// cannot hold a count the map never had. That is the distinction from #325's
+    /// rejected option 3, whose failure mode was a SESSION present in one store and
+    /// absent from the other.
+    pub fn set_session_gauge(&self, gauge: Arc<AtomicUsize>) {
+        *self.session_gauge.write().unwrap() = Some(gauge);
     }
 
-    // ========================================================================
-    // Session Management
-    // ========================================================================
-
-    /// Add a new session by F-SEID
-    pub fn sess_add(&self, f_seid: &FSeid) -> Option<UpfSess> {
-        let mut sess_list = self.sess_list.write().ok()?;
-        let mut smf_n4_f_seid_hash = self.smf_n4_f_seid_hash.write().ok()?;
-        let mut smf_n4_seid_hash = self.smf_n4_seid_hash.write().ok()?;
-        let mut upf_n4_seid_hash = self.upf_n4_seid_hash.write().ok()?;
-
-        if sess_list.len() >= self.max_num_of_sess && self.max_num_of_sess > 0 {
-            log::error!(
-                "Maximum number of sessions [{}] reached",
-                self.max_num_of_sess
-            );
-            return None;
-        }
-
-        let id = self.next_sess_id.fetch_add(1, Ordering::SeqCst) as u64;
-        let upf_n4_seid = self.next_n4_seid();
-
-        let mut sess = UpfSess::new(id, upf_n4_seid);
-        sess.smf_n4_f_seid = f_seid.clone();
-
-        // Add to hash tables
-        smf_n4_f_seid_hash.insert(f_seid.clone(), id);
-        smf_n4_seid_hash.insert(f_seid.seid, id);
-        upf_n4_seid_hash.insert(upf_n4_seid, id);
-
-        sess_list.insert(id, sess.clone());
-
-        log::info!(
-            "[Added] UPF Session (id={}, upf_seid={}, smf_seid={})",
-            id,
-            upf_n4_seid,
-            f_seid.seid
-        );
-        Some(sess)
-    }
-
-    /// Remove a session by ID
-    pub fn sess_remove(&self, id: u64) -> Option<UpfSess> {
-        let mut sess_list = self.sess_list.write().ok()?;
-        let mut smf_n4_f_seid_hash = self.smf_n4_f_seid_hash.write().ok()?;
-        let mut smf_n4_seid_hash = self.smf_n4_seid_hash.write().ok()?;
-        let mut upf_n4_seid_hash = self.upf_n4_seid_hash.write().ok()?;
-        let mut ipv4_hash = self.ipv4_hash.write().ok()?;
-        let mut ipv6_hash = self.ipv6_hash.write().ok()?;
-
-        if let Some(sess) = sess_list.remove(&id) {
-            // Remove from hash tables
-            smf_n4_f_seid_hash.remove(&sess.smf_n4_f_seid);
-            smf_n4_seid_hash.remove(&sess.smf_n4_f_seid.seid);
-            upf_n4_seid_hash.remove(&sess.upf_n4_seid);
-
-            // Remove IP addresses from hash
-            if let Some(ref ipv4) = sess.ipv4 {
-                ipv4_hash.remove(&ipv4.addr[0]);
-            }
-            if let Some(ref ipv6) = sess.ipv6 {
-                ipv6_hash.remove(&[ipv6.addr[0], ipv6.addr[1]]);
-            }
-
-            // Remove framed routes from tries
-            if let Some(ref routes) = sess.ipv4_framed_routes {
-                if let Ok(mut trie) = self.ipv4_framed_routes.write() {
-                    for route in routes {
-                        let prefix_len = route.mask[0].leading_ones() as u8;
-                        trie.remove(&route.sub, prefix_len, false);
-                    }
-                }
-            }
-            if let Some(ref routes) = sess.ipv6_framed_routes {
-                if let Ok(mut trie) = self.ipv6_framed_routes.write() {
-                    for route in routes {
-                        let prefix_len = (route.mask[0].leading_ones()
-                            + route.mask[1].leading_ones()
-                            + route.mask[2].leading_ones()
-                            + route.mask[3].leading_ones())
-                            as u8;
-                        trie.remove(&route.sub, prefix_len, true);
-                    }
-                }
-            }
-
-            log::info!("[Removed] UPF Session (id={id})");
-            return Some(sess);
-        }
-        None
-    }
-
-    /// Remove all sessions
-    pub fn sess_remove_all(&self) {
-        if let Ok(sess_list) = self.sess_list.read() {
-            let ids: Vec<u64> = sess_list.keys().copied().collect();
-            drop(sess_list);
-            for id in ids {
-                self.sess_remove(id);
-            }
-        }
-        log::info!("All UPF sessions removed");
-    }
-
-    /// Find session by SMF N4 SEID
-    pub fn sess_find_by_smf_n4_seid(&self, seid: u64) -> Option<UpfSess> {
-        // Resolve the id and DROP the index guard before locking sess_list:
-        // sess_add/sess_remove lock sess_list before the index hashes, so holding
-        // an index lock while acquiring sess_list would be an AB-BA deadlock.
-        let sess_id = *self.smf_n4_seid_hash.read().ok()?.get(&seid)?;
-        let sess_list = self.sess_list.read().ok()?;
-        sess_list.get(&sess_id).cloned()
-    }
-
-    /// Find session by SMF N4 F-SEID
-    pub fn sess_find_by_smf_n4_f_seid(&self, f_seid: &FSeid) -> Option<UpfSess> {
-        // Drop the index guard before locking sess_list (see sess_find_by_smf_n4_seid).
-        let sess_id = *self.smf_n4_f_seid_hash.read().ok()?.get(f_seid)?;
-        let sess_list = self.sess_list.read().ok()?;
-        sess_list.get(&sess_id).cloned()
-    }
-
-    /// Find session by UPF N4 SEID
-    pub fn sess_find_by_upf_n4_seid(&self, seid: u64) -> Option<UpfSess> {
-        // Drop the index guard before locking sess_list (see sess_find_by_smf_n4_seid).
-        let sess_id = *self.upf_n4_seid_hash.read().ok()?.get(&seid)?;
-        let sess_list = self.sess_list.read().ok()?;
-        sess_list.get(&sess_id).cloned()
-    }
-
-    /// Find session by IPv4 address
-    pub fn sess_find_by_ipv4(&self, addr: u32) -> Option<UpfSess> {
-        // Resolve the session id from the direct hash first, then the framed-routes
-        // trie. In each step DROP the index/trie guard before locking sess_list:
-        // sess_add/sess_remove lock sess_list before ipv4_hash/ipv4_framed_routes,
-        // so holding either before sess_list would be an AB-BA deadlock.
-        let direct_id = self
-            .ipv4_hash
-            .read()
-            .ok()
-            .and_then(|h| h.get(&addr).copied());
-        if let Some(id) = direct_id {
-            if let Some(sess) = self.sess_list.read().ok().and_then(|l| l.get(&id).cloned()) {
-                return Some(sess);
-            }
-        }
-
-        let route_id = self
-            .ipv4_framed_routes
-            .read()
-            .ok()
-            .and_then(|t| t.find(&[addr, 0, 0, 0], false));
-        if let Some(id) = route_id {
-            if let Some(sess) = self.sess_list.read().ok().and_then(|l| l.get(&id).cloned()) {
-                return Some(sess);
-            }
-        }
-
-        None
-    }
-
-    /// Find session by IPv6 address
-    pub fn sess_find_by_ipv6(&self, addr: &[u32; 4]) -> Option<UpfSess> {
-        // See sess_find_by_ipv4: resolve the id from the direct hash then the
-        // framed-routes trie, dropping each guard before locking sess_list.
-        let direct_id = self
-            .ipv6_hash
-            .read()
-            .ok()
-            .and_then(|h| h.get(&[addr[0], addr[1]]).copied());
-        if let Some(id) = direct_id {
-            if let Some(sess) = self.sess_list.read().ok().and_then(|l| l.get(&id).cloned()) {
-                return Some(sess);
-            }
-        }
-
-        let route_id = self
-            .ipv6_framed_routes
-            .read()
-            .ok()
-            .and_then(|t| t.find(addr, true));
-        if let Some(id) = route_id {
-            if let Some(sess) = self.sess_list.read().ok().and_then(|l| l.get(&id).cloned()) {
-                return Some(sess);
-            }
-        }
-
-        None
-    }
-
-    /// Find session by ID
-    pub fn sess_find_by_id(&self, id: u64) -> Option<UpfSess> {
-        let sess_list = self.sess_list.read().ok()?;
-        sess_list.get(&id).cloned()
-    }
-
-    /// Set UE IP for session
-    pub fn sess_set_ue_ip(
-        &self,
-        sess_id: u64,
-        ipv4: Option<Ipv4Addr>,
-        ipv6: Option<Ipv6Addr>,
-    ) -> bool {
-        let mut sess_list = self.sess_list.write().unwrap();
-        let mut ipv4_hash = self.ipv4_hash.write().unwrap();
-        let mut ipv6_hash = self.ipv6_hash.write().unwrap();
-
-        if let Some(sess) = sess_list.get_mut(&sess_id) {
-            if let Some(addr) = ipv4 {
-                let addr_u32 = u32::from_be_bytes(addr.octets());
-                sess.set_ipv4(addr);
-                ipv4_hash.insert(addr_u32, sess_id);
-            }
-            if let Some(addr) = ipv6 {
-                let octets = addr.octets();
-                let addr_key = [
-                    u32::from_be_bytes([octets[0], octets[1], octets[2], octets[3]]),
-                    u32::from_be_bytes([octets[4], octets[5], octets[6], octets[7]]),
-                ];
-                sess.set_ipv6(addr);
-                ipv6_hash.insert(addr_key, sess_id);
-            }
-            return true;
-        }
-        false
-    }
-
-    /// Add framed route for session
-    pub fn sess_add_framed_route(&self, sess_id: u64, subnet: IpSubnet, is_ipv6: bool) -> bool {
-        let mut sess_list = self.sess_list.write().unwrap();
-
-        if let Some(sess) = sess_list.get_mut(&sess_id) {
-            let prefix_len = if is_ipv6 {
-                (subnet.mask[0].leading_ones()
-                    + subnet.mask[1].leading_ones()
-                    + subnet.mask[2].leading_ones()
-                    + subnet.mask[3].leading_ones()) as u8
-            } else {
-                subnet.mask[0].leading_ones() as u8
-            };
-
-            // Add to trie
-            if is_ipv6 {
-                if let Ok(mut trie) = self.ipv6_framed_routes.write() {
-                    trie.insert(&subnet.sub, prefix_len, sess_id, true);
-                }
-                sess.add_ipv6_framed_route(subnet);
-            } else {
-                if let Ok(mut trie) = self.ipv4_framed_routes.write() {
-                    trie.insert(&subnet.sub, prefix_len, sess_id, false);
-                }
-                sess.add_ipv4_framed_route(subnet);
-            }
-            return true;
-        }
-        false
-    }
-
-    /// Get session count
+    /// Live N4 session count, read from the gauge the PFCP server published.
+    ///
+    /// 0 before [`UpfContext::set_session_gauge`] has been called, which is the
+    /// truthful answer during start-up. Before #325 this read a `sess_list` that
+    /// only tests ever wrote, so it was 0 FOREVER — and `get_load` below is the
+    /// production caller that turned that into a wire-visible lie.
     pub fn sess_count(&self) -> usize {
-        self.sess_list.read().map(|l| l.len()).unwrap_or(0)
+        self.session_gauge
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().map(|g| g.load(Ordering::Relaxed)))
+            .unwrap_or(0)
     }
 
     /// NFProfile `load` gauge (`0..=100`) reported to the NRF on each
     /// heartbeat PATCH (TS 29.510 §5.2.2.3.2; `NFProfile.load` is a
-    /// percentage `0..=100`).
+    /// percentage `0..=100`), and the PFCP Load Control Information metric
+    /// (TS 29.244 §5.19.1) under `compute-aware-upf`.
     ///
-    /// Reports active PFCP/N4 session occupancy as a percentage of the
-    /// configured `max_num_of_sess`. When no session ceiling is configured
-    /// (`max_num_of_sess == 0`) the raw session count is reported, saturated
-    /// at 100. This is an honest occupancy metric derived from real session
-    /// state — the UPF never fabricates a CPU-based load figure (G2-2).
+    /// Occupancy of the live N4 session store against the configured
+    /// `--max-sessions` ceiling. When no ceiling is configured the raw session
+    /// count is reported, saturated at 100.
+    ///
+    /// #325 fixed two independent defects on these four lines. The numerator came
+    /// from a store nothing wrote in production, so this returned 0 for every
+    /// deployment; and the denominator was a `usize` that `upf_context_init`
+    /// discarded, so the percentage branch was unreachable and a UPF at 100 of 1024
+    /// sessions reported `load: 100`. An SMF or NRF doing load-aware selection could
+    /// act on neither.
     pub fn get_load(&self) -> u8 {
         let sessions = self.sess_count();
-        // `checked_div` yields `None` iff `max_num_of_sess == 0` (no ceiling
-        // configured), in which case we report the raw session count.
+        // `checked_div` yields `None` iff no ceiling is configured, in which case we
+        // report the raw session count.
         let load = match sessions
             .saturating_mul(100)
-            .checked_div(self.max_num_of_sess)
+            .checked_div(self.max_num_of_sess.load(Ordering::Relaxed))
         {
             Some(pct) => pct.min(100),
             None => sessions.min(100),
         };
         load as u8
-    }
-
-    /// Get all sessions (for iteration)
-    pub fn get_all_sessions(&self) -> Vec<UpfSess> {
-        self.sess_list
-            .read()
-            .map(|l| l.values().cloned().collect())
-            .expect("value expected")
-    }
-
-    /// Update session in context
-    pub fn sess_update(&self, sess: &UpfSess) -> bool {
-        if let Ok(mut sess_list) = self.sess_list.write() {
-            if let std::collections::hash_map::Entry::Occupied(mut e) = sess_list.entry(sess.id) {
-                e.insert(sess.clone());
-                return true;
-            }
-        }
-        false
     }
 }
 
@@ -1809,21 +953,36 @@ pub fn upf_self() -> &'static UpfContext {
     UPF_CONTEXT.get_or_init(UpfContext::new)
 }
 
-/// Initialize the global UPF context
+/// Initialize the global UPF context, recording the session ceiling.
+///
+/// This used to DISCARD `max_sess` behind a comment saying a `OnceLock` could not
+/// be mutated. True of the old `&mut self` `UpfContext::init`, and the consequence
+/// was that `--max-sessions` never reached `get_load`'s denominator (#325).
+/// `max_num_of_sess` is an atomic now, so the ceiling arrives.
 pub fn upf_context_init(max_sess: usize) {
-    let _ctx = UPF_CONTEXT.get_or_init(UpfContext::new);
-    // Note: We can't mutate through OnceLock, so init is a no-op after first call
-    // In real implementation, would use a different pattern
-    log::info!("UPF context initialized with max {max_sess} sessions");
+    UPF_CONTEXT.get_or_init(UpfContext::new).init(max_sess);
 }
 
 /// Finalize the global UPF context
 pub fn upf_context_final() {
     if let Some(ctx) = UPF_CONTEXT.get() {
-        ctx.sess_remove_all();
+        ctx.fini();
     }
     log::info!("UPF context finalized");
 }
+
+/// The one agreement about the process-global [`UPF_CONTEXT`] in tests.
+///
+/// `upf_self()` hands out a `&'static UpfContext`, so a test that publishes a
+/// session gauge or records a session ceiling is mutating state every sibling test
+/// can see. Declared HERE, beside the global it protects, rather than inside a
+/// `mod tests`: a lock declared inside one module's test block is unreachable from
+/// a sibling module's, so the next test that needs one declares a second — and two
+/// locks are two disjoint agreements about one variable (#308).
+///
+/// Have any `mod tests` that touches `upf_self()` `use` this.
+#[cfg(test)]
+pub(crate) static UPF_GLOBAL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 // ============================================================================
 // Tests
@@ -1832,109 +991,6 @@ pub fn upf_context_final() {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_ip_subnet_ipv4() {
-        let subnet = IpSubnet::new_ipv4(0xC0A80100, 24); // 192.168.1.0/24
-        assert!(subnet.matches(&[0xC0A80101, 0, 0, 0])); // 192.168.1.1
-        assert!(subnet.matches(&[0xC0A801FF, 0, 0, 0])); // 192.168.1.255
-        assert!(!subnet.matches(&[0xC0A80201, 0, 0, 0])); // 192.168.2.1
-    }
-
-    #[test]
-    fn test_route_trie_ipv4() {
-        let mut trie = RouteTrie::new();
-
-        // Insert 192.168.1.0/24 -> session 1
-        trie.insert(&[0xC0A80100, 0, 0, 0], 24, 1, false);
-
-        // Insert 192.168.0.0/16 -> session 2
-        trie.insert(&[0xC0A80000, 0, 0, 0], 16, 2, false);
-
-        // Find 192.168.1.1 - should match /24 (longest prefix)
-        assert_eq!(trie.find(&[0xC0A80101, 0, 0, 0], false), Some(1));
-
-        // Find 192.168.2.1 - should match /16
-        assert_eq!(trie.find(&[0xC0A80201, 0, 0, 0], false), Some(2));
-
-        // Find 10.0.0.1 - no match
-        assert_eq!(trie.find(&[0x0A000001, 0, 0, 0], false), None);
-    }
-
-    #[test]
-    fn test_urr_accounting() {
-        let mut acc = UrrAccounting::default();
-
-        acc.add(100, true); // uplink
-        acc.add(200, false); // downlink
-
-        assert_eq!(acc.total_octets, 300);
-        assert_eq!(acc.ul_octets, 100);
-        assert_eq!(acc.dl_octets, 200);
-        assert_eq!(acc.total_pkts, 2);
-        assert_eq!(acc.ul_pkts, 1);
-        assert_eq!(acc.dl_pkts, 1);
-
-        acc.snapshot();
-        assert_eq!(acc.last_report.total_octets, 300);
-        assert_eq!(acc.report_seqn, 1);
-    }
-
-    #[test]
-    fn test_urr_per_qos_flow_accounting() {
-        let mut acc = UrrAccounting::default();
-
-        acc.add_with_qfi(100, true, 5); // QFI 5 uplink
-        acc.add_with_qfi(200, false, 5); // QFI 5 downlink
-        acc.add_with_qfi(50, true, 9); // QFI 9 uplink
-
-        // Overall accounting
-        assert_eq!(acc.total_octets, 350);
-        assert_eq!(acc.total_pkts, 3);
-
-        // Per-flow accounting
-        assert_eq!(acc.tracked_flow_count(), 2);
-        let flow5 = acc.flow_accounting(5).unwrap();
-        assert_eq!(flow5.total_octets, 300);
-        assert_eq!(flow5.ul_octets, 100);
-        assert_eq!(flow5.dl_octets, 200);
-        assert_eq!(flow5.total_pkts, 2);
-
-        let flow9 = acc.flow_accounting(9).unwrap();
-        assert_eq!(flow9.total_octets, 50);
-        assert_eq!(flow9.ul_octets, 50);
-        assert_eq!(flow9.total_pkts, 1);
-    }
-
-    #[test]
-    fn test_urr_volume_threshold() {
-        let mut acc = UrrAccounting::default();
-        acc.volume_threshold = Some(500);
-        acc.time_start = Some(Instant::now());
-        // below threshold
-        acc.add(200, true);
-        assert!(acc.check_thresholds().is_none());
-        // exceed threshold
-        acc.add(400, false);
-        let reason = acc.check_thresholds();
-        assert_eq!(reason, Some(UrrTriggerReason::VolumeThreshold));
-        assert!(acc.triggered);
-    }
-
-    #[test]
-    fn test_urr_volume_quota() {
-        let mut acc = UrrAccounting::default();
-        acc.volume_quota = Some(300);
-
-        assert!(acc.consume_quota(100)); // 200 remaining
-        assert!(acc.consume_quota(100)); // 100 remaining
-        assert!(acc.consume_quota(100)); // 0 remaining
-        assert!(!acc.consume_quota(1)); // exhausted
-        assert!(acc.triggered);
-
-        let reason = acc.check_thresholds();
-        assert_eq!(reason, Some(UrrTriggerReason::VolumeQuotaExhausted));
-    }
 
     #[test]
     fn test_tsn_bridge() {
@@ -1997,85 +1053,67 @@ mod tests {
         assert_eq!(clock.mean_path_delay_ns, 400);
     }
 
-    #[test]
-    fn test_upf_sess_framed_routes() {
-        let mut sess = UpfSess::new(1, 100);
-
-        let subnet = IpSubnet::new_ipv4(0xC0A80100, 24);
-        sess.add_ipv4_framed_route(subnet);
-
-        assert!(sess.check_framed_routes(&[0xC0A80101, 0, 0, 0], false));
-        assert!(!sess.check_framed_routes(&[0xC0A80201, 0, 0, 0], false));
-    }
-
-    #[test]
-    fn test_upf_context_session_lifecycle() {
-        let ctx = UpfContext::new();
-
-        let f_seid = FSeid::with_ipv4(1000, Ipv4Addr::new(10, 0, 0, 1));
-
-        // Add session
-        let sess = ctx.sess_add(&f_seid).unwrap();
-        assert_eq!(sess.smf_n4_f_seid.seid, 1000);
-
-        // Find by various keys
-        assert!(ctx.sess_find_by_smf_n4_seid(1000).is_some());
-        assert!(ctx.sess_find_by_upf_n4_seid(sess.upf_n4_seid).is_some());
-        assert!(ctx.sess_find_by_smf_n4_f_seid(&f_seid).is_some());
-
-        // Set UE IP
-        ctx.sess_set_ue_ip(sess.id, Some(Ipv4Addr::new(192, 168, 1, 100)), None);
-
-        // Find by IP
-        let addr = u32::from_be_bytes([192, 168, 1, 100]);
-        assert!(ctx.sess_find_by_ipv4(addr).is_some());
-
-        // Remove session
-        ctx.sess_remove(sess.id);
-        assert!(ctx.sess_find_by_smf_n4_seid(1000).is_none());
-        assert!(ctx.sess_find_by_ipv4(addr).is_none());
-    }
-
-    #[test]
-    fn test_f_seid() {
-        let f_seid1 = FSeid::with_ipv4(100, Ipv4Addr::new(10, 0, 0, 1));
-        let f_seid2 = FSeid::with_ipv4(100, Ipv4Addr::new(10, 0, 0, 1));
-        let f_seid3 = FSeid::with_ipv4(101, Ipv4Addr::new(10, 0, 0, 1));
-
-        assert_eq!(f_seid1, f_seid2);
-        assert_ne!(f_seid1, f_seid3);
-    }
-
-    // G2-2: PFCP-session occupancy load gauge (TS 29.510 §5.2.2.3.2, 0..=100).
+    /// G2-2: PFCP-session occupancy load gauge (TS 29.510 §5.2.2.3.2, `0..=100`).
+    ///
+    /// This is the arithmetic only. It used to drive the count by calling
+    /// `ctx.sess_add` — a writer that exists ONLY in tests — so it proved the
+    /// percentage while the shipped binary reported 0 for every deployment (#325).
+    /// The count now comes from a gauge, and the test that the gauge is fed by the
+    /// live N4 path lives in `pfcp_path`, where that path can actually be driven:
+    /// `the_load_gauge_follows_the_live_n4_session_store`.
     #[test]
     fn test_get_load_gauge() {
-        // No sessions → 0 regardless of ceiling.
+        let gauge = |n: usize| Arc::new(AtomicUsize::new(n));
+
+        // No gauge published yet → 0. Truthful during start-up.
         let ctx = UpfContext::new();
         assert_eq!(ctx.get_load(), 0);
 
-        // With a ceiling, load is percentage occupancy (monotonic in count).
-        let mut ctx = UpfContext::new();
+        // With a ceiling, load is percentage occupancy.
+        let ctx = UpfContext::new();
         ctx.init(10);
-        for i in 0..2u64 {
-            ctx.sess_add(&FSeid::with_ipv4(1000 + i, Ipv4Addr::new(10, 0, 0, 1)))
-                .expect("session added under ceiling");
-        }
+        ctx.set_session_gauge(gauge(2));
         assert_eq!(ctx.sess_count(), 2);
         assert_eq!(ctx.get_load(), 20, "2/10 sessions = 20%");
 
         // At the ceiling → saturates at 100%.
-        let mut ctx = UpfContext::new();
+        let ctx = UpfContext::new();
         ctx.init(2);
-        for i in 0..2u64 {
-            ctx.sess_add(&FSeid::with_ipv4(2000 + i, Ipv4Addr::new(10, 0, 0, 2)));
-        }
+        ctx.set_session_gauge(gauge(2));
         assert_eq!(ctx.get_load(), 100, "full occupancy = 100%");
+
+        // Over the ceiling cannot exceed 100: NFProfile.load is a percentage.
+        let ctx = UpfContext::new();
+        ctx.init(2);
+        ctx.set_session_gauge(gauge(5));
+        assert_eq!(ctx.get_load(), 100, "a percentage cannot exceed 100");
 
         // No ceiling configured (max == 0) → raw count reported, capped at 100.
         let ctx = UpfContext::new();
-        for i in 0..3u64 {
-            ctx.sess_add(&FSeid::with_ipv4(3000 + i, Ipv4Addr::new(10, 0, 0, 3)));
-        }
+        ctx.set_session_gauge(gauge(3));
         assert_eq!(ctx.get_load(), 3, "no ceiling → raw session count");
+    }
+
+    /// The ceiling has to survive the trip through the process-global, because that
+    /// is the trip it did not survive: `upf_context_init` took `--max-sessions` and
+    /// dropped it, so `get_load` never took its percentage branch in production
+    /// however the arithmetic tested above behaved (#325).
+    #[test]
+    fn the_session_ceiling_reaches_the_global_context() {
+        let _guard = UPF_GLOBAL_TEST_LOCK.lock().unwrap();
+
+        upf_context_init(200);
+        let ctx = upf_self();
+        assert!(
+            ctx.is_initialized(),
+            "upf_context_init must mark the global live"
+        );
+        ctx.set_session_gauge(Arc::new(AtomicUsize::new(50)));
+        assert_eq!(
+            ctx.get_load(),
+            25,
+            "50 of the 200 sessions --max-sessions configured is 25%, not the raw \
+             count 50 the discarded ceiling used to produce"
+        );
     }
 }

--- a/src/bins/nextgcore-upfd/src/main.rs
+++ b/src/bins/nextgcore-upfd/src/main.rs
@@ -258,6 +258,17 @@ async fn main() -> Result<()> {
         .context("Failed to create PFCP server")?;
     let pfcp_server = Arc::new(pfcp_server);
 
+    // #325: point the NFProfile/LCI load gauge at the N4 session census. It used to
+    // read `UpfContext::sess_list`, which nothing outside `mod tests` ever wrote, so
+    // this UPF advertised `load: 0` to the NRF and to the SMF however many sessions
+    // it was carrying. The handle is taken from the server rather than the count
+    // being pushed into the context, so there is one store and one reader of it.
+    //
+    // The NRF heartbeat worker was spawned above with a closure that calls
+    // `get_load()` per tick, so it picks this up on its next tick; the load reported
+    // in the registration itself is 0, which is correct at start-up.
+    upf_self().set_session_gauge(pfcp_server.session_count_handle());
+
     // Run data plane (if enabled)
     let data_plane = Arc::new(data_plane);
 

--- a/src/bins/nextgcore-upfd/src/n4_handler.rs
+++ b/src/bins/nextgcore-upfd/src/n4_handler.rs
@@ -48,8 +48,6 @@ pub struct Pdr {
     pub f_teid: FTeidInfo,
     pub ue_ip_addr_len: usize,
     pub ue_ip_addr: UeIpAddrInfo,
-    pub ipv4_framed_routes: Vec<String>,
-    pub ipv6_framed_routes: Vec<String>,
 }
 
 /// PDI (Packet Detection Information)

--- a/src/bins/nextgcore-upfd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-upfd/src/pfcp_path.rs
@@ -15,7 +15,7 @@ use crate::n4_build::{
 };
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
@@ -503,6 +503,17 @@ pub struct PfcpServer {
     session_tx: mpsc::Sender<PfcpSessionEvent>,
     /// Active sessions: UPF SEID -> SessionInfo
     sessions: tokio::sync::RwLock<HashMap<u64, PfcpSessionInfo>>,
+    /// How many sessions [`Self::sessions`] holds, published for
+    /// `UpfContext::get_load` (#325).
+    ///
+    /// `sessions` is behind a `tokio` lock, so a synchronous load gauge cannot read
+    /// it; this is the sync-readable projection. Maintained by
+    /// [`Self::publish_session_count`], which is called inside EVERY write scope
+    /// that changes the map's size and always ASSIGNS `sessions.len()` -- never
+    /// increments -- so it cannot hold a count the map never had. A future mutation
+    /// site that forgot it would leave a stale number until the next write, which is
+    /// a wrong gauge, not a wrong forwarding decision.
+    session_count: Arc<AtomicUsize>,
     /// Current PFCP association (None until Association Setup succeeds)
     association: tokio::sync::RwLock<Option<PfcpAssociation>>,
     /// Data plane handle for pulling final URR counters on session deletion
@@ -691,6 +702,7 @@ impl PfcpServer {
             shutdown,
             session_tx,
             sessions: tokio::sync::RwLock::new(HashMap::new()),
+            session_count: Arc::new(AtomicUsize::new(0)),
             association: tokio::sync::RwLock::new(None),
             data_plane: std::sync::RwLock::new(None),
             pending_reports: tokio::sync::Mutex::new(HashMap::new()),
@@ -758,6 +770,7 @@ impl PfcpServer {
             let mut sessions = self.sessions.write().await;
             let n = sessions.len();
             sessions.clear();
+            self.publish_session_count(&sessions);
             n
         };
         log::warn!("Cleared {count} PFCP sessions after peer failure");
@@ -1454,6 +1467,7 @@ impl PfcpServer {
         {
             let mut sessions = self.sessions.write().await;
             sessions.insert(upf_seid, session_info.clone());
+            self.publish_session_count(&sessions);
         }
 
         // Notify data plane with full rule set
@@ -1990,7 +2004,9 @@ impl PfcpServer {
         // Remove session
         let session_info = {
             let mut sessions = self.sessions.write().await;
-            sessions.remove(&upf_seid)
+            let removed = sessions.remove(&upf_seid);
+            self.publish_session_count(&sessions);
+            removed
         };
 
         // Unknown SEID → Session Context Not Found (TS 29.244 7.5.7, cause 65)
@@ -2051,6 +2067,26 @@ impl PfcpServer {
     /// for Session Deletion Responses.
     pub fn set_data_plane(&self, dp: Arc<crate::data_plane::DataPlane>) {
         *self.data_plane.write().unwrap() = Some(dp);
+    }
+
+    /// Republish the session count from the map's own length.
+    ///
+    /// Takes the write guard so it can only be called from inside a critical section
+    /// that already holds the map — which is the point: a projection computed
+    /// outside the lock could publish a length the map no longer has. Assignment
+    /// rather than increment/decrement for the same reason.
+    fn publish_session_count(&self, sessions: &HashMap<u64, PfcpSessionInfo>) {
+        self.session_count
+            .store(sessions.len(), std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// A read handle on the live N4 session count, for `UpfContext::get_load`.
+    ///
+    /// Handed to the process-global context at start-up rather than read from it:
+    /// this server owns the session store, and the context owning a *copy* is the
+    /// two-stores-one-path shape #325 rejected.
+    pub fn session_count_handle(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.session_count)
     }
 
     /// Collect final usage reports (TERMR trigger) from the data-plane URRs
@@ -2429,7 +2465,9 @@ impl PfcpServer {
     /// Test hook: insert a session so UPF-initiated reports can resolve the
     /// CP function (SMF) address.
     async fn test_insert_session(&self, info: PfcpSessionInfo) {
-        self.sessions.write().await.insert(info.upf_seid, info);
+        let mut sessions = self.sessions.write().await;
+        sessions.insert(info.upf_seid, info);
+        self.publish_session_count(&sessions);
     }
 
     /// Test hook: force every pending report's T1 timer to be considered
@@ -3092,7 +3130,7 @@ mod tests {
     /// library decoder would have given for free.
     #[test]
     fn the_library_decoder_and_upfds_walk_agree_on_one_modification() {
-        use bytes::{Bytes, BytesMut};
+        use bytes::BytesMut;
         use nextgcore_pfcp::message::SessionModificationRequest;
         use nextgcore_pfcp::types::{RemoveQer, RemoveUrr, UpdateUrr, VolumeThreshold};
 
@@ -3383,6 +3421,93 @@ mod tests {
         assert_eq!(
             response_cause(&resp),
             PfcpCause::SessionContextNotFound as u8
+        );
+    }
+
+    /// #325 criterion 3: the store the production load reader reads is the store the
+    /// production N4 writer writes.
+    ///
+    /// A test cannot assert the *absence* of some future parallel session store, but
+    /// it can assert that property — and its violation was the bug.
+    /// `UpfContext::get_load` read `sess_list`, which only `mod tests` ever wrote, so
+    /// the gauge was 0 in every deployment while a test that called `sess_add`
+    /// directly proved 20% for 2-of-10 and passed.
+    ///
+    /// So nothing here touches a session store: the count is driven entirely by
+    /// Association Setup / Session Establishment / Session Deletion over the socket,
+    /// through the real handlers.
+    // A `std::sync::Mutex` guard across awaits, deliberately: the lock's whole job is
+    // to serialise this test against every sibling that touches the process-global
+    // context, and the awaits are exactly the window a sibling could interleave in. A
+    // second, `tokio` lock for the async half would recreate the split this lock
+    // exists to prevent (#308).
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn the_load_gauge_follows_the_live_n4_session_store() {
+        let _guard = crate::context::UPF_GLOBAL_TEST_LOCK.lock().unwrap();
+
+        let (server, smf, addr, _rx) = spawn_test_server().await;
+        crate::context::upf_self().set_session_gauge(server.session_count_handle());
+
+        assert_eq!(
+            crate::context::upf_self().sess_count(),
+            0,
+            "no session has been established yet"
+        );
+
+        let assoc = build_association_setup_request_payload(Some(1));
+        let _ = exchange(&smf, addr, &encode_pfcp(5, None, 1, &assoc)).await;
+
+        let mut b = crate::n4_build::PfcpMessageBuilder::new();
+        b.add_node_id(&NodeId::Ipv4(Ipv4Addr::new(127, 0, 0, 9)));
+        b.add_f_seid(&crate::n4_build::FSeid {
+            seid: 0x325,
+            ipv4: Some(Ipv4Addr::new(127, 0, 0, 9)),
+            ipv6: None,
+        });
+        b.add_tlv(pfcp_ie::CREATE_PDR, &pdr_body(1, 100, 1, 1, 1));
+        b.add_tlv(pfcp_ie::CREATE_FAR, &far_body(1, 0x02));
+        let resp = exchange(&smf, addr, &encode_pfcp(50, Some(0), 2, &b.build())).await;
+        assert_eq!(
+            response_cause(&resp),
+            PfcpCause::RequestAccepted as u8,
+            "the establishment this assertion depends on must succeed"
+        );
+
+        let upf_seid = server
+            .sessions
+            .read()
+            .await
+            .keys()
+            .copied()
+            .next()
+            .expect("the server must hold the session it just accepted");
+        assert_eq!(
+            crate::context::upf_self().sess_count(),
+            1,
+            "an established N4 session must be visible to the load gauge; 0 here is \
+             the shipped defect, a UPF advertising load 0 while serving a session"
+        );
+
+        // A ceiling makes get_load report a percentage rather than a raw count.
+        crate::context::upf_self().init(4);
+        assert_eq!(
+            crate::context::upf_self().get_load(),
+            25,
+            "1 of 4 sessions is 25%"
+        );
+
+        let resp = exchange(&smf, addr, &encode_pfcp(54, Some(upf_seid), 3, &[])).await;
+        assert_eq!(
+            response_cause(&resp),
+            PfcpCause::RequestAccepted as u8,
+            "the deletion this assertion depends on must succeed"
+        );
+        assert_eq!(
+            crate::context::upf_self().sess_count(),
+            0,
+            "a deleted session must leave the gauge; a gauge that only ever counts up \
+             would pass the establishment assertion above and still be wrong"
         );
     }
 

--- a/src/bins/nextgcore-upfd/src/rule_match.rs
+++ b/src/bins/nextgcore-upfd/src/rule_match.rs
@@ -2,10 +2,16 @@
 //!
 //! Port of src/upf/rule-match.c - Rule matching for packet forwarding
 //!
-//! This module provides functions to find UPF sessions based on packet content,
-//! specifically by extracting the destination IP address from IP headers.
-
-use crate::context::{upf_self, UpfSess};
+//! This module provides IP-header accessors used to extract addresses and the IP
+//! version from a raw packet buffer.
+//!
+//! #325: it also carried `upf_sess_find_by_ue_ip_address` and its `_src` sibling,
+//! which mapped a packet to a `context::UpfSess` through `UpfContext::sess_list` --
+//! a store nothing outside `mod tests` ever wrote, so both always returned `None`.
+//! Neither had a caller outside this file's own tests either, so no packet was ever
+//! affected: the live UE-IP lookup is `data_plane::DataPlaneSessionManager`'s
+//! `find_by_ue_ip`, over an index the N4 establishment path populates. Both
+//! functions are gone with the store.
 
 // ============================================================================
 // IP Header Constants
@@ -145,174 +151,6 @@ impl Ipv6Header {
 // ============================================================================
 // Rule Matching Functions
 // ============================================================================
-
-/// Find UPF session by UE IP address from packet buffer
-///
-/// This function extracts the destination IP address from the packet's IP header
-/// and finds the corresponding UPF session.
-///
-/// Port of upf_sess_find_by_ue_ip_address() from src/upf/rule-match.c
-///
-/// # Arguments
-/// * `data` - Packet data buffer containing IP packet
-///
-/// # Returns
-/// * `Some(UpfSess)` - The session matching the destination IP address
-/// * `None` - If no matching session found or packet is invalid
-pub fn upf_sess_find_by_ue_ip_address(data: &[u8]) -> Option<UpfSess> {
-    if data.is_empty() {
-        log::error!("Empty packet buffer");
-        return None;
-    }
-
-    // Get IP version from first byte
-    let version = (data[0] >> 4) & 0x0F;
-
-    match version {
-        IP_VERSION_4 => {
-            if data.len() < IPV4_MIN_HEADER_LEN {
-                log::error!(
-                    "Invalid IPv4 packet [Packet Length:{}, Min Required:{}]",
-                    data.len(),
-                    IPV4_MIN_HEADER_LEN
-                );
-                return None;
-            }
-
-            // Safety: We've verified the buffer is large enough
-            let ip_hdr = unsafe { &*(data.as_ptr() as *const Ipv4Header) };
-
-            // Verify version matches
-            if ip_hdr.version() != IP_VERSION_4 {
-                log::error!("IPv4 version mismatch in header");
-                return None;
-            }
-
-            let dst_addr = ip_hdr.dst_addr();
-            let sess = upf_self().sess_find_by_ipv4(dst_addr);
-
-            if let Some(ref s) = sess {
-                if let Some(ref ipv4) = s.ipv4 {
-                    let addr_bytes = ipv4.addr[0].to_be_bytes();
-                    log::trace!(
-                        "PAA IPv4:{}.{}.{}.{}",
-                        addr_bytes[0],
-                        addr_bytes[1],
-                        addr_bytes[2],
-                        addr_bytes[3]
-                    );
-                }
-            }
-
-            sess
-        }
-        IP_VERSION_6 => {
-            if data.len() < IPV6_HEADER_LEN {
-                log::error!(
-                    "Invalid IPv6 packet [Packet Length:{}, Min Required:{}]",
-                    data.len(),
-                    IPV6_HEADER_LEN
-                );
-                return None;
-            }
-
-            // Safety: We've verified the buffer is large enough
-            let ip6_hdr = unsafe { &*(data.as_ptr() as *const Ipv6Header) };
-
-            let dst_addr = ip6_hdr.dst_addr();
-            let sess = upf_self().sess_find_by_ipv6(&dst_addr);
-
-            if let Some(ref s) = sess {
-                if let Some(ref ipv6) = s.ipv6 {
-                    log::trace!(
-                        "PAA IPv6:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}",
-                        (ipv6.addr[0] >> 16) & 0xFFFF,
-                        ipv6.addr[0] & 0xFFFF,
-                        (ipv6.addr[1] >> 16) & 0xFFFF,
-                        ipv6.addr[1] & 0xFFFF,
-                        (ipv6.addr[2] >> 16) & 0xFFFF,
-                        ipv6.addr[2] & 0xFFFF,
-                        (ipv6.addr[3] >> 16) & 0xFFFF,
-                        ipv6.addr[3] & 0xFFFF
-                    );
-                }
-            }
-
-            sess
-        }
-        _ => {
-            log::error!(
-                "Invalid packet [IP version:{}, Packet Length:{}]",
-                version,
-                data.len()
-            );
-            // Log hex dump for debugging (first 64 bytes max)
-            let dump_len = data.len().min(64);
-            log::error!("Packet hex dump: {:02x?}", &data[..dump_len]);
-            None
-        }
-    }
-}
-
-/// Find UPF session by source IP address from packet buffer
-///
-/// This function extracts the source IP address from the packet's IP header
-/// and finds the corresponding UPF session. Useful for uplink packet matching.
-///
-/// # Arguments
-/// * `data` - Packet data buffer containing IP packet
-///
-/// # Returns
-/// * `Some(UpfSess)` - The session matching the source IP address
-/// * `None` - If no matching session found or packet is invalid
-pub fn upf_sess_find_by_ue_ip_address_src(data: &[u8]) -> Option<UpfSess> {
-    if data.is_empty() {
-        log::error!("Empty packet buffer");
-        return None;
-    }
-
-    // Get IP version from first byte
-    let version = (data[0] >> 4) & 0x0F;
-
-    match version {
-        IP_VERSION_4 => {
-            if data.len() < IPV4_MIN_HEADER_LEN {
-                log::error!(
-                    "Invalid IPv4 packet [Packet Length:{}, Min Required:{}]",
-                    data.len(),
-                    IPV4_MIN_HEADER_LEN
-                );
-                return None;
-            }
-
-            let ip_hdr = unsafe { &*(data.as_ptr() as *const Ipv4Header) };
-            let src_addr = ip_hdr.src_addr();
-            upf_self().sess_find_by_ipv4(src_addr)
-        }
-        IP_VERSION_6 => {
-            if data.len() < IPV6_HEADER_LEN {
-                log::error!(
-                    "Invalid IPv6 packet [Packet Length:{}, Min Required:{}]",
-                    data.len(),
-                    IPV6_HEADER_LEN
-                );
-                return None;
-            }
-
-            let ip6_hdr = unsafe { &*(data.as_ptr() as *const Ipv6Header) };
-            let src_addr = ip6_hdr.src_addr();
-            upf_self().sess_find_by_ipv6(&src_addr)
-        }
-        _ => {
-            log::error!(
-                "Invalid packet [IP version:{}, Packet Length:{}]",
-                version,
-                data.len()
-            );
-            None
-        }
-    }
-}
 
 /// Extract IP version from packet buffer
 ///
@@ -554,19 +392,25 @@ mod tests {
         assert!(get_ipv6_dst_addr(&ipv4_packet).is_none());
     }
 
+    /// The malformed-buffer rejections that `upf_sess_find_by_ue_ip_address` used
+    /// to assert (#325 removed it). Restated against `get_ip_version`, which is the
+    /// surviving entry point that inspects the version nibble, so the coverage the
+    /// deleted test provided is not silently lost with it.
     #[test]
     fn test_invalid_packets() {
         // Empty packet
-        assert!(upf_sess_find_by_ue_ip_address(&[]).is_none());
+        assert!(get_ip_version(&[]).is_none());
 
-        // Too short IPv4 packet
-        assert!(upf_sess_find_by_ue_ip_address(&[0x45; 10]).is_none());
+        // Invalid IP version (3)
+        assert!(get_ip_version(&[0x30u8; 40]).is_none());
 
-        // Too short IPv6 packet
-        assert!(upf_sess_find_by_ue_ip_address(&[0x60; 20]).is_none());
+        // A well-formed version nibble is still accepted, so the assertions above
+        // fail for the version and not because the function rejects everything.
+        assert_eq!(get_ip_version(&[0x45u8; 20]), Some(IP_VERSION_4));
+        assert_eq!(get_ip_version(&[0x60u8; 40]), Some(IP_VERSION_6));
 
-        // Invalid IP version
-        let invalid = vec![0x30u8; 40]; // Version 3
-        assert!(upf_sess_find_by_ue_ip_address(&invalid).is_none());
+        // Too-short buffers are the ACCESSORS' business, not the version nibble's.
+        assert!(get_ipv4_dst_addr(&[0x45; 10]).is_none());
+        assert!(get_ipv6_dst_addr(&[0x60; 20]).is_none());
     }
 }


### PR DESCRIPTION
Closes #325. Files #335 for the adjacent dead *rule* model (see Ceilings).

## Criterion 1 first — what `rule_match`'s callers do with `None`

#325 asks this first because its answer decides which of the three options is right. The answer is **neither of the two the issue anticipated**.

`rule_match`'s four `sess_find_by_ipv4/6` sites live inside exactly two functions, and **both have no caller outside `rule_match`'s own `mod tests`**:

| function | site | its own callers |
|---|---|---|
| `upf_sess_find_by_ue_ip_address` | `rule_match.rs:192,223` | `rule_match.rs:560,563,566,570` — all in `#[cfg(test)] mod tests` |
| `upf_sess_find_by_ue_ip_address_src` | `rule_match.rs:290,304` | **none, anywhere** |

So the chain was dead at *both* ends, not just the write end. **No traffic was affected** — the live UE-IP lookup is `DataPlaneSessionManager::ue_ip_map` (`data_plane.rs:1466`), written by `add_session_from_pfcp` on the N4 establishment path and read for downlink (`:2474`) and for the uplink source-spoofing check (`:2267`). That index works.

## But the dead store *was* reachable, by a path #325 does not mention

`sess_count()` reads `sess_list`; `get_load()` calls `sess_count()`; and `get_load` has three live consumers:

| consumer | site | what it advertises |
|---|---|---|
| NRF heartbeat `NFProfile.load` PATCH | `main.rs:173` | TS 29.510 §5.2.2.3.2 load percentage |
| NRF registration `NFProfile.load` | `main.rs:529` | same, at registration |
| PFCP Heartbeat **Load Control Information** | `pfcp_path.rs:1062` | TS 29.244 §5.19.1 metric (behind `compute-aware-upf`) |

**So this UPF advertised `load: 0` to the NRF and to the SMF no matter how many sessions it was serving** — while `get_load`'s own doc comment asserted *"an honest occupancy metric derived from real session state — the UPF never fabricates a CPU-based load figure"*. It does not fabricate a CPU figure; it reports a constant. An SMF doing load-aware UPF selection sees every UPF at 0 and cannot balance; a saturated UPF keeps attracting sessions.

### A second, independent defect on the same four lines

`max_num_of_sess` is the denominator, and it was **always 0**. `UpfContext::init` needed `&mut self`, `upf_self()` hands out `&'static UpfContext`, so `upf_context_init` *discarded* its argument behind a comment saying a `OnceLock` could not be mutated (`context.rs:1813-1817`) — while `main.rs:149` dutifully passed `--max-sessions` (default 1024). With a zero denominator `get_load` takes its `checked_div → None` branch and reports the **raw count** saturated at 100, so even with a working numerator a UPF at 100 of 1024 sessions would report `load: 100`. Both halves had to move together: repointing the count is what makes the denominator visible.

## Criterion 2 — the decision

**Option 1, delete.** Option 2 (re-point `rule_match` at `PfcpSessionInfo`) would build a second UE-IP index to serve **a caller that does not exist**, and would have to reinvent the framed-route/`RouteTrie` support on a type that lacks it — for a lookup no packet reaches. Option 3 is what #325 already argues against. Option 1 is also the only one that satisfies criterion 3 as written, since 2 and 3 both keep a `UpfSess` alive.

Gone: `UpfSess` (with `tsn_bridge` — criterion 4), `sess_list` and all thirteen `sess_*` plus `get_all_sessions`, the five indices that only resolved into it, `RouteTrie` and both tries (criterion 4), `IpSubnet`, `context::PfcpSess`/`FSeid`, the per-session URR accounting types, `rule_match`'s two lookups, and `n4_handler::Pdr::ipv4_framed_routes`/`ipv6_framed_routes` — declared, never assigned, never read, and the last thing making a framed-route decode look present.

Kept, and not the same defect: `PfcpSessionInfo` and `DataPlaneSession` are both production-written **and** production-read.

## What replaces the count

`sess_count()` keeps its name and its callers and changes its source: an `Arc<AtomicUsize>` published by `PfcpServer`, stored from `sessions.len()` inside **every** write scope that changes the map's size (establishment insert, deletion remove, peer-failure clear, and the test hook).

**Why this is not option 3 in disguise.** The value is *assigned* from a `len()`, never incremented, always inside the same critical section as the mutation, so it cannot hold a count the map never had. Option 3's failure mode was a **session** present in one store and absent from the other — #325's own words, "actively worse than `None`". A missed publish here leaves a stale *number* until the next write: a wrong gauge, not a wrong forwarding decision.

`init`/`fini` take `&self` now (`&mut self` is precisely what made them uncallable from `upf_self()`), and `init` stores the ceiling **unconditionally**, using the `initialized` flag only to latch liveness — gating the store on the flag would let whichever test reached the shared process-global first decide the ceiling for every other.

## Criterion 3 — the test that pins it

`the_load_gauge_follows_the_live_n4_session_store` runs Association Setup, Session Establishment and Session Deletion over a socket through the real handlers and asserts `upf_self().sess_count()` after each step. **Nothing in it touches a session store directly**, which is what makes it an assertion about wiring rather than arithmetic. The deletion half is not redundant with the establishment half: a gauge that only ever counted up would pass the first and still be wrong.

The old `test_get_load_gauge` is the counter-example that motivates the split — it drove the count with `ctx.sess_add(...)`, a writer that exists only in tests, so it proved 20% for 2-of-10 and **passed** while the shipped binary reported 0 for every deployment. It survives, rewritten, as a test of the arithmetic only (now also pinning that a percentage cannot exceed 100).

`the_session_ceiling_reaches_the_global_context` covers the denominator half *through the process-global*, because that is the trip the ceiling did not survive.

## Revert-verify

Both properties were made to fail before being trusted, each revert confirmed applied by `grep` before the test was run:

- Removing `publish_session_count` from the establishment path → fails on the named assertion, *"an established N4 session must be visible to the load gauge; 0 here is the shipped defect, a UPF advertising load 0 while serving a session"*.
- Removing the ceiling `store` from `UpfContext::init` → fails with `left: 50, right: 25`, reproducing the shipped raw-count behaviour exactly.

The second revert was **narrowed on purpose**: reverting `upf_context_init` wholesale also stopped `initialized` being set, so the test failed on its *liveness* assertion instead of its *ceiling* assertion — a signal that could not distinguish "init never ran" from "the ceiling was dropped".

## Verification

- Workspace **6520 → 6513** tests, 0 failures (9 tests removed with the types they exercised, 2 added).
- `cargo clippy --workspace` 0 errors; `nextgcore-upfd` now at **0 warnings** — the pre-existing `unused import: Bytes` went with it, a one-line broken window in a file this change already touches. `cargo fmt` clean. Gated `easdfd --features dns-udp` clean.
- **8 consecutive `nextgcore-upfd` runs**, 297 passed each. Required, not optional: the two new tests share a process-global, on a lock declared beside it per #308, and one green run of a test that serialises on a lock proves nothing about the lock.

## Ceilings, stated rather than implied

- **`add_session_from_pfcp` is gated on `ue_ipv4.is_some()`** (`main.rs:755`), so an IPv6-only session never enters the data plane's `seid_map`. That is why the gauge comes from `PfcpServer::sessions`, which every established session enters, rather than from `DataPlaneSessionManager::session_count()`. The IPv6-only gap in the data-plane store is a separate defect, untouched here.
- **`context.rs` still carries a second, unreferenced PFCP *rule* model** (`Pdr`/`Far`/`FTeid`/…) that no module imports. Milder than this issue — nothing reads it, so it never reached the wire — and removing it needs a call on the workspace-wide `dead_code = "allow"` (`Cargo.toml:210`) that hid both. Filed as **#335**.
- **`dead_code = "allow"` is the ambient condition that let this rot.** It is why a store with production readers and test-only writers raised nothing for as long as it did.
- **#223 is the same defect class in `smfd`** and is deliberately untouched: it is `decision`-labelled and its `SmfSess` has far more production readers than `UpfSess` had.
- **#321's note is updated** (criterion 4): the `UpfSess.tsn_bridge` duplication it flagged is resolved in the direction it was waiting for — the dead half deleted, not populated.