### PR TITLE
fix(mmed,s1ap,sgwcd): S1 Status Transfer, data forwarding, Handover Cancel release (#48)

### DIFF
--- a/specs/fix-s1-handover-status-transfer-and-data-forwarding.md
+++ b/specs/fix-s1-handover-status-transfer-and-data-forwarding.md
@@ -1,0 +1,201 @@
+# fix(mmed,s1ap,sgwcd): S1 Status Transfer, data forwarding, and Handover Cancel release
+
+Closes #48. Both of its workstreams — (a) `mmed` + `nextgcore-s1ap` and (b) `sgwcd`'s S11
+CIDFT — in one PR, per the whole-issue convention. #48 calls them "independently testable",
+which they are, but it does not mark either separable, and the forwarding path does not
+exist unless both land: the MME's request and the SGW's response are two halves of one
+F-TEID exchange.
+
+## Claim-vs-site-vs-still-true
+
+Re-located against `741f0e9`. Every claim held, and two IE numbers the issue does not
+mention turned out to be wrong.
+
+| # | #48's claim | site now | still true? |
+|---|---|---|---|
+| 1 | no eNB/MME Status Transfer decode; proc 24 is a dead enum entry | `parser.rs` had no arm for `ENB_STATUS_TRANSFER`; `sm.rs:746` | **yes** |
+| 2 | a mid-handover STATUS TRANSFER is answered with Error Indication | `s1ap_handler.rs` `S1apMessage::Unknown` arm | **yes** |
+| 3 | `HandoverRequired` has no Direct Forwarding Path Availability field | `types.rs:430` | **yes** |
+| 4 | `ErabAdmittedItem` DOES decode the DL/UL forwarding TEIDs | `types.rs:1135` | **yes** — decoded and then discarded |
+| 5 | `handle_handover_request_acknowledge` stores only `gtp_teid` | it stored exactly those two fields | **yes** |
+| 6 | `HandoverCommand` always built with an empty forwarding list | `erab_subject_to_forwarding_list: Vec::new()` | **yes** |
+| 7 | `handle_handover_cancel` never releases the target | it cleared `target_ue_id` and removed the context, no release | **yes** |
+| 8 | no handover-preparation supervision timer | nothing on `EnbUe` held a deadline | **yes** |
+| 9 | the dispatcher passes `&[]` into the CIDFT handlers | `gtp_path.rs` `dispatch_indirect_tunnel_request` | **yes** |
+| 10 | the CIDFT handler ignores the body and allocates nothing | `s11_handler.rs` | **yes** |
+| 11 | `bearer_add` never adds forwarding tunnel types | `context.rs:902` adds only S5/S8 and S1-U | **yes** |
+| 12 | forwarding F-TEIDs are emitted only for tunnels that never exist | `s11_build.rs:381` | **yes** |
+
+### Three wire-format constants #48 does not mention, all wrong, all inert
+
+Found while making the CIDFT path reachable. Values read from the vendored spec
+(`6g_docs/specs/29274-j60.txt`), not from memory:
+
+| constant | said | TS 29.274 §8.22 says | what the wrong value means |
+|---|---|---|---|
+| `mmed` `S1U_ENB_GTP_U_DL_FORWARDING` | 4 | **19** (`eNodeB/gNodeB GTP-U for DL data forwarding`) | 4 is "S5/S8 SGW GTP-U interface" |
+| `sgwcd` `SGW_GTP_U_DL_DATA_FORWARDING` | 22 | **23** (Table 7.2.19-2 NOTE 3) | 22 is "SGSN GTP-U for data forwarding" |
+| `sgwcd` `SGW_GTP_U_UL_DATA_FORWARDING` | 23 | **28** (Table 7.2.19-2 NOTE 4) | 23 is the DL value, so both directions went out identical |
+
+Plus one instance number: `sgwcd` emitted its UL forwarding F-TEID at **instance 1**, which
+Table 7.2.19-2 assigns to "S12 SGW F-TEID for DL data forwarding". A conformant MME would
+have read the UL endpoint as a second DL one on an interface the deployment does not have.
+It is now instance **4**.
+
+This is the same latency that hid `smfd`'s `S_NSSAI = 250` (#321): a hand-maintained wire
+table is wrong, and nothing notices because the emitting branch has no caller. Both crates
+now carry `f_teid_interface_types_match_ts29274_clause_8_22`, asserting the numbers as
+literals against the clause — a 30-row wire table cannot be kept correct by review.
+
+`mmed` also had no UL forwarding constant at all, so the UL half of a forwarding pair was
+inexpressible.
+
+## What it does
+
+### Status Transfer (criteria 1, 2)
+
+`nextgcore-s1ap` gains `EnbStatusTransfer` (proc 24) and `MmeStatusTransfer` (proc 25) —
+types, parser, builders — and `mmed` relays the container from the source to the target
+under the **target's** UE ids.
+
+The container is carried as the **raw APER open-type value** and re-emitted verbatim, never
+decoded. §8.4.6's whole purpose is that the PDCP SN/HFN counts arrive UNCHANGED; putting a
+`Bearers-SubjectToStatusTransfer` codec between the two eNBs would make every modelling gap
+a silently corrupted PDCP count. `encode_enb_status_transfer_container` therefore pushes a
+`ProtocolIeField` directly rather than going through `push_ie`, because re-running the bytes
+through an `AperEncoder` that pads differently from the peer that produced them is exactly
+the corruption to avoid. Byte-preservation becomes a property of the type, not of a test.
+
+### Direct vs. indirect forwarding (criteria 3, 4, 5)
+
+`HandoverRequired` decodes `Direct-Forwarding-Path-Availability` (IE **79**, read from
+`36413-j20.txt:34389`; a value guessed from neighbouring handover IEs would be wrong, since
+79 sits between the 60s and `id-UEIdentityIndexValue`). Modelled as
+`Option<DirectForwardingPathAvailability>` rather than a `bool`: the ASN.1 has exactly one
+root value, so PRESENCE carries the whole meaning, and a `bool` invites a caller to write
+`false` where the wire has no IE at all. **Absent selects indirect forwarding**, which is
+the reading that matters.
+
+`handle_handover_request_acknowledge` now records the admitted `dl_gtp_teid`/`ul_gtp_teid`
+and their addresses on the bearer, and builds the Handover Command's E-RABs Subject to
+Forwarding List from them.
+
+### The deferral, which is not an optimisation
+
+For the indirect case the Handover Command **cannot** be built when the ack arrives: the
+endpoints the source must forward to are the SGW's, and the SGW allocates them in the CIDFT
+Response. So `mmed` sends the S11 CIDFT, returns nothing, and sends the command from
+`s11_handler`'s response path. That is the only order in which the command can carry real
+endpoints; sending it immediately with an empty list is what the code used to do.
+
+The ack's own contribution is parked on the target context as `PendingHandoverCommand` and
+**taken** (not cloned) when the response lands, because TS 29.274 §7.6 makes a GTP-C
+response retransmittable and a second Handover Command would have the source hand the UE
+over twice.
+
+Failure handling is stated rather than implied: when the SGW refuses, or the request cannot
+be sent, the handover **completes without forwarding** and the loss is logged. A UE that
+loses its buffered downlink data is better off on the target than stranded between cells —
+but falling through with the TARGET's endpoints instead would tell the source to forward
+over a path it just said it does not have, which sends the data into a black hole rather
+than dropping it.
+
+### Handover Cancel and preparation supervision (criterion 6)
+
+`handle_handover_cancel` sends a UE Context Release Command with cause
+`handover-cancelled` to the prepared target before dropping the MME's record of it —
+otherwise the target keeps its radio, S1-U endpoint and UE context with nothing left that
+could ever ask for them back, since the ids that addressed it are gone.
+
+The supervision timer rides `MmeApp::run`'s existing 100 ms tick, the same way
+`nas_timer::expire_nas_timers` does — no extra task, no channel, and it cannot silently stop
+firing. 10 s, a local choice (TS 36.413 names TS1RELOCprep/TS1RELOCoverall for the *source*
+eNB and leaves the MME's own supervision to implementation), deliberately longer than the
+source's own timer so the source's failure handling runs first and this fires only when the
+source went away too — which is the case that used to leak the context forever. Cause
+`tS1relocoverall-expiry` (value 8) rather than `handover-cancelled`, so the target can tell
+a timeout from a cancel.
+
+`expire_handover_preparations` **returns** its release commands instead of sending them, so
+the DECISION (which target, and freeing the context) is separable from the TRANSMISSION
+(which needs the process-global S1AP queue and a live SCTP association). This follows the
+convention recorded for #70: when a handler's observable effect is an outbound message the
+harness cannot deliver, return what was decided and let the test assert that.
+
+### sgwcd (criterion 7)
+
+The dispatcher passes the **decoded** `Gtp2Message`, not `&[]` — and not re-encoded bytes
+either, since the message is already decoded at the dispatch site and the library has
+`Gtp2BearerContextIe::decode` / `.fteid(instance)`. The handler parses the Bearer Contexts,
+allocates a DL and a UL forwarding tunnel per bearer with real TEIDs, PDR and FAR ids, and
+records the target eNB's endpoints as the tunnels' remote ends.
+
+F-TEIDs are matched on **instance AND interface type**, both. An F-TEID whose instance says
+"UL" and whose interface type says "DL" is contradictory, and believing the instance alone
+would install a forwarding rule in the wrong direction. NOTE 1/NOTE 2 permit the SGW to send
+several instances when it cannot decide, so first match wins.
+
+The PFCP rules use `ACCESS` for **both** the PDI source and the FAR destination — unlike
+every other rule `sxa_build` builds. Indirect forwarding is an eNB-to-eNB relay through the
+SGW-U, so both ends are radio; getting that wrong would send forwarded user data out of SGi.
+
+And the S11 answer is now **gated** on the SGW-U's response through a new
+`S11Continuation::IndirectForwarding`, for the reason #54 gated Create Session: TS 29.274
+§7.2.2 makes `Request accepted` mean the request was FULFILLED, and this response carries
+F-TEIDs the source eNB is about to send user data to.
+
+## Revert-verify
+
+Six behavioural claims, each revert confirmed applied by `grep`/assertion before the test
+ran, each failing on its own named assertion:
+
+| revert | test that fails |
+|---|---|
+| status-transfer arm answers an Error Indication (the pre-#48 behaviour) | `enb_status_transfer_is_relayed_to_the_target_unchanged` — "the relay goes to the TARGET eNB", `left: 1 right: 6` |
+| admitted DL forwarding TEID dropped again | `direct_forwarding_populates_the_handover_command_forwarding_list` |
+| forwarding list hard-coded to `Vec::new()` | same test, on the list length |
+| cancel no longer sends the target release | `handover_cancel_releases_the_prepared_target` |
+| supervision deadline never armed | `handover_preparation_supervision_releases_a_target_that_never_completes` |
+| sgwcd allocates no forwarding tunnels | `cidft_request_allocates_forwarding_tunnels_and_the_response_carries_them` |
+
+The first attempt at the status-transfer revert **deleted** the dispatch arm, which made the
+match non-exhaustive and produced a compile error. A compile error is not a revert-verify: it
+proves nothing about the test. Redone as a behavioural revert that reproduces the shipped
+Error Indication.
+
+Worth naming what the pre-existing sgwcd test shows: `test_indirect_tunnel_responses`
+asserted only that a Cause IE was present, so it passed against the empty accept for as long
+as the defect existed. The new test asserts per-bearer DL/UL F-TEIDs at the right instances
+with the right interface types.
+
+## Verification
+
+- Workspace **6520 → 6530** tests, 0 failures (+2 `nextgcore-s1ap`, +5 `mmed`, +3 `sgwcd`).
+- `cargo clippy --workspace` 0 errors; `nextgcore-s1ap`, `nextgcore-mmed`, `nextgcore-sgwcd`
+  and `nextgcore-asn1c` all at **0 warnings** — two pre-existing ones in files this change
+  already touches went with it (`unused import: Gtp2FTeidIe`, and a hex-grouping lint on
+  `0x0102_03`). `cargo fmt` clean.
+
+## Ceilings, stated rather than implied
+
+- **The MME does not inspect the PDCP SN/HFN counts**, by design: it relays the container.
+  A deployment that needs the MME to reason about per-E-RAB PDCP state would need the
+  `Bearers-SubjectToStatusTransfer` codec this deliberately avoids.
+- **`send_create_indirect_data_forwarding_tunnel_request` had no caller before this**, and
+  `CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE` had no dispatch arm. Both now do. The
+  DELETE direction is still not driven by the handover paths — an indirect forwarding tunnel
+  is torn down only when the session goes, so a completed handover leaves the forwarding
+  rules installed until then. TS 23.401 §5.5.1.2.2 step 15 has the MME delete them on a
+  timer after the handover completes; that timer does not exist here.
+- **No `Data Forwarding Not Possible` handling.** It is an *extension* IE
+  (`id-Data-Forwarding-Not-Possible = 143`) on `E-RABToBeSetupItemHOReq`, not a top-level IE
+  of Handover Required, and this tree has no protocol-extension container plumbing for S1AP
+  E-RAB items. A target that cannot forward a particular E-RAB signals it there, and the MME
+  would omit that E-RAB from the forwarding list; today it is not read.
+- **Only the intra-LTE, single-MME case is driven.** `TargetId::TargetRncId`/`Cgi` still
+  fail preparation with `unknown-targetID`, and there is no S10 Forward Relocation leg, so
+  the "source MME to a different SGW" variants of Table 7.2.18-2 (instances 1, 2, 3, 5, 6)
+  are neither emitted nor read.
+- **IPv6 forwarding endpoints are not supported**: `parse_wire_f_teid`'s IPv4-only read and
+  `outer_header_creation`'s `remote_ip.ipv4?` both bail, because the SGW-U datapath in this
+  build is IPv4. Returning `None` is honest where a zero address would not be.

--- a/src/bins/nextgcore-mmed/src/context.rs
+++ b/src/bins/nextgcore-mmed/src/context.rs
@@ -723,6 +723,22 @@ pub struct EnbUeRelCause {
     pub cause: i64,
 }
 
+/// The parts of a Handover Request Acknowledge a deferred Handover Command still needs.
+///
+/// Only the pieces that cannot be recovered from context: the forwarding list is
+/// rebuilt from the bearers at send time, but the target-to-source container is an
+/// opaque blob the target produced once, and the failed-E-RAB list is the target's
+/// verdict on bearers it declined.
+#[derive(Debug, Clone)]
+pub struct PendingHandoverCommand {
+    /// Handover type, as it will be echoed in the command
+    pub handover_type: nextgcore_s1ap::HandoverType,
+    /// E-RABs the target declined, to be released by the source
+    pub erab_to_release_list: Vec<nextgcore_s1ap::ErabItem>,
+    /// The target's opaque container for the source
+    pub target_to_source_container: Vec<u8>,
+}
+
 /// eNB UE context
 #[derive(Debug, Clone, Default)]
 pub struct EnbUe {
@@ -754,6 +770,37 @@ pub struct EnbUe {
     pub enb_id: u64,
     /// Related MME UE pool ID
     pub mme_ue_id: u64,
+
+    /// Whether the source eNB reported a DIRECT forwarding path to the target
+    /// (TS 36.413 §8.4.1.2), recorded on the SOURCE context from the Handover
+    /// Required.
+    ///
+    /// Set on the source rather than the target because it is the source's statement
+    /// about its own transport, and because the Handover Request Acknowledge -- where
+    /// the decision is acted on -- resolves the source through `target.source_ue_id`
+    /// anyway. `false` (the `Default`) means indirect forwarding through the Serving
+    /// GW, which is the correct reading of an ABSENT IE (#48).
+    pub direct_forwarding_available: bool,
+
+    /// The Handover Command deferred while indirect forwarding tunnels are set up.
+    ///
+    /// Indirect forwarding needs the Serving GW's endpoints, which only the CIDFT
+    /// Response carries, so the command cannot be built when the Handover Request
+    /// Acknowledge arrives -- but the ack is the only carrier of the failed-E-RAB list
+    /// and the target-to-source container. Rather than re-derive those (which is not
+    /// possible: the container is opaque), the ack's contribution is parked here and
+    /// replayed when the response lands (#48). `None` on the direct-forwarding path,
+    /// where the command goes out immediately.
+    pub pending_handover_command: Option<PendingHandoverCommand>,
+
+    /// Deadline for a handover preparation this context is the TARGET of.
+    ///
+    /// Set when `handle_handover_required` allocates the target context; cleared on
+    /// Handover Notify, Handover Cancel and Handover Failure. On expiry the target
+    /// eNB is told to release and the context is freed -- without it a UE that never
+    /// arrives leaks an `enb_ue` per attempt (#48). `Option` rather than a sentinel
+    /// `Instant` so "no preparation outstanding" is unrepresentable as a time.
+    pub handover_prep_deadline: Option<std::time::Instant>,
 }
 
 // ============================================================================

--- a/src/bins/nextgcore-mmed/src/main.rs
+++ b/src/bins/nextgcore-mmed/src/main.rs
@@ -271,6 +271,14 @@ impl MmeApp {
             // sweep walks the UE pool and does nothing unless a deadline passed.
             nas_timer::expire_nas_timers(ctx, std::time::Instant::now());
 
+            // Release target eNB resources for handover preparations that ran out of
+            // time (#48, TS 36.413 §8.4.5.2). Rides the same tick for the same reason:
+            // a sweep that cannot silently stop firing. A no-op unless a handover is
+            // outstanding.
+            for send in s1ap_handler::expire_handover_preparations(ctx, std::time::Instant::now()) {
+                s1ap_path::s1ap_send(send);
+            }
+
             // Signal or lift S1AP overload if the attached-UE count crossed the
             // configured threshold (TS 36.413 §8.7.6). A no-op unless
             // `mme.overload.max_ue` is set, which it is not by default.

--- a/src/bins/nextgcore-mmed/src/s11_build.rs
+++ b/src/bins/nextgcore-mmed/src/s11_build.rs
@@ -273,8 +273,27 @@ use nextgcore_gtp::v2::{
 pub mod f_teid_interface {
     /// S1-U eNodeB GTP-U
     pub const S1U_ENB_GTP_U: u8 = 0;
-    /// S1-U eNodeB GTP-U for downlink data forwarding
-    pub const S1U_ENB_GTP_U_DL_FORWARDING: u8 = 4;
+    /// eNodeB/gNodeB GTP-U interface for DL data forwarding.
+    ///
+    /// #48: this constant said **4**, which TS 29.274 §8.22 defines as "S5/S8 SGW
+    /// GTP-U interface". The only user was `build_create_indirect_data_forwarding_tunnel_request`,
+    /// which itself had no caller, so the wrong value was inert -- exactly the shape
+    /// of the S_NSSAI=250 defect #321 found in `smfd`'s hand-copied IE table. Making
+    /// the CIDFT path reachable makes it live, so it is read from the spec here:
+    /// `6g_docs/specs/29274-j60.txt:27219` lists "19: eNodeB/gNodeB GTP-U interface
+    /// for DL data forwarding".
+    pub const ENB_GTP_U_DL_DATA_FORWARDING: u8 = 19;
+    /// eNodeB GTP-U interface for UL data forwarding (TS 29.274 §8.22, value 20).
+    ///
+    /// Absent before #48, so the UL half of a forwarding pair could not be expressed
+    /// at all.
+    pub const ENB_GTP_U_UL_DATA_FORWARDING: u8 = 20;
+    /// SGW/UPF GTP-U interface for DL data forwarding (TS 29.274 §8.22, value 23;
+    /// Table 7.2.19-2 NOTE 3 mandates it for the SGW's DL forwarding F-TEID).
+    pub const SGW_GTP_U_DL_DATA_FORWARDING: u8 = 23;
+    /// SGW GTP-U interface for UL data forwarding (TS 29.274 §8.22, value 28;
+    /// Table 7.2.19-2 NOTE 4).
+    pub const SGW_GTP_U_UL_DATA_FORWARDING: u8 = 28;
     /// S11 MME GTP-C
     pub const S11_MME_GTP_C: u8 = 10;
 }
@@ -348,6 +367,20 @@ fn enb_s1u_fteid(bearer: &MmeBearer, interface_type: u8) -> Option<Gtp2FTeidIe> 
         bearer.enb_s1u_teid,
         ipv4,
     ))
+}
+
+/// An F-TEID from an explicit TEID and context address, for the data-forwarding
+/// endpoints (which are NOT the bearer's serving S1-U endpoint).
+fn forwarding_fteid(
+    interface_type: u8,
+    teid: u32,
+    ip: &crate::context::IpAddr,
+) -> Option<Gtp2FTeidIe> {
+    if teid == 0 {
+        return None;
+    }
+    let ipv4 = ip.ipv4?;
+    Some(Gtp2FTeidIe::new_ipv4(interface_type, teid, ipv4))
 }
 
 /// Build Create Session Request (TS 29.274 §7.2.1)
@@ -695,13 +728,29 @@ pub fn build_create_indirect_data_forwarding_tunnel_request(
         sgw_ue.sgw_s11_teid,
         sequence_number,
     );
+    // #48: this used to send the bearer's SERVING S1-U endpoint
+    // (`bearer.enb_s1u_teid`, the SOURCE eNB's) under the wrong interface type, which
+    // asked the SGW to forward downlink data to the eNB the UE is leaving. TS 29.274
+    // Table 7.2.18-2 wants the TARGET eNodeB's DL data-forwarding F-TEID at instance
+    // 0 and its UL one at instance 4 -- the endpoints the target admits in the
+    // Handover Request Acknowledge, which `handle_handover_request_acknowledge` now
+    // records on `enb_dl_*` / `enb_ul_*`.
     for bearer in bearers {
         let mut bc = Gtp2BearerContextIe::new();
         bc.set_ebi(bearer.ebi);
-        if bearer.enb_s1u_teid != 0 {
-            if let Some(ft) = enb_s1u_fteid(bearer, f_teid_interface::S1U_ENB_GTP_U_DL_FORWARDING) {
-                bc.set_fteid(0, &ft);
-            }
+        if let Some(ft) = forwarding_fteid(
+            f_teid_interface::ENB_GTP_U_DL_DATA_FORWARDING,
+            bearer.enb_dl_teid,
+            &bearer.enb_dl_ip,
+        ) {
+            bc.set_fteid(0, &ft);
+        }
+        if let Some(ft) = forwarding_fteid(
+            f_teid_interface::ENB_GTP_U_UL_DATA_FORWARDING,
+            bearer.enb_ul_teid,
+            &bearer.enb_ul_ip,
+        ) {
+            bc.set_fteid(4, &ft);
         }
         msg.add_bearer_context(0, &bc);
     }
@@ -774,6 +823,39 @@ fn encode_apn_dns(apn: &str) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
+
+    /// #48: the F-TEID interface types are wire values from TS 29.274 §8.22, read from
+    /// `6g_docs/specs/29274-j60.txt`, and two of them were WRONG while their only user
+    /// had no caller. A hand-maintained wire table cannot be kept correct by review, so
+    /// the numbers are asserted as literals against the spec clause -- the same guard
+    /// #321 added after `smfd` shipped S-NSSAI under IE 250.
+    #[test]
+    fn f_teid_interface_types_match_ts29274_clause_8_22() {
+        use super::f_teid_interface as iface;
+        assert_eq!(iface::S1U_ENB_GTP_U, 0, "0: S1-U eNodeB GTP-U interface");
+        assert_eq!(iface::S11_MME_GTP_C, 10, "10: S11 MME GTP-C interface");
+        assert_eq!(
+            iface::ENB_GTP_U_DL_DATA_FORWARDING,
+            19,
+            "19: eNodeB/gNodeB GTP-U interface for DL data forwarding (was 4, which is \
+             S5/S8 SGW GTP-U)"
+        );
+        assert_eq!(
+            iface::ENB_GTP_U_UL_DATA_FORWARDING,
+            20,
+            "20: eNodeB GTP-U interface for UL data forwarding"
+        );
+        assert_eq!(
+            iface::SGW_GTP_U_DL_DATA_FORWARDING,
+            23,
+            "23: SGW/UPF GTP-U interface for DL data forwarding (Table 7.2.19-2 NOTE 3)"
+        );
+        assert_eq!(
+            iface::SGW_GTP_U_UL_DATA_FORWARDING,
+            28,
+            "28: SGW GTP-U interface for UL data forwarding (Table 7.2.19-2 NOTE 4)"
+        );
+    }
     use super::*;
 
     #[test]

--- a/src/bins/nextgcore-mmed/src/s11_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s11_handler.rs
@@ -108,6 +108,27 @@ pub struct CreateSessionResponseData {
     pub epco: Option<Vec<u8>>,
 }
 
+/// One bearer's forwarding endpoints from a Create Indirect Data Forwarding Tunnel
+/// Response (TS 29.274 Table 7.2.19-2).
+#[derive(Debug, Clone, Default)]
+pub struct IndirectForwardingBearer {
+    pub ebi: u8,
+    pub cause: u8,
+    /// SGW DL data-forwarding TEID (instance 0 or 3, interface type 23)
+    pub sgw_dl_teid: u32,
+    pub sgw_dl_ipv4: Option<[u8; 4]>,
+    /// SGW UL data-forwarding TEID (instance 4 or 5, interface type 28)
+    pub sgw_ul_teid: u32,
+    pub sgw_ul_ipv4: Option<[u8; 4]>,
+}
+
+/// A parsed Create Indirect Data Forwarding Tunnel Response.
+#[derive(Debug, Clone, Default)]
+pub struct CreateIndirectTunnelResponseData {
+    pub cause: u8,
+    pub bearers: Vec<IndirectForwardingBearer>,
+}
+
 /// Bearer context created
 #[derive(Debug, Clone, Default)]
 pub struct BearerContextCreated {
@@ -270,6 +291,20 @@ pub fn dispatch_triggered(raw: &[u8], msg_type: u8, sequence_number: u32, peer: 
                 log::error!("S11 Release Access Bearers Response from {peer} unparsable: {e:?}")
             }
         },
+        mt::CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE => {
+            match handle_create_indirect_tunnel_response(raw) {
+                Ok(data) => {
+                    let local_teid = parse_gtp_header(raw)
+                        .map(|(_, teid, _, _)| teid)
+                        .unwrap_or(0);
+                    apply_indirect_forwarding_response(&data, local_teid, peer)
+                }
+                Err(e) => log::error!(
+                    "S11 Create Indirect Data Forwarding Tunnel Response from {peer} \
+                     unparsable: {e:?}"
+                ),
+            }
+        }
         other => log::info!(
             "S11 triggered message type={other} seq={sequence_number} from {peer} correlated but \
              not acted on: this MME has no handler for it"
@@ -859,6 +894,246 @@ pub fn handle_delete_session_response(data: &[u8]) -> S11Result<DeleteSessionRes
 }
 
 /// Handle Release Access Bearers Response
+/// Parse a Create Indirect Data Forwarding Tunnel Response (TS 29.274 §7.2.19).
+///
+/// The SGW's forwarding endpoints are keyed by INSTANCE, per Table 7.2.19-2: DL at
+/// instance 0 (S1-U) or 3 (target-selected SGW), UL at 4 (S1-U) or 5 (SGW). NOTE 3 and
+/// NOTE 4 also fix the interface types at 23 for DL and 28 for UL, and both are
+/// checked -- an F-TEID whose instance says "UL" and whose interface type says "DL" is
+/// contradictory, and taking the instance's word for it would install a forwarding rule
+/// in the wrong direction. NOTE 1/NOTE 2 permit the SGW to send SEVERAL instances when
+/// it cannot decide which applies, so the first match wins and later ones are ignored
+/// rather than overwriting it.
+pub fn handle_create_indirect_tunnel_response(
+    data: &[u8],
+) -> S11Result<CreateIndirectTunnelResponseData> {
+    let (msg_type, _, _, payload) = parse_gtp_header(data)?;
+    if msg_type != message_type::CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE {
+        return Err(S11Error::InvalidMessageFormat);
+    }
+
+    let mut result = CreateIndirectTunnelResponseData::default();
+    let mut offset = 0;
+    while offset < payload.len() {
+        let Some((ie_t, length, _instance, value)) = parse_ie_header(&payload[offset..]) else {
+            break;
+        };
+        match ie_t {
+            ie_type::CAUSE => {
+                if let Some(cause) = parse_cause(value) {
+                    result.cause = cause;
+                }
+            }
+            ie_type::BEARER_CONTEXT => {
+                if let Some(bearer) = parse_indirect_forwarding_bearer(value) {
+                    result.bearers.push(bearer);
+                }
+            }
+            _ => {}
+        }
+        offset += 4 + length as usize;
+    }
+
+    if result.cause == 0 {
+        return Err(S11Error::MandatoryIeMissing("Cause".to_string()));
+    }
+    Ok(result)
+}
+
+/// Parse one Bearer Context of a CIDFT Response (Table 7.2.19-2).
+fn parse_indirect_forwarding_bearer(value: &[u8]) -> Option<IndirectForwardingBearer> {
+    use crate::s11_build::f_teid_interface as iface;
+
+    let mut bearer = IndirectForwardingBearer::default();
+    let mut have_ebi = false;
+    let mut offset = 0;
+    while offset < value.len() {
+        let Some((ie_t, length, instance, inner)) = parse_ie_header(&value[offset..]) else {
+            break;
+        };
+        match ie_t {
+            ie_type::EBI => {
+                if let Some(ebi) = parse_ebi(inner) {
+                    bearer.ebi = ebi;
+                    have_ebi = true;
+                }
+            }
+            ie_type::CAUSE => {
+                if let Some(cause) = parse_cause(inner) {
+                    bearer.cause = cause;
+                }
+            }
+            ie_type::F_TEID => {
+                if let Some((iface_type, teid, ipv4, _)) = parse_f_teid(inner) {
+                    match instance {
+                        // DL: S1-U (0) or target-selected SGW (3)
+                        0 | 3
+                            if iface_type == iface::SGW_GTP_U_DL_DATA_FORWARDING
+                                && bearer.sgw_dl_teid == 0 =>
+                        {
+                            bearer.sgw_dl_teid = teid;
+                            bearer.sgw_dl_ipv4 = ipv4;
+                        }
+                        // UL: S1-U (4) or SGW (5)
+                        4 | 5
+                            if iface_type == iface::SGW_GTP_U_UL_DATA_FORWARDING
+                                && bearer.sgw_ul_teid == 0 =>
+                        {
+                            bearer.sgw_ul_teid = teid;
+                            bearer.sgw_ul_ipv4 = ipv4;
+                        }
+                        other => log::debug!(
+                            "CIDFT Response F-TEID at instance {other} with interface type \
+                             {iface_type} ignored: not a forwarding endpoint this MME uses"
+                        ),
+                    }
+                }
+            }
+            _ => {}
+        }
+        offset += 4 + length as usize;
+    }
+
+    have_ebi.then_some(bearer)
+}
+
+/// Record the SGW's forwarding endpoints and send the Handover Command that was
+/// deferred waiting for them (#48, TS 23.401 §5.5.1.2.2).
+///
+/// The command could not be sent at Handover Request Acknowledge time because the
+/// endpoints the source eNB must forward to are the SGW's, and only this response
+/// carries them. The UE is found by the LOCAL S11 TEID in the header for the same
+/// reason `apply_create_session_response` does: it is the TEID this MME told the SGW to
+/// use, so a malformed body cannot attribute the response to another UE.
+fn apply_indirect_forwarding_response(
+    data: &CreateIndirectTunnelResponseData,
+    local_teid: u32,
+    peer: std::net::SocketAddr,
+) {
+    let ctx = crate::context::mme_self();
+
+    let Some(mme_ue_id) = ctx.mme_ue_find_by_s11_local_teid(local_teid) else {
+        log::error!(
+            "CIDFT Response from {peer} for unknown local S11 TEID {local_teid:#x}: no UE to \
+             complete the handover for"
+        );
+        return;
+    };
+
+    // TS 29.274 §8.4: 16 is "Request accepted". Anything else means no forwarding
+    // tunnels exist, and the handover must still proceed -- a UE that cannot get its
+    // buffered downlink data forwarded is better off attached to the target than stuck
+    // between cells. So the command goes out with an EMPTY forwarding list, and the
+    // loss is logged rather than hidden.
+    if data.cause != 16 {
+        log::error!(
+            "SGW refused indirect forwarding tunnels (cause={}); completing the handover WITHOUT \
+             data forwarding, so buffered downlink data is lost",
+            data.cause
+        );
+    } else {
+        for bearer in &data.bearers {
+            let Some(bearer_id) = ctx.bearer_find_by_ebi(mme_ue_id, bearer.ebi) else {
+                log::warn!(
+                    "CIDFT Response names EBI {} which this UE does not have",
+                    bearer.ebi
+                );
+                continue;
+            };
+            if let Some(b) = ctx.bearer_pool.write().unwrap().get_mut(&bearer_id) {
+                b.sgw_dl_teid = bearer.sgw_dl_teid;
+                b.sgw_dl_ip = ipv4_to_context_ip(bearer.sgw_dl_ipv4);
+                b.sgw_ul_teid = bearer.sgw_ul_teid;
+                b.sgw_ul_ip = ipv4_to_context_ip(bearer.sgw_ul_ipv4);
+            }
+        }
+    }
+
+    // The prepared target is the one this UE is moving to; the command goes to its
+    // SOURCE.
+    let Some(mme_ue) = ctx.mme_ue_find_by_id(mme_ue_id) else {
+        return;
+    };
+    let Some(source_ue) = ctx.enb_ue_find_by_id(mme_ue.enb_ue_id) else {
+        log::error!("CIDFT Response with no source eNB UE context");
+        return;
+    };
+    let target_ue_id = source_ue.target_ue_id;
+    if target_ue_id == crate::context::NEXTGCORE_INVALID_POOL_ID {
+        log::error!(
+            "CIDFT Response for mme_ue_id={mme_ue_id} with no handover in preparation: the \
+             forwarding tunnels are recorded but there is no Handover Command to send"
+        );
+        return;
+    }
+    // Confirm the target context still exists before building a command that names it;
+    // the supervision sweep may have released it while the SGW was answering.
+    if ctx.enb_ue_find_by_id(target_ue_id).is_none() {
+        log::warn!(
+            "CIDFT Response for target enb_ue_id={target_ue_id} that no longer exists; the \
+             preparation was released while the SGW was answering"
+        );
+        return;
+    }
+
+    let forwarding_list = if data.cause == 16 {
+        crate::s1ap_handler::sgw_forwarding_list(ctx, mme_ue_id)
+    } else {
+        Vec::new()
+    };
+
+    // The Handover Request Acknowledge's failed-E-RAB list and target-to-source
+    // container were consumed when the ack arrived, so they are replayed from what the
+    // deferral stored on the target context.
+    // TAKEN, not cloned: TS 29.274 §7.6 makes a GTP-C response retransmittable, and a
+    // second Handover Command for one handover would have the source eNB hand the UE
+    // over twice. Clearing it here makes the send idempotent.
+    let pending = {
+        let mut pool = ctx.enb_ue_pool.write().unwrap();
+        match pool.get_mut(&target_ue_id) {
+            Some(target) => target.pending_handover_command.take(),
+            None => None,
+        }
+    };
+    let Some(pending) = pending else {
+        log::warn!(
+            "CIDFT Response for a handover with no stored Handover Request Acknowledge: either \
+             the command already went out (a retransmitted response) or the preparation is gone"
+        );
+        return;
+    };
+
+    let command = nextgcore_s1ap::HandoverCommand {
+        mme_ue_s1ap_id: source_ue.mme_ue_s1ap_id,
+        enb_ue_s1ap_id: source_ue.enb_ue_s1ap_id,
+        handover_type: pending.handover_type,
+        erab_subject_to_forwarding_list: forwarding_list,
+        erab_to_release_list: pending.erab_to_release_list,
+        target_to_source_container: pending.target_to_source_container,
+    };
+    match nextgcore_s1ap::builder::build_handover_command(&command) {
+        Ok(pdu) => {
+            log::info!(
+                "Indirect forwarding tunnels ready; sending the deferred Handover Command to \
+                 source eNB {}",
+                source_ue.enb_id
+            );
+            crate::s1ap_path::s1ap_send(crate::s1ap_handler::S1apSend {
+                enb_id: source_ue.enb_id,
+                pdu,
+            });
+        }
+        Err(e) => log::error!("Failed to build the deferred Handover Command: {e}"),
+    }
+}
+
+/// A context IP from an optional wire IPv4 address.
+fn ipv4_to_context_ip(ipv4: Option<[u8; 4]>) -> crate::context::IpAddr {
+    let mut ip = crate::context::IpAddr::default();
+    ip.ipv4 = ipv4;
+    ip
+}
+
 pub fn handle_release_access_bearers_response(
     data: &[u8],
 ) -> S11Result<ReleaseAccessBearersResponseData> {

--- a/src/bins/nextgcore-mmed/src/s1ap_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s1ap_handler.rs
@@ -18,15 +18,16 @@ use crate::s1ap_build::{
 };
 use nextgcore_s1ap::{
     builder, decode_s1ap_pdu, BroadcastCancelledAreaList, BroadcastCompletedAreaList, Cause,
-    CauseRadioNetwork, CriticalityDiagnostics, EnbConfigurationUpdate, EnbId, ErabSwitchedItem,
-    ErabToBeSetupItemHoReq, ErrorIndication, HandoverCancel, HandoverCancelAcknowledge,
-    HandoverCommand, HandoverFailure, HandoverNotify, HandoverPreparationFailure, HandoverRequest,
-    HandoverRequestAcknowledge, HandoverRequired, HandoverType as S1apHandoverType,
-    InitialContextSetupFailure, InitialContextSetupResponse, InitialUeMessage, KillResponse,
-    NasNonDeliveryIndication, PathSwitchRequest, PathSwitchRequestAcknowledge,
-    PathSwitchRequestFailure, Reset, ResetAcknowledge, ResetType, S1SetupRequest, S1apMessage,
-    SecurityContext, TargetId, TimeToWait, UeAmbr, UeCapabilityInfoIndication,
-    UeContextReleaseComplete, UeContextReleaseRequest, UlNasTransport, WriteReplaceWarningResponse,
+    CauseRadioNetwork, CriticalityDiagnostics, EnbConfigurationUpdate, EnbId, EnbStatusTransfer,
+    ErabDataForwardingItem, ErabSwitchedItem, ErabToBeSetupItemHoReq, ErrorIndication,
+    HandoverCancel, HandoverCancelAcknowledge, HandoverCommand, HandoverFailure, HandoverNotify,
+    HandoverPreparationFailure, HandoverRequest, HandoverRequestAcknowledge, HandoverRequired,
+    HandoverType as S1apHandoverType, InitialContextSetupFailure, InitialContextSetupResponse,
+    InitialUeMessage, KillResponse, MmeStatusTransfer, NasNonDeliveryIndication, PathSwitchRequest,
+    PathSwitchRequestAcknowledge, PathSwitchRequestFailure, Reset, ResetAcknowledge, ResetType,
+    S1SetupRequest, S1apMessage, SecurityContext, TargetId, TimeToWait, UeAmbr,
+    UeCapabilityInfoIndication, UeContextReleaseComplete, UeContextReleaseRequest, UlNasTransport,
+    WriteReplaceWarningResponse,
 };
 
 // ============================================================================
@@ -103,6 +104,19 @@ impl S1apSend {
         vec![S1apSend { enb_id, pdu }]
     }
 }
+
+/// How long a prepared handover may stay outstanding before the MME releases the
+/// target eNB's resources (#48).
+///
+/// TS 36.413 names TS1RELOCprep and TS1RELOCoverall for the SOURCE eNB and leaves the
+/// MME's own supervision to implementation, so this value is a local choice, not a
+/// specified one. 10 s is comfortably longer than the source's own TS1RELOCprep (a few
+/// seconds in practice) so the source's failure handling runs first and this only fires
+/// when the source went away too -- which is exactly the case that used to leak the
+/// context forever. `cause = tS1relocoverall-expiry` (TS 36.413 §9.2.1.3, value 8) is
+/// the cause that says so on the wire.
+pub const HANDOVER_PREPARATION_SUPERVISION: std::time::Duration =
+    std::time::Duration::from_secs(10);
 
 // ============================================================================
 // Top-Level Dispatch
@@ -211,6 +225,7 @@ pub fn handle_s1ap_message(ctx: &MmeContext, enb_id: u64, data: &[u8]) -> Vec<S1
         S1apMessage::HandoverFailure(msg) => handle_handover_failure(ctx, enb_id, &msg),
         S1apMessage::HandoverNotify(msg) => handle_handover_notify(ctx, enb_id, &msg),
         S1apMessage::HandoverCancel(msg) => handle_handover_cancel(ctx, enb_id, &msg),
+        S1apMessage::EnbStatusTransfer(msg) => handle_enb_status_transfer(ctx, enb_id, &msg),
         S1apMessage::PathSwitchRequest(msg) => handle_path_switch_request(ctx, enb_id, &msg),
         S1apMessage::InitialContextSetupResponse(msg) => {
             handle_initial_context_setup_response(ctx, enb_id, &msg);
@@ -293,6 +308,7 @@ pub fn handle_s1ap_message(ctx: &MmeContext, enb_id: u64, data: &[u8]) -> Vec<S1
         | S1apMessage::PathSwitchRequestAcknowledge(_)
         | S1apMessage::PathSwitchRequestFailure(_)
         | S1apMessage::HandoverCancelAcknowledge(_)
+        | S1apMessage::MmeStatusTransfer(_)
         | S1apMessage::MmeConfigurationUpdate(_)
         | S1apMessage::EnbConfigurationUpdateAcknowledge(_)
         | S1apMessage::EnbConfigurationUpdateFailure(_)
@@ -1086,16 +1102,27 @@ pub fn handle_handover_required(
 
     // Allocate the target eNB UE context (eNB UE S1AP ID arrives in the Ack)
     let target_ue_id = ctx.enb_ue_add(target_enb_pool_id, INVALID_UE_S1AP_ID);
+    // #48: the source eNB's own statement about its transport to the target
+    // (TS 36.413 §8.4.1.2). ABSENT means no direct path, which is what selects
+    // indirect forwarding through the Serving GW -- so the default is `false` and the
+    // IE's presence is the only thing that turns direct forwarding on.
+    let direct_forwarding_available = msg.direct_forwarding_path_availability.is_some();
+
     let target_mme_ue_s1ap_id = {
         let mut pool = ctx.enb_ue_pool.write().unwrap();
         if let Some(source) = pool.get_mut(&source_ue_id) {
             source.target_ue_id = target_ue_id;
             source.handover_type = ho_type_from_s1ap(msg.handover_type);
+            source.direct_forwarding_available = direct_forwarding_available;
         }
         if let Some(target) = pool.get_mut(&target_ue_id) {
             target.source_ue_id = source_ue_id;
             target.mme_ue_id = source_ue.mme_ue_id;
             target.handover_type = ho_type_from_s1ap(msg.handover_type);
+            // #48: arm the preparation supervision. Without this a UE that never
+            // arrives at the target leaks this context for the life of the process.
+            target.handover_prep_deadline =
+                Some(std::time::Instant::now() + HANDOVER_PREPARATION_SUPERVISION);
             target.mme_ue_s1ap_id
         } else {
             return handover_preparation_failure(
@@ -1213,12 +1240,34 @@ pub fn handle_handover_request_acknowledge(
         target.clone()
     };
 
-    // Record the admitted DL endpoints on the bearer contexts
+    // Record the admitted S1-U endpoint AND the data-forwarding endpoints on the
+    // bearer contexts.
+    //
+    // #48: the forwarding endpoints used to be decoded by `nextgcore-s1ap` and then
+    // DROPPED here -- only `gtp_teid`/`transport_layer_address` were stored -- so the
+    // target's answer to "where should the source forward my buffered downlink data?"
+    // was thrown away and the Handover Command's forwarding list was always empty.
+    // §9.1.5.2's E-RABs Subject to Forwarding List is built from exactly these.
+    let mut admitted_forwarding = false;
     for item in &msg.erab_admitted_list {
         if let Some(bearer_id) = ctx.bearer_find_by_ebi(target_ue.mme_ue_id, item.erab_id) {
             if let Some(bearer) = ctx.bearer_pool.write().unwrap().get_mut(&bearer_id) {
                 bearer.target_s1u_teid = item.gtp_teid;
                 bearer.target_s1u_ip = transport_address_to_ip(&item.transport_layer_address);
+                if let Some(teid) = item.dl_gtp_teid {
+                    bearer.enb_dl_teid = teid;
+                    admitted_forwarding = true;
+                }
+                if let Some(addr) = &item.dl_transport_layer_address {
+                    bearer.enb_dl_ip = transport_address_to_ip(addr);
+                }
+                if let Some(teid) = item.ul_gtp_teid {
+                    bearer.enb_ul_teid = teid;
+                    admitted_forwarding = true;
+                }
+                if let Some(addr) = &item.ul_transport_layer_address {
+                    bearer.enb_ul_ip = transport_address_to_ip(addr);
+                }
             }
         }
     }
@@ -1228,12 +1277,107 @@ pub fn handle_handover_request_acknowledge(
         return Vec::new();
     };
 
+    // #48: choose the forwarding path (TS 23.401 §5.5.1.1.2 vs §5.5.1.2).
+    //
+    // Indirect forwarding needs a Serving GW round trip BEFORE the Handover Command
+    // can be built, because the endpoints the source must forward to are the SGW's and
+    // the SGW allocates them in the CIDFT response. So the command is DEFERRED in that
+    // case and sent from `s11_handler`'s CIDFT-response path -- deferring is not an
+    // optimisation, it is the only order in which the command can carry real
+    // endpoints. Sending it now with an empty list is what this used to do.
+    //
+    // The target admitting no forwarding endpoints at all means it does not want
+    // forwarding, so neither path applies and the command goes out immediately with an
+    // empty list -- which §9.1.5.2 permits, the IE being optional.
+    if !source_ue.direct_forwarding_available && admitted_forwarding {
+        // Park what the command will need before the request goes out: the
+        // target-to-source container is opaque and produced once, so it cannot be
+        // re-derived when the response lands.
+        {
+            let mut pool = ctx.enb_ue_pool.write().unwrap();
+            if let Some(target) = pool.get_mut(&target_ue.id) {
+                target.pending_handover_command = Some(crate::context::PendingHandoverCommand {
+                    handover_type: ho_type_to_s1ap(target_ue.handover_type),
+                    erab_to_release_list: msg
+                        .erab_failed_list
+                        .iter()
+                        .map(|item| nextgcore_s1ap::ErabItem {
+                            erab_id: item.erab_id,
+                            cause: item.cause,
+                        })
+                        .collect(),
+                    target_to_source_container: msg.target_to_source_container.clone(),
+                });
+            }
+        }
+        match crate::gtp_path::send_create_indirect_data_forwarding_tunnel_request(
+            ctx,
+            target_ue.id,
+            target_ue.mme_ue_id,
+        ) {
+            Ok(_) => {
+                log::info!(
+                    "No direct forwarding path for mme_ue_s1ap_id={}: requested indirect \
+                     forwarding tunnels from the SGW, Handover Command deferred until the \
+                     response",
+                    msg.mme_ue_s1ap_id
+                );
+                return Vec::new();
+            }
+            Err(e) => {
+                // Falling through with the TARGET's endpoints would tell the source to
+                // forward straight to the target over a path the source just said it
+                // does not have. An empty list loses the buffered data; a wrong list
+                // sends it into a black hole. So: empty, and say so.
+                log::error!(
+                    "Indirect forwarding tunnel request failed ({e:?}); continuing the handover \
+                     WITHOUT data forwarding, so buffered downlink data for \
+                     mme_ue_s1ap_id={} is lost",
+                    msg.mme_ue_s1ap_id
+                );
+                // The command is about to be sent synchronously below, so the parked
+                // copy must go: a late CIDFT response finding it would send a SECOND
+                // Handover Command for the same handover.
+                let mut pool = ctx.enb_ue_pool.write().unwrap();
+                if let Some(target) = pool.get_mut(&target_ue.id) {
+                    target.pending_handover_command = None;
+                }
+            }
+        }
+    }
+
+    let forwarding_list = if source_ue.direct_forwarding_available && admitted_forwarding {
+        target_forwarding_list(ctx, target_ue.mme_ue_id)
+    } else {
+        Vec::new()
+    };
+
+    match build_handover_command_pdu(ctx, &source_ue, &target_ue, msg, forwarding_list) {
+        Some(send) => vec![send],
+        None => Vec::new(),
+    }
+}
+
+/// Build the Handover Command for a prepared handover.
+///
+/// Shared by the direct-forwarding path (which returns it from the S1AP handler) and
+/// the indirect path (which sends it from the CIDFT response, once the SGW's endpoints
+/// are known). One builder rather than two because the only difference between the two
+/// cases is which endpoints are in the forwarding list, and a second copy of the
+/// release-list and container plumbing is a second copy that can drift.
+pub(crate) fn build_handover_command_pdu(
+    _ctx: &MmeContext,
+    source_ue: &crate::context::EnbUe,
+    target_ue: &crate::context::EnbUe,
+    ack: &HandoverRequestAcknowledge,
+    erab_subject_to_forwarding_list: Vec<ErabDataForwardingItem>,
+) -> Option<S1apSend> {
     let command = HandoverCommand {
         mme_ue_s1ap_id: source_ue.mme_ue_s1ap_id,
         enb_ue_s1ap_id: source_ue.enb_ue_s1ap_id,
         handover_type: ho_type_to_s1ap(target_ue.handover_type),
-        erab_subject_to_forwarding_list: Vec::new(),
-        erab_to_release_list: msg
+        erab_subject_to_forwarding_list,
+        erab_to_release_list: ack
             .erab_failed_list
             .iter()
             .map(|item| nextgcore_s1ap::ErabItem {
@@ -1241,16 +1385,168 @@ pub fn handle_handover_request_acknowledge(
                 cause: item.cause,
             })
             .collect(),
-        target_to_source_container: msg.target_to_source_container.clone(),
+        target_to_source_container: ack.target_to_source_container.clone(),
     };
 
     match builder::build_handover_command(&command) {
-        Ok(pdu) => vec![S1apSend {
+        Ok(pdu) => Some(S1apSend {
             enb_id: source_ue.enb_id,
             pdu,
-        }],
+        }),
         Err(e) => {
             log::error!("Failed to build Handover Command: {e}");
+            None
+        }
+    }
+}
+
+/// E-RABs Subject to Forwarding List pointing at the TARGET eNB's endpoints, for
+/// DIRECT forwarding (TS 23.401 §5.5.1.1.2).
+pub(crate) fn target_forwarding_list(
+    ctx: &MmeContext,
+    mme_ue_id: u64,
+) -> Vec<ErabDataForwardingItem> {
+    forwarding_list_from(ctx, mme_ue_id, |bearer| {
+        (
+            bearer.enb_dl_teid,
+            &bearer.enb_dl_ip,
+            bearer.enb_ul_teid,
+            &bearer.enb_ul_ip,
+        )
+    })
+}
+
+/// E-RABs Subject to Forwarding List pointing at the SERVING GW's endpoints, for
+/// INDIRECT forwarding (TS 23.401 §5.5.1.2).
+pub(crate) fn sgw_forwarding_list(ctx: &MmeContext, mme_ue_id: u64) -> Vec<ErabDataForwardingItem> {
+    forwarding_list_from(ctx, mme_ue_id, |bearer| {
+        (
+            bearer.sgw_dl_teid,
+            &bearer.sgw_dl_ip,
+            bearer.sgw_ul_teid,
+            &bearer.sgw_ul_ip,
+        )
+    })
+}
+
+/// Build the forwarding list from whichever endpoint pair `pick` selects.
+///
+/// A bearer with a zero TEID contributes NOTHING for that direction rather than an
+/// item with `teid: 0`: §9.1.5.2's DL/UL members are optional, and a zero TEID is a
+/// valid-looking instruction to forward into nowhere. A bearer with neither direction
+/// is left out of the list entirely.
+fn forwarding_list_from<F>(ctx: &MmeContext, mme_ue_id: u64, pick: F) -> Vec<ErabDataForwardingItem>
+where
+    F: Fn(
+        &crate::context::MmeBearer,
+    ) -> (u32, &crate::context::IpAddr, u32, &crate::context::IpAddr),
+{
+    ue_bearers(ctx, mme_ue_id)
+        .iter()
+        .filter_map(|bearer| {
+            let (dl_teid, dl_ip, ul_teid, ul_ip) = pick(bearer);
+            if dl_teid == 0 && ul_teid == 0 {
+                return None;
+            }
+            Some(ErabDataForwardingItem {
+                erab_id: bearer.ebi,
+                dl_transport_layer_address: (dl_teid != 0)
+                    .then(|| s1ap_build::ip_to_transport_address(dl_ip)),
+                dl_gtp_teid: (dl_teid != 0).then_some(dl_teid),
+                ul_transport_layer_address: (ul_teid != 0)
+                    .then(|| s1ap_build::ip_to_transport_address(ul_ip)),
+                ul_gtp_teid: (ul_teid != 0).then_some(ul_teid),
+            })
+        })
+        .collect()
+}
+
+/// Handle eNB Status Transfer from the source eNB (TS 36.413 §8.4.6) by relaying the
+/// transparent container to the target eNB as an MME Status Transfer (§8.4.7).
+///
+/// The container carries the uplink PDCP-SN/HFN receiver status and the downlink
+/// PDCP-SN/HFN transmitter status per E-RAB, and §8.4.6 says it is transferred "from
+/// the source to the target eNB via the MME". This message used to decode to
+/// `S1apMessage::Unknown` and be answered with an Error Indication carrying
+/// `abstract-syntax-error-reject`, so every S1 handover with RLC-AM bearers lost PDCP
+/// continuity AND the source eNB was told the MME could not parse a message it had
+/// sent correctly (#48).
+///
+/// The relay is byte-for-byte: the container is not decoded on the way through. See
+/// `nextgcore_s1ap::EnbStatusTransfer::status_transfer_container` for why.
+pub fn handle_enb_status_transfer(
+    ctx: &MmeContext,
+    enb_id: u64,
+    msg: &EnbStatusTransfer,
+) -> Vec<S1apSend> {
+    let Some(source_ue_id) = ctx.enb_ue_find_by_mme_ue_s1ap_id(msg.mme_ue_s1ap_id) else {
+        return error_indication(
+            enb_id,
+            Some(msg.enb_ue_s1ap_id),
+            Some(msg.mme_ue_s1ap_id),
+            S1apCauseGroup::RadioNetwork,
+            radio_network_cause::UNKNOWN_MME_UE_S1AP_ID,
+        );
+    };
+    let Some(source_ue) = ctx.enb_ue_find_by_id(source_ue_id) else {
+        return error_indication(
+            enb_id,
+            Some(msg.enb_ue_s1ap_id),
+            Some(msg.mme_ue_s1ap_id),
+            S1apCauseGroup::RadioNetwork,
+            radio_network_cause::UNKNOWN_MME_UE_S1AP_ID,
+        );
+    };
+
+    // No prepared target means there is no handover to carry the status into. §8.4.6
+    // defines no failure message for this procedure, so an Error Indication is the
+    // only conformant way to say so -- and "message not compatible with receiver
+    // state" is the accurate cause, unlike the abstract-syntax-error this used to get.
+    let target_ue_id = source_ue.target_ue_id;
+    if target_ue_id == NEXTGCORE_INVALID_POOL_ID {
+        log::warn!(
+            "eNB Status Transfer for mme_ue_s1ap_id={} with no handover in preparation",
+            msg.mme_ue_s1ap_id
+        );
+        return error_indication(
+            enb_id,
+            Some(msg.enb_ue_s1ap_id),
+            Some(msg.mme_ue_s1ap_id),
+            S1apCauseGroup::Protocol,
+            protocol_cause::MESSAGE_NOT_COMPATIBLE_WITH_RECEIVER_STATE,
+        );
+    }
+    let Some(target_ue) = ctx.enb_ue_find_by_id(target_ue_id) else {
+        return error_indication(
+            enb_id,
+            Some(msg.enb_ue_s1ap_id),
+            Some(msg.mme_ue_s1ap_id),
+            S1apCauseGroup::Protocol,
+            protocol_cause::MESSAGE_NOT_COMPATIBLE_WITH_RECEIVER_STATE,
+        );
+    };
+
+    // Addressed with the TARGET association's ids, not the source's: the container is
+    // the only thing that crosses unchanged.
+    let relay = MmeStatusTransfer {
+        mme_ue_s1ap_id: target_ue.mme_ue_s1ap_id,
+        enb_ue_s1ap_id: target_ue.enb_ue_s1ap_id,
+        status_transfer_container: msg.status_transfer_container.clone(),
+    };
+    match builder::build_mme_status_transfer(&relay) {
+        Ok(pdu) => {
+            log::info!(
+                "Relaying eNB Status Transfer ({} bytes) to target eNB {} as MME Status Transfer",
+                msg.status_transfer_container.len(),
+                target_ue.enb_id
+            );
+            vec![S1apSend {
+                enb_id: target_ue.enb_id,
+                pdu,
+            }]
+        }
+        Err(e) => {
+            log::error!("Failed to build MME Status Transfer: {e}");
             Vec::new()
         }
     }
@@ -1273,6 +1569,15 @@ pub fn handle_handover_failure(
     let Some(target_ue) = ctx.enb_ue_find_by_id(target_ue_id) else {
         return Vec::new();
     };
+    // #48: the target reported the failure itself, so it is releasing its own
+    // resources -- no release command, but the supervision must be disarmed before the
+    // context goes, or the sweep would try to release an id that no longer exists.
+    {
+        let mut pool = ctx.enb_ue_pool.write().unwrap();
+        if let Some(target) = pool.get_mut(&target_ue_id) {
+            target.handover_prep_deadline = None;
+        }
+    }
     ctx.enb_ue_remove(target_ue_id);
 
     let Some(source_ue) = ctx.enb_ue_find_by_id(target_ue.source_ue_id) else {
@@ -1280,6 +1585,7 @@ pub fn handle_handover_failure(
     };
     if let Some(source) = ctx.enb_ue_pool.write().unwrap().get_mut(&source_ue.id) {
         source.target_ue_id = NEXTGCORE_INVALID_POOL_ID;
+        source.direct_forwarding_available = false;
     }
 
     let failure = HandoverPreparationFailure {
@@ -1343,6 +1649,16 @@ pub fn handle_handover_notify(
         mme_ue.enb_ue_id = target_ue_id;
     }
 
+    // #48: the UE arrived, so the preparation is no longer outstanding. Disarming here
+    // rather than letting the deadline lapse harmlessly matters because the sweep would
+    // otherwise release a target that is now SERVING the UE.
+    {
+        let mut pool = ctx.enb_ue_pool.write().unwrap();
+        if let Some(target) = pool.get_mut(&target_ue_id) {
+            target.handover_prep_deadline = None;
+        }
+    }
+
     // Release the source eNB context (TS 36.413 §8.4.3: successful handover)
     let Some(source_ue) = ctx.enb_ue_find_by_id(target_ue.source_ue_id) else {
         return Vec::new();
@@ -1390,12 +1706,26 @@ pub fn handle_handover_cancel(
             Some(source) => {
                 let target = source.target_ue_id;
                 source.target_ue_id = NEXTGCORE_INVALID_POOL_ID;
+                source.direct_forwarding_available = false;
                 target
             }
             None => NEXTGCORE_INVALID_POOL_ID,
         }
     };
+
+    // #48: tell the TARGET to release before dropping our own record of it.
+    //
+    // §8.4.5.2 says the MME/target "release any resources associated with the handover
+    // preparation", and the target's resources are reserved from the Handover Request
+    // Acknowledge onwards -- radio, an S1-U endpoint, a UE context. Freeing only the
+    // MME's copy (what this used to do) leaves the target holding all of it with
+    // nothing left that could ever ask for it back, since the ids that addressed it
+    // are gone.
+    let mut sends = Vec::new();
     if target_ue_id != NEXTGCORE_INVALID_POOL_ID {
+        if let Some(release) = release_prepared_target(ctx, target_ue_id, "handover cancelled") {
+            sends.push(release);
+        }
         ctx.enb_ue_remove(target_ue_id);
     }
 
@@ -1409,12 +1739,122 @@ pub fn handle_handover_cancel(
         mme_ue_s1ap_id: msg.mme_ue_s1ap_id,
         enb_ue_s1ap_id: msg.enb_ue_s1ap_id,
     }) {
-        Ok(pdu) => S1apSend::to_origin(enb_id, pdu),
+        Ok(pdu) => {
+            sends.push(S1apSend { enb_id, pdu });
+            sends
+        }
         Err(e) => {
             log::error!("Failed to build Handover Cancel Acknowledge: {e}");
-            Vec::new()
+            sends
         }
     }
+}
+
+/// Tell a prepared target eNB to release the resources it reserved for a handover that
+/// is not going to complete, and disarm the preparation supervision.
+///
+/// `HANDOVER_CANCELLED` on an explicit cancel and `TS1_RELOCOVERALL_EXPIRY` on a
+/// timeout, since those are what §9.2.1.3 provides and they tell the target which of
+/// the two happened -- a distinction it needs for its own counters.
+fn release_prepared_target(ctx: &MmeContext, target_ue_id: u64, reason: &str) -> Option<S1apSend> {
+    let target_ue = ctx.enb_ue_find_by_id(target_ue_id)?;
+    {
+        let mut pool = ctx.enb_ue_pool.write().unwrap();
+        if let Some(target) = pool.get_mut(&target_ue_id) {
+            target.handover_prep_deadline = None;
+        }
+    }
+
+    // A target that never answered the Handover Request has no eNB-UE-S1AP-ID yet, so
+    // there is nothing to address a release to; the reservation is the target's own to
+    // time out. Passing INVALID_UE_S1AP_ID on the wire would name a context the target
+    // does not have.
+    if target_ue.enb_ue_s1ap_id == INVALID_UE_S1AP_ID {
+        log::info!(
+            "Prepared target for mme_ue_s1ap_id={} never acknowledged ({reason}); no release to \
+             send",
+            target_ue.mme_ue_s1ap_id
+        );
+        return None;
+    }
+
+    let cause_value = if reason == "handover cancelled" {
+        radio_network_cause::HANDOVER_CANCELLED
+    } else {
+        radio_network_cause::TS1_RELOCOVERALL_EXPIRY
+    };
+    match s1ap_build::build_ue_context_release_command(
+        Some(target_ue.enb_ue_s1ap_id),
+        target_ue.mme_ue_s1ap_id,
+        S1apCauseGroup::RadioNetwork,
+        cause_value,
+    ) {
+        Ok(pdu) => {
+            log::info!(
+                "Releasing prepared target eNB {} for mme_ue_s1ap_id={} ({reason})",
+                target_ue.enb_id,
+                target_ue.mme_ue_s1ap_id
+            );
+            Some(S1apSend {
+                enb_id: target_ue.enb_id,
+                pdu,
+            })
+        }
+        Err(e) => {
+            log::error!("Failed to build UE Context Release Command for prepared target: {e}");
+            None
+        }
+    }
+}
+
+/// Sweep the eNB-UE pool for handover preparations that ran out of time, releasing the
+/// target and freeing the context (#48).
+///
+/// Rides `MmeApp::run`'s existing 100 ms tick, the same way `nas_timer::expire_nas_timers`
+/// does: no extra task, no channel, and it cannot silently stop firing. Cheap when
+/// idle -- a walk of the pool that does nothing unless a deadline passed.
+///
+/// RETURNS the release commands rather than sending them, so the DECISION (which target
+/// to release, and freeing the context) is separable from the TRANSMISSION (which needs
+/// the process-global S1AP queue and a live SCTP association). A test can then assert
+/// the decision; asserting the send would need an eNB.
+#[must_use]
+pub fn expire_handover_preparations(ctx: &MmeContext, now: std::time::Instant) -> Vec<S1apSend> {
+    let mut sends = Vec::new();
+    let expired: Vec<u64> = ctx
+        .enb_ue_pool
+        .read()
+        .unwrap()
+        .values()
+        .filter(|ue| ue.handover_prep_deadline.is_some_and(|at| now >= at))
+        .map(|ue| ue.id)
+        .collect();
+
+    for target_ue_id in expired {
+        let source_ue_id = ctx
+            .enb_ue_find_by_id(target_ue_id)
+            .map(|ue| ue.source_ue_id)
+            .unwrap_or(NEXTGCORE_INVALID_POOL_ID);
+
+        log::warn!(
+            "Handover preparation supervision expired for target enb_ue_id={target_ue_id} after \
+             {}s; releasing the target",
+            HANDOVER_PREPARATION_SUPERVISION.as_secs()
+        );
+        if let Some(send) = release_prepared_target(ctx, target_ue_id, "preparation timed out") {
+            sends.push(send);
+        }
+        if source_ue_id != NEXTGCORE_INVALID_POOL_ID {
+            let mut pool = ctx.enb_ue_pool.write().unwrap();
+            if let Some(source) = pool.get_mut(&source_ue_id) {
+                source.target_ue_id = NEXTGCORE_INVALID_POOL_ID;
+                source.direct_forwarding_available = false;
+            }
+        }
+        ctx.enb_ue_remove(target_ue_id);
+    }
+
+    sends
 }
 
 /// Handle Path Switch Request (X2 handover, TS 36.413 §8.4.4): move the UE's
@@ -2116,6 +2556,9 @@ mod tests {
                     tac: 2,
                 },
             },
+            // #48: ABSENT, which means no direct path and therefore INDIRECT
+            // forwarding -- the behaviour these tests were written against.
+            direct_forwarding_path_availability: None,
             source_to_target_container: vec![0xDE, 0xAD],
         };
         let bytes = builder::build_handover_required(&ho).unwrap();
@@ -2156,6 +2599,9 @@ mod tests {
                     tac: 2,
                 },
             },
+            // #48: ABSENT, which means no direct path and therefore INDIRECT
+            // forwarding -- the behaviour these tests were written against.
+            direct_forwarding_path_availability: None,
             source_to_target_container: vec![0x01],
         };
         let bytes = builder::build_handover_required(&ho).unwrap();
@@ -2207,6 +2653,9 @@ mod tests {
                     tac: 2,
                 },
             },
+            // #48: ABSENT, which means no direct path and therefore INDIRECT
+            // forwarding -- the behaviour these tests were written against.
+            direct_forwarding_path_availability: None,
             source_to_target_container: vec![0x01],
         };
         let out = handle_s1ap_message(
@@ -2294,6 +2743,295 @@ mod tests {
         assert_eq!(
             source_ue.ue_ctx_rel_action,
             UeCtxRelAction::S1HandoverComplete
+        );
+    }
+
+    /// Set up a prepared handover: source UE, one bearer, a registered target eNB, and a
+    /// Handover Required already processed. Returns
+    /// `(source_enb_id, source_ue_id, target_enb_id, mme_ue_s1ap_id, target_mme_ue_s1ap_id, bearer_id)`.
+    ///
+    /// `direct` decides whether the Handover Required carries Direct Forwarding Path
+    /// Availability, which is what selects direct over indirect forwarding.
+    fn prepared_handover(ctx: &MmeContext, direct: bool) -> (u64, u64, u64, u32, u32, u64) {
+        let (source_enb_id, source_ue_id, mme_ue_id, mme_ue_s1ap_id) = add_ue(ctx);
+        let bearer_id = ctx.bearer_add(0, mme_ue_id);
+        {
+            let mut pool = ctx.bearer_pool.write().unwrap();
+            let bearer = pool.get_mut(&bearer_id).unwrap();
+            bearer.ebi = 5;
+            bearer.sgw_s1u_teid = 0x5555;
+            bearer.sgw_s1u_ip.ipv4 = Some([10, 0, 0, 2]);
+            bearer.qos.qci = 9;
+            bearer.qos.arp.priority_level = 8;
+        }
+        let target_enb_id = ctx.enb_add("127.0.0.8:36412".parse().unwrap());
+        ctx.enb_set_enb_id(target_enb_id, 0x2222);
+
+        let ho = HandoverRequired {
+            mme_ue_s1ap_id,
+            enb_ue_s1ap_id: 100,
+            handover_type: S1apHandoverType::IntraLte,
+            cause: Cause::RadioNetwork(CauseRadioNetwork::HandoverDesirableForRadioReason),
+            target_id: TargetId::TargetEnbId {
+                global_enb_id: GlobalEnbId {
+                    plmn_identity: s1ap_build::encode_plmn_id(&PlmnId::new("310", "410")),
+                    enb_id: nextgcore_s1ap::EnbId::Macro(0x2222),
+                },
+                selected_tai: nextgcore_s1ap::Tai {
+                    plmn_identity: s1ap_build::encode_plmn_id(&PlmnId::new("310", "410")),
+                    tac: 2,
+                },
+            },
+            direct_forwarding_path_availability: direct
+                .then_some(nextgcore_s1ap::DirectForwardingPathAvailability::DirectPathAvailable),
+            source_to_target_container: vec![0x01],
+        };
+        let out = handle_s1ap_message(
+            ctx,
+            source_enb_id,
+            &builder::build_handover_required(&ho).unwrap(),
+        );
+        let target_mme_ue_s1ap_id = match decode_s1ap_pdu(&out[0].pdu).unwrap() {
+            S1apMessage::HandoverRequest(req) => req.mme_ue_s1ap_id,
+            other => panic!("expected HandoverRequest, got {other:?}"),
+        };
+        (
+            source_enb_id,
+            source_ue_id,
+            target_enb_id,
+            mme_ue_s1ap_id,
+            target_mme_ue_s1ap_id,
+            bearer_id,
+        )
+    }
+
+    /// A Handover Request Acknowledge admitting DL and UL data-forwarding endpoints.
+    fn ack_with_forwarding(target_mme_ue_s1ap_id: u32) -> HandoverRequestAcknowledge {
+        HandoverRequestAcknowledge {
+            mme_ue_s1ap_id: target_mme_ue_s1ap_id,
+            enb_ue_s1ap_id: 300,
+            erab_admitted_list: vec![nextgcore_s1ap::ErabAdmittedItem {
+                erab_id: 5,
+                transport_layer_address: vec![10, 0, 0, 8],
+                gtp_teid: 0x8888,
+                dl_transport_layer_address: Some(vec![10, 0, 0, 9]),
+                dl_gtp_teid: Some(0xDDDD),
+                ul_transport_layer_address: Some(vec![10, 0, 0, 10]),
+                ul_gtp_teid: Some(0xEEEE),
+            }],
+            erab_failed_list: Vec::new(),
+            target_to_source_container: vec![0xBE, 0xEF],
+        }
+    }
+
+    /// #48 criterion 4: the admitted DL/UL forwarding TEIDs reach the Handover Command's
+    /// E-RABs Subject to Forwarding List.
+    ///
+    /// Both halves are asserted, because they failed for different reasons before: the
+    /// TEIDs were decoded by `nextgcore-s1ap` and DROPPED in
+    /// `handle_handover_request_acknowledge` (so the bearer never held them), and the
+    /// list was hard-coded to `Vec::new()` (so even a populated bearer could not reach
+    /// the wire).
+    #[test]
+    fn direct_forwarding_populates_the_handover_command_forwarding_list() {
+        let ctx = ctx_with_gummei();
+        let (source_enb_id, _, target_enb_id, mme_ue_s1ap_id, target_mme_ue_s1ap_id, bearer_id) =
+            prepared_handover(&ctx, true);
+
+        let out = handle_s1ap_message(
+            &ctx,
+            target_enb_id,
+            &builder::build_handover_request_acknowledge(&ack_with_forwarding(
+                target_mme_ue_s1ap_id,
+            ))
+            .unwrap(),
+        );
+
+        // The endpoints were recorded on the bearer.
+        let bearer = ctx.bearer_find_by_id(bearer_id).unwrap();
+        assert_eq!(bearer.enb_dl_teid, 0xDDDD, "admitted DL forwarding TEID");
+        assert_eq!(bearer.enb_dl_ip.ipv4, Some([10, 0, 0, 9]));
+        assert_eq!(bearer.enb_ul_teid, 0xEEEE, "admitted UL forwarding TEID");
+        assert_eq!(bearer.enb_ul_ip.ipv4, Some([10, 0, 0, 10]));
+
+        // And they reached the Handover Command.
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].enb_id, source_enb_id);
+        match decode_s1ap_pdu(&out[0].pdu).unwrap() {
+            S1apMessage::HandoverCommand(cmd) => {
+                assert_eq!(cmd.mme_ue_s1ap_id, mme_ue_s1ap_id);
+                assert_eq!(
+                    cmd.erab_subject_to_forwarding_list.len(),
+                    1,
+                    "a direct-forwarding handover must carry a forwarding list, not the empty \
+                     one this used to send"
+                );
+                let item = &cmd.erab_subject_to_forwarding_list[0];
+                assert_eq!(item.erab_id, 5);
+                assert_eq!(item.dl_gtp_teid, Some(0xDDDD));
+                assert_eq!(item.dl_transport_layer_address, Some(vec![10, 0, 0, 9]));
+                assert_eq!(item.ul_gtp_teid, Some(0xEEEE));
+                assert_eq!(item.ul_transport_layer_address, Some(vec![10, 0, 0, 10]));
+            }
+            other => panic!("expected HandoverCommand, got {other:?}"),
+        }
+    }
+
+    /// #48 criteria 1 and 2: an eNB Status Transfer is dispatched (not answered with an
+    /// Error Indication) and relayed to the target under the TARGET's ids with the
+    /// container byte for byte.
+    #[test]
+    fn enb_status_transfer_is_relayed_to_the_target_unchanged() {
+        let ctx = ctx_with_gummei();
+        let (source_enb_id, _, target_enb_id, mme_ue_s1ap_id, target_mme_ue_s1ap_id, _) =
+            prepared_handover(&ctx, true);
+        let _ = handle_s1ap_message(
+            &ctx,
+            target_enb_id,
+            &builder::build_handover_request_acknowledge(&ack_with_forwarding(
+                target_mme_ue_s1ap_id,
+            ))
+            .unwrap(),
+        );
+
+        let payload = vec![0x00, 0x01, 0xF0, 0x0D, 0x7F, 0x80, 0x2A];
+        let status = nextgcore_s1ap::EnbStatusTransfer {
+            mme_ue_s1ap_id,
+            enb_ue_s1ap_id: 100,
+            status_transfer_container: payload.clone(),
+        };
+        let out = handle_s1ap_message(
+            &ctx,
+            source_enb_id,
+            &builder::build_enb_status_transfer(&status).unwrap(),
+        );
+
+        assert_eq!(out.len(), 1, "the status must be relayed, not dropped");
+        assert_eq!(
+            out[0].enb_id, target_enb_id,
+            "the relay goes to the TARGET eNB"
+        );
+        match decode_s1ap_pdu(&out[0].pdu).unwrap() {
+            S1apMessage::MmeStatusTransfer(relay) => {
+                assert_eq!(
+                    relay.status_transfer_container, payload,
+                    "the PDCP SN/HFN status must cross unchanged"
+                );
+                assert_eq!(
+                    relay.mme_ue_s1ap_id, target_mme_ue_s1ap_id,
+                    "addressed with the target association's MME-UE-S1AP-ID"
+                );
+                assert_eq!(relay.enb_ue_s1ap_id, 300, "and the target's eNB-UE-S1AP-ID");
+            }
+            // This is the pre-#48 behaviour: proc 24 fell through to Unknown and was
+            // answered with abstract-syntax-error-reject.
+            S1apMessage::ErrorIndication(e) => {
+                panic!("status transfer answered with an Error Indication: {e:?}")
+            }
+            other => panic!("expected MmeStatusTransfer, got {other:?}"),
+        }
+    }
+
+    /// #48 criterion 6, first half: a cancelled handover tells the prepared target to
+    /// release, with cause `handover-cancelled`.
+    #[test]
+    fn handover_cancel_releases_the_prepared_target() {
+        let ctx = ctx_with_gummei();
+        let (source_enb_id, source_ue_id, target_enb_id, mme_ue_s1ap_id, target_mme_ue_s1ap_id, _) =
+            prepared_handover(&ctx, true);
+        let _ = handle_s1ap_message(
+            &ctx,
+            target_enb_id,
+            &builder::build_handover_request_acknowledge(&ack_with_forwarding(
+                target_mme_ue_s1ap_id,
+            ))
+            .unwrap(),
+        );
+        let target_ue_id = ctx.enb_ue_find_by_id(source_ue_id).unwrap().target_ue_id;
+        assert_ne!(target_ue_id, NEXTGCORE_INVALID_POOL_ID);
+
+        let cancel = HandoverCancel {
+            mme_ue_s1ap_id,
+            enb_ue_s1ap_id: 100,
+            cause: Cause::RadioNetwork(CauseRadioNetwork::HandoverCancelled),
+        };
+        let out = handle_s1ap_message(
+            &ctx,
+            source_enb_id,
+            &builder::build_handover_cancel(&cancel).unwrap(),
+        );
+
+        let release = out.iter().find(|send| send.enb_id == target_enb_id).expect(
+            "the prepared target must be told to release; freeing only the MME's copy \
+                     strands the target's radio and S1-U reservation",
+        );
+        match decode_s1ap_pdu(&release.pdu).unwrap() {
+            S1apMessage::UeContextReleaseCommand(cmd) => assert_eq!(
+                cmd.cause,
+                Cause::RadioNetwork(CauseRadioNetwork::HandoverCancelled)
+            ),
+            other => panic!("expected UeContextReleaseCommand to the target, got {other:?}"),
+        }
+
+        // The source still gets its acknowledge, and the target context is gone.
+        assert!(
+            out.iter().any(|send| send.enb_id == source_enb_id),
+            "the source must still be acknowledged"
+        );
+        assert!(ctx.enb_ue_find_by_id(target_ue_id).is_none());
+    }
+
+    /// #48 criterion 6, second half: a preparation that never completes is released by
+    /// the supervision sweep instead of leaking the target context.
+    ///
+    /// Asserts the DECISION (which target, and that the context is freed), not the
+    /// transmission: `expire_handover_preparations` returns the sends precisely so this
+    /// is assertable without an eNB on the other end of an SCTP association.
+    #[test]
+    fn handover_preparation_supervision_releases_a_target_that_never_completes() {
+        let ctx = ctx_with_gummei();
+        let (_, source_ue_id, target_enb_id, _, target_mme_ue_s1ap_id, _) =
+            prepared_handover(&ctx, true);
+        let _ = handle_s1ap_message(
+            &ctx,
+            target_enb_id,
+            &builder::build_handover_request_acknowledge(&ack_with_forwarding(
+                target_mme_ue_s1ap_id,
+            ))
+            .unwrap(),
+        );
+        let target_ue_id = ctx.enb_ue_find_by_id(source_ue_id).unwrap().target_ue_id;
+
+        // Nothing has expired yet, so the sweep is a no-op. Asserted so the expiry below
+        // cannot pass merely because the sweep releases everything it sees.
+        assert!(
+            expire_handover_preparations(&ctx, std::time::Instant::now()).is_empty(),
+            "a live preparation must not be released"
+        );
+        assert!(ctx.enb_ue_find_by_id(target_ue_id).is_some());
+
+        let past = std::time::Instant::now() + HANDOVER_PREPARATION_SUPERVISION;
+        let sends = expire_handover_preparations(&ctx, past);
+
+        assert_eq!(sends.len(), 1, "the expired target must be released");
+        assert_eq!(sends[0].enb_id, target_enb_id);
+        match decode_s1ap_pdu(&sends[0].pdu).unwrap() {
+            S1apMessage::UeContextReleaseCommand(cmd) => assert_eq!(
+                cmd.cause,
+                Cause::RadioNetwork(CauseRadioNetwork::TS1relocoverallExpiry),
+                "the cause must say the relocation supervision expired, not that it was \
+                 cancelled"
+            ),
+            other => panic!("expected UeContextReleaseCommand, got {other:?}"),
+        }
+        assert!(
+            ctx.enb_ue_find_by_id(target_ue_id).is_none(),
+            "the leaked context is the defect; the release alone does not fix it"
+        );
+        assert_eq!(
+            ctx.enb_ue_find_by_id(source_ue_id).unwrap().target_ue_id,
+            NEXTGCORE_INVALID_POOL_ID,
+            "the source must no longer point at a context that is gone"
         );
     }
 

--- a/src/bins/nextgcore-sgwcd/src/gtp_path.rs
+++ b/src/bins/nextgcore-sgwcd/src/gtp_path.rs
@@ -1746,11 +1746,15 @@ fn dispatch_indirect_tunnel_request(
         return;
     };
 
+    // #48: the DECODED message, not `&[]`. The handler needs the request's Bearer
+    // Contexts to know which bearers to allocate forwarding tunnels for and where the
+    // target eNB wants the data sent; passing an empty slice is why it could only ever
+    // return a bare accept.
     let result = if create {
         s11_handler::handle_create_indirect_data_forwarding_tunnel_request(
             Some(&ue),
             seq as u64,
-            &[],
+            msg,
         )
     } else {
         s11_handler::handle_delete_indirect_data_forwarding_tunnel_request(
@@ -1763,17 +1767,26 @@ fn dispatch_indirect_tunnel_request(
     match result {
         HandlerResult::SendPfcp => {
             if create {
-                match s11_build::build_create_indirect_data_forwarding_tunnel_response(
-                    ue.id,
-                    seq,
-                    gtp_cause::REQUEST_ACCEPTED,
-                ) {
-                    Ok(response) => {
-                        if let Err(e) = server.send_response(peer, &response) {
-                            log::error!("Indirect tunnel response to {peer} failed: {e}");
-                        }
+                // #48: the answer is now GATED on the SGW-U installing the forwarding
+                // rules. It used to be built right here with a hard-coded
+                // REQUEST_ACCEPTED and no F-TEIDs, before any PFCP message existed --
+                // the same "accepted means fulfilled" violation #54 fixed for Create
+                // Session, one procedure over.
+                match install_indirect_forwarding(&ue, peer, seq) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        log::error!(
+                            "Failed to install indirect forwarding rules on the SGW-U: {e}"
+                        );
+                        send_cause_response(
+                            server,
+                            peer,
+                            response_type,
+                            ue.mme_s11_teid,
+                            seq,
+                            gtp_cause::SYSTEM_FAILURE,
+                        );
                     }
-                    Err(e) => log::error!("Failed to build indirect tunnel response: {e}"),
                 }
             } else {
                 send_cause_response(
@@ -1791,6 +1804,65 @@ fn dispatch_indirect_tunnel_request(
         }
         _ => {}
     }
+}
+
+/// Ask the SGW-U to install the forwarding rules the CIDFT handler just allocated, and
+/// gate the MME's answer on its response (#48).
+fn install_indirect_forwarding(
+    ue: &crate::context::SgwcUe,
+    peer: SocketAddr,
+    seq: u32,
+) -> Result<(), String> {
+    let ctx = sgwc_self();
+    // A UE may hold several sessions; the forwarding tunnels were allocated on the
+    // bearers of whichever session held the requested EBIs, so each session with a
+    // forwarding tunnel gets its own modification. In practice that is one.
+    let mut sent = 0usize;
+    for sess_id in &ue.sess_ids {
+        let Some(sess) = ctx.sess_find_by_id(*sess_id) else {
+            continue;
+        };
+        let bearer_ids: Vec<u64> = sess
+            .bearer_ids
+            .iter()
+            .copied()
+            .filter(|bid| has_forwarding_tunnel(&ctx, *bid))
+            .collect();
+        if bearer_ids.is_empty() {
+            continue;
+        }
+        pfcp_path::send_indirect_forwarding_tunnels(
+            &sess,
+            &bearer_ids,
+            pfcp_path::S11Continuation::IndirectForwarding {
+                peer,
+                seq,
+                teid: ue.mme_s11_teid,
+                sgwc_ue_id: ue.id,
+            },
+        )?;
+        sent += 1;
+    }
+    if sent == 0 {
+        return Err("no session carries a forwarding tunnel".to_string());
+    }
+    Ok(())
+}
+
+/// Whether a bearer carries at least one data-forwarding tunnel.
+fn has_forwarding_tunnel(ctx: &crate::context::SgwcContext, bearer_id: u64) -> bool {
+    let Some(bearer) = ctx.bearer_find_by_id(bearer_id) else {
+        return false;
+    };
+    bearer.tunnel_ids.iter().any(|tid| {
+        ctx.tunnel_find_by_id(*tid).is_some_and(|t| {
+            matches!(
+                t.interface_type,
+                crate::context::gtp_interface::SGW_GTP_U_DL_DATA_FORWARDING
+                    | crate::context::gtp_interface::SGW_GTP_U_UL_DATA_FORWARDING
+            )
+        })
+    })
 }
 
 fn dispatch_bearer_resource_command(server: &GtpcServer, msg: &Gtp2Message, peer: SocketAddr) {
@@ -3407,7 +3479,7 @@ mod tests {
     /// builder so a change to it fails here rather than only over a socket.
     #[test]
     fn version_not_supported_is_eight_octets_with_no_teid() {
-        let bytes = build_version_not_supported(0x0102_03);
+        let bytes = build_version_not_supported(0x0001_0203);
         assert_eq!(bytes.len(), 8);
         assert_eq!((bytes[0] >> 5) & 0x07, 2);
         assert_eq!(bytes[0] & 0x08, 0, "the T flag must be clear (no TEID)");

--- a/src/bins/nextgcore-sgwcd/src/pfcp_path.rs
+++ b/src/bins/nextgcore-sgwcd/src/pfcp_path.rs
@@ -175,6 +175,20 @@ pub enum S11Continuation {
         teid: u32,
         sess_id: u64,
     },
+    /// Answer the MME's Create Indirect Data Forwarding Tunnel Request once the SGW-U
+    /// has installed the forwarding rules (#48).
+    ///
+    /// Gated for the same reason the Create Session answer is: TS 29.274 §7.2.2 makes
+    /// `Request accepted` mean the request was FULFILLED, and this response carries
+    /// F-TEIDs the source eNB is about to forward user data to. Answering before the
+    /// SGW-U has the rules would advertise a datapath that does not exist yet -- which
+    /// is the defect #48 describes, one step earlier.
+    IndirectForwarding {
+        peer: SocketAddr,
+        seq: u32,
+        teid: u32,
+        sgwc_ue_id: u64,
+    },
 }
 
 /// An outbound PFCP request queued by a synchronous caller.
@@ -878,6 +892,28 @@ pub fn send_bearer_to_modify_list(
         flags
     );
     enqueue(&msg, sess.id, S11Continuation::None)
+}
+
+/// Install the indirect data-forwarding rules on the SGW-U (#48).
+///
+/// A Session Modification carrying a Create PDR / Create FAR pair per forwarding
+/// tunnel: the PDR matches on the tunnel's own local F-TEID and the FAR forwards to the
+/// endpoint the MME gave for that direction. Without this the SGW-C allocated F-TEIDs
+/// and answered `REQUEST_ACCEPTED` while the SGW-U had no rule for them, so anything the
+/// source eNB forwarded was dropped at the user plane.
+pub fn send_indirect_forwarding_tunnels(
+    sess: &SgwcSess,
+    bearer_ids: &[u64],
+    continuation: S11Continuation,
+) -> Result<(), String> {
+    let msg = sxa_build::build_indirect_forwarding_rules(sess, bearer_ids)
+        .ok_or_else(|| "Failed to build indirect forwarding rules".to_string())?;
+    log::info!(
+        "PFCP Session Modification for indirect forwarding: sess_id={}, bearers={}",
+        sess.id,
+        bearer_ids.len()
+    );
+    enqueue(&msg, sess.id, continuation)
 }
 
 /// Send Session Deletion Request to SGW-U

--- a/src/bins/nextgcore-sgwcd/src/s11_build.rs
+++ b/src/bins/nextgcore-sgwcd/src/s11_build.rs
@@ -30,8 +30,21 @@ pub mod f_teid_interface {
     pub const S5_S8_PGW_GTP_C: u8 = 7;
     pub const S11_MME_GTP_C: u8 = 10;
     pub const S11_S4_SGW_GTP_C: u8 = 11;
-    pub const SGW_GTP_U_DL_DATA_FORWARDING: u8 = 22;
-    pub const SGW_GTP_U_UL_DATA_FORWARDING: u8 = 23;
+    /// SGW/UPF GTP-U interface for DL data forwarding.
+    ///
+    /// #48: this said **22**, which TS 29.274 §8.22 defines as "SGSN GTP-U interface
+    /// for data forwarding". The authoritative value is 23, and Table 7.2.19-2 NOTE 3
+    /// says so twice over: "for DL data forwarding the SGW shall set the interface type
+    /// in the F-TEID to 23". Inert until #48 because nothing allocated a forwarding
+    /// tunnel, so the emitting branch was never taken -- the same latency that hid
+    /// `smfd`'s S_NSSAI=250 (#321).
+    pub const SGW_GTP_U_DL_DATA_FORWARDING: u8 = 23;
+    /// SGW GTP-U interface for UL data forwarding.
+    ///
+    /// #48: this said **23**, which is the DL value above, so the two directions would
+    /// have gone out indistinguishable. Table 7.2.19-2 NOTE 4: "for UL data forwarding
+    /// the SGW shall set the interface type in the F-TEID to 28".
+    pub const SGW_GTP_U_UL_DATA_FORWARDING: u8 = 28;
 }
 
 /// RAT Type values (TS 29.274 Section 8.17)
@@ -411,7 +424,14 @@ pub fn build_create_indirect_data_forwarding_tunnel_response(
                                 f_teid_interface::SGW_GTP_U_UL_DATA_FORWARDING,
                                 &tunnel,
                             ) {
-                                bc.set_fteid(1, &ft);
+                                // #48: instance **4**, "S1-U SGW F-TEID for UL data
+                                // forwarding" (TS 29.274 Table 7.2.19-2). This was
+                                // instance 1, which that table assigns to "S12 SGW
+                                // F-TEID for DL data forwarding" -- so an MME reading
+                                // the response conformantly would have taken the UL
+                                // endpoint for a second DL one on an interface this
+                                // deployment does not have.
+                                bc.set_fteid(4, &ft);
                             }
                         }
                         _ => {}
@@ -686,6 +706,30 @@ pub fn build_s5c_create_bearer_response(
 
 #[cfg(test)]
 mod tests {
+
+    /// #48: same guard as `mmed`'s. Both SGW forwarding interface types were wrong here
+    /// (22 and 23, i.e. "SGSN GTP-U for data forwarding" and the DL value used twice) and
+    /// inert because nothing allocated a forwarding tunnel.
+    #[test]
+    fn f_teid_interface_types_match_ts29274_clause_8_22() {
+        use super::f_teid_interface as iface;
+        assert_eq!(iface::S1_U_SGW_GTP_U, 1, "1: S1-U SGW GTP-U interface");
+        assert_eq!(
+            iface::S11_S4_SGW_GTP_C,
+            11,
+            "11: S11/S4 SGW GTP-C interface"
+        );
+        assert_eq!(
+            iface::SGW_GTP_U_DL_DATA_FORWARDING,
+            23,
+            "23: SGW/UPF GTP-U interface for DL data forwarding (Table 7.2.19-2 NOTE 3)"
+        );
+        assert_eq!(
+            iface::SGW_GTP_U_UL_DATA_FORWARDING,
+            28,
+            "28: SGW GTP-U interface for UL data forwarding (Table 7.2.19-2 NOTE 4)"
+        );
+    }
     use super::*;
     use bytes::Bytes;
 

--- a/src/bins/nextgcore-sgwcd/src/s11_handler.rs
+++ b/src/bins/nextgcore-sgwcd/src/s11_handler.rs
@@ -2,7 +2,9 @@
 //!
 //! Port of src/sgwc/s11-handler.c - Handlers for GTPv2-C messages from MME
 
-use crate::context::{sgwc_self, SgwcSess, SgwcUe};
+use crate::context::{gtp_interface, sgwc_self, SgwcSess, SgwcUe};
+use nextgcore_gtp::v2::{Gtp2BearerContextIe, Gtp2IeType, Gtp2Message};
+use std::net::Ipv4Addr;
 
 // ============================================================================
 // GTP Cause Values (from NEXTGCORE_GTP2_CAUSE_*)
@@ -478,12 +480,22 @@ pub fn handle_downlink_data_notification_ack(
     HandlerResult::Ok
 }
 
-/// Handle Create Indirect Data Forwarding Tunnel Request from MME
-/// Port of sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request
+/// Handle Create Indirect Data Forwarding Tunnel Request from the MME
+/// (TS 29.274 §7.2.18, TS 23.401 §5.5.1.2).
+///
+/// #48: this used to ignore `_gtpbuf` entirely -- the dispatcher passed `&[]` anyway --
+/// allocate nothing, install nothing, and return `SendPfcp` so the dispatcher answered
+/// `REQUEST_ACCEPTED` with no forwarding F-TEIDs. A false success: the MME was told the
+/// indirect forwarding path existed, and no packet could traverse it.
+///
+/// Now it parses the request's Bearer Contexts, allocates a DL and a UL
+/// data-forwarding tunnel per bearer (interface types 23 and 28, TS 29.274 §8.22), and
+/// records the TARGET eNB's endpoints from the request as those tunnels' remote ends so
+/// the SGW-U rules point somewhere real.
 pub fn handle_create_indirect_data_forwarding_tunnel_request(
     sgwc_ue: Option<&SgwcUe>,
     _xact_id: u64,
-    _gtpbuf: &[u8],
+    request: &Gtp2Message,
 ) -> HandlerResult {
     log::info!("Create Indirect Data Forwarding Tunnel Request");
 
@@ -501,10 +513,164 @@ pub fn handle_create_indirect_data_forwarding_tunnel_request(
         sgwc_ue.sgw_s11_teid
     );
 
-    // Need to send PFCP Session Modification Request
+    let requested = parse_indirect_forwarding_request(request);
+    if requested.is_empty() {
+        // §7.2.18 makes Bearer Contexts mandatory, so a request with none is malformed
+        // rather than a request for nothing. Answering `REQUEST_ACCEPTED` to it is what
+        // this used to do for EVERY request.
+        log::error!(
+            "CIDFT Request carries no usable Bearer Context: rejecting rather than accepting a \
+             forwarding path with no bearers"
+        );
+        return HandlerResult::Error(gtp_cause::MANDATORY_IE_MISSING);
+    }
+
+    let ctx = sgwc_self();
+    let Some(gtpu_addr) = ctx.gtpu_address() else {
+        log::error!("No SGW-U GTP-U address configured: cannot allocate forwarding tunnels");
+        return HandlerResult::Error(gtp_cause::SYSTEM_FAILURE);
+    };
+
+    let mut allocated = 0usize;
+    for req in &requested {
+        let Some(bearer_id) = find_bearer_by_ebi(&ctx, sgwc_ue, req.ebi) else {
+            log::warn!(
+                "CIDFT Request names EBI {} which this UE does not have; skipped",
+                req.ebi
+            );
+            continue;
+        };
+
+        for (interface_type, remote_teid, remote_ip) in [
+            (
+                gtp_interface::SGW_GTP_U_DL_DATA_FORWARDING,
+                req.enb_dl_teid,
+                req.enb_dl_ipv4,
+            ),
+            (
+                gtp_interface::SGW_GTP_U_UL_DATA_FORWARDING,
+                req.enb_ul_teid,
+                req.enb_ul_ipv4,
+            ),
+        ] {
+            // A direction the MME did not ask for gets no tunnel. Allocating one anyway
+            // would put an endpoint in the response that the source eNB would then
+            // forward to, with no rule at the far end.
+            if remote_teid == 0 {
+                continue;
+            }
+            let Some(mut tunnel) = ctx.tunnel_add(bearer_id, interface_type) else {
+                log::error!("Failed to allocate a forwarding tunnel for EBI {}", req.ebi);
+                continue;
+            };
+            tunnel.local_teid = ctx.next_gtpu_teid();
+            tunnel.local_addr = Some(gtpu_addr);
+            tunnel.pdr_id = Some(ctx.next_pdr_id());
+            tunnel.far_id = Some(ctx.next_far_id());
+            tunnel.remote_teid = remote_teid;
+            if let Some(v4) = remote_ip {
+                tunnel.remote_ip = crate::context::IpAddr {
+                    ipv4: Some(Ipv4Addr::from(v4)),
+                    ipv6: None,
+                };
+            }
+            ctx.tunnel_update(&tunnel);
+            allocated += 1;
+        }
+    }
+
+    if allocated == 0 {
+        log::error!("CIDFT Request allocated no forwarding tunnels: rejecting");
+        return HandlerResult::Error(gtp_cause::SYSTEM_FAILURE);
+    }
+
+    log::info!("Allocated {allocated} indirect data-forwarding tunnel(s)");
     HandlerResult::SendPfcp
 }
 
+/// One bearer's forwarding request from a CIDFT Request Bearer Context
+/// (TS 29.274 Table 7.2.18-2).
+#[derive(Debug, Default)]
+pub(crate) struct IndirectForwardingRequest {
+    pub ebi: u8,
+    /// Target eNodeB DL data-forwarding endpoint (instance 0, interface type 19)
+    pub enb_dl_teid: u32,
+    pub enb_dl_ipv4: Option<[u8; 4]>,
+    /// Target eNodeB UL data-forwarding endpoint (instance 4, interface type 20)
+    pub enb_ul_teid: u32,
+    pub enb_ul_ipv4: Option<[u8; 4]>,
+}
+
+/// Parse the Bearer Contexts of a CIDFT Request (TS 29.274 Table 7.2.18-2).
+///
+/// Keyed by INSTANCE (eNodeB DL at 0, eNodeB UL at 4) and cross-checked against the
+/// interface type (§8.22: 19 for eNodeB DL, 20 for eNodeB UL). Both, because an F-TEID
+/// whose instance and interface type disagree is contradictory, and believing the
+/// instance alone would install a forwarding rule in the wrong direction.
+pub(crate) fn parse_indirect_forwarding_request(
+    msg: &Gtp2Message,
+) -> Vec<IndirectForwardingRequest> {
+    /// eNodeB/gNodeB GTP-U interface for DL data forwarding (TS 29.274 §8.22).
+    const ENB_DL_FORWARDING: u8 = 19;
+    /// eNodeB GTP-U interface for UL data forwarding (TS 29.274 §8.22).
+    const ENB_UL_FORWARDING: u8 = 20;
+
+    msg.get_ies(Gtp2IeType::BearerContext as u8)
+        .into_iter()
+        .filter_map(|ie| {
+            let bc = Gtp2BearerContextIe::decode(&ie.value).ok()?;
+            let ebi = bc.ebi().ok()?;
+            let mut req = IndirectForwardingRequest {
+                ebi,
+                ..Default::default()
+            };
+            if let Ok(Some(ft)) = bc.fteid(0) {
+                if ft.interface_type == ENB_DL_FORWARDING {
+                    req.enb_dl_teid = ft.teid;
+                    req.enb_dl_ipv4 = ft.ipv4_addr;
+                } else {
+                    log::debug!(
+                        "CIDFT Request F-TEID at instance 0 has interface type {} (expected {} \
+                         for eNodeB DL forwarding); ignored",
+                        ft.interface_type,
+                        ENB_DL_FORWARDING
+                    );
+                }
+            }
+            if let Ok(Some(ft)) = bc.fteid(4) {
+                if ft.interface_type == ENB_UL_FORWARDING {
+                    req.enb_ul_teid = ft.teid;
+                    req.enb_ul_ipv4 = ft.ipv4_addr;
+                } else {
+                    log::debug!(
+                        "CIDFT Request F-TEID at instance 4 has interface type {} (expected {} \
+                         for eNodeB UL forwarding); ignored",
+                        ft.interface_type,
+                        ENB_UL_FORWARDING
+                    );
+                }
+            }
+            Some(req)
+        })
+        .collect()
+}
+
+/// Resolve a bearer of this UE by EPS Bearer ID.
+fn find_bearer_by_ebi(ctx: &crate::context::SgwcContext, sgwc_ue: &SgwcUe, ebi: u8) -> Option<u64> {
+    for sess_id in &sgwc_ue.sess_ids {
+        let Some(sess) = ctx.sess_find_by_id(*sess_id) else {
+            continue;
+        };
+        for bearer_id in &sess.bearer_ids {
+            if let Some(bearer) = ctx.bearer_find_by_id(*bearer_id) {
+                if bearer.ebi == ebi {
+                    return Some(bearer.id);
+                }
+            }
+        }
+    }
+    None
+}
 /// Handle Delete Indirect Data Forwarding Tunnel Request from MME
 /// Port of sgwc_s11_handle_delete_indirect_data_forwarding_tunnel_request
 pub fn handle_delete_indirect_data_forwarding_tunnel_request(
@@ -624,5 +790,152 @@ mod tests {
     fn test_delete_session_request_no_ue() {
         let result = handle_delete_session_request(None, 1, &[], 5, false);
         matches!(result, HandlerResult::Error(gtp_cause::CONTEXT_NOT_FOUND));
+    }
+
+    /// Build a CIDFT Request the way `mmed` does: one Bearer Context carrying the target
+    /// eNodeB's DL forwarding F-TEID at instance 0 (interface type 19) and its UL one at
+    /// instance 4 (type 20). TS 29.274 Table 7.2.18-2.
+    fn cidft_request(ebi: u8, dl_teid: u32, ul_teid: u32) -> Gtp2Message {
+        use nextgcore_gtp::v2::header::{Gtp2Header, Gtp2MessageType};
+        use nextgcore_gtp::v2::ie::Gtp2FTeidIe;
+
+        let mut msg = Gtp2Message::new(Gtp2Header::new(
+            Gtp2MessageType::CreateIndirectDataForwardingTunnelRequest as u8,
+            0x1234,
+            7,
+        ));
+        let mut bc = Gtp2BearerContextIe::new();
+        bc.set_ebi(ebi);
+        bc.set_fteid(0, &Gtp2FTeidIe::new_ipv4(19, dl_teid, [10, 0, 0, 9]));
+        bc.set_fteid(4, &Gtp2FTeidIe::new_ipv4(20, ul_teid, [10, 0, 0, 10]));
+        msg.add_bearer_context(0, &bc);
+        msg
+    }
+
+    /// #48 criterion 7 and criterion 8's third assertion: a CIDFT Request allocates real
+    /// DL and UL forwarding tunnels, and the response carries their F-TEIDs.
+    ///
+    /// The handler used to ignore the request body, allocate nothing, and return
+    /// `SendPfcp` so the dispatcher answered `REQUEST_ACCEPTED` with no F-TEIDs at all —
+    /// a false success the MME could not distinguish from a working forwarding path. The
+    /// pre-existing `test_indirect_tunnel_responses` asserted only that a Cause IE was
+    /// present, so it passed against exactly that.
+    #[test]
+    fn cidft_request_allocates_forwarding_tunnels_and_the_response_carries_them() {
+        use crate::s11_build::{
+            build_create_indirect_data_forwarding_tunnel_response, f_teid_interface,
+        };
+        let ctx = sgwc_self();
+        ctx.set_gtpu_address(Some(Ipv4Addr::new(10, 11, 0, 7)));
+
+        // Unique IMSI: the context is a process global shared with sibling tests.
+        let ue = ctx
+            .ue_add(&[0x48, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48])
+            .unwrap();
+        let sess = ctx.sess_add(ue.id, "internet").unwrap();
+        let bearer = ctx.bearer_add(sess.id).unwrap();
+        {
+            let mut bearer = ctx.bearer_find_by_id(bearer.id).unwrap();
+            bearer.ebi = 5;
+            ctx.bearer_update(&bearer);
+        }
+        let ue = ctx.ue_find_by_id(ue.id).unwrap();
+
+        let request = cidft_request(5, 0xDDDD, 0xEEEE);
+        let result = handle_create_indirect_data_forwarding_tunnel_request(Some(&ue), 7, &request);
+        assert!(
+            matches!(result, HandlerResult::SendPfcp),
+            "the request must be accepted and gated on the SGW-U, got {result:?}"
+        );
+
+        // Two forwarding tunnels exist, each pointing at the endpoint the MME gave.
+        let bearer = ctx.bearer_find_by_id(bearer.id).unwrap();
+        let mut dl = None;
+        let mut ul = None;
+        for tid in &bearer.tunnel_ids {
+            let t = ctx.tunnel_find_by_id(*tid).unwrap();
+            match t.interface_type {
+                gtp_interface::SGW_GTP_U_DL_DATA_FORWARDING => dl = Some(t),
+                gtp_interface::SGW_GTP_U_UL_DATA_FORWARDING => ul = Some(t),
+                _ => {}
+            }
+        }
+        let dl = dl.expect("a DL data-forwarding tunnel must be allocated");
+        let ul = ul.expect("a UL data-forwarding tunnel must be allocated");
+        assert_ne!(dl.local_teid, 0, "the SGW-U endpoint must be allocated");
+        assert_eq!(dl.remote_teid, 0xDDDD, "the target eNB's DL endpoint");
+        assert_eq!(ul.remote_teid, 0xEEEE, "the target eNB's UL endpoint");
+        assert!(dl.pdr_id.is_some() && dl.far_id.is_some());
+
+        // And the response carries them at the instances TS 29.274 Table 7.2.19-2
+        // assigns, with the interface types NOTE 3 and NOTE 4 mandate.
+        let response = build_create_indirect_data_forwarding_tunnel_response(
+            ue.id,
+            9,
+            gtp_cause::REQUEST_ACCEPTED,
+        )
+        .unwrap();
+        let bc_ie = response
+            .get_ie(Gtp2IeType::BearerContext as u8, 0)
+            .expect("the response must carry a Bearer Context, not a bare accept");
+        let bc = Gtp2BearerContextIe::decode(&bc_ie.value).unwrap();
+        assert_eq!(bc.ebi().unwrap(), 5);
+
+        let dl_ft = bc
+            .fteid(0)
+            .unwrap()
+            .expect("instance 0: S1-U SGW F-TEID for DL data forwarding");
+        assert_eq!(
+            dl_ft.interface_type,
+            f_teid_interface::SGW_GTP_U_DL_DATA_FORWARDING,
+            "Table 7.2.19-2 NOTE 3 fixes the DL interface type at 23"
+        );
+        assert_eq!(dl_ft.interface_type, 23);
+        assert_eq!(dl_ft.teid, dl.local_teid);
+        assert_eq!(dl_ft.ipv4_addr, Some([10, 11, 0, 7]));
+
+        let ul_ft = bc.fteid(4).unwrap().expect(
+            "instance 4: S1-U SGW F-TEID for UL data forwarding; instance 1 is an S12 \
+                     DL endpoint and is where this used to go",
+        );
+        assert_eq!(
+            ul_ft.interface_type,
+            f_teid_interface::SGW_GTP_U_UL_DATA_FORWARDING,
+            "Table 7.2.19-2 NOTE 4 fixes the UL interface type at 28"
+        );
+        assert_eq!(ul_ft.interface_type, 28);
+        assert_eq!(ul_ft.teid, ul.local_teid);
+        assert_ne!(
+            ul_ft.teid, dl_ft.teid,
+            "the two directions must have distinct endpoints"
+        );
+    }
+
+    /// A CIDFT Request with no Bearer Context is malformed (§7.2.18 makes them
+    /// mandatory), so it is REJECTED rather than accepted -- which is what the old
+    /// body-ignoring handler did to every request, including this one.
+    #[test]
+    fn cidft_request_without_bearer_contexts_is_rejected() {
+        use nextgcore_gtp::v2::header::{Gtp2Header, Gtp2MessageType};
+
+        let ctx = sgwc_self();
+        let ue = ctx
+            .ue_add(&[0x48, 0x00, 0x00, 0x00, 0x00, 0x00, 0x49])
+            .unwrap();
+        let ue = ctx.ue_find_by_id(ue.id).unwrap();
+
+        let empty = Gtp2Message::new(Gtp2Header::new(
+            Gtp2MessageType::CreateIndirectDataForwardingTunnelRequest as u8,
+            0x1234,
+            7,
+        ));
+        let result = handle_create_indirect_data_forwarding_tunnel_request(Some(&ue), 7, &empty);
+        assert!(
+            matches!(
+                result,
+                HandlerResult::Error(gtp_cause::MANDATORY_IE_MISSING)
+            ),
+            "expected a mandatory-IE-missing rejection, got {result:?}"
+        );
     }
 }

--- a/src/bins/nextgcore-sgwcd/src/sxa_build.rs
+++ b/src/bins/nextgcore-sgwcd/src/sxa_build.rs
@@ -372,6 +372,80 @@ pub fn build_session_report_response(sess: &SgwcSess, cause: u8) -> Option<PfcpM
 ///
 /// The PDR matches inbound traffic on the tunnel's own F-TEID and strips the GTP-U
 /// header; the FAR forwards it to the peer endpoint, or buffers when there is not one yet.
+/// Build the Session Modification that installs the indirect data-forwarding rules
+/// (#48, TS 23.401 §5.5.1.2).
+///
+/// One Create PDR / Create FAR pair per forwarding tunnel. The direction mapping is the
+/// forwarding path's, not the serving path's:
+///
+/// - the DL forwarding tunnel receives from the SOURCE eNB (ACCESS) and forwards to the
+///   TARGET eNB (also ACCESS) -- both ends are radio, which is what makes indirect
+///   forwarding an eNB-to-eNB relay through the SGW-U rather than a core-bound path;
+/// - the UL forwarding tunnel is the mirror.
+///
+/// So both PDI source and FAR destination are ACCESS, unlike every other rule this
+/// module builds. Getting that wrong would send forwarded user data out of the SGi
+/// interface.
+pub fn build_indirect_forwarding_rules(sess: &SgwcSess, bearer_ids: &[u64]) -> Option<PfcpMessage> {
+    let ctx = sgwc_self();
+
+    let mut msg = PfcpMessage::new(pfcp_type::SESSION_MODIFICATION_REQUEST, sess.sgwu_sxa_seid);
+    let mut req = LibSessionModificationRequest::new();
+    let mut rules = 0usize;
+
+    for bearer_id in bearer_ids {
+        let Some(bearer) = ctx.bearer_find_by_id(*bearer_id) else {
+            continue;
+        };
+        for tunnel_id in &bearer.tunnel_ids {
+            let Some(tunnel) = ctx.tunnel_find_by_id(*tunnel_id) else {
+                continue;
+            };
+            if !matches!(
+                tunnel.interface_type,
+                crate::context::gtp_interface::SGW_GTP_U_DL_DATA_FORWARDING
+                    | crate::context::gtp_interface::SGW_GTP_U_UL_DATA_FORWARDING
+            ) {
+                continue;
+            }
+            let mut create = LibSessionEstablishmentRequest::new(
+                NodeId::new_ipv4([0, 0, 0, 0]),
+                FSeid::new_ipv4(0, [0, 0, 0, 0]),
+            );
+            push_create_rules(
+                &mut create,
+                &tunnel,
+                pfcp_interface::ACCESS,
+                pfcp_interface::ACCESS,
+            );
+            rules += create.create_pdrs.len();
+            req.create_pdrs.extend(create.create_pdrs);
+            req.create_fars.extend(create.create_fars);
+        }
+    }
+
+    // No rules means no forwarding tunnel had a usable PDR id, so there is nothing to
+    // install. Sending an empty modification would be answered `REQUEST_ACCEPTED` and
+    // would gate the S11 answer on a message that provisioned nothing.
+    if rules == 0 {
+        log::error!(
+            "No indirect forwarding rules to install for session {}",
+            sess.id
+        );
+        return None;
+    }
+
+    let mut body = BytesMut::new();
+    req.encode(&mut body);
+    msg.data = body.to_vec();
+    log::debug!(
+        "Built indirect forwarding Session Modification: seid=0x{:x}, rules={rules}, len={}",
+        msg.seid,
+        msg.data.len()
+    );
+    Some(msg)
+}
+
 fn push_create_rules(
     req: &mut LibSessionEstablishmentRequest,
     tunnel: &SgwcTunnel,

--- a/src/bins/nextgcore-sgwcd/src/sxa_response.rs
+++ b/src/bins/nextgcore-sgwcd/src/sxa_response.rs
@@ -30,16 +30,71 @@ pub fn dispatch(sess_id: u64, continuation: S11Continuation, resp_type: u8, body
         }
         pfcp_msg_type::SESSION_DELETION_RESPONSE => deletion_response(sess_id, continuation, body),
         pfcp_msg_type::SESSION_MODIFICATION_RESPONSE => {
-            // Modification responses gate no S11 procedure today (see the spec's
-            // ceiling); the cause is logged so a rejected modification is not silent.
             let cause = find_cause(body);
             if cause != Some(sxa_handler::pfcp_cause::REQUEST_ACCEPTED) {
                 log::warn!(
                     "PFCP Session Modification for session {sess_id} was REJECTED: cause={cause:?}"
                 );
             }
+            // #48: ONE modification now gates an S11 procedure -- the indirect
+            // forwarding install. Every other modification still gates nothing, which is
+            // why this dispatches on the continuation rather than on the response.
+            if let S11Continuation::IndirectForwarding { .. } = continuation {
+                indirect_forwarding_response(continuation, cause);
+            }
         }
         other => log::warn!("Unexpected PFCP response type {other} for session {sess_id}"),
+    }
+}
+
+/// Answer the MME's Create Indirect Data Forwarding Tunnel Request now that the SGW-U
+/// has spoken (#48).
+///
+/// The response is built by `s11_build`, not by [`answer`], because a bare cause is not
+/// enough: TS 29.274 Table 7.2.19-2 wants the per-bearer forwarding F-TEIDs, and those
+/// are the whole point of the procedure. A cause-only accept is what this used to send.
+fn indirect_forwarding_response(continuation: S11Continuation, pfcp_cause: Option<u8>) {
+    let S11Continuation::IndirectForwarding {
+        peer,
+        seq,
+        teid,
+        sgwc_ue_id,
+    } = continuation
+    else {
+        return;
+    };
+
+    let accepted = pfcp_cause == Some(sxa_handler::pfcp_cause::REQUEST_ACCEPTED);
+    let cause = if accepted {
+        gtp_cause::REQUEST_ACCEPTED
+    } else {
+        log::warn!(
+            "Create Indirect Data Forwarding Tunnel Response to {peer} carries a failure: the \
+             SGW-U refused the forwarding rules (pfcp_cause={pfcp_cause:?})"
+        );
+        gtp_cause::SYSTEM_FAILURE
+    };
+
+    let Some(server) = gtp_path::s11_server() else {
+        log::error!("S11 server not open: cannot answer {peer}");
+        return;
+    };
+    match s11_build::build_create_indirect_data_forwarding_tunnel_response(sgwc_ue_id, seq, cause) {
+        Ok(response) => {
+            if let Err(e) = server.send_response(peer, &response) {
+                log::error!("Indirect tunnel response to {peer} failed: {e}");
+            }
+        }
+        Err(e) => {
+            log::error!("Failed to build indirect tunnel response: {e}");
+            answer(
+                peer,
+                Gtp2MessageType::CreateIndirectDataForwardingTunnelResponse,
+                teid,
+                seq,
+                gtp_cause::SYSTEM_FAILURE,
+            );
+        }
     }
 }
 
@@ -67,6 +122,17 @@ pub fn fail_with_cause(continuation: S11Continuation, cause: u8) {
             answer(
                 peer,
                 Gtp2MessageType::DeleteSessionResponse,
+                teid,
+                seq,
+                cause,
+            );
+        }
+        S11Continuation::IndirectForwarding {
+            peer, seq, teid, ..
+        } => {
+            answer(
+                peer,
+                Gtp2MessageType::CreateIndirectDataForwardingTunnelResponse,
                 teid,
                 seq,
                 cause,
@@ -112,6 +178,24 @@ pub fn fail(continuation: S11Continuation, reason: &str) {
             answer(
                 peer,
                 Gtp2MessageType::DeleteSessionResponse,
+                teid,
+                seq,
+                gtp_cause::REMOTE_PEER_NOT_RESPONDING,
+            );
+        }
+        S11Continuation::IndirectForwarding {
+            peer, seq, teid, ..
+        } => {
+            // #48: the MME is waiting to send its Handover Command. Answering a failure
+            // now lets the handover proceed WITHOUT forwarding, which loses buffered
+            // downlink data -- but leaving the MME to time out loses the handover.
+            log::error!(
+                "Create Indirect Data Forwarding Tunnel Response to {peer} carries a failure: \
+                 the SGW-U never installed the forwarding rules ({reason})"
+            );
+            answer(
+                peer,
+                Gtp2MessageType::CreateIndirectDataForwardingTunnelResponse,
                 teid,
                 seq,
                 gtp_cause::REMOTE_PEER_NOT_RESPONDING,

--- a/src/libs/nextgcore-asn1c/src/s1ap/types.rs
+++ b/src/libs/nextgcore-asn1c/src/s1ap/types.rs
@@ -174,6 +174,12 @@ impl ProtocolIeId {
     pub const E_RAB_SETUP_ITEM_BEARER_SU_RES: Self = Self(39);
     pub const SECURITY_CONTEXT: Self = Self(40);
     pub const HANDOVER_RESTRICTION_LIST: Self = Self(41);
+    /// `id-Direct-Forwarding-Path-Availability` (TS 36.413 §9.3.5, ProtocolIE-ID 79).
+    ///
+    /// Read from the vendored spec (`6g_docs/specs/36413-j20.txt:34389`), not inferred
+    /// from neighbouring ids: 79 sits between `id-UEIdentityIndexValue` (80) and the
+    /// 60s, nowhere near the handover IEs, so guessing from context gets it wrong.
+    pub const DIRECT_FORWARDING_PATH_AVAILABILITY: Self = Self(79);
     pub const UE_PAGING_ID: Self = Self(43);
     pub const PAGING_DRX: Self = Self(44);
     pub const TAI_LIST: Self = Self(46);

--- a/src/libs/nextgcore-s1ap/src/builder.rs
+++ b/src/libs/nextgcore-s1ap/src/builder.rs
@@ -654,12 +654,52 @@ pub fn build_handover_required(msg: &HandoverRequired) -> S1apResult<Vec<u8>> {
     ie::encode_handover_type(&mut container, msg.handover_type)?;
     ie::encode_cause(&mut container, &msg.cause)?;
     ie::encode_target_id(&mut container, &msg.target_id)?;
+    if let Some(availability) = msg.direct_forwarding_path_availability {
+        ie::encode_direct_forwarding_path_availability(&mut container, availability)?;
+    }
     ie::encode_source_to_target_container(&mut container, &msg.source_to_target_container)?;
 
     encode_pdu(&initiating(
         ProcedureCode::HANDOVER_PREPARATION,
         Criticality::Reject,
         InitiatingMessageValue::HandoverRequired(container),
+    ))
+}
+
+/// Build an eNB Status Transfer PDU (TS 36.413 §8.4.6, procedure code 24).
+///
+/// The MME never sends this -- the source eNB does. It exists so a test can produce a
+/// real one, and because a builder that can only construct half of a relay cannot
+/// prove the relay preserves anything.
+pub fn build_enb_status_transfer(msg: &EnbStatusTransfer) -> S1apResult<Vec<u8>> {
+    let mut container = ProtocolIeContainer::new();
+    ie::encode_mme_ue_s1ap_id(&mut container, msg.mme_ue_s1ap_id, Criticality::Reject)?;
+    ie::encode_enb_ue_s1ap_id(&mut container, msg.enb_ue_s1ap_id, Criticality::Reject)?;
+    ie::encode_enb_status_transfer_container(&mut container, &msg.status_transfer_container)?;
+
+    encode_pdu(&initiating(
+        ProcedureCode::ENB_STATUS_TRANSFER,
+        Criticality::Ignore,
+        InitiatingMessageValue::Other(container),
+    ))
+}
+
+/// Build an MME Status Transfer PDU (TS 36.413 §8.4.7, procedure code 25).
+///
+/// Criticality `ignore` for both: §8.4.7 makes the whole procedure best-effort from the
+/// target's point of view -- a target that cannot use the status still completes the
+/// handover, it just re-establishes PDCP. Rejecting would turn a continuity
+/// optimisation into a handover failure.
+pub fn build_mme_status_transfer(msg: &MmeStatusTransfer) -> S1apResult<Vec<u8>> {
+    let mut container = ProtocolIeContainer::new();
+    ie::encode_mme_ue_s1ap_id(&mut container, msg.mme_ue_s1ap_id, Criticality::Reject)?;
+    ie::encode_enb_ue_s1ap_id(&mut container, msg.enb_ue_s1ap_id, Criticality::Reject)?;
+    ie::encode_enb_status_transfer_container(&mut container, &msg.status_transfer_container)?;
+
+    encode_pdu(&initiating(
+        ProcedureCode::MME_STATUS_TRANSFER,
+        Criticality::Ignore,
+        InitiatingMessageValue::Other(container),
     ))
 }
 

--- a/src/libs/nextgcore-s1ap/src/ie.rs
+++ b/src/libs/nextgcore-s1ap/src/ie.rs
@@ -35,6 +35,10 @@ const EXTENDED_RNC_ID_CONSTRAINT: Constraint = Constraint::new(4096, 65535);
 /// `CSFallbackIndicator ::= ENUMERATED { cs-fallback-required, ...,
 /// cs-fallback-high-priority }`: one root value, one extension addition.
 const CS_FALLBACK_INDICATOR_CONSTRAINT: Constraint = Constraint::extensible(0, 0);
+/// `Direct-Forwarding-Path-Availability ::= ENUMERATED { directPathAvailable, ... }`:
+/// one root value and an extension marker, so the root needs no value bits at all and
+/// the IE's PRESENCE is what carries the meaning.
+const DIRECT_FORWARDING_PATH_AVAILABILITY_CONSTRAINT: Constraint = Constraint::extensible(0, 0);
 /// `OverloadAction ::= ENUMERATED { .. 3 root values .., ..., 4 additions }`
 const OVERLOAD_ACTION_CONSTRAINT: Constraint = Constraint::extensible(0, 2);
 /// `SubscriberProfileIDforRFP ::= INTEGER (1..256)`
@@ -2619,6 +2623,71 @@ pub fn decode_erab_data_forwarding_list(
         ProtocolIeId::E_RAB_DATA_FORWARDING_ITEM,
         decode_erab_data_forwarding_item,
     )
+}
+
+// ============================================================================
+// Status Transfer IEs (§9.1.5.6 / §9.1.5.7)
+// ============================================================================
+
+/// Push an `ENB-StatusTransfer-TransparentContainer` IE carrying `value` verbatim.
+///
+/// The bytes are installed as the open-type value with NO re-encoding, which is what
+/// makes the MME's relay byte-preserving (TS 36.413 §8.4.7). Going through `push_ie`
+/// would run them back through an `AperEncoder`, and an encoder that pads or aligns
+/// differently from the peer that produced them would change the PDCP SN/HFN status
+/// the procedure exists to carry intact.
+pub fn encode_enb_status_transfer_container(
+    container: &mut ProtocolIeContainer,
+    value: &[u8],
+) -> S1apResult<()> {
+    container.push(ProtocolIeField {
+        id: ProtocolIeId::ENB_STATUS_TRANSFER_TRANSPARENT_CONTAINER,
+        criticality: Criticality::Reject,
+        value: value.to_vec(),
+    });
+    Ok(())
+}
+
+/// The raw open-type value of an `ENB-StatusTransfer-TransparentContainer` IE.
+///
+/// Not decoded into a `Bearers-SubjectToStatusTransfer` model on purpose; see
+/// [`crate::types::EnbStatusTransfer::status_transfer_container`].
+pub fn decode_enb_status_transfer_container(field: &ProtocolIeField) -> S1apResult<Vec<u8>> {
+    Ok(field.value.clone())
+}
+
+/// Push a `Direct-Forwarding-Path-Availability` IE (TS 36.413 §9.2.1.16).
+pub fn encode_direct_forwarding_path_availability(
+    container: &mut ProtocolIeContainer,
+    value: DirectForwardingPathAvailability,
+) -> S1apResult<()> {
+    let index = match value {
+        DirectForwardingPathAvailability::DirectPathAvailable => 0,
+    };
+    push_ie(
+        container,
+        ProtocolIeId::DIRECT_FORWARDING_PATH_AVAILABILITY,
+        Criticality::Ignore,
+        |encoder| {
+            encoder.encode_enumerated(index, &DIRECT_FORWARDING_PATH_AVAILABILITY_CONSTRAINT)?;
+            Ok(())
+        },
+    )
+}
+
+/// Decode a `Direct-Forwarding-Path-Availability` IE.
+///
+/// An unknown value is an EXTENSION ADDITION, not a protocol error: the ASN.1 marks
+/// the type extensible, and §9.2.1.16's only defined root value already means "a
+/// direct path is available". A future addition still tells us that much, so it is
+/// mapped to the root value rather than rejected -- refusing it would fail a handover
+/// over an IE whose criticality is `ignore`.
+pub fn decode_direct_forwarding_path_availability(
+    field: &ProtocolIeField,
+) -> S1apResult<DirectForwardingPathAvailability> {
+    let mut decoder = AperDecoder::new(&field.value);
+    let _ = decoder.decode_enumerated(&DIRECT_FORWARDING_PATH_AVAILABILITY_CONSTRAINT)?;
+    Ok(DirectForwardingPathAvailability::DirectPathAvailable)
 }
 
 // ============================================================================

--- a/src/libs/nextgcore-s1ap/src/parser.rs
+++ b/src/libs/nextgcore-s1ap/src/parser.rs
@@ -52,6 +52,8 @@ pub enum S1apMessage {
     PathSwitchRequestFailure(PathSwitchRequestFailure),
     HandoverCancel(HandoverCancel),
     HandoverCancelAcknowledge(HandoverCancelAcknowledge),
+    EnbStatusTransfer(EnbStatusTransfer),
+    MmeStatusTransfer(MmeStatusTransfer),
     UeCapabilityInfoIndication(UeCapabilityInfoIndication),
     EnbConfigurationUpdate(EnbConfigurationUpdate),
     EnbConfigurationUpdateAcknowledge(EnbConfigurationUpdateAcknowledge),
@@ -208,6 +210,12 @@ fn decode_initiating(
         ProcedureCode::HANDOVER_CANCEL => {
             Ok(S1apMessage::HandoverCancel(parse_handover_cancel(ies)?))
         }
+        ProcedureCode::ENB_STATUS_TRANSFER => Ok(S1apMessage::EnbStatusTransfer(
+            parse_enb_status_transfer(ies)?,
+        )),
+        ProcedureCode::MME_STATUS_TRANSFER => Ok(S1apMessage::MmeStatusTransfer(
+            parse_mme_status_transfer(ies)?,
+        )),
         ProcedureCode::UE_CAPABILITY_INFO_INDICATION => Ok(
             S1apMessage::UeCapabilityInfoIndication(parse_ue_capability_info_indication(ies)?),
         ),
@@ -1040,6 +1048,7 @@ fn parse_handover_required(container: ProtocolIeContainer) -> S1apResult<Handove
     let mut handover_type = None;
     let mut cause = None;
     let mut target_id = None;
+    let mut direct_forwarding_path_availability = None;
     let mut source_to_target_container = None;
 
     for field in &container.ies {
@@ -1059,6 +1068,10 @@ fn parse_handover_required(container: ProtocolIeContainer) -> S1apResult<Handove
             ProtocolIeId::TARGET_ID => {
                 target_id = Some(ie::decode_target_id(field)?);
             }
+            ProtocolIeId::DIRECT_FORWARDING_PATH_AVAILABILITY => {
+                direct_forwarding_path_availability =
+                    Some(ie::decode_direct_forwarding_path_availability(field)?);
+            }
             ProtocolIeId::SOURCE_TO_TARGET_TRANSPARENT_CONTAINER => {
                 source_to_target_container = Some(ie::decode_source_to_target_container(field)?);
             }
@@ -1072,10 +1085,68 @@ fn parse_handover_required(container: ProtocolIeContainer) -> S1apResult<Handove
         handover_type: handover_type.ok_or(S1apError::MissingMandatoryIe("HandoverType"))?,
         cause: cause.ok_or(S1apError::MissingMandatoryIe("Cause"))?,
         target_id: target_id.ok_or(S1apError::MissingMandatoryIe("TargetID"))?,
+        direct_forwarding_path_availability,
         source_to_target_container: source_to_target_container.ok_or(
             S1apError::MissingMandatoryIe("Source-ToTarget-TransparentContainer"),
         )?,
     })
+}
+
+/// Parse an eNB Status Transfer (TS 36.413 §9.1.5.6). All three IEs are mandatory.
+fn parse_enb_status_transfer(container: ProtocolIeContainer) -> S1apResult<EnbStatusTransfer> {
+    let (mme_ue_s1ap_id, enb_ue_s1ap_id, status_transfer_container) =
+        parse_status_transfer_ies(&container)?;
+    Ok(EnbStatusTransfer {
+        mme_ue_s1ap_id,
+        enb_ue_s1ap_id,
+        status_transfer_container,
+    })
+}
+
+/// Parse an MME Status Transfer (TS 36.413 §9.1.5.7).
+///
+/// The MME sends this, so an MME receiving one is a protocol error -- but decoding it
+/// is what lets the receiver SAY so with the right cause instead of answering
+/// "abstract syntax error" to a message it understands perfectly well. It is also what
+/// a test needs to assert the relay is byte-identical.
+fn parse_mme_status_transfer(container: ProtocolIeContainer) -> S1apResult<MmeStatusTransfer> {
+    let (mme_ue_s1ap_id, enb_ue_s1ap_id, status_transfer_container) =
+        parse_status_transfer_ies(&container)?;
+    Ok(MmeStatusTransfer {
+        mme_ue_s1ap_id,
+        enb_ue_s1ap_id,
+        status_transfer_container,
+    })
+}
+
+/// The IE set shared by §9.1.5.6 and §9.1.5.7, which is identical in both.
+fn parse_status_transfer_ies(container: &ProtocolIeContainer) -> S1apResult<(u32, u32, Vec<u8>)> {
+    let mut mme_ue_s1ap_id = None;
+    let mut enb_ue_s1ap_id = None;
+    let mut status_container = None;
+
+    for field in &container.ies {
+        match field.id {
+            ProtocolIeId::MME_UE_S1AP_ID => {
+                mme_ue_s1ap_id = Some(ie::decode_mme_ue_s1ap_id(field)?);
+            }
+            ProtocolIeId::ENB_UE_S1AP_ID => {
+                enb_ue_s1ap_id = Some(ie::decode_enb_ue_s1ap_id(field)?);
+            }
+            ProtocolIeId::ENB_STATUS_TRANSFER_TRANSPARENT_CONTAINER => {
+                status_container = Some(ie::decode_enb_status_transfer_container(field)?);
+            }
+            _ => {}
+        }
+    }
+
+    Ok((
+        mme_ue_s1ap_id.ok_or(S1apError::MissingMandatoryIe("MME-UE-S1AP-ID"))?,
+        enb_ue_s1ap_id.ok_or(S1apError::MissingMandatoryIe("eNB-UE-S1AP-ID"))?,
+        status_container.ok_or(S1apError::MissingMandatoryIe(
+            "eNB-StatusTransfer-TransparentContainer",
+        ))?,
+    ))
 }
 
 fn parse_handover_command(container: ProtocolIeContainer) -> S1apResult<HandoverCommand> {

--- a/src/libs/nextgcore-s1ap/src/types.rs
+++ b/src/libs/nextgcore-s1ap/src/types.rs
@@ -438,8 +438,69 @@ pub struct HandoverRequired {
     pub cause: Cause,
     /// Target ID
     pub target_id: TargetId,
+    /// Direct Forwarding Path Availability (optional, TS 36.413 §8.4.1.2).
+    ///
+    /// Present means the source eNB has a direct X2/transport path to the target, so
+    /// the MME must NOT set up indirect forwarding through the Serving GW. Absent
+    /// means no direct path is available, which is what selects indirect forwarding.
+    /// `Direct-Forwarding-Path-Availability ::= ENUMERATED { directPathAvailable,
+    /// ... }` has exactly one root value, so its presence carries the whole meaning
+    /// -- which is why this is an `Option<()>`-shaped enum rather than a bool with a
+    /// default: "absent" and "present" are the two states, and a `bool` would invite
+    /// a caller to write `false` where the wire has no IE at all.
+    pub direct_forwarding_path_availability: Option<DirectForwardingPathAvailability>,
     /// Source to Target Transparent Container
     pub source_to_target_container: Vec<u8>,
+}
+
+/// Direct Forwarding Path Availability (TS 36.413 §9.2.1.16).
+///
+/// ASN.1: `Direct-Forwarding-Path-Availability ::= ENUMERATED { directPathAvailable,
+/// ... }` -- one root value plus an extension marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectForwardingPathAvailability {
+    /// `directPathAvailable`: the source eNB can forward straight to the target.
+    DirectPathAvailable,
+}
+
+/// eNB Status Transfer - sent by the source eNB to the MME (TS 36.413 §8.4.6).
+///
+/// Carries the PDCP SN and HFN receiver/transmitter status for each E-RAB to which
+/// PDCP-SN and HFN status preservation applies, so the target eNB can continue the
+/// RLC-AM bearers without a PDCP re-establishment. The MME's job is to relay it
+/// (§8.4.7), not to interpret it.
+#[derive(Debug, Clone)]
+pub struct EnbStatusTransfer {
+    /// MME UE S1AP ID (the SOURCE side's, since the source eNB sends this)
+    pub mme_ue_s1ap_id: u32,
+    /// eNB UE S1AP ID (the source eNB's)
+    pub enb_ue_s1ap_id: u32,
+    /// `ENB-StatusTransfer-TransparentContainer`, held as the RAW APER-encoded
+    /// open-type value of the IE rather than as a decoded structure.
+    ///
+    /// Deliberate. §8.4.6 makes this a container the MME forwards, and the whole
+    /// point of the procedure is that the PDCP SN/HFN counts reach the target
+    /// UNCHANGED. Decoding into a `Bearers-SubjectToStatusTransfer` model and
+    /// re-encoding would put a codec this tree does not need between the two eNBs,
+    /// where any modelling gap silently becomes a corrupted PDCP count -- which is
+    /// exactly the failure the procedure exists to prevent. Carrying the bytes makes
+    /// byte-preservation a property of the type rather than of a test.
+    pub status_transfer_container: Vec<u8>,
+}
+
+/// MME Status Transfer - sent by the MME to the target eNB (TS 36.413 §8.4.7).
+///
+/// The relay half of the eNB Status Transfer. Same IE set, with the ids of the
+/// TARGET eNB's UE association rather than the source's.
+#[derive(Debug, Clone)]
+pub struct MmeStatusTransfer {
+    /// MME UE S1AP ID of the TARGET association
+    pub mme_ue_s1ap_id: u32,
+    /// eNB UE S1AP ID allocated by the TARGET eNB
+    pub enb_ue_s1ap_id: u32,
+    /// The container relayed verbatim from the eNB Status Transfer. See
+    /// [`EnbStatusTransfer::status_transfer_container`].
+    pub status_transfer_container: Vec<u8>,
 }
 
 /// Handover Command - sent by MME to source eNB

--- a/src/libs/nextgcore-s1ap/tests/roundtrip.rs
+++ b/src/libs/nextgcore-s1ap/tests/roundtrip.rs
@@ -767,6 +767,9 @@ fn handover_required_roundtrip() {
             },
             selected_tai: sample_tai(),
         },
+        direct_forwarding_path_availability: Some(
+            DirectForwardingPathAvailability::DirectPathAvailable,
+        ),
         source_to_target_container: vec![1, 2, 3, 4, 5],
     };
     let bytes = build_handover_required(&msg).unwrap();
@@ -775,6 +778,99 @@ fn handover_required_roundtrip() {
             assert_eq!(decoded.handover_type, HandoverType::IntraLte);
             assert_eq!(decoded.target_id, msg.target_id);
             assert_eq!(decoded.source_to_target_container, vec![1, 2, 3, 4, 5]);
+            // #48: the IE that decides direct vs. indirect forwarding. Asserted here
+            // because the MME's whole forwarding decision rests on it, and the
+            // absent case is covered by the two sibling tests below -- which is the
+            // half that matters, since ABSENT is what selects indirect forwarding.
+            assert_eq!(
+                decoded.direct_forwarding_path_availability,
+                Some(DirectForwardingPathAvailability::DirectPathAvailable)
+            );
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+}
+
+/// #48: a Handover Required with NO Direct Forwarding Path Availability IE decodes to
+/// `None`, which is what makes the MME choose indirect forwarding. Separate from the
+/// present-case assertion above because a decoder that hard-coded `Some(..)` would
+/// pass that one.
+#[test]
+fn handover_required_without_direct_forwarding_availability_decodes_to_none() {
+    let msg = HandoverRequired {
+        mme_ue_s1ap_id: 7,
+        enb_ue_s1ap_id: 8,
+        handover_type: HandoverType::IntraLte,
+        cause: Cause::RadioNetwork(CauseRadioNetwork::HandoverDesirableForRadioReason),
+        target_id: TargetId::TargetEnbId {
+            global_enb_id: GlobalEnbId {
+                plmn_identity: PLMN,
+                enb_id: EnbId::Macro(0x11111),
+            },
+            selected_tai: sample_tai(),
+        },
+        direct_forwarding_path_availability: None,
+        source_to_target_container: vec![0xAA],
+    };
+    let bytes = build_handover_required(&msg).unwrap();
+    match decode_s1ap_pdu(&bytes).unwrap() {
+        S1apMessage::HandoverRequired(decoded) => {
+            assert_eq!(
+                decoded.direct_forwarding_path_availability, None,
+                "an absent IE must not become Some(..); indirect forwarding depends on it"
+            );
+            assert_eq!(decoded.source_to_target_container, vec![0xAA]);
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+}
+
+/// #48 criterion 2: the eNB Status Transfer container survives source -> MME -> target
+/// UNCHANGED (TS 36.413 §8.4.6/§8.4.7).
+///
+/// The container is a `SEQUENCE`, not an `OCTET STRING`, so "byte-preserving" is a real
+/// claim and not a tautology: this decodes a real eNB Status Transfer, relays the
+/// container into an MME Status Transfer under the TARGET's UE ids, and decodes that
+/// back. The payload is asserted equal; the ids are asserted DIFFERENT, since relaying
+/// the source's ids to the target is the obvious way to get this wrong.
+#[test]
+fn status_transfer_container_round_trips_source_to_target_unchanged() {
+    // Shaped like a real Bearers-SubjectToStatusTransfer payload rather than a flat
+    // run of one byte, so a codec that truncated or padded would show up.
+    let payload = vec![0x00, 0x01, 0xF0, 0x0D, 0x7F, 0x80, 0x00, 0x2A, 0xFF];
+
+    let from_source = build_enb_status_transfer(&EnbStatusTransfer {
+        mme_ue_s1ap_id: 1001,
+        enb_ue_s1ap_id: 11,
+        status_transfer_container: payload.clone(),
+    })
+    .unwrap();
+
+    let decoded_at_mme = match decode_s1ap_pdu(&from_source).unwrap() {
+        S1apMessage::EnbStatusTransfer(m) => m,
+        other => panic!("unexpected message: {other:?}"),
+    };
+    assert_eq!(
+        decoded_at_mme.status_transfer_container, payload,
+        "the MME must receive the container the source eNB sent"
+    );
+
+    let to_target = build_mme_status_transfer(&MmeStatusTransfer {
+        mme_ue_s1ap_id: 2002,
+        enb_ue_s1ap_id: 22,
+        status_transfer_container: decoded_at_mme.status_transfer_container.clone(),
+    })
+    .unwrap();
+
+    match decode_s1ap_pdu(&to_target).unwrap() {
+        S1apMessage::MmeStatusTransfer(m) => {
+            assert_eq!(
+                m.status_transfer_container, payload,
+                "the target eNB must receive the SOURCE's container byte for byte; a \
+                 modified PDCP SN/HFN status is worse than none"
+            );
+            assert_eq!(m.mme_ue_s1ap_id, 2002, "relayed under the target's ids");
+            assert_eq!(m.enb_ue_s1ap_id, 22);
         }
         other => panic!("unexpected message: {other:?}"),
     }
@@ -793,6 +889,7 @@ fn handover_required_target_rnc_roundtrip() {
             rac: Some(0x42),
             rnc_id: 5000, // > 4095, exercises extendedRNC-ID
         },
+        direct_forwarding_path_availability: None,
         source_to_target_container: vec![9, 9],
     };
     let bytes = build_handover_required(&msg).unwrap();
@@ -817,6 +914,7 @@ fn handover_required_target_cgi_roundtrip() {
             ci: 0x0002,
             rac: None,
         },
+        direct_forwarding_path_availability: None,
         source_to_target_container: vec![7],
     };
     let bytes = build_handover_required(&msg).unwrap();


### PR DESCRIPTION
Closes #48 — both workstreams. #48 calls them "independently testable", which they are, but it marks neither separable, and the forwarding path does not exist unless both land: the MME's CIDFT request and the SGW's response are two halves of one F-TEID exchange.

## Claim-vs-site-vs-still-true

Re-located against `741f0e9`. All twelve claims held. Two IE numbers the issue does *not* mention turned out to be wrong.

| # | #48's claim | still true? |
|---|---|---|
| 1 | no eNB/MME Status Transfer decode; proc 24 a dead enum entry | **yes** |
| 2 | a mid-handover STATUS TRANSFER is answered with Error Indication | **yes** |
| 3 | `HandoverRequired` has no Direct Forwarding Path Availability field | **yes** |
| 4 | `ErabAdmittedItem` DOES decode the DL/UL forwarding TEIDs | **yes** — decoded, then discarded |
| 5 | the ack handler stores only `gtp_teid`/`transport_layer_address` | **yes** |
| 6 | `HandoverCommand` always built with an empty forwarding list | **yes** |
| 7 | `handle_handover_cancel` never releases the target | **yes** |
| 8 | no handover-preparation supervision timer | **yes** |
| 9 | the dispatcher passes `&[]` into the CIDFT handlers | **yes** |
| 10 | the CIDFT handler ignores the body and allocates nothing | **yes** |
| 11 | `bearer_add` never adds forwarding tunnel types | **yes** |
| 12 | forwarding F-TEIDs emitted only for tunnels that never exist | **yes** |

### Three wire constants were wrong, and all three were inert

Found while making the CIDFT path reachable. Read from the vendored spec (`6g_docs/specs/29274-j60.txt`), not from memory:

| constant | said | TS 29.274 §8.22 says | what the wrong value meant |
|---|---|---|---|
| `mmed` `S1U_ENB_GTP_U_DL_FORWARDING` | 4 | **19** eNodeB GTP-U for DL data forwarding | 4 is "S5/S8 SGW GTP-U interface" |
| `sgwcd` `SGW_GTP_U_DL_DATA_FORWARDING` | 22 | **23** (Table 7.2.19-2 NOTE 3) | 22 is "SGSN GTP-U for data forwarding" |
| `sgwcd` `SGW_GTP_U_UL_DATA_FORWARDING` | 23 | **28** (Table 7.2.19-2 NOTE 4) | 23 is the DL value — both directions identical |

Plus an instance number: `sgwcd` emitted its UL forwarding F-TEID at **instance 1**, which Table 7.2.19-2 assigns to "S12 SGW F-TEID for DL data forwarding". A conformant MME would have read the UL endpoint as a second DL one, on an interface this deployment does not have. Now instance **4**. `mmed` had no UL constant at all, so the UL half of a pair was inexpressible.

Same latency that hid `smfd`'s `S_NSSAI = 250` (#321): a hand-maintained wire table is wrong and nothing notices because the emitting branch has no caller. Both crates now carry `f_teid_interface_types_match_ts29274_clause_8_22`, asserting the numbers as literals against the clause.

## Status Transfer (criteria 1, 2)

The container is carried as the **raw APER open-type value** and re-emitted verbatim, never decoded. §8.4.6 exists so the PDCP SN/HFN counts arrive UNCHANGED; a `Bearers-SubjectToStatusTransfer` codec between the two eNBs would turn every modelling gap into a silently corrupted count. `encode_enb_status_transfer_container` pushes a `ProtocolIeField` directly rather than through `push_ie` for the same reason — re-running the bytes through an `AperEncoder` that pads differently from the peer that produced them is precisely the corruption to avoid. **Byte-preservation becomes a property of the type, not of a test.**

## Direct vs. indirect forwarding (criteria 3, 4, 5)

IE **79**, read from `36413-j20.txt:34389`. A value guessed from neighbouring handover IEs would be wrong: 79 sits between the 60s and `id-UEIdentityIndexValue`, nowhere near them.

Modelled as `Option<DirectForwardingPathAvailability>`, not `bool`: the ASN.1 has exactly one root value, so PRESENCE carries the whole meaning, and a `bool` invites a caller to write `false` where the wire has no IE at all. **Absent selects indirect forwarding** — the half that matters.

### The deferral is not an optimisation

For the indirect case the Handover Command **cannot** be built when the ack arrives: the endpoints the source must forward to are the SGW's, and the SGW allocates them in the CIDFT Response. So `mmed` sends the CIDFT, returns nothing, and sends the command from the response path. That is the only order in which the command can carry real endpoints.

The ack's contribution is parked as `PendingHandoverCommand` and **taken**, not cloned, when the response lands — TS 29.274 §7.6 makes a GTP-C response retransmittable, and a second Handover Command would have the source hand the UE over twice.

When the SGW refuses, the handover **completes without forwarding** and says so. Falling through with the *target's* endpoints instead would tell the source to forward over a path it just said it does not have — black-holing the data rather than dropping it.

## Cancel and supervision (criterion 6)

The prepared target is told to release (cause `handover-cancelled`) **before** the MME drops its record. Freeing only our copy leaves the target holding radio, an S1-U endpoint and a UE context with nothing left that could ask for them back, since the ids that addressed it are gone.

The supervision timer rides `MmeApp::run`'s existing 100 ms tick the way `nas_timer::expire_nas_timers` does — no extra task, and it cannot silently stop firing. 10 s is a local choice (TS 36.413 names TS1RELOCprep/TS1RELOCoverall for the *source* eNB), deliberately longer than the source's own timer so this fires only when the source went away too — the case that used to leak the context forever. Cause `tS1relocoverall-expiry` (8), so the target can tell a timeout from a cancel.

`expire_handover_preparations` **returns** its release commands instead of sending them, so the DECISION (which target, and freeing the context) is separable from the TRANSMISSION (which needs the process-global S1AP queue and a live SCTP association). That is the shape recorded for #70.

## sgwcd (criterion 7)

The dispatcher passes the **decoded** `Gtp2Message` — not `&[]`, and not re-encoded bytes either, since the message is already decoded at the dispatch site and the library has `Gtp2BearerContextIe::decode` / `.fteid(instance)`.

F-TEIDs are matched on **instance AND interface type**. One whose instance says "UL" and whose interface type says "DL" is contradictory, and believing the instance alone installs a forwarding rule in the wrong direction. NOTE 1/NOTE 2 let the SGW send several instances when it cannot decide, so first match wins.

The PFCP rules use `ACCESS` for **both** the PDI source and the FAR destination — unlike every other rule `sxa_build` builds. Indirect forwarding is an eNB-to-eNB relay through the SGW-U, so both ends are radio; getting that wrong sends forwarded user data out of SGi.

The S11 answer is now **gated** on the SGW-U's response via `S11Continuation::IndirectForwarding`, for the reason #54 gated Create Session: §7.2.2 makes `Request accepted` mean FULFILLED, and this response carries F-TEIDs the source eNB is about to send user data to.

## Revert-verify

Six behavioural claims, each revert confirmed applied before the test ran, each failing on its own named assertion:

| revert | test that fails |
|---|---|
| status-transfer arm answers an Error Indication (pre-#48 behaviour) | `enb_status_transfer_is_relayed_to_the_target_unchanged` — *"the relay goes to the TARGET eNB"*, `left: 1 right: 6` |
| admitted DL forwarding TEID dropped again | `direct_forwarding_populates_the_handover_command_forwarding_list` |
| forwarding list hard-coded to `Vec::new()` | same test, on the list length |
| cancel no longer releases the target | `handover_cancel_releases_the_prepared_target` |
| supervision deadline never armed | `handover_preparation_supervision_releases_a_target_that_never_completes` |
| sgwcd allocates no forwarding tunnels | `cidft_request_allocates_forwarding_tunnels_and_the_response_carries_them` |

The **first** attempt at the status-transfer revert *deleted* the dispatch arm, which made the match non-exhaustive and produced a compile error. A compile error is not a revert-verify — it proves nothing about the test — so it was redone as a behavioural revert reproducing the shipped Error Indication.

Worth naming: the pre-existing `test_indirect_tunnel_responses` asserted only that a Cause IE was present, so it passed against the empty accept for as long as the defect existed.

## Verification

- Workspace **6520 → 6530** tests, 0 failures (+2 `nextgcore-s1ap`, +5 `mmed`, +3 `sgwcd`).
- `cargo clippy --workspace` 0 errors; `nextgcore-s1ap`, `nextgcore-mmed`, `nextgcore-sgwcd`, `nextgcore-asn1c` all at **0 warnings** — two pre-existing ones in files this change already touches went with it. `cargo fmt` clean.

## Ceilings, stated rather than implied

- **The MME does not inspect the PDCP counts**, by design — it relays. A deployment needing per-E-RAB PDCP reasoning would need the codec this deliberately avoids.
- **The DELETE forwarding-tunnel direction is still not driven by the handover paths**, so a completed handover leaves the rules installed until the session goes. TS 23.401 §5.5.1.2.2 step 15's post-handover timer does not exist here.
- **No `Data Forwarding Not Possible` handling.** It is an E-RAB-item protocol *extension* (`id 143`), not a top-level Handover Required IE, and this tree has no S1AP extension-container plumbing for E-RAB items.
- **Only intra-LTE, single-MME is driven.** `TargetRncId`/`Cgi` still fail preparation with `unknown-targetID`, and there is no S10 Forward Relocation leg, so Table 7.2.18-2's instances 1/2/3/5/6 are neither emitted nor read.
- **IPv6 forwarding endpoints bail** (`parse_wire_f_teid`, `outer_header_creation`), because the SGW-U datapath here is IPv4. `None` is honest where a zero address would not be.