### PR TITLE
fix(pcfd): a poisoned index turned every removal into a silent no-op (#338)

### DIFF
--- a/specs/fix-pcfd-poisoned-index-silent-no-op-removal.md
+++ b/specs/fix-pcfd-poisoned-index-silent-no-op-removal.md
@@ -1,0 +1,158 @@
+# fix(pcfd): a poisoned index turned every removal into a silent no-op
+
+Closes #338.
+
+#338 filed a once-seen, never-reproduced failure of `each_uav_guard_refuses_on_its_own` and
+asked, in its last criterion, whether the leak was **real** or a test race — "worth deciding
+which before fixing".
+
+**It is real.** There is a production leak, it is deterministically reproducible, and the same
+mechanism explains why the flake appeared only in the run #338 describes and never again. The
+test was *also* fragile, for the reason #338 suspected, and that is fixed too — but it is the
+second finding, not the first.
+
+## Criterion 1 — the enumeration
+
+Every pcfd test that mutates the process-global PCF context or a `PCF_*` env var, and whether it
+takes `CONTEXT_GUARD` (57 tests; mechanically enumerated, not eyeballed):
+
+| | tests | takes `CONTEXT_GUARD` |
+|---|---|---|
+| touch the global PCF context | 49 | 20 |
+| **touch the global PCF context WITHOUT the guard** | **29** | — |
+| mutate a `PCF_*` env var | 15 | 7 |
+| mutate a `PCF_UAV_*` env var | 3 | **3 (all)** |
+
+So #338's hypothesis 1 is confirmed and hypothesis 2 is not:
+
+- **29 unguarded context mutators**, including session-creating ones — `sm_policy_lifecycle_over_real_http`, `sm_policy_create_negotiates_supp_feat_not_echo`, `app_session_create_*`, `ue_policy_create_get_update_delete_lifecycle`, `create_binds_by_ipv6_address_within_the_session_prefix`, … A `sess_count()` delta read across an `await` is therefore falsifiable by any of them. `CONTEXT_GUARD` "only helps against tests that also take it", exactly as #338 says.
+- **The `PCF_UAV_*` env vars are not the exposure.** All three tests that set them take the guard, and no unguarded test sets any of them. The 8 unguarded env mutators touch `PCF_UE_POLICY_DELIVERY`, `PCF_URSP_RULES`, `PCF_T3501_SECS`, `PCF_LOCAL_PLMN` — none of which `is_uav_dnn()` reads.
+
+## Criterion 4 — decided first, because it changes what the fix is
+
+`sess_count()` is `self.sess_list.read().map(|l| l.len()).unwrap_or(0)`. It reports **0 on a
+poisoned lock**. And `sess_remove` acquired five locks as `self.x.write().ok()?`, which returns
+`None` — silently — if any is poisoned.
+
+Two of those five, `ipv4addr_hash` and `ipv6prefix_hash`, **are not touched by `sess_add`**. That
+asymmetry is the whole defect:
+
+1. a create takes the `sess_add` path and **succeeds**;
+2. the UAV guard refuses, and the compensating `sess_remove` hits the poisoned index and returns
+   `None` **before reaching `sess_list.remove(&id)`** — having removed nothing;
+3. the caller cannot tell that from "was not there", because both are `None`;
+4. the session is leaked, and **a poisoned lock stays poisoned for the life of the process**, so
+   every later removal leaks too — ordinary SM-policy deletes included — until
+   `max_num_of_sess` refuses all creates.
+
+That is the unbounded growth #90 fixed, reachable again by another route. Reproduced
+deterministically in `a_poisoned_index_does_not_turn_a_removal_into_a_silent_no_op`: with
+`ipv6prefix_hash` poisoned, `sess_add` returns a session, `sess_remove` returns `None`, and
+`sess_count()` stays 1.
+
+### Why this explains the observation and the non-reproduction
+
+#338 records that the failure happened in a run where **four other tests were also failing**, and
+that it never recurred across 8 green suite runs and 5 runs of the test alone. A panicking test
+poisons any lock it held, permanently, for every test that follows it in that binary. So:
+
+- **panicking siblings → poisoned index → the refusal genuinely leaks → the assertion fails.**
+- **green suite → no panic → no poison → nothing to see**, at any load.
+
+The "conditions" section of #338 is therefore the strongest single piece of evidence for this
+mechanism, and it is why a load loop was never going to reproduce it (see criterion 3).
+
+### The fix
+
+`write_through_poison(&lock)` — `lock.write().unwrap_or_else(|e| e.into_inner())` — applied to
+the **removal family**, where a silent give-up is a leak rather than a "not found":
+`sess_remove`, `ue_sm_remove`, `ue_am_remove`, `app_remove`, `event_sub_remove`. After the change
+the only `None` these can return is the genuine "the record was not there".
+
+Using the data through the poison is the right trade: the alternative is a permanent, unbounded
+leak, and the worst case is a **stale index entry**, whose lookups resolve to an id no longer in
+the primary list and answer `None` — which is what a caller of a removed record should get.
+
+Lock **order and atomicity are unchanged**: the same locks are taken, in the same order, in the
+same single scope. Only the poison arm differs. That matters because six documented AB-BA
+inversion fixes in this file (#66/#192) depend on the order, and the `drop(..)`-before-`persist`
+discipline depends on the scoping.
+
+## Criterion 2 — the test is de-fragilised too
+
+The `sess_count()` delta is replaced, in both UAV refusal tests, by a **per-`(SUPI, PSI)`**
+assertion, which no sibling's session can move:
+
+```rust
+let ue_sm = ctx.read().expect("ctx").ue_sm_find_by_supi(&supi)
+    .expect("the refused create must still have resolved a UE-SM");
+assert!(ctx.read().expect("ctx").sess_find_by_psi(ue_sm.id, 9).is_none(), ...);
+```
+
+The UE-SM lookup is `expect`, not `if let Some(..)` as one of them had. The session assertion is
+**negative**, and a negative assertion is satisfied by every path that never arrived — including
+a create rejected before it resolved a UE-SM at all. Requiring the UE-SM first is the positive
+half that proves the path did run. It holds by construction: the refusal removes the session, not
+the UE, and the create resolves the UE-SM find-then-add (`app.rs:1960`), so a retry reuses it
+rather than orphaning one.
+
+## Revert-verify
+
+- **The production fix.** Restoring `self.ipv6prefix_hash.write().ok()?` on that one line —
+  a *behavioural* revert, not a deletion, so it cannot fail as a compile error — makes
+  `a_poisoned_index_does_not_turn_a_removal_into_a_silent_no_op` fail on its named assertion,
+  *"a poisoned INDEX must not make the removal report 'was not there'"*.
+- **The de-fragilised assertions are stronger, not weaker.** Short-circuiting the compensating
+  removal (`if false && context.sess_remove(..)`) makes **both** UAV tests fail on their own
+  named assertions — `"authorization withheld: the refusal must leave no session for this (SUPI,
+  PSI)"` and the `uav_session_is_refused_*` equivalent — while the
+  `uav_session_is_allowed_once_*` control still passes. So the per-SUPI form still catches the
+  #90 defect the count delta was there to catch.
+- Each injection and restoration was confirmed by grep count before and after the run.
+
+## Criterion 3 — the loop, and what it can and cannot show
+
+25 consecutive runs of the pcfd unit-test binary with **3 concurrent load generators** (the smfd,
+amfd and upfd unit-test binaries on repeat, competing for cores):
+
+**25 pass, 0 fail.**
+
+Stated plainly: this is a **non-regression measurement, not a reproduction**. The original
+failure needed a *panicking* sibling to poison a lock, which a green load loop by construction
+never produces — so this loop could not have failed either before or after the fix. The thing
+that pins the defect is the deterministic poisoning test, not the loop. Recording the loop
+because #338 asked for it, and recording its ceiling because a 25/25 here would otherwise read
+as "the flake is gone" when what closed it is the mechanism above.
+
+## Ceilings, stated rather than implied
+
+- **20 of the 24 poison-fragile functions are untouched.** `.write().ok()?` / `.read().ok()?`
+  appears at **50 sites in 24 functions**. Only the 5 removal functions are changed, because
+  there a silent give-up leaks. The `*_find_*` family answering `None` on poison is wrong but
+  bounded (it reads as "not found"), and the `*_add` family returning `None` is fail-loud. Both
+  deserve the same treatment and neither is this issue; filed as a follow-up rather than swept
+  in, because "use the data through the poison" is a different judgement call on a read path
+  than on a removal.
+- **`sess_count()` still answers `unwrap_or(0)` on poison**, i.e. it under-reports rather than
+  failing. It feeds `get_load()`, so a poisoned `sess_list` makes the PCF advertise load 0 — the
+  same shape as #325's UPF defect. Not fixed here: it needs a decision about whether a load
+  gauge should be able to report "unknown", which is #325's question over again.
+- **The refusal leaves a `PcfUeSm` behind** with no sessions. Bounded — one per SUPI, reused by
+  the find-then-add on retry — so it is not the unbounded leak, and #90 deliberately removed only
+  the session. Recorded because the new assertion now depends on that UE-SM being there.
+- The enumeration is of `#[test]`/`#[tokio::test]` functions in `bins/nextgcore-pcfd/src`;
+  peer-crate strict-peer tests that call `test_support::init_context()` from *other* crates are
+  not counted, and they are a further population of unguarded global mutators.
+
+## Verification
+
+- Workspace **6538 tests, 0 failures** (6537 + the new poisoning guard). `cargo clippy
+  --workspace` 0 errors. `cargo fmt --all -- --check` clean.
+- `nextgcore-pcfd --lib`: 200 passed, 1 ignored.
+
+## Files
+
+- `src/bins/nextgcore-pcfd/src/context.rs` — `write_through_poison` and the five removal paths;
+  the deterministic poisoning guard.
+- `src/bins/nextgcore-pcfd/src/app.rs` — both UAV refusal tests re-scoped from a `sess_count()`
+  delta to a per-`(SUPI, PSI)` lookup.

--- a/src/bins/nextgcore-pcfd/src/app.rs
+++ b/src/bins/nextgcore-pcfd/src/app.rs
@@ -6841,11 +6841,13 @@ mod tests {
         std::env::remove_var("PCF_UAV_POSITION");
         std::env::set_var("PCF_UAV_DNN", "uav");
 
-        // The PCF context is process-global and is not reset between tests, so the
-        // leak is asserted as a DELTA over this one create rather than as an
-        // absolute count of the whole suite's sessions.
+        // The PCF context is process-global and is not reset between tests. This
+        // used to be asserted as a `sess_count()` DELTA over the one create, which
+        // is the fragile part (#338): 29 pcfd tests mutate the global context
+        // WITHOUT taking CONTEXT_GUARD, so any of them can move the count between
+        // the two reads. The leak is asserted per-(SUPI, PSI) below instead, which
+        // no sibling's session can move.
         let ctx = crate::context::pcf_self();
-        let before = ctx.read().expect("ctx").sess_count();
 
         let resp = pcf_sbi_request_handler(make_request(
             "POST",
@@ -6870,26 +6872,28 @@ mod tests {
         assert_eq!(body["cause"], "UAV_FLIGHT_NOT_AUTHORIZED");
 
         // #90 criterion 5: the refusal leaves NO session behind.
-        let after = ctx.read().expect("ctx").sess_count();
-        assert_eq!(
-            after, before,
-            "a rejected UAV create must not leak a PcfSess (it leaked one per attempt before #90)"
-        );
-        // And specifically: the (ue_sm, psi) pair the refused create used holds no
-        // session, so a later legitimate create for it is not blocked by a ghost.
+        //
+        // The UE-SM lookup is `expect`, not `if let Some(..)`. That matters: the
+        // session assertion below is a NEGATIVE one, and a negative assertion is
+        // satisfied by every path that never arrived — including a create rejected
+        // before it ever resolved a UE-SM. Requiring the UE-SM to be there first is
+        // the positive half that proves the path DID arrive, and it is true by
+        // construction because the refusal removes the session, not the UE (the
+        // create resolves the UE-SM find-then-add, so a retry reuses it).
         let ue_sm = ctx
             .read()
             .expect("ctx")
-            .ue_sm_find_by_supi("imsi-001010000000910");
-        if let Some(ue_sm) = ue_sm {
-            assert!(
-                ctx.read()
-                    .expect("ctx")
-                    .sess_find_by_psi(ue_sm.id, 5)
-                    .is_none(),
-                "the refused (ue_sm, psi) must hold no session"
-            );
-        }
+            .ue_sm_find_by_supi("imsi-001010000000910")
+            .expect("the refused create must still have resolved a UE-SM");
+        assert!(
+            ctx.read()
+                .expect("ctx")
+                .sess_find_by_psi(ue_sm.id, 5)
+                .is_none(),
+            "a rejected UAV create must leave no PcfSess for its (SUPI, PSI) — it \
+             leaked one per attempt before #90, and again for every removal once any \
+             index lock was poisoned (#338)"
+        );
 
         std::env::remove_var("PCF_UAV_DNN");
     }
@@ -6934,7 +6938,6 @@ mod tests {
             }
 
             let ctx = crate::context::pcf_self();
-            let before = ctx.read().expect("ctx").sess_count();
             let supi = format!("imsi-00101000000093{i}");
             let resp = pcf_sbi_request_handler(make_request(
                 "POST",
@@ -6957,10 +6960,27 @@ mod tests {
             let body: serde_json::Value =
                 serde_json::from_str(resp.http.content.as_deref().unwrap()).unwrap();
             assert_eq!(body["cause"], "UAV_FLIGHT_NOT_AUTHORIZED", "{label}");
-            assert_eq!(
-                ctx.read().expect("ctx").sess_count(),
-                before,
-                "{label}: the refusal must not leak a session"
+            // Scoped to THIS (SUPI, PSI), not a `sess_count()` delta. The delta was
+            // the flake #338 reported: 29 pcfd tests mutate the process-global PCF
+            // context without taking CONTEXT_GUARD, so a sibling creating or
+            // deleting a session between the two reads falsified it — and it read 0
+            // outright if any sibling had poisoned `sess_list`, since `sess_count`
+            // answers `unwrap_or(0)`. The UE-SM `expect` is the positive half: it
+            // proves the create reached the point of resolving a UE-SM, so the
+            // negative session assertion is not satisfied by a path that never ran.
+            let ue_sm = ctx
+                .read()
+                .expect("ctx")
+                .ue_sm_find_by_supi(&supi)
+                .unwrap_or_else(|| {
+                    panic!("{label}: the refused create must still have resolved a UE-SM")
+                });
+            assert!(
+                ctx.read()
+                    .expect("ctx")
+                    .sess_find_by_psi(ue_sm.id, 9)
+                    .is_none(),
+                "{label}: the refusal must leave no session for this (SUPI, PSI)"
             );
         }
 

--- a/src/bins/nextgcore-pcfd/src/context.rs
+++ b/src/bins/nextgcore-pcfd/src/context.rs
@@ -1350,6 +1350,34 @@ pub enum PcfStateError {
     },
 }
 
+/// Take a write guard, using the data even when the lock is POISONED (#338).
+///
+/// The pattern this replaces on the removal paths is `self.x.write().ok()?`, which
+/// turns a poisoned lock into a silent `None` return. On a *lookup* that reads as
+/// "not found"; on a *removal* it is a LEAK, because the record stays and the
+/// caller is told the removal happened as far as it can tell — it only sees
+/// `Option`, and every removal already returns `None` for "was not there".
+///
+/// The concrete failure it caused: `sess_remove` acquired five locks this way
+/// BEFORE `sess_list.remove(&id)`, and two of them (`ipv4addr_hash`,
+/// `ipv6prefix_hash`) are not touched by `sess_add`. So with either one poisoned,
+/// a create SUCCEEDS, the UAV refusal path's compensating `sess_remove` returns
+/// `None` having removed nothing, and the refused session is leaked — reproduced
+/// deterministically in
+/// `a_poisoned_index_does_not_turn_a_removal_into_a_silent_no_op`. Because a
+/// poisoned lock stays poisoned for the life of the process, EVERY later removal
+/// leaked too, including ordinary SM-policy deletes, until `max_num_of_sess`
+/// refused all creates. That is the unbounded growth #90 fixed, reachable again by
+/// another route.
+///
+/// Using the data through the poison is the right trade here: the alternative is a
+/// permanent, unbounded leak, and the worst case is a stale INDEX entry, whose
+/// lookups resolve to an id that is no longer in the primary list and answer
+/// `None` — which is what a caller of a removed record should get anyway.
+fn write_through_poison<T>(lock: &RwLock<T>) -> std::sync::RwLockWriteGuard<'_, T> {
+    lock.write().unwrap_or_else(|e| e.into_inner())
+}
+
 impl PcfContext {
     pub fn new() -> Self {
         Self {
@@ -1520,8 +1548,9 @@ impl PcfContext {
 
     pub fn event_sub_remove(&self, sub_id: &str) -> Option<PcEventSubscription> {
         let sub = {
-            let mut list = self.event_sub_list.write().ok()?;
-            let mut hash = self.event_sub_id_hash.write().ok()?;
+            // Poison-tolerant (#338): see `write_through_poison`.
+            let mut list = write_through_poison(&self.event_sub_list);
+            let mut hash = write_through_poison(&self.event_sub_id_hash);
             let id = hash.remove(sub_id)?;
             list.remove(&id)?
         };
@@ -1935,9 +1964,11 @@ impl PcfContext {
     }
 
     pub fn ue_am_remove(&self, id: u64) -> Option<PcfUeAm> {
-        let mut ue_am_list = self.ue_am_list.write().ok()?;
-        let mut supi_am_hash = self.supi_am_hash.write().ok()?;
-        let mut association_id_hash = self.association_id_hash.write().ok()?;
+        // Poison-tolerant for the reason given on `write_through_poison`: a
+        // removal that gives up silently is a leak, not a "not found" (#338).
+        let mut ue_am_list = write_through_poison(&self.ue_am_list);
+        let mut supi_am_hash = write_through_poison(&self.supi_am_hash);
+        let mut association_id_hash = write_through_poison(&self.association_id_hash);
 
         if let Some(ue_am) = ue_am_list.remove(&id) {
             supi_am_hash.remove(&ue_am.supi);
@@ -2040,8 +2071,11 @@ impl PcfContext {
         // sess_list -> ue_sm_list order used by sess_add/sess_remove and
         // deadlocks under concurrent SBI requests (AB-BA lock inversion).
         let ue_sm = {
-            let mut ue_sm_list = self.ue_sm_list.write().ok()?;
-            let mut supi_sm_hash = self.supi_sm_hash.write().ok()?;
+            // Poison-tolerant (#338): see `write_through_poison`. This one also
+            // cascades into `sess_remove_all_for_ue`, so giving up here would strand
+            // the UE's sessions as well as the UE.
+            let mut ue_sm_list = write_through_poison(&self.ue_sm_list);
+            let mut supi_sm_hash = write_through_poison(&self.supi_sm_hash);
             let ue_sm = ue_sm_list.remove(&id)?;
             supi_sm_hash.remove(&ue_sm.supi);
             ue_sm
@@ -2169,12 +2203,17 @@ impl PcfContext {
         // snapshot read-locks sess_list and ue_sm_list, and std RwLock is not
         // reentrant, so persisting inside this block deadlocks (issue #66/#192).
         let sess = {
-            let mut sess_list = self.sess_list.write().ok()?;
-            let mut sm_policy_id_hash = self.sm_policy_id_hash.write().ok()?;
-            let mut ipv4addr_hash = self.ipv4addr_hash.write().ok()?;
-            let mut ipv6prefix_hash = self.ipv6prefix_hash.write().ok()?;
-            let mut ue_sm_list = self.ue_sm_list.write().ok()?;
+            // `write_through_poison`, not `.write().ok()?`: two of these five are
+            // never touched by `sess_add`, so a poisoned one used to abort the
+            // removal here having added nothing -- leaking the session and, from
+            // then on, every session (#338).
+            let mut sess_list = write_through_poison(&self.sess_list);
+            let mut sm_policy_id_hash = write_through_poison(&self.sm_policy_id_hash);
+            let mut ipv4addr_hash = write_through_poison(&self.ipv4addr_hash);
+            let mut ipv6prefix_hash = write_through_poison(&self.ipv6prefix_hash);
+            let mut ue_sm_list = write_through_poison(&self.ue_sm_list);
 
+            // The ONLY `None` this function may return: the session was not there.
             let sess = sess_list.remove(&id)?;
             sm_policy_id_hash.remove(&sess.sm_policy_id);
             if sess.ipv4addr != 0 {
@@ -2379,9 +2418,10 @@ impl PcfContext {
 
     pub fn app_remove(&self, id: u64) -> Option<PcfApp> {
         // Canonical lock order: sess_list before app_list (see app_add).
-        let mut sess_list = self.sess_list.write().ok()?;
-        let mut app_list = self.app_list.write().ok()?;
-        let mut app_session_id_hash = self.app_session_id_hash.write().ok()?;
+        // Poison-tolerant (#338): see `write_through_poison`.
+        let mut sess_list = write_through_poison(&self.sess_list);
+        let mut app_list = write_through_poison(&self.app_list);
+        let mut app_session_id_hash = write_through_poison(&self.app_session_id_hash);
 
         if let Some(app) = app_list.remove(&id) {
             app_session_id_hash.remove(&app.app_session_id);
@@ -2516,6 +2556,59 @@ pub fn pcf_instance_get_load() -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #338: a poisoned auxiliary index must not turn a removal into a silent no-op.
+    ///
+    /// This is the mechanism behind the flake #338 filed, and it is a CORRECTNESS
+    /// defect rather than a test artefact — which is the fork #338's last criterion
+    /// asks to be decided before fixing.
+    ///
+    /// `ipv6prefix_hash` is chosen deliberately: `sess_add` does not touch it, so a
+    /// create SUCCEEDS while the compensating `sess_remove` on the UAV refusal path
+    /// used to abort before reaching `sess_list.remove` and return `None` having
+    /// removed nothing. The caller cannot tell that from "was not there", because
+    /// both are `None`. And a poisoned lock stays poisoned for the life of the
+    /// process, so from the first panic onward EVERY removal leaked — ordinary
+    /// SM-policy deletes included.
+    ///
+    /// A LOCAL `PcfContext` is used, never `pcf_self()`: poisoning is permanent, so
+    /// poisoning the process-global here would break every sibling test in the
+    /// binary — which is precisely how this defect surfaced in the first place.
+    #[test]
+    fn a_poisoned_index_does_not_turn_a_removal_into_a_silent_no_op() {
+        let mut ctx = PcfContext::new();
+        ctx.init(64, 64);
+        let ue = ctx.ue_sm_add("imsi-001010000000999").expect("ue_sm");
+        let sess = ctx.sess_add(ue.id, 7).expect("sess");
+        assert_eq!(ctx.sess_count(), 1, "precondition: the session was created");
+
+        // Poison ONE index that `sess_add` never acquires, the way a panicking
+        // sibling does: hold its write guard and unwind.
+        let joined = std::thread::scope(|s| {
+            s.spawn(|| {
+                let _held = ctx.ipv6prefix_hash.write().unwrap();
+                panic!("deliberate: poison ipv6prefix_hash");
+            })
+            .join()
+        });
+        assert!(joined.is_err(), "the poisoning thread must have panicked");
+        assert!(
+            ctx.ipv6prefix_hash.is_poisoned(),
+            "precondition: the index is poisoned"
+        );
+
+        assert!(
+            ctx.sess_remove(sess.id).is_some(),
+            "a poisoned INDEX must not make the removal report 'was not there'"
+        );
+        assert_eq!(
+            ctx.sess_count(),
+            0,
+            "the session must be gone: reporting the removal while leaving the record \
+             is how a refused UAV create leaked one session per attempt, and then every \
+             later delete leaked too, until max_num_of_sess refused all creates"
+        );
+    }
 
     #[test]
     fn test_pcf_context_new() {


### PR DESCRIPTION
Closes #338.

Spec: `specs/fix-pcfd-poisoned-index-silent-no-op-removal.md`

#338's last criterion asks whether the leak was **real or a test race**, "worth deciding which before fixing". **It is real**, it is deterministically reproducible, and the same mechanism explains why it appeared only in the run #338 describes and never again. The test was *also* fragile, for the reason #338 suspected — but that is the second finding, not the first.

## Criterion 4 (decided first, because it changes what the fix is)

`sess_count()` is `sess_list.read().map(|l| l.len()).unwrap_or(0)` — it reports **0 on a poisoned lock**. And `sess_remove` acquired five locks as `self.x.write().ok()?`, which returns `None` *silently* if any is poisoned.

Two of those five — `ipv4addr_hash`, `ipv6prefix_hash` — **are not touched by `sess_add`**. That asymmetry is the defect:

1. the create takes the `sess_add` path and **succeeds**;
2. the UAV guard refuses, and the compensating `sess_remove` hits the poisoned index and returns `None` **before reaching `sess_list.remove(&id)`** — having removed nothing;
3. the caller cannot tell that from "was not there", because both are `None`;
4. the session leaks — and a poisoned lock stays poisoned **for the life of the process**, so every later removal leaks too, ordinary SM-policy deletes included, until `max_num_of_sess` refuses all creates.

That is the unbounded growth #90 fixed, reachable again by another route.

### This also explains the non-reproduction

#338 records the failure happened in a run where **four other tests were also failing**, and never recurred in 8 green suite runs. A panicking test poisons any lock it held, permanently, for every test after it in that binary:

- panicking siblings → poisoned index → the refusal genuinely leaks → assertion fails
- green suite → no panic → no poison → **nothing to see, at any load**

#338's own "Conditions" section is the strongest evidence for this mechanism.

### The fix

`write_through_poison(&lock)` = `lock.write().unwrap_or_else(|e| e.into_inner())`, applied to the **removal family** — `sess_remove`, `ue_sm_remove`, `ue_am_remove`, `app_remove`, `event_sub_remove` — where a silent give-up is a *leak* rather than a *not-found*. Afterwards the only `None` they return is the genuine one.

Using the data through the poison is the right trade: the alternative is a permanent unbounded leak, and the worst case is a **stale index entry**, whose lookups resolve to an id no longer in the primary list and answer `None` — which is what a caller of a removed record should get.

**Lock order and atomicity are unchanged** — same locks, same order, same single scope, only the poison arm differs. That matters: six documented AB-BA inversion fixes in this file (#66/#192) depend on the order, and the `drop(..)`-before-`persist` discipline on the scoping.

## Criterion 1 — the enumeration

Mechanically enumerated, not eyeballed. 57 pcfd tests touch the global PCF context or a `PCF_*` env var:

| | tests | take `CONTEXT_GUARD` |
|---|---|---|
| touch the global PCF context | 49 | 20 |
| **…without the guard** | **29** | — |
| mutate a `PCF_*` env var | 15 | 7 |
| mutate a `PCF_UAV_*` env var | 3 | **3 (all)** |

- **Hypothesis 1 confirmed**: 29 unguarded context mutators, including session-creating ones (`sm_policy_lifecycle_over_real_http`, `app_session_create_*`, `ue_policy_create_get_update_delete_lifecycle`, …). A `sess_count()` delta read across an `await` is falsifiable by any of them.
- **Hypothesis 2 not confirmed**: all three `PCF_UAV_*` tests take the guard, and no unguarded test touches those vars. The 8 unguarded env mutators touch `PCF_UE_POLICY_DELIVERY`, `PCF_URSP_RULES`, `PCF_T3501_SECS`, `PCF_LOCAL_PLMN` — none of which `is_uav_dnn()` reads.

## Criterion 2 — the test de-fragilised

Both UAV refusal tests now assert per-`(SUPI, PSI)` instead of on a `sess_count()` delta. The UE-SM lookup is `expect`, not the `if let Some(..)` one of them had: the session assertion is **negative**, and a negative assertion is satisfied by every path that never arrived — including a create rejected before it resolved a UE-SM. Requiring the UE-SM first is the positive half proving the path ran, and it holds by construction (the refusal removes the session, not the UE; the create resolves the UE-SM find-then-add at `app.rs:1960`, so a retry reuses it).

## Revert-verify

- Restoring `self.ipv6prefix_hash.write().ok()?` on that one line — a **behavioural** revert, so it cannot fail as a compile error — fails the new guard on its named assertion: *"a poisoned INDEX must not make the removal report 'was not there'"*.
- Short-circuiting the compensating removal (`if false && context.sess_remove(..)`) fails **both** UAV tests on their own named assertions, while the `uav_session_is_allowed_once_*` control still passes. So the per-SUPI form still catches the #90 defect the count delta was there for — it is stronger, not weaker.
- Every injection and restoration confirmed by grep count before and after.

## Criterion 3 — the loop, and what it cannot show

25 consecutive runs of the pcfd unit-test binary under **3 concurrent load generators** (smfd/amfd/upfd unit-test binaries on repeat): **25 pass, 0 fail.**

Stated plainly: a **non-regression measurement, not a reproduction**. The original failure needed a *panicking* sibling to poison a lock, which a green load loop by construction never produces — so this loop could not have failed before *or* after the fix. What pins the defect is the deterministic poisoning test. Recorded because #338 asked, with its ceiling recorded because 25/25 would otherwise read as "the flake is gone".

## Ceilings

- **20 of the 24 poison-fragile functions are untouched.** `.ok()?` on a lock appears at **50 sites in 24 functions**; only the 5 removal ones are changed. The `*_find_*` family answering `None` on poison is wrong but bounded; the `*_add` family is fail-loud. Filed as a follow-up rather than swept in — "use the data through the poison" is a different judgement on a read path than on a removal.
- **`sess_count()` still answers `unwrap_or(0)` on poison**, so it under-reports; it feeds `get_load()`, so a poisoned `sess_list` makes the PCF advertise `load: 0` — the same shape as #325's UPF defect. Needs a decision about whether a load gauge may report "unknown".
- **The refusal leaves a `PcfUeSm`** with no sessions — bounded (one per SUPI, reused on retry), and #90 deliberately removed only the session. Noted because the new assertion depends on it.
- The enumeration covers `bins/nextgcore-pcfd/src`; peer-crate strict-peer tests calling `test_support::init_context()` are a further unguarded population.

## Verification

- Workspace **6538 tests, 0 failures** (6537 + the new poisoning guard); `nextgcore-pcfd --lib` 200 passed, 1 ignored.
- `cargo clippy --workspace` 0 errors, `cargo fmt --all -- --check` clean.