### PR TITLE
fix(upfd): delete the dead PFCP rule model, and close the blind spot that hid it (#335)

### DIFF
--- a/specs/fix-upfd-delete-the-dead-pfcp-rule-model.md
+++ b/specs/fix-upfd-delete-the-dead-pfcp-rule-model.md
@@ -1,0 +1,143 @@
+# fix(upfd): delete the dead PFCP rule model, and close the blind spot that hid it
+
+Closes #335.
+
+## Criteria 1 and 2 — the types go, `UeIp` with them
+
+Every type in #335's table was re-verified unreferenced at `3129aea` before deletion, and the
+check has to be spelled carefully because **the names are reused for live types in three other
+modules** — which is what #335 warns makes a grep misleading:
+
+| type | live namesake elsewhere | referents of THIS one |
+|---|---|---|
+| `Pdr`, `Pdi`, `SdfFilter`, `Far`, `OuterHeaderCreation`, `ForwardingParameters` | `n4_handler` (parsed from the N4 wire) | none |
+| `FTeid` | `n4_build`, and `pfcp_path` imports `n4_build::FTeid` | none |
+| `DuplicatingParameters`, `RedirectInformation`, `HeaderEnrichment`, `RateLimiter` | none anywhere | none |
+| `UeIp` | none | only `Pdr.ue_ip` and `Pdr::pdr_match`, so it follows `Pdr` (criterion 2) |
+
+`rg 'use crate::context::' bins/nextgcore-upfd/src` plus `rg 'context::' bins/nextgcore-upfd/src`
+together return only `upf_self`, `upf_context_init`, `upf_context_final`, `TsnBridge`,
+`TsnPortType` and `UPF_GLOBAL_TEST_LOCK`. No test referenced the rule types either, so they were
+unreferenced from **every** target, not just the bin.
+
+**287 lines removed**, no behaviour change: unlike #325's session model — which reached the wire
+through `sess_count` → `get_load` → the NRF's `NFProfile.load` — this half had no reader at all.
+Deleting it also retired the last uses of `Ipv4Addr`/`Ipv6Addr` and `AtomicU64` in the module, so
+those imports went too. `nextgcore-ipfw` stays a dependency: `Pdr::pdr_match` was one of three
+callers of `compile_rule`, and `main.rs:718` and `data_plane.rs` are the live ones.
+
+## Criterion 3 — the module doc
+
+`context.rs`'s doc claimed it held "the PFCP rule types" (a line #325 added). It now names what it
+holds — the TSN bridge model and the process-global whose only live business is the load gauge —
+and records this second deletion beside the first, including the three-modules-one-name hazard.
+
+## Criterion 4 — the `dead_code = "allow"` decision, and why the premise was wrong
+
+**Decision: the workspace-wide `allow` stays. It is not what hid either half of this rot.**
+
+#335 and #325 both name `Cargo.toml:210` as the ambient condition that let the rot survive. That
+is measurable, so it was measured rather than asserted — and it is false.
+
+With `dead_code` flipped to `warn` workspace-wide, `cargo check --workspace --all-targets` emits
+**277 warnings**, distributed:
+
+| crate | warnings | crate | warnings |
+|---|---|---|---|
+| smfd | 121 | mbsmfd | 6 |
+| lmfd | 37 | amfd | 5 |
+| easdfd | 34 | 14 others | 1–3 each |
+| seppd | 19 | integration tests | 9 |
+| eesd | 17 | **upfd** | **0** |
+
+**upfd emits none of them** — not one warning for the very types this issue is about. Three probes
+in the same file, same run, same lint level pin the mechanism:
+
+| probe | result |
+|---|---|
+| `fn probe(..)` (private), no caller | **warns** |
+| `pub fn probe(..)`, no caller | **silent** |
+| `pub(crate) fn probe(..)`, no caller | **warns** |
+
+The lint does not fire on a `pub` item, and `pub mod context;` gave every item inside an effective
+visibility of `pub` — in a **bin** crate, which has no external consumer to be `pub` *for*. So
+narrowing the workspace `allow` would have bought 277 warnings of a *different population*
+(private items, 121 of them belonging to smfd's tracked #223) and still not caught #325 or #335.
+The thing that finds this class is the importer grep both issues used.
+
+One probe was **invalid and had to be re-run**, which is worth recording because its output looked
+like a finding: probe 3 first ran after `Cargo.toml` had already been restored to `allow`, so
+`pub(crate)` appeared silent too, "confirming" that visibility made no difference. The instrument
+was off, not the hypothesis — the same shape as a revert that does not bite (#326).
+
+### What the decision does instead
+
+Keeping the blanket and writing a note would leave the file exactly as detectable as before. So the
+blind spot is closed where the issue lives, in two one-line changes to `main.rs`:
+
+- `pub mod context;` → `mod context;` — drops the module's items to an effective `pub(crate)`,
+  which the lint *does* cover. This is what turns detection on; no per-item edit needed.
+- `#![deny(dead_code)]` — re-enables the lint over the workspace `allow` for this crate.
+
+`deny`, not `warn`, because CI runs `cargo clippy --workspace` with **no** `-D warnings`
+("Gate on errors only", `.github/workflows/ci.yml:88-91`). A `warn` would print into a log nobody
+reads and gate nothing — the same mistake as the test retry that hid a 20% flake for months
+(#308). At `deny` the crate is at zero today, so the gate costs nothing to adopt.
+
+This is #335's **option 2 enforced rather than requested**: future-use code in upfd now has to
+state what it waits for in an `#[allow(dead_code)]` reason, instead of resting on a workspace
+blanket that documents nothing. It is deliberately **not** option 3: scoped to one crate, because
+the workspace sweep is 277 sites and 121 of them are a different open issue.
+
+### The gate found one immediately
+
+Turning it on failed the build on `UpfContext::is_initialized` — **production-dead, read only by
+`the_session_ceiling_reaches_the_global_context`**. That is the same test-only-reader shape as
+#325, surfacing within seconds of the gate existing, which is the argument for the gate.
+
+It is now `#[cfg(test)]`, with the distinction stated in the doc: the `initialized` **flag** is
+production state (`init` latches double-initialisation on it, `fini` refuses a second teardown on
+it); only the *accessor* was test-only. Gating the accessor is honest; gating the flag would not be.
+
+## Revert-verify
+
+The gate is the only new behaviour here, so it is the thing that had to be made to fail — and
+against **CI's own command**, not a stricter local one, since the difference between `warn` and
+`deny` was the entire point:
+
+- Inject `pub(crate) fn gate_probe_zzz(&self) -> bool` into `context.rs` with no caller →
+  `cargo clippy -p nextgcore-upfd` fails: `error: method gate_probe_zzz is never used`. Before this
+  change the identical injection was **silent**.
+- Injection and restoration were each confirmed by grep count (1, then 0) before and after the
+  run, because an edit that never landed reports as a pass (#326's `cd` short-circuit).
+- A first attempt injected the probe *after* `mod tests`, which failed with
+  `error: items after a test module` instead of the dead-code error — a compile error proves
+  nothing about the lint, so it was re-injected before the test module.
+
+The deletion needs no revert-verify: there is no assertion it could falsify, which is precisely
+the difference between this half and #325's.
+
+## Ceilings, stated rather than implied
+
+- The gate covers **upfd only**, and within upfd it fully covers `context.rs`. The other 14 modules
+  are still `pub mod`, so a dead `pub` item in them remains invisible; making them crate-private is
+  mechanical but touches every module and belongs with a decision about the workspace sweep.
+- **#223** (smfd's `SmfSess`, the same class, 121 of the 277 warnings) is untouched and
+  `decision`-labelled.
+- The 277 figure is from `--all-targets` at `warn`; it is a *count of warning lines*, and several
+  cover multiple fields, so it is a floor on the item count, not an exact tally.
+
+## Verification
+
+- Workspace **6537 tests, 0 failures** — unchanged from `main`, as expected for a change that
+  deletes no test and adds no behaviour. `cargo clippy --workspace` 0 errors, upfd 0 warnings.
+  `cargo fmt --all --check` clean.
+- `Cargo.toml` was flipped to `warn` twice for measurement and restored both times; the working
+  tree was confirmed identical to `HEAD` (`git diff --stat` empty) before the real edits began.
+
+## Files
+
+- `src/bins/nextgcore-upfd/src/context.rs` — 287-line rule model and `UeIp` deleted; imports
+  trimmed; module doc corrected; `is_initialized` gated `#[cfg(test)]`.
+- `src/bins/nextgcore-upfd/src/main.rs` — `mod context;` and `#![deny(dead_code)]`, with the
+  measurement that justifies both.

--- a/src/bins/nextgcore-upfd/src/context.rs
+++ b/src/bins/nextgcore-upfd/src/context.rs
@@ -14,54 +14,35 @@
 //! how a dead store reached the wire: as a `load: 0` advertised to the NRF and to
 //! the SMF by a UPF serving any number of sessions.
 //!
+//! It used to carry a second, parallel PFCP RULE model beside that session model —
+//! `Pdr`/`Pdi`/`FTeid`/`SdfFilter`/`Far`/`OuterHeaderCreation`/`ForwardingParameters`/
+//! `DuplicatingParameters`/`RedirectInformation`/`HeaderEnrichment`, a `UeIp` reachable
+//! only from `Pdr.ue_ip`, and a token-bucket `RateLimiter` — with no importer in any
+//! module and no reader in any test, so unlike the session model it never reached the
+//! wire. Deleted in #335. The live rule model is `n4_handler`'s (parsed from the N4
+//! wire) feeding `data_plane`'s `DataPlanePdr`/`DataPlaneFar`; note that `n4_handler`,
+//! `n4_build` and `data_plane` each spell some of those names for THEIR OWN type, which
+//! is what made a grep-based reachability check misleading and is why both halves of
+//! this rot survived so long.
+//!
+//! What did NOT hide either half is `dead_code = "allow"` (`Cargo.toml`), despite being
+//! the obvious suspect. Measured on this branch: with the lint at `warn` the workspace
+//! emits 277 warnings and **upfd emits none of them**, because the lint does not fire on
+//! `pub` items in a bin crate — a `pub fn` added to this file warns not at all, while the
+//! same `fn` made private warns immediately. Narrowing the allow would therefore have
+//! bought noise, not detection; the thing that finds this class is the importer grep both
+//! #325 and #335 used.
+//!
 //! The live session stores are `pfcp_path::PfcpServer::sessions` (the N4 census,
 //! written by the establishment/deletion handlers) and
 //! `data_plane::DataPlaneSessionManager` (the forwarding tables, including the UE-IP
-//! index the data path actually uses). This module holds neither. It holds the TSN
-//! bridge model that `PfcpSessionInfo` points at, the PFCP rule types, and the
-//! process-global context whose only live business is the load gauge.
+//! index the data path actually uses). This module holds neither, and no longer holds
+//! any PFCP rule type. It holds the TSN bridge model that `PfcpSessionInfo` points at
+//! and the process-global context whose only live business is the load gauge.
 
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
-
-// ============================================================================
-// UE IP Address
-// ============================================================================
-
-/// UE IP address structure
-#[derive(Debug, Clone, Default)]
-pub struct UeIp {
-    /// IPv4 address (network byte order)
-    pub addr: [u32; 4],
-    /// Subnet reference (for IPv4/IPv6 pool management)
-    pub subnet_id: Option<u64>,
-}
-
-impl UeIp {
-    /// Create from IPv4 address
-    pub fn from_ipv4(addr: Ipv4Addr) -> Self {
-        Self {
-            addr: [u32::from_be_bytes(addr.octets()), 0, 0, 0],
-            subnet_id: None,
-        }
-    }
-
-    /// Create from IPv6 address
-    pub fn from_ipv6(addr: Ipv6Addr) -> Self {
-        let octets = addr.octets();
-        Self {
-            addr: [
-                u32::from_be_bytes([octets[0], octets[1], octets[2], octets[3]]),
-                u32::from_be_bytes([octets[4], octets[5], octets[6], octets[7]]),
-                u32::from_be_bytes([octets[8], octets[9], octets[10], octets[11]]),
-                u32::from_be_bytes([octets[12], octets[13], octets[14], octets[15]]),
-            ],
-            subnet_id: None,
-        }
-    }
-}
 
 // ============================================================================
 // TSN Bridge (Rel-18, IEEE 802.1Q)
@@ -517,293 +498,6 @@ impl TsnBridge {
 }
 
 // ============================================================================
-// PDR / FAR Structures for Rel-16 Completeness
-// ============================================================================
-
-/// Packet Detection Rule - comprehensive structure per TS 29.244
-#[derive(Debug, Clone)]
-pub struct Pdr {
-    /// PDR ID
-    pub pdr_id: u16,
-    /// Precedence
-    pub precedence: u32,
-    /// Source interface (0=Access, 1=Core, 2=SGi-LAN, etc.)
-    pub source_interface: u8,
-    /// UE IP address for matching
-    pub ue_ip: Option<UeIp>,
-    /// F-TEID for GTP-U matching
-    pub f_teid: Option<FTeid>,
-    /// SDF filter (optional)
-    pub sdf_filter: Option<SdfFilter>,
-    /// Associated FAR ID
-    pub far_id: Option<u32>,
-    /// Associated QER ID
-    pub qer_id: Option<u32>,
-    /// Associated URR IDs
-    pub urr_ids: Vec<u32>,
-    /// Outer header removal
-    pub outer_header_removal: Option<u8>,
-}
-
-impl Pdr {
-    /// Match a packet against this PDR
-    /// Returns true if all PDR matching criteria are met
-    pub fn pdr_match(
-        &self,
-        source_interface: u8,
-        ue_ip: Option<&UeIp>,
-        f_teid: Option<u32>,
-        _sdf_match: bool, // SDF filter matching placeholder
-    ) -> bool {
-        // Check source interface
-        if self.source_interface != source_interface {
-            return false;
-        }
-
-        // Check UE IP if specified
-        if let Some(pdr_ue_ip) = &self.ue_ip {
-            match ue_ip {
-                Some(packet_ue_ip) => {
-                    if pdr_ue_ip.addr != packet_ue_ip.addr {
-                        return false;
-                    }
-                }
-                None => return false,
-            }
-        }
-
-        // Check F-TEID if specified
-        if let Some(pdr_fteid) = &self.f_teid {
-            match f_teid {
-                Some(packet_teid) => {
-                    if pdr_fteid.teid != packet_teid {
-                        return false;
-                    }
-                }
-                None => return false,
-            }
-        }
-
-        // SDF filter matching: compile and check flow description if present
-        if let Some(ref sdf) = self.sdf_filter {
-            if let Some(ref desc) = sdf.flow_description {
-                if let Ok(rule) = nextgcore_ipfw::compile_rule(desc) {
-                    // Without actual packet data here, we accept if the rule compiled OK.
-                    // Real per-packet SDF matching happens in DataPlaneSession::match_pdr_with_packet.
-                    let _ = rule;
-                }
-            }
-        }
-
-        true
-    }
-}
-
-/// F-TEID for PDR matching
-#[derive(Debug, Clone)]
-pub struct FTeid {
-    /// TEID value
-    pub teid: u32,
-    /// IPv4 address
-    pub ipv4: Option<Ipv4Addr>,
-    /// IPv6 address
-    pub ipv6: Option<Ipv6Addr>,
-}
-
-/// SDF Filter for application-level filtering
-#[derive(Debug, Clone)]
-pub struct SdfFilter {
-    /// Flow description (e.g., "permit in ip from 10.0.0.0/8 to assigned")
-    pub flow_description: Option<String>,
-    /// TOS traffic class
-    pub tos_traffic_class: Option<u16>,
-    /// Security parameter index
-    pub security_parameter_index: Option<u32>,
-    /// Flow label
-    pub flow_label: Option<u32>,
-}
-
-/// Forwarding Action Rule - comprehensive structure per TS 29.244
-#[derive(Debug, Clone)]
-pub struct Far {
-    /// FAR ID
-    pub far_id: u32,
-    /// Apply Action (bitmask: DROP=0x01, FORW=0x02, BUFF=0x04, NOCP=0x08, DUPL=0x10)
-    pub apply_action: u16,
-    /// Destination interface
-    pub destination_interface: u8,
-    /// Outer header creation (for forwarding)
-    pub outer_header_creation: Option<OuterHeaderCreation>,
-    /// Forwarding parameters
-    pub forwarding_parameters: Option<ForwardingParameters>,
-    /// Duplicating parameters (for packet duplication)
-    pub duplicating_parameters: Vec<DuplicatingParameters>,
-    /// BAR ID (for buffering)
-    pub bar_id: Option<u8>,
-}
-
-impl Far {
-    /// Check if FAR action includes forwarding
-    pub fn should_forward(&self) -> bool {
-        (self.apply_action & 0x02) != 0
-    }
-
-    /// Check if FAR action includes dropping
-    pub fn should_drop(&self) -> bool {
-        (self.apply_action & 0x01) != 0
-    }
-
-    /// Check if FAR action includes buffering
-    pub fn should_buffer(&self) -> bool {
-        (self.apply_action & 0x04) != 0
-    }
-
-    /// Check if FAR action includes duplicating
-    pub fn should_duplicate(&self) -> bool {
-        (self.apply_action & 0x10) != 0
-    }
-}
-
-/// Outer Header Creation for FAR
-#[derive(Debug, Clone)]
-pub struct OuterHeaderCreation {
-    /// GTP-U TEID for encapsulation
-    pub teid: u32,
-    /// Peer IPv4 address
-    pub ipv4: Option<Ipv4Addr>,
-    /// Peer IPv6 address
-    pub ipv6: Option<Ipv6Addr>,
-    /// Port number
-    pub port: u16,
-}
-
-/// Forwarding Parameters
-#[derive(Debug, Clone)]
-pub struct ForwardingParameters {
-    /// Destination interface
-    pub destination_interface: u8,
-    /// Network instance (e.g., APN/DNN)
-    pub network_instance: Option<String>,
-    /// Redirect information
-    pub redirect_information: Option<RedirectInformation>,
-    /// Header enrichment
-    pub header_enrichment: Option<HeaderEnrichment>,
-}
-
-/// Duplicating Parameters (for packet duplication to multiple destinations)
-#[derive(Debug, Clone)]
-pub struct DuplicatingParameters {
-    /// Destination interface
-    pub destination_interface: u8,
-    /// Outer header creation
-    pub outer_header_creation: Option<OuterHeaderCreation>,
-}
-
-/// Redirect Information
-#[derive(Debug, Clone)]
-pub struct RedirectInformation {
-    /// Redirect server address type
-    pub redirect_address_type: u8,
-    /// Redirect server address
-    pub redirect_server_address: String,
-}
-
-/// Header Enrichment
-#[derive(Debug, Clone)]
-pub struct HeaderEnrichment {
-    /// Header type
-    pub header_type: u8,
-    /// Header field name
-    pub header_field_name: String,
-    /// Header field value
-    pub header_field_value: String,
-}
-
-// ============================================================================
-// Rate Limiter (Token Bucket) - Rel-16
-// ============================================================================
-
-/// Per-flow token bucket rate limiter
-#[derive(Debug)]
-pub struct RateLimiter {
-    /// Rate in bits per second
-    pub rate_bps: u64,
-    /// Burst size in bytes
-    pub burst_bytes: u64,
-    /// Current token count (in bytes)
-    tokens: AtomicU64,
-    /// Last update timestamp (nanoseconds since epoch)
-    last_update: AtomicU64,
-}
-
-impl RateLimiter {
-    /// Create a new rate limiter
-    pub fn new(rate_bps: u64, burst_bytes: u64) -> Self {
-        Self {
-            rate_bps,
-            burst_bytes,
-            tokens: AtomicU64::new(burst_bytes),
-            last_update: AtomicU64::new(Self::now_nanos()),
-        }
-    }
-
-    /// Get current time in nanoseconds
-    fn now_nanos() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("value expected")
-            .as_nanos() as u64
-    }
-
-    /// Check if a packet of given size can be forwarded
-    /// Returns true if packet is allowed, false if it should be rate-limited
-    pub fn allow_packet(&self, packet_size: usize) -> bool {
-        let now = Self::now_nanos();
-        let last = self.last_update.load(Ordering::Relaxed);
-
-        // Calculate elapsed time in seconds
-        let elapsed_ns = now.saturating_sub(last);
-        let elapsed_secs = elapsed_ns as f64 / 1_000_000_000.0;
-
-        // Calculate tokens to add based on rate
-        let tokens_to_add = (self.rate_bps as f64 * elapsed_secs / 8.0) as u64;
-
-        // Get current tokens and add new tokens (capped at burst size)
-        let current_tokens = self.tokens.load(Ordering::Relaxed);
-        let new_tokens = (current_tokens + tokens_to_add).min(self.burst_bytes);
-
-        // Check if we have enough tokens for this packet
-        if new_tokens >= packet_size as u64 {
-            // Consume tokens
-            self.tokens
-                .store(new_tokens - packet_size as u64, Ordering::Relaxed);
-            self.last_update.store(now, Ordering::Relaxed);
-            true
-        } else {
-            // Not enough tokens - rate limit
-            false
-        }
-    }
-
-    /// Reset the rate limiter
-    pub fn reset(&self) {
-        self.tokens.store(self.burst_bytes, Ordering::Relaxed);
-        self.last_update.store(Self::now_nanos(), Ordering::Relaxed);
-    }
-}
-
-impl Clone for RateLimiter {
-    fn clone(&self) -> Self {
-        Self {
-            rate_bps: self.rate_bps,
-            burst_bytes: self.burst_bytes,
-            tokens: AtomicU64::new(self.tokens.load(Ordering::Relaxed)),
-            last_update: AtomicU64::new(self.last_update.load(Ordering::Relaxed)),
-        }
-    }
-}
-
-// ============================================================================
 // UPF Context
 // ============================================================================
 
@@ -872,7 +566,17 @@ impl UpfContext {
         log::info!("UPF context finalized");
     }
 
-    /// Check if context is initialized
+    /// Check if context is initialized.
+    ///
+    /// `#[cfg(test)]` because the only reader is
+    /// `the_session_ceiling_reaches_the_global_context`, and the newly-effective
+    /// `dead_code` gate (see the crate attribute in `main.rs`) said so the moment it
+    /// was turned on. The FLAG is production state — `init` uses it to latch
+    /// double-initialisation and `fini` to refuse a second teardown — so what is
+    /// test-only is this accessor, not the thing it reads. Saying that in the
+    /// signature is the difference between a test affordance and the test-only
+    /// reader class that #325 was.
+    #[cfg(test)]
     pub fn is_initialized(&self) -> bool {
         self.initialized.load(Ordering::SeqCst)
     }

--- a/src/bins/nextgcore-upfd/src/main.rs
+++ b/src/bins/nextgcore-upfd/src/main.rs
@@ -8,8 +8,35 @@
 //! - Traffic usage reporting
 //! - Uplink/downlink traffic detection
 
+// `dead_code` is `allow` workspace-wide (`Cargo.toml`, "Future-use code for
+// Rel-17/18/20 features"), and #335 asked whether that is what hid two parallel
+// models in `context.rs`. Measured: it is not. At `warn` the workspace emits 277
+// warnings and upfd emits NONE of them, because the lint does not fire on a `pub`
+// item — a `pub fn` added to `context.rs` warns not at all, while the same
+// function written `pub(crate)` warns immediately. So the blind spot is
+// visibility, not the lint level, and `pub mod` is what created it: it gives
+// every item inside an effective visibility of `pub`, in a crate that has no
+// external consumers to be `pub` FOR.
+//
+// `mod context` (crate-private) drops those items to an effective `pub(crate)`,
+// which the lint does cover, and the local level re-enables it over the workspace
+// `allow`. Together they are what would have caught #325 and #335. Verified by
+// probe: a `pub(crate)` method with no caller now fails the build here; before
+// this change it was silent.
+//
+// `deny` and not `warn`, because CI runs `cargo clippy --workspace` with no
+// `-D warnings` ("Gate on errors only", `.github/workflows/ci.yml`) -- a `warn`
+// here would print into a log nobody reads and gate nothing, which is the same
+// mistake as the retry that hid a 20% flake (#308). At `deny` this crate is at
+// zero today, so the gate costs nothing to adopt, and future-use code has to say
+// what it is waiting for in an `#[allow(dead_code)]` reason rather than resting on
+// a workspace-wide blanket -- which is #335's option 2, enforced instead of asked
+// for. Scoped to upfd: the workspace has 277 such items, 121 of them in smfd's
+// tracked #223, so a workspace sweep is a different change.
+#![deny(dead_code)]
+
 pub mod arp_nd;
-pub mod context;
+mod context;
 pub mod data_plane;
 pub mod event;
 pub mod gtp_path;


### PR DESCRIPTION
Closes #335.

Spec: `specs/fix-upfd-delete-the-dead-pfcp-rule-model.md`

## Criteria 1–3: the types go

287 lines deleted from `bins/nextgcore-upfd/src/context.rs` — `Pdr`, `Pdi`, `FTeid`, `SdfFilter`, `Far`, `OuterHeaderCreation`, `ForwardingParameters`, `DuplicatingParameters`, `RedirectInformation`, `HeaderEnrichment`, the token-bucket `RateLimiter`, and the `UeIp` reachable only from `Pdr.ue_ip` (criterion 2). Re-verified unreferenced at `3129aea` from **every** target, not just the bin.

The check needs care because the names are reused for **live** types in three other modules — `n4_handler`'s (parsed from the N4 wire), `n4_build`'s `FTeid`, `data_plane`'s `DataPlanePdr`/`DataPlaneFar` — which is exactly what #335 warns makes a grep misleading. `nextgcore-ipfw` stays a dependency: `Pdr::pdr_match` was one of three callers of `compile_rule` and the other two are live.

No behaviour change. Unlike #325's session model, which reached the wire via `sess_count` → `get_load` → `NFProfile.load`, this half had no reader at all.

Module doc (criterion 3) no longer claims to hold "the PFCP rule types", and records the second deletion beside the first.

## Criterion 4: the decision — and the premise was wrong

**The workspace-wide `dead_code = "allow"` stays. It is not what hid either half of this rot.**

Both #335 and #325 name `Cargo.toml:210` as the ambient cause. That is measurable, so it was measured. At `warn`, the workspace emits **277 warnings** — smfd 121, lmfd 37, easdfd 34, seppd 19, eesd 17, … and **upfd emits zero**. Not one warning for the types this issue is about.

Three probes in the same file, same run, same lint level pin the mechanism:

| probe | result |
|---|---|
| `fn probe(..)` private, no caller | **warns** |
| `pub fn probe(..)`, no caller | **silent** |
| `pub(crate) fn probe(..)`, no caller | **warns** |

The lint does not fire on `pub` items, and `pub mod context;` gave everything inside an effective `pub` — in a **bin** crate, which has no external consumer to be `pub` for. Narrowing the workspace allow would have bought 277 warnings of a *different population* (private items, 121 belonging to smfd's tracked #223) and still missed #325 and #335.

One probe was **invalid and re-run**: it first ran after `Cargo.toml` was already restored to `allow`, so `pub(crate)` looked silent too, "confirming" that visibility didn't matter. The instrument was off, not the hypothesis — same shape as a revert that doesn't bite (#326).

### What the decision does instead of writing a note

Two one-line changes to `main.rs`, closing the blind spot where the issue lives:

- `pub mod context;` → `mod context;` — drops its items to an effective `pub(crate)`, which the lint **does** cover. This is what turns detection on, with no per-item edit.
- `#![deny(dead_code)]` — re-enables the lint over the workspace allow, for this crate.

`deny` and not `warn` because CI runs `cargo clippy --workspace` with **no** `-D warnings` (`ci.yml:88-91`, "Gate on errors only"). A `warn` would print into a log nobody reads and gate nothing — the same mistake as the retry that hid a 20% flake (#308). The crate is at zero today, so the gate costs nothing to adopt.

This is #335's **option 2 enforced rather than requested**: future-use code must now state what it waits for in an `#[allow(dead_code)]` reason. It is deliberately **not** option 3 — scoped to one crate, because the sweep is 277 sites and 121 are a different open issue.

### The gate found one immediately

It failed the build on `UpfContext::is_initialized` — production-dead, read only by `the_session_ceiling_reaches_the_global_context`. The same test-only-reader shape as #325, surfacing seconds after the gate existed, which is the argument for the gate.

Now `#[cfg(test)]`, with the distinction stated: the `initialized` **flag** is production state (`init` latches double-init on it, `fini` refuses a second teardown on it); only the **accessor** was test-only.

## Revert-verify

The gate is the only new behaviour, so it is what was made to fail — against **CI's own command**, since the `warn`/`deny` difference was the whole point:

- Injecting `pub(crate) fn gate_probe_zzz(&self)` with no caller → `cargo clippy -p nextgcore-upfd` fails with `error: method gate_probe_zzz is never used`. Before this change the identical injection was **silent**.
- Injection and restoration each confirmed by grep count (1, then 0), because an edit that never landed reports as a pass (#326's `cd` short-circuit).
- A first attempt injected the probe *after* `mod tests` and got `error: items after a test module` — a compile error proves nothing about the lint, so it was re-injected before the test module.

The deletion itself gets no revert-verify: there is no assertion it could falsify, which is the difference between this half and #325's.

## Ceilings

- The gate covers **upfd only**, and fully covers `context.rs`. The other 14 modules are still `pub mod`, so a dead `pub` item in them stays invisible; converting them is mechanical but belongs with a decision on the workspace sweep.
- **#223** (smfd's `SmfSess`, 121 of the 277) untouched and `decision`-labelled.
- 277 is a count of warning *lines* at `--all-targets`; some cover multiple fields, so it is a floor.

## Verification

- Workspace **6537 tests, 0 failures** — unchanged from `main`, as expected for a change that deletes no test and adds no behaviour.
- `cargo clippy --workspace` 0 errors, upfd 0 warnings. `cargo fmt --all -- --check` clean.
- `Cargo.toml` was flipped to `warn` twice for measurement and restored both times; tree confirmed identical to `HEAD` before the real edits began.