### PR TITLE
fix(nas,amfd,smfd,docs): the 5GS↔EPS interworking seam, non-N26 path (#116)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NextGCore — Agentic 6G Core Network</title>
-  <meta name="description" content="5G Core Network in Rust. 24 Network Functions with AI-native analytics, intent-based automation, zero-trust security, and full 4G/EPC interworking. Targets 3GPP Rel-15 with selected Rel-17/18 features; 6G/Rel-20 capabilities are non-normative research prototypes (no frozen Rel-20 specs exist).">
+  <meta name="description" content="5G Core Network in Rust. 24 Network Functions with AI-native analytics, intent-based automation, zero-trust security, and a full 4G/EPC network-function set (MME, HSS, SGW, PCRF). 5GS&#8596;EPS interworking is PARTIAL: capability signalling and identity mapping are implemented, N26 session continuity is not. Targets 3GPP Rel-15 with selected Rel-17/18 features; 6G/Rel-20 capabilities are non-normative research prototypes (no frozen Rel-20 specs exist).">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔷</text></svg>">
 </head>
@@ -36,7 +36,7 @@
         <span>v0.1.0</span> &middot; 3GPP Rel-15 / Rel-17/18 features &middot; 6G prototypes (non-normative, no frozen Rel-20 specs)
       </div>
       <h1>Agentic <span class="accent">6G Core</span> Network</h1>
-      <p>The first AI-native 5G/6G Core Network — 24 Network Functions with ML-driven analytics, intent-based autonomous operations, zero-trust security, and edge intelligence — plus full 4G/EPC interworking (MME, HSS, SGW, PCRF). Built entirely in Rust.</p>
+      <p>The first AI-native 5G/6G Core Network — 24 Network Functions with ML-driven analytics, intent-based autonomous operations, zero-trust security, and edge intelligence — plus a full 4G/EPC network-function set (MME, HSS, SGW, PCRF). Built entirely in Rust. <strong>5GS&#8596;EPS interworking is partial</strong>: the AMF signals the IWK-N26 indicator and maps 5G-GUTI&#8596;EPS-GUTI, and the SMF registers a PGW-C+SMF FQDN for the non-N26 path, but there is no N26 interface and therefore no inter-system session continuity — see the <a href="features.html">feature matrix</a>.</p>
       <div class="hero-buttons">
         <a href="#quickstart" class="btn btn-primary">Get Started</a>
         <a href="#ai-native" class="btn btn-secondary">Explore AI Features</a>

--- a/specs/fix-5gs-eps-interworking-seam.md
+++ b/specs/fix-5gs-eps-interworking-seam.md
@@ -1,0 +1,248 @@
+# fix(nas,amfd,smfd,docs): the 5GS↔EPS interworking seam, non-N26 path
+
+Closes #116.
+
+#116's criterion 6 is an explicit either/or: deliver the **N26** leg, **or** complete the
+**non-N26** path "and document it as the supported mode". This takes the second branch,
+which is also the order #116's own suggested approach asks for ("Deliver the lower-risk
+non-N26 path first, then the N26 leg behind a feature gate"). The N26 leg is #62.
+
+## Three of #116's cited sites were stale, and two of them would have made this unreachable
+
+Re-verified at `bf57ddd` before any code was written. This is not pedantry: two of the
+three would have produced a correct fix in a place nothing calls.
+
+| #116 says | actually | consequence |
+|---|---|---|
+| criterion 2: populate `context.s1_mode` via the parser at `gmm_handler.rs:52-83` | that parser is **dead**. `gmm_handler::handle_registration_request` has three callers, all inside `mod tests` (`gmm_handler.rs:776`). `ngap_path.rs:6508` already says so: "Mirrors the (dead-code) gmm_handler logic" | done in `parse_registration_request_pdu`, the parser `handle_registration_request_nas` actually uses |
+| criterion 7: `ngap_handler.rs:657-658` errors when `handover_type != 0` | **that reject no longer exists.** The only survivor is the `HO_TARGET_NOT_ALLOWED` constant at `:38` | see below — its absence was *worse* than the reject |
+| `s1_mode` at `context.rs:1989` | now `context.rs:2070`, on `GmmCapability`, reached as `AmfUe.gmm_capability.s1_mode` | line drift only |
+
+Also already present, contrary to the gap description: `bins/nextgcore-smfd/src/eps_iwk.rs`
+(EBI assignment over `Namf_Communication`, from #117) and
+`gsm_build::encode_mapped_eps_bearer_context`. So the mapped-EPS-bearer half of
+interworking exists; what was missing is the seam #116 lists.
+
+### Criterion 7 was not "an over-strict reject" but a silent mis-handling
+
+With the reject gone, `handle_handover_required` logged the type and then passed
+`required.handover_type` **straight into the `HandoverRequest`**. So a `fivegs-to-eps`
+preparation was resolved against connected gNBs and either
+
+- failed with `unknown-target-id` — a cause that describes an MME as an unknown gNB, and
+  would send an operator hunting a RAN misconfiguration; or
+- if some gNB's id happened to match, was **forwarded to a gNB** as a 5GS→EPS handover
+  this AMF cannot carry out.
+
+Now declined with `ho-target-not-allowed` (CauseRadioNetwork 8) plus local cleanup. The UE
+keeps its registration and PDU sessions — the graceful degradation #116 asks for, not a
+hard failure.
+
+## The IWK N26 bit is inverted from the obvious reading
+
+The single most important finding, and the reason the wire constants were read out of the
+vendored spec rather than from memory.
+
+`IWK N26` is **not** "N26 supported". TS 24.501 Table 9.11.3.5.1
+(`24501-j62.txt:75100`) names it *"Interworking without N26 interface indicator"*:
+
+| bit | means | UE behaviour (§5.5.1.2.4) |
+|---|---|---|
+| `0` | interworking without N26 **not** supported → the AMF **has** N26 | must use single-registration mode |
+| `1` | interworking without N26 supported → the AMF has **no** N26 | may use dual-registration mode |
+
+An implementation that sets the bit because "we support interworking" tells every UE the
+exact opposite of the truth, and a UE believing it would expect session continuity on an
+inter-system move this core cannot perform. It is also invisible to an encode/decode
+test — the same symmetric-defect trap as #91's payload container type.
+
+Two defences: the API is an `enum Iwk26 { N26Supported, WithoutN26Supported }` rather
+than a `bool` (at a call site `WithoutN26Supported` cannot be misread the way `true`
+can), and `iwk_n26_bit_matches_ts24501_table_9_11_3_5_1` asserts both encodings as
+literals against the clause.
+
+**Value shipped: `WithoutN26Supported` (bit SET)**, because this AMF has no N26 leg.
+
+## Criterion 1 — the IE, emitted conditionally
+
+`libs/nextgcore-nas/src/interworking.rs` adds `FiveGsNetworkFeatureSupport` (IEI `0x21`,
+TLV, TS 24.501 Table 8.2.7.1), and `RegistrationAccept` gains the field, encoded in
+§8.2.7 table order (after `0x11`/`0x31`, before `0x50`) with a decode arm that consumes
+the whole contents field so the IE walk stays aligned.
+
+`build_registration_accept` emits it **only to a UE that claimed S1 mode**, because that
+is what §5.5.1.2.4 says: *"If the UE included S1 mode supported indication in the
+REGISTRATION REQUEST message, the AMF supporting interworking with EPS shall set the IWK
+N26 bit"*. A UE that never asked gets the IE omitted, not a bit it has no use for. That
+makes criterion 1 depend on criterion 2, which is the right coupling.
+
+Only the two octet-3 bits this core can honestly speak to are modelled; a contents length
+of 1 makes the UE read octets 4-6 as zero (§9.11.3.5), and zero is the correct "not
+supported" for every bit in them, so three octets of zeroes would assert the same thing
+at greater length.
+
+**Stated deviation from criterion 1**: "set according to configured capability" — there is
+no config knob. `iwk_n26_posture()` is a constant. Its only other setting would advertise
+an N26 interface that does not exist, and a configuration option whose non-default value
+is always a lie is worse than a constant. When #62 lands, that function is the single
+place that changes.
+
+## Criterion 2 — S1 mode, in the live parser
+
+The 5GMM capability IE (IEI `0x10`, TLV) was walked past by the default TLV arm. Now
+parsed for octet 3 bit 1, recorded as `AmfUe.gmm_capability.s1_mode` — which had **no
+writer at all** before this.
+
+`claims_s1_mode` **delegates to `FiveGmmCapability`'s existing decoder** rather than
+masking the bit itself. That type already derives `s1_mode` from the same octet with the
+same mask, and a second `& 0x01` would be a second implementation of one wire fact, free
+to drift — the shape that bit #335 (three modules spelling `Pdr` for different types) and
+#340 (four hand-maintained wire tables wrong). A test asserts the two agree for **all 256**
+octet-3 values, so they cannot diverge silently.
+
+## Criterion 4 — a mapped GUTI is recognised as mapped
+
+There is no separate identity *type* for a mapped 5G-GUTI: §9.11.3.4 has one `5G-GUTI`
+value and a mapped one is structurally identical to a native one. That is exactly why
+storing it as native was silent.
+
+The discriminator is the **EPS NAS message container** (IEI `0x70`), which was previously
+skipped:
+
+- §5.5.1.2.2 requires a UE that maps its 4G-GUTI to include an ATTACH REQUEST in that IE;
+- §5.5.1.3.4 case c.2 reads the same way round — *"has included the 5G-GUTI mapped from
+  the 4G-GUTI in the 5GS mobile identity IE and not included an Additional GUTI IE"*.
+
+So on a Registration Request carrying a GUTI **and** an EPS NAS message container:
+
+- the mapped identity is reverse-mapped per §2.10.2.1.3 and stored in the new
+  `AmfUe.mapped_eps_guti`, **not** in `old_guti` — keeping it where it cannot be mistaken
+  for a native 5G-GUTI, and preserving the one identity an MME could be asked about;
+- the **Additional GUTI IE** (`0x77`) is now *decoded* rather than merely counted, because
+  per §5.5.1.2.2 that is the UE's native 5G-GUTI, and so it — and only it — may become
+  `old_guti`;
+- the container's presence and size are logged, and its contents are **not** interpreted.
+  Decoding an EPS ATTACH/TAU REQUEST *is* the N26 leg (#62); claiming to have processed it
+  would be worse than saying it was not.
+
+## Criterion 5 — GUTI mapping in production code
+
+`five_g_guti_to_eps_guti` / `eps_guti_to_5g_guti`, TS 23.003 §2.10.2. Previously the only
+such arithmetic in the tree was in `libs/nextgcore-nas/tests` fixtures, so no NF could
+perform it.
+
+The mapping is a **bijection** — 8 + 10 + 6 = 24 bits of
+`<AMF Region ID><AMF Set ID><AMF Pointer>` against 16 + 8 = 24 of
+`<MME Group ID><MME Code>` — which is why it round-trips exactly, and it *has* to be
+lossless for §2.10.2.1.3 to work at all (the old AMF must recover its **stored** 5G-GUTI
+from the GUTI an MME sends).
+
+The two-bit split of `<AMF Set ID>` across the Group-ID/Code boundary is the part that is
+easy to get wrong, and a round-trip test would pass with that split at *any* bit boundary
+as long as both directions agreed. So the field values are computed from the clause by
+hand and asserted literally, with a separate round-trip over the field boundaries
+(including all-ones, where a mask one bit too wide bleeds into a neighbour).
+
+## Criterion 3 — the non-N26 bootstrap
+
+`epsInterworkingInd` (TS 29.502) is parsed from `SmContextCreateData` — it was read
+nowhere in smfd — as the four values the OpenAPI defines, not as a bool: `WITHOUT_N26` and
+`WITH_N26` differ in *mechanism*, and `IWK_NON_3GPP` is a different interface again, a
+distinction #62 will need. An unrecognised value is `NONE`, because the OpenAPI defines the
+type as `anyOf [enum, string]` expressly for forward compatibility.
+
+`pgwFqdn` (TS 29.503 `SmfRegistration`, verified against `TS29503_Nudm_UECM.yaml`) is then
+added to the UECM registration when **both** hold: the AMF marked the session
+EPS-interworking-capable, and `SMF_PGW_FQDN` is set. `IWK_NON_3GPP` deliberately does not
+count — it is interworking with non-3GPP access, so no MME will ever look for a PGW-C+SMF
+because of it.
+
+**No FQDN is derived when the variable is unset.** TS 23.003 §19.4.2.8 fixes the zone
+(`node.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org`) and explicitly places it "into the
+operator's control", so the leaf label is the operator's to choose: a synthesised name
+would be well-formed and still NXDOMAIN. An MME that resolves a fabricated FQDN and fails
+is worse off than one that finds no `pgwFqdn` and falls back to its own APN-based PGW
+selection. The member is omitted and the reason logged.
+
+An env var rather than a cargo feature, for the reason `eps_iwk.rs` records: CI builds
+default features, so a feature-gated path is left uncompiled and rots.
+
+## Criterion 8 — the docs
+
+`docs/features.html` already marked GTPv2-C (S5/S8/N26) as **prototype**, "no wire
+listener" — so `index.html`'s "full 4G/EPC interworking" contradicted the project's own
+feature matrix, not just the code. Both `index.html:7` and `:39` now claim what is true: a
+full 4G/EPC **network-function set** (MME, HSS, SGW, PCRF — which does exist), with
+5GS↔EPS interworking named as **partial**, saying which parts work and that there is no
+N26 and therefore no inter-system session continuity, and linking the matrix.
+
+## Revert-verify
+
+Five behavioural reverts, each confirmed applied by grep before the run and restored
+after, each failing its own NAMED assertion:
+
+| revert | test that failed |
+|---|---|
+| `iwk_n26_posture()` → `N26Supported` | `registration_accept_carries_iwk_n26_only_for_an_s1_mode_ue` — "IWK N26 SET, meaning 'interworking WITHOUT N26 interface supported'" |
+| `req.s1_mode = false && …` | `the_live_parser_captures_ue_s1_mode_capability` |
+| `guti_is_mapped_from_eps` → `false && …` | `a_mapped_eps_guti_is_recognised_as_mapped_and_reverse_maps_to_the_4g_guti` |
+| `Ht::FivegsToEps => return None` | `an_inter_system_handover_is_declined_with_ho_target_not_allowed` — "FivegsToEps must be refused, not forwarded to a gNB" |
+| drop the `body["pgwFqdn"]` assignment | `the_uecm_registration_carries_pgw_fqdn_only_for_an_interworking_session` |
+
+All are **value/condition flips**, not deletions, because a revert that fails to *compile*
+proves nothing about the assertion (#48's match-arm lesson).
+
+Criterion 7's test asserts the **decision**, not the transmission: driving
+`handle_handover_required` needs an SCTP-connected gNB the unit harness does not have —
+`context.rs` says so in as many words. `inter_system_handover_refusal` is split out for
+that, the same decision/transmission split used for #70, #91, #48 and #69. It also pins
+`HoTargetNotAllowed as i64 == 8` against the spec table, so renaming the enum cannot
+silently change the wire value.
+
+## Ceilings, stated rather than implied
+
+- **No N26 leg.** No GTPv2-C toward an MME, no Forward Relocation, no Context Request, no
+  inter-system session continuity. That is #62, and every claim shipped here is worded so
+  it stays true when #62 lands.
+- **The EPS NAS message container is captured, not interpreted.** An ATTACH/TAU REQUEST
+  inside it is an EPS NAS message; decoding and acting on it is the N26 leg.
+- **`pgwFqdn` is registered, and nothing consumes it here.** It is the bootstrap an
+  MME/HSS uses; this core has no MME-facing S5/S8 listener to be found *on* (`features.html`
+  already says "no bound GTP-C socket").
+- **`mapped_eps_guti` is recorded and has no reader yet.** Deliberate and load-bearing: it
+  is the value a Context Request would carry, and recording it is what makes the mapped
+  identity survive instead of being flattened into `old_guti`. Named here because
+  "production writer, no production reader" is the shape #325/#335/#341 warn about — the
+  difference is that the alternative was *losing* the identity, not storing it twice.
+- **The EPS→5GS path still asks for a SUCI** and re-authenticates rather than retrieving
+  context from the old MME. That is the honest degradation with no N26; it is not session
+  continuity.
+- amfd's registration parser remains hand-rolled and does not go through
+  `nextgcore-nas`'s `RegistrationRequest` decoder. `claims_s1_mode` bridges the two so the
+  S1-mode bit has one implementation; the rest of the parser is unchanged.
+
+## Verification
+
+- Workspace **6550 tests, 0 failures** (6538 + 12). `cargo clippy --workspace` 0 errors,
+  `cargo fmt --all -- --check` clean.
+- Wire constants read out of the vendored specs, not from memory: `24501-j62.txt` (IE
+  layouts, IEIs, §5.5.1.2.2/§5.5.1.2.4/§5.5.1.3.4), `23003-k00.txt` (§2.10.2, §19.4.2.8),
+  `TS29503_Nudm_UECM.yaml` (`pgwFqdn`), `TS29502_Nsmf_PDUSession.yaml`
+  (`EpsInterworkingIndication`).
+
+## Files
+
+- `src/libs/nextgcore-nas/src/interworking.rs` — new: GUTI mapping, the network feature
+  support IE, `Iwk26`, `claims_s1_mode`.
+- `src/libs/nextgcore-nas/src/fiveg/message.rs` — `RegistrationAccept.network_feature_support`
+  plus encode/decode.
+- `src/libs/nextgcore-nas/tests/message_roundtrip.rs` — the IE inside a full IE walk, and
+  its bytes and IEI order.
+- `src/bins/nextgcore-amfd/src/gmm_build.rs` — emits the IE for an S1-mode UE;
+  `iwk_n26_posture`.
+- `src/bins/nextgcore-amfd/src/ngap_path.rs` — 5GMM capability and EPS NAS container arms,
+  Additional GUTI decode, mapped-GUTI branch, `inter_system_handover_refusal`.
+- `src/bins/nextgcore-amfd/src/context.rs` — `AmfUe.mapped_eps_guti`.
+- `src/bins/nextgcore-smfd/src/udm.rs` — `EpsInterworkingInd`, `pgwFqdn`.
+- `src/bins/nextgcore-smfd/src/main.rs` — parses the indication on SM context create.
+- `docs/index.html` — the claim matches the delivered path and `features.html`.

--- a/src/bins/nextgcore-amfd/src/context.rs
+++ b/src/bins/nextgcore-amfd/src/context.rs
@@ -2213,6 +2213,17 @@ pub struct AmfUe {
     pub next_guti: Guti5gs,
     /// Old GUTI (for context transfer)
     pub old_guti: Guti5gs,
+    /// The 4G-GUTI recovered from a 5G-GUTI the UE mapped from EPS (TS 23.003
+    /// §2.10.2.1.3 reverse mapping), when this registration arrived from EPS.
+    ///
+    /// `Some` only when the Registration Request carried an EPS NAS message container
+    /// alongside a GUTI, which is the discriminator §5.5.1.3.4 c.2 uses. Kept SEPARATE
+    /// from [`AmfUe::old_guti`] on purpose (#116): a mapped 5G-GUTI is structurally
+    /// identical to a native one, so storing it in `old_guti` made the AMF look up a
+    /// native context that never existed, and lose the one identity an MME could have
+    /// been asked about. This is the value a Context Request over N26 would carry when
+    /// that leg exists (#62).
+    pub mapped_eps_guti: Option<nextgcore_nas::eps::types::EpsGuti>,
     /// UE context transfer state
     pub amf_ue_context_transfer_state: UeContextTransferState,
     /// GUAMI pointer index
@@ -2808,6 +2819,7 @@ impl AmfUe {
             next_m_tmsi: None,
             next_guti: Guti5gs::default(),
             old_guti: Guti5gs::default(),
+            mapped_eps_guti: None,
             amf_ue_context_transfer_state: UeContextTransferState::Initial,
             guami_index: None,
             gnb_ostream_id: 0,

--- a/src/bins/nextgcore-amfd/src/gmm_build.rs
+++ b/src/bins/nextgcore-amfd/src/gmm_build.rs
@@ -485,6 +485,27 @@ pub fn build_registration_accept(amf_ue: &AmfUe) -> Option<Vec<u8>> {
         .unwrap_or(540);
     let t3512_value = Some(encode_gprs_timer3_seconds(t3512_seconds));
 
+    // 5GS network feature support (IEI 0x21, TS 24.501 §9.11.3.5), carrying IWK N26.
+    //
+    // Emitted ONLY to a UE that claimed S1 mode, because that is what §5.5.1.2.4
+    // says: "If the UE included S1 mode supported indication in the REGISTRATION
+    // REQUEST message, the AMF supporting interworking with EPS shall set the IWK N26
+    // bit". A UE that never asked gets the IE omitted rather than a bit it has no use
+    // for. `gmm_capability.s1_mode` is populated by the live registration parser
+    // (`ngap_path::parse_registration_request_pdu`), which is where #116's criterion 2
+    // had to land: the `gmm_handler` parser its text cites has only test callers.
+    let network_feature_support = if amf_ue.gmm_capability.s1_mode {
+        Some(nextgcore_nas::interworking::FiveGsNetworkFeatureSupport {
+            iwk_n26: iwk_n26_posture(),
+            // IMS voice over PS is not offered by this core: there is no IMS leg, and
+            // claiming it would have a UE attempt voice over a PS session that cannot
+            // carry it. Omitted as false rather than left unstated.
+            ims_vops_3gpp: false,
+        })
+    } else {
+        None
+    };
+
     let msg =
         nextgcore_msg::FiveGmmMessage::RegistrationAccept(nextgcore_msg::RegistrationAccept {
             registration_result,
@@ -494,6 +515,7 @@ pub fn build_registration_accept(amf_ue: &AmfUe) -> Option<Vec<u8>> {
             tai_list,
             allowed_nssai,
             rejected_nssai: None,
+            network_feature_support,
             pdu_session_status: None,
             t3512_value,
             t3502_value: None,
@@ -501,10 +523,31 @@ pub fn build_registration_accept(amf_ue: &AmfUe) -> Option<Vec<u8>> {
     Some(nextgcore_msg::build_5gmm_message(&msg).to_vec())
 }
 
+/// The interworking posture this AMF can honestly advertise (TS 24.501 §9.11.3.5).
+///
+/// A **constant**, and deliberately not a config knob, which is a stated deviation
+/// from #116's criterion 1 ("set according to configured capability").
+///
+/// The bit does not mean "interworking supported"; it means *"interworking WITHOUT an
+/// N26 interface is supported"*. So the value follows from one fact: this AMF has no
+/// N26 leg — no GTPv2-C toward an MME, no Forward Relocation, nothing (#62 tracks
+/// building it). Therefore `WithoutN26Supported`, i.e. the bit is SET, and a UE that
+/// supports dual-registration mode may use it (§5.5.1.2.4 case b).
+///
+/// A knob was considered and rejected: its only other setting would advertise an N26
+/// interface that does not exist, and a UE believing it would operate in
+/// single-registration mode and expect session continuity on an inter-system move
+/// that this core cannot perform. A configuration option whose non-default value is
+/// always a lie is worse than a constant — and when #62 lands, this function is the
+/// single place that changes.
+fn iwk_n26_posture() -> nextgcore_nas::interworking::Iwk26 {
+    nextgcore_nas::interworking::Iwk26::WithoutN26Supported
+}
+
 /// Convert amfd's nibble-encoded PLMN into the nextgcore-nas digit-array `PlmnId` so the
 /// two encoders emit identical bytes. amfd marks a 2-digit MNC with `mnc3 == 0xf`;
 /// nextgcore-nas derives the 0xF filler from `mnc_len == 2`, so the two agree byte-for-byte.
-fn to_nextgcore_plmn(p: &crate::context::PlmnId) -> nextgcore_types::PlmnId {
+pub(crate) fn to_nextgcore_plmn(p: &crate::context::PlmnId) -> nextgcore_types::PlmnId {
     let mnc_len = if p.mnc3 == 0x0f { 2 } else { 3 };
     nextgcore_types::PlmnId::new([p.mcc1, p.mcc2, p.mcc3], [p.mnc1, p.mnc2, p.mnc3], mnc_len)
 }
@@ -1749,5 +1792,75 @@ mod tests {
         assert_eq!(GmmCause::from(11), GmmCause::PlmnNotAllowed);
         assert_eq!(GmmCause::from(0), GmmCause::RequestAccepted);
         assert_eq!(GmmCause::from(255), GmmCause::ProtocolErrorUnspecified);
+    }
+    /// #116 criterion 1: the Registration Accept carries the 5GS network feature
+    /// support IE with `IWK N26`, and carries it ONLY to a UE that claimed S1 mode.
+    ///
+    /// Asserted as exact bytes in position, not by searching for the pattern: a
+    /// `windows(3)` search for `21 01 40` would also match those three octets
+    /// occurring inside a neighbouring IE's value, which is how a
+    /// wrongly-positioned IE passes a sloppy test.
+    #[test]
+    fn registration_accept_carries_iwk_n26_only_for_an_s1_mode_ue() {
+        let mut ue = create_test_amf_ue();
+        ue.access_type = 1;
+        ue.next_guti.tmsi = 0; // omit the GUTI IE, to keep the expected image short
+        ue.allowed_nssai.clear();
+        ue.requested_nssai.clear();
+        ue.nr_tai = crate::context::Tai5gs {
+            plmn_id: crate::context::PlmnId::new("001", "01"),
+            tac: 0x010203,
+        };
+
+        // A UE that did NOT claim S1 mode: no IE at all. TS 24.501 §5.5.1.2.4 makes
+        // the indication conditional on the UE's S1-mode indication, and a UE that
+        // never asked has no use for an interworking posture.
+        ue.gmm_capability.s1_mode = false;
+        let mut expected = vec![0x7e, 0x00, 0x42, 0x01, ue.access_type & 0x07];
+        let tl = encode_tai_list(&ue.nr_tai);
+        expected.extend_from_slice(&[0x54, tl.len() as u8]);
+        expected.extend_from_slice(&tl);
+        expected.extend_from_slice(&[0x5e, 0x01, 0xA9]);
+        assert_eq!(
+            build_registration_accept(&ue),
+            Some(expected.clone()),
+            "a UE that did not claim S1 mode must get NO 5GS network feature support IE"
+        );
+
+        // A UE that DID: the IE appears between the TAI list (0x54) and T3512 (0x5E),
+        // per the §8.2.7 table order, with contents length 1 and IWK N26 SET.
+        ue.gmm_capability.s1_mode = true;
+        let mut expected_s1 = vec![0x7e, 0x00, 0x42, 0x01, ue.access_type & 0x07];
+        expected_s1.extend_from_slice(&[0x54, tl.len() as u8]);
+        expected_s1.extend_from_slice(&tl);
+        expected_s1.extend_from_slice(&[0x21, 0x01, 0x40]);
+        expected_s1.extend_from_slice(&[0x5e, 0x01, 0xA9]);
+        assert_eq!(
+            build_registration_accept(&ue),
+            Some(expected_s1),
+            "IEI 0x21, length 1, octet 3 = 0x40: IWK N26 SET, meaning 'interworking \
+             WITHOUT N26 interface supported' -- which is the truthful value because this \
+             AMF has no N26 leg. A 0x00 here would tell the UE the opposite (that N26 \
+             exists and it must use single-registration mode)"
+        );
+    }
+
+    /// The posture is the one the absence of an N26 leg dictates.
+    ///
+    /// Separate from the byte test so that when #62 lands and this becomes variable,
+    /// the thing that changes is one assertion with a name that says why.
+    #[test]
+    fn iwk_n26_posture_says_this_amf_has_no_n26_leg() {
+        assert_eq!(
+            iwk_n26_posture(),
+            nextgcore_nas::interworking::Iwk26::WithoutN26Supported,
+            "with no GTPv2-C leg toward an MME, the only honest posture is \
+             'interworking without N26 supported' (#62 builds the leg)"
+        );
+        assert_eq!(
+            iwk_n26_posture().bit(),
+            0x40,
+            "and it encodes as octet 3 bit 7 SET"
+        );
     }
 }

--- a/src/bins/nextgcore-amfd/src/ngap_path.rs
+++ b/src/bins/nextgcore-amfd/src/ngap_path.rs
@@ -1818,6 +1818,22 @@ impl NgapServer {
         state.amf_ue.registration_type = req.registration_type;
         state.amf_ue.nas_ue_tsc = req.tsc;
         state.amf_ue.nas_ue_ksi = req.ksi;
+        // #116: EPC NAS ("S1 mode") support from the UE's 5GMM capability IE
+        // (TS 24.501 §9.11.3.1 octet 3 bit 1). `gmm_capability.s1_mode` had no writer
+        // at all before this, so `build_registration_accept` could not obey
+        // §5.5.1.2.4 -- which makes the IWK N26 indication conditional on precisely
+        // this bit. Recorded here, with the other capability-shaped fields, so it is
+        // set before any branch that reads it.
+        state.amf_ue.gmm_capability.s1_mode = req.s1_mode;
+        // Computed here, before anything moves a field out of `req` (the security
+        // capability below is not `Copy`): this predicate reads three of them.
+        let guti_mapped_from_eps = req.guti_is_mapped_from_eps();
+        if req.s1_mode {
+            log::info!(
+                "UE claims S1 mode (EPC NAS) support: the Registration Accept will carry \
+                 the 5GS network feature support IE with IWK N26 (TS 24.501 §5.5.1.2.4)"
+            );
+        }
         // #91: park the UE policy container for the Npcf_UEPolicyControl_Create that
         // happens later in the procedure. Overwritten, not merged, on a re-sent
         // Registration Request: the latest one is the UE's current installed set, and
@@ -1937,7 +1953,59 @@ impl NgapServer {
                     .await?;
             }
             t if t == mobile_identity_type::GUTI => {
-                if let Some(guti) = req.guti {
+                if guti_mapped_from_eps {
+                    // EPS→5GS mobility (#116). The identity is a 5G-GUTI the UE MAPPED
+                    // from its 4G-GUTI (TS 23.003 §2.10.2.2.2), not a native one, and
+                    // the two are structurally indistinguishable -- so storing it in
+                    // `old_guti` claimed a native context that never existed and threw
+                    // away the only identity an MME could be asked about.
+                    //
+                    // Recover the 4G-GUTI by the reverse mapping §2.10.2.1.3 requires,
+                    // and keep it where it cannot be mistaken for a native 5G-GUTI.
+                    let mapped = req.guti.as_ref().map(|g| {
+                        nextgcore_nas::interworking::five_g_guti_to_eps_guti(
+                            &nextgcore_nas::fiveg::types::FiveGGuti {
+                                plmn_id: crate::gmm_build::to_nextgcore_plmn(&g.plmn_id),
+                                amf_region_id: g.amf_region_id,
+                                amf_set_id: g.amf_set_id,
+                                amf_pointer: g.amf_pointer,
+                                tmsi: g.tmsi,
+                            },
+                        )
+                    });
+                    if let Some(ref eps_guti) = mapped {
+                        log::info!(
+                            "EPS→5GS registration: 5GS mobile identity is a 5G-GUTI mapped \
+                             from EPS; recovered 4G-GUTI (MME GID={:#06x}, MME code={:#04x}, \
+                             M-TMSI={:#010x}) from the reverse mapping (TS 23.003 §2.10.2.1.3). \
+                             This AMF has no N26 leg, so the UE context is NOT retrieved from \
+                             the old MME (#62); the UE is identified afresh by SUCI instead of \
+                             the registration being rejected",
+                            eps_guti.mme_gid,
+                            eps_guti.mme_code,
+                            eps_guti.m_tmsi
+                        );
+                    }
+                    state.amf_ue.mapped_eps_guti = mapped;
+                    // The Additional GUTI IE, when the UE included one, IS the native
+                    // 5G-GUTI (§5.5.1.2.2) -- so that, and only that, may become
+                    // `old_guti`.
+                    if let Some(native) = req.additional_guti {
+                        state.amf_ue.old_guti = native;
+                    }
+                    if let Some(ref container) = req.eps_nas_message_container {
+                        // Not decoded: the ATTACH/TAU REQUEST inside is an EPS NAS
+                        // message whose handling IS the N26 leg (#62). Recording its
+                        // presence and size is the honest ceiling -- pretending to
+                        // have processed it would be worse than saying it was not.
+                        log::info!(
+                            "EPS NAS message container present ({} octets): carries the \
+                             ATTACH/TAU REQUEST the MME would handle. Not processed -- \
+                             EPS NAS interpretation is the N26 leg (#62)",
+                            container.len()
+                        );
+                    }
+                } else if let Some(guti) = req.guti {
                     state.amf_ue.old_guti = guti;
                 }
                 // GUTI unknown to this AMF instance: identify the UE by SUCI
@@ -4780,6 +4848,56 @@ impl NgapServer {
             required.handover_type
         );
 
+        // Inter-system handover (TS 38.413 §9.3.1.22 HandoverType): decide on the
+        // TYPE before looking for a target gNB, because for anything but intra-5GS
+        // there is no gNB to look for (#116).
+        //
+        // #116's criterion 7 describes an unconditional `handover_type != 0` reject in
+        // `ngap_handler`. That reject no longer exists -- re-verified at `bf57ddd`, the
+        // only survivor is the `HO_TARGET_NOT_ALLOWED` constant -- and its absence left
+        // something WORSE than an honest refusal: the type was logged and then passed
+        // straight through into the `HandoverRequest` below. So a `fivegs-to-eps`
+        // preparation was resolved against connected gNBs and either failed with
+        // `UnknownTargetId` (a cause that misdescribes the reason: the target is an
+        // MME, not an unknown gNB) or, if some gNB's id happened to match, was
+        // forwarded to a gNB as a 5GS→EPS handover the AMF cannot carry out.
+        //
+        // Declined honestly instead, with local cleanup. `ho-target-not-allowed` is
+        // the accurate cause: the target system is not one this AMF may hand over to,
+        // because it has no N26 leg toward an MME (#62 builds it). Nothing is torn
+        // down for the UE -- it stays registered and served on 5GS, which is the
+        // graceful degradation #116 asks for rather than a hard failure.
+        if let Some((cause, target_system)) = inter_system_handover_refusal(required.handover_type)
+        {
+            log::warn!(
+                "HandoverRequired with HandoverType={:?} ({target_system}): declining with \
+                 ho-target-not-allowed. This AMF has no inter-system handover leg -- N26 \
+                 toward an MME is not implemented (#62) -- so the preparation is refused \
+                 rather than forwarded to a gNB as if it were intra-5GS. The UE keeps its \
+                 5GS registration and PDU sessions; nothing is released.",
+                required.handover_type
+            );
+            let failure = nextgcore_ngap::types::HandoverPreparationFailure {
+                amf_ue_ngap_id: required.amf_ue_ngap_id,
+                ran_ue_ngap_id: required.ran_ue_ngap_id,
+                cause: nextgcore_ngap::types::Cause::RadioNetwork(cause),
+                criticality_diagnostics: None,
+            };
+            // Local cleanup, the same state HandoverCancel drops: a relay target and
+            // any per-session transfers left from an earlier preparation for this UE.
+            // Dropped BEFORE the failure is sent, so a failed send cannot leave a
+            // stale relay target that a later Uplink RAN Status Transfer would follow
+            // to a gNB this UE is not moving to.
+            self.handover_target_assoc.remove(&required.amf_ue_ngap_id);
+            self.handover_target_transfers
+                .retain(|(ue, _psi), _| *ue != required.amf_ue_ngap_id);
+            if let Ok(bytes) = nextgcore_ngap::builder::build_handover_preparation_failure(&failure)
+            {
+                self.send_to_association(association_id, &bytes).await?;
+            }
+            return Ok(());
+        }
+
         // Locate the target gNB association from the TargetID's Global RAN Node
         // ID. Without a matching connected gNB the AMF cannot allocate handover
         // resources (inter-AMF / N2 relocation needs Namf_Communication, which
@@ -6390,6 +6508,27 @@ struct ParsedRegistrationRequest {
     nas_message_container_present: bool,
     /// Payload container type from the half-octet IEI `8-` (TS 24.501 §9.11.3.40).
     payload_container_type: Option<u8>,
+    /// Whether the UE claimed S1 mode (EPC NAS) support in its 5GMM capability IE
+    /// (IEI 0x10, TS 24.501 §9.11.3.1 octet 3 bit 1).
+    ///
+    /// #116: the IE was walked past by the default TLV arm, so `s1_mode` was
+    /// write-never and the AMF could not obey §5.5.1.2.4 — which makes signalling
+    /// `IWK N26` conditional on exactly this bit.
+    s1_mode: bool,
+    /// EPS NAS message container contents (IEI 0x70, TLV-E, TS 24.501 §9.11.3.24).
+    ///
+    /// #116: previously skipped. Per §5.5.1.2.2 a UE arriving from EPS puts an
+    /// ATTACH REQUEST (or TRACKING AREA UPDATE REQUEST) here, and its PRESENCE is how
+    /// the AMF knows the 5GS mobile identity holds a 5G-GUTI **mapped** from a
+    /// 4G-GUTI rather than a native one — see [`Self::guti_is_mapped_from_eps`].
+    eps_nas_message_container: Option<Vec<u8>>,
+    /// Additional GUTI IE (IEI 0x77, TLV-E) decoded as a 5G-GUTI.
+    ///
+    /// Per §5.5.1.2.2 a UE that maps a 4G-GUTI into the 5GS mobile identity IE puts
+    /// its valid NATIVE 5G-GUTI here, if it holds one. So on the EPS→5GS path this is
+    /// the identity that may be treated as native, and the one in the mobile identity
+    /// IE is not.
+    additional_guti: Option<Guti5gs>,
     /// Payload container contents from IEI 0x7B (§9.11.3.39).
     ///
     /// #91: §5.5.1.2.2 lets a UE carry a "UE policy container" here holding a UE
@@ -6412,6 +6551,26 @@ impl ParsedRegistrationRequest {
             (Some(PAYLOAD_CONTAINER_TYPE_UE_POLICY), Some(bytes)) => Some(bytes),
             _ => None,
         }
+    }
+
+    /// Is the 5GS mobile identity a 5G-GUTI **mapped from a 4G-GUTI** (TS 23.003
+    /// §2.10.2.2.2) rather than a native one?
+    ///
+    /// There is no separate identity TYPE for it — §9.11.3.4 has one `5G-GUTI` value
+    /// and a mapped GUTI is structurally identical to a native one, which is exactly
+    /// why storing it as native was silent. The discriminator is the **EPS NAS message
+    /// container**: §5.5.1.2.2 requires a UE that maps its 4G-GUTI to include an
+    /// ATTACH REQUEST in that IE, and §5.5.1.3.4 case c.2 reads the same way round
+    /// ("has included the 5G-GUTI mapped from the 4G-GUTI in the 5GS mobile identity
+    /// IE and not included an Additional GUTI IE").
+    ///
+    /// Gated on the identity actually being a GUTI: a UE registering with a SUCI can
+    /// also carry an EPS NAS message container, and calling that a mapped GUTI would
+    /// be a second wrong answer.
+    fn guti_is_mapped_from_eps(&self) -> bool {
+        self.eps_nas_message_container.is_some()
+            && self.identity_type == mobile_identity_type::GUTI
+            && self.guti.is_some()
     }
 }
 
@@ -6784,6 +6943,41 @@ fn extract_nas_message_container(nas: &[u8]) -> Option<Vec<u8>> {
     None
 }
 
+/// Should this HandoverRequired be refused because it is an INTER-SYSTEM handover?
+///
+/// Returns the NGAP cause and a label for the log, or `None` for intra-5GS (which the
+/// AMF does handle).
+///
+/// Split out from `handle_handover_required` so the DECISION is assertable without the
+/// transmission: driving that handler needs an SCTP-connected gNB the unit harness does
+/// not have (`context.rs` says so in as many words -- "amfd has no harness that drives
+/// `handle_handover_required`"). The same decision/transmission split this tree uses for
+/// #70, #91, #48 and #69.
+///
+/// `ho-target-not-allowed` (TS 38.413 CauseRadioNetwork 8) is the accurate cause: the
+/// target system is not one this AMF may hand over to, because it has no N26 leg toward
+/// an MME (#62). Deliberately NOT `unknown-target-id`, which is what the pre-#116 code
+/// ended up answering by falling through to the connected-gNB search -- that cause says
+/// "I do not know that gNB" about a target which is an MME, and it would send an
+/// operator looking for a RAN misconfiguration.
+fn inter_system_handover_refusal(
+    handover_type: nextgcore_ngap::types::HandoverType,
+) -> Option<(
+    nextgcore_asn1c::ngap::cause::CauseRadioNetwork,
+    &'static str,
+)> {
+    use nextgcore_ngap::types::HandoverType as Ht;
+    let target_system = match handover_type {
+        Ht::Intra5gs => return None,
+        Ht::FivegsToEps => "EPS (fivegs-to-eps)",
+        Ht::EpsTo5gs => "5GS (eps-to-5gs)",
+    };
+    Some((
+        nextgcore_asn1c::ngap::cause::CauseRadioNetwork::HoTargetNotAllowed,
+        target_system,
+    ))
+}
+
 fn parse_registration_request_pdu(nas: &[u8]) -> Option<ParsedRegistrationRequest> {
     // EPD + sec hdr + msg type + (ngKSI | 5GS registration type) + LV-E identity
     if nas.len() < 6 {
@@ -6913,6 +7107,21 @@ fn parse_registration_request_pdu(nas: &[u8]) -> Option<ParsedRegistrationReques
                 req.presencemask |= reg_present::LAST_VISITED_TAI;
                 pos += 7;
             }
+            // 5GMM capability (IEI 0x10, TLV, TS 24.501 §9.11.3.1). Parsed for its
+            // octet-3 bit 1 (`S1 mode` / EPC NAS supported), which §5.5.1.2.4 makes
+            // the precondition for signalling IWK N26 back (#116). Must precede the
+            // default TLV arm, which used to walk straight past it.
+            0x10 => {
+                if pos + 1 >= nas.len() {
+                    break;
+                }
+                let len = nas[pos + 1] as usize;
+                if pos + 2 + len <= nas.len() {
+                    req.s1_mode =
+                        nextgcore_nas::interworking::claims_s1_mode(&nas[pos + 2..pos + 2 + len]);
+                }
+                pos += 2 + len;
+            }
             // TLV-E IEs (2-byte length): EPS NAS container (0x70),
             // NAS message container (0x71), additional GUTI (0x77),
             // payload containers (0x7B/0x7C)
@@ -6922,11 +7131,30 @@ fn parse_registration_request_pdu(nas: &[u8]) -> Option<ParsedRegistrationReques
                 }
                 let len = ((nas[pos + 1] as usize) << 8) | (nas[pos + 2] as usize);
                 match iei {
+                    // EPS NAS message container (§9.11.3.24). KEPT, not skipped
+                    // (#116): its presence is how the AMF learns the 5GS mobile
+                    // identity holds a GUTI mapped from EPS, and its contents are the
+                    // ATTACH / TAU REQUEST the MME would have handled. Bounds-checked
+                    // rather than trusted -- `len` came off the wire.
+                    0x70 => {
+                        if pos + 3 + len <= nas.len() {
+                            req.eps_nas_message_container =
+                                Some(nas[pos + 3..pos + 3 + len].to_vec());
+                        }
+                    }
                     // NAS message container (TS 24.501 §4.4.6): not permitted in
                     // an unprotected initial NAS message.
                     0x71 => req.nas_message_container_present = true,
-                    // Additional GUTI — cleartext IE.
-                    0x77 => req.presencemask |= reg_present::ADDITIONAL_GUTI,
+                    // Additional GUTI — cleartext IE. Decoded (#116), not just
+                    // counted: on the EPS→5GS path this carries the UE's NATIVE
+                    // 5G-GUTI, so it is the one that may be treated as native.
+                    0x77 => {
+                        req.presencemask |= reg_present::ADDITIONAL_GUTI;
+                        if pos + 3 + len <= nas.len() {
+                            req.additional_guti =
+                                crate::gmm_handler::parse_guti(&nas[pos + 3..pos + 3 + len]);
+                        }
+                    }
                     // Payload container (#91): kept, not skipped. Bounds-checked
                     // here rather than trusted, since `len` comes off the wire.
                     0x7B => {
@@ -7626,6 +7854,222 @@ mod tests {
         // Requested NSSAI (IEI 0x2F): one S-NSSAI, SST=1
         nas.extend_from_slice(&[0x2F, 0x02, 0x01, 0x01]);
         nas
+    }
+
+    /// A Registration Request from a UE arriving from EPS (TS 24.501 §5.5.1.2.2):
+    /// the 5GS mobile identity holds a 5G-GUTI **mapped** from the UE's 4G-GUTI, and
+    /// an ATTACH REQUEST rides in the EPS NAS message container IE.
+    ///
+    /// The GUTI bytes are built by mapping a chosen 4G-GUTI FORWARD through
+    /// TS 23.003 §2.10.2.2.2, exactly as the UE would, so the test's fixture is not
+    /// produced by the code under test -- the AMF's reverse mapping has something
+    /// independent to be checked against.
+    fn eps_mobility_registration_request(with_additional_guti: bool) -> (Vec<u8>, (u16, u8, u32)) {
+        // The 4G-GUTI the (imaginary) MME issued.
+        const MME_GID: u16 = 0xAB9B;
+        const MME_CODE: u8 = 0b0110_1010;
+        const M_TMSI: u32 = 0x1234_5678;
+
+        // UE-side mapping, §2.10.2.2.2: MME GID 15..8 -> AMF Region ID;
+        // GID 7..0 -> Set ID 9..2; Code 7..6 -> Set ID 1..0; Code 5..0 -> Pointer.
+        let region = (MME_GID >> 8) as u8;
+        let set_id = ((MME_GID & 0x00FF) << 2) | ((MME_CODE >> 6) as u16 & 0x03);
+        let pointer = MME_CODE & 0x3F;
+
+        let mut nas = vec![0x7E, 0x00, 0x41, 0x09];
+        // 5GS mobile identity (LV-E): type 2 = 5G-GUTI, PLMN 001/01.
+        let guti = vec![
+            0xF2, // spare | type 5G-GUTI (2)
+            0x00,
+            0xF1,
+            0x10, // PLMN 001/01
+            region,
+            (set_id >> 2) as u8,
+            (((set_id & 0x03) as u8) << 6) | pointer,
+            (M_TMSI >> 24) as u8,
+            (M_TMSI >> 16) as u8,
+            (M_TMSI >> 8) as u8,
+            M_TMSI as u8,
+        ];
+        nas.extend_from_slice(&(guti.len() as u16).to_be_bytes());
+        nas.extend_from_slice(&guti);
+        // 5GMM capability (IEI 0x10, TLV): octet 3 bit 1 = S1 mode supported.
+        nas.extend_from_slice(&[0x10, 0x01, 0x01]);
+        // EPS NAS message container (IEI 0x70, TLV-E) holding a stand-in ATTACH REQUEST.
+        let attach: &[u8] = &[0x07, 0x41, 0x71, 0x0B];
+        nas.push(0x70);
+        nas.extend_from_slice(&(attach.len() as u16).to_be_bytes());
+        nas.extend_from_slice(attach);
+        if with_additional_guti {
+            // Additional GUTI (IEI 0x77, TLV-E): the UE's NATIVE 5G-GUTI, deliberately
+            // a different TMSI so it cannot be confused with the mapped one.
+            let native = vec![
+                0xF2, 0x00, 0xF1, 0x10, 0x01, 0x00, 0x40, 0xDE, 0xAD, 0xBE, 0xEF,
+            ];
+            nas.push(0x77);
+            nas.extend_from_slice(&(native.len() as u16).to_be_bytes());
+            nas.extend_from_slice(&native);
+        }
+        (nas, (MME_GID, MME_CODE, M_TMSI))
+    }
+
+    /// #116 criterion 7: an inter-system HandoverRequired is declined with the correct
+    /// cause instead of being treated as intra-5GS.
+    ///
+    /// #116's text describes an unconditional `handover_type != 0` reject in
+    /// `ngap_handler` at a cited line pair. **That reject no longer exists** -- only the
+    /// `HO_TARGET_NOT_ALLOWED` constant survives -- and its absence was worse than the
+    /// reject: the type was logged and then passed STRAIGHT INTO the `HandoverRequest`,
+    /// so a 5GS→EPS preparation was resolved against connected gNBs and either failed
+    /// with `unknown-target-id` (a cause that misdescribes an MME as an unknown gNB) or
+    /// was forwarded to a gNB as a handover this AMF cannot carry out.
+    #[test]
+    fn an_inter_system_handover_is_declined_with_ho_target_not_allowed() {
+        use nextgcore_asn1c::ngap::cause::CauseRadioNetwork as Cr;
+        use nextgcore_ngap::types::HandoverType as Ht;
+
+        assert_eq!(
+            inter_system_handover_refusal(Ht::Intra5gs),
+            None,
+            "intra-5GS handover is handled, not refused: this must stay the ONLY \
+             accepted type, or the refusal would break working N2 handover"
+        );
+
+        for (ht, label) in [
+            (Ht::FivegsToEps, "EPS (fivegs-to-eps)"),
+            (Ht::EpsTo5gs, "5GS (eps-to-5gs)"),
+        ] {
+            let (cause, target) = inter_system_handover_refusal(ht)
+                .unwrap_or_else(|| panic!("{ht:?} must be refused, not forwarded to a gNB"));
+            assert_eq!(
+                cause,
+                Cr::HoTargetNotAllowed,
+                "{ht:?}: the target system is not one this AMF may hand over to -- it has \
+                 no N26 leg (#62). NOT UnknownTargetId, which would blame RAN config"
+            );
+            assert_eq!(target, label);
+        }
+
+        // The cause's wire value, against the spec table rather than the enum name:
+        // an enum renamed or reordered must not silently change what goes on the wire.
+        assert_eq!(
+            Cr::HoTargetNotAllowed as i64,
+            8,
+            "ho-target-not-allowed is CauseRadioNetwork 8 (TS 38.413 §9.3.1.2)"
+        );
+    }
+
+    /// #116 criterion 2: the LIVE parser captures the UE's S1-mode capability.
+    ///
+    /// The parser #116's text cites (`gmm_handler`'s) has only test callers -- its own
+    /// `handle_registration_request` is called from three places, all inside
+    /// `mod tests` -- so implementing this there would have been a correct fix in an
+    /// unreachable place. This is the parser `handle_registration_request_nas` uses.
+    #[test]
+    fn the_live_parser_captures_ue_s1_mode_capability() {
+        let (nas, _) = eps_mobility_registration_request(false);
+        let req = parse_registration_request_pdu(&nas).expect("parse");
+        assert!(
+            req.s1_mode,
+            "5GMM capability IEI 0x10 with octet 3 bit 1 set means S1 mode supported \
+             (TS 24.501 §9.11.3.1); it used to be walked past by the default TLV arm"
+        );
+
+        // And the bit is read, not merely the IE's presence: HO attach (bit 2) is not
+        // S1 mode. Same IE, one bit over.
+        let mut ho_attach_only = nas.clone();
+        let iei = ho_attach_only
+            .windows(3)
+            .position(|w| w == [0x10, 0x01, 0x01])
+            .expect("the capability IE is in the fixture");
+        ho_attach_only[iei + 2] = 0x02;
+        let req = parse_registration_request_pdu(&ho_attach_only).expect("parse");
+        assert!(
+            !req.s1_mode,
+            "octet 3 bit 2 is HO attach, not S1 mode -- a presence-only check would \
+             pass here and advertise IWK N26 to a UE that never claimed EPC NAS"
+        );
+    }
+
+    /// #116 criterion 4: a mapped EPS-GUTI is recognised AS mapped, and is not stored
+    /// as a native 5G-GUTI.
+    #[test]
+    fn a_mapped_eps_guti_is_recognised_as_mapped_and_reverse_maps_to_the_4g_guti() {
+        let (nas, (mme_gid, mme_code, m_tmsi)) = eps_mobility_registration_request(false);
+        let req = parse_registration_request_pdu(&nas).expect("parse");
+
+        assert_eq!(
+            req.identity_type,
+            mobile_identity_type::GUTI,
+            "precondition: the identity is a GUTI"
+        );
+        assert_eq!(
+            req.eps_nas_message_container.as_deref(),
+            Some(&[0x07u8, 0x41, 0x71, 0x0B][..]),
+            "the EPS NAS message container must be KEPT, not skipped: it carries the \
+             ATTACH/TAU REQUEST, and its presence is the discriminator"
+        );
+        assert!(
+            req.guti_is_mapped_from_eps(),
+            "a GUTI plus an EPS NAS message container is a MAPPED 5G-GUTI \
+             (TS 24.501 §5.5.1.2.2, §5.5.1.3.4 c.2), not a native one"
+        );
+
+        // The reverse mapping (§2.10.2.1.3) must recover the MME's own 4G-GUTI --
+        // the fixture computed the 5GS fields forward, independently of this code.
+        let g = req.guti.as_ref().expect("guti");
+        let eps = nextgcore_nas::interworking::five_g_guti_to_eps_guti(
+            &nextgcore_nas::fiveg::types::FiveGGuti {
+                plmn_id: crate::gmm_build::to_nextgcore_plmn(&g.plmn_id),
+                amf_region_id: g.amf_region_id,
+                amf_set_id: g.amf_set_id,
+                amf_pointer: g.amf_pointer,
+                tmsi: g.tmsi,
+            },
+        );
+        assert_eq!(eps.mme_gid, mme_gid, "MME Group ID must round-trip");
+        assert_eq!(eps.mme_code, mme_code, "MME Code must round-trip");
+        assert_eq!(eps.m_tmsi, m_tmsi, "M-TMSI must round-trip");
+
+        // A GUTI with NO EPS NAS message container is native, and must not be
+        // mistaken for mapped -- otherwise every ordinary mobility registration
+        // would be treated as an inter-system move.
+        let mut native_only = nas.clone();
+        let at = native_only
+            .windows(3)
+            .position(|w| w == [0x70, 0x00, 0x04])
+            .expect("container IEI in fixture");
+        native_only.drain(at..at + 3 + 4);
+        let req = parse_registration_request_pdu(&native_only).expect("parse");
+        assert!(req.guti.is_some(), "still a GUTI");
+        assert!(
+            !req.guti_is_mapped_from_eps(),
+            "without an EPS NAS message container the GUTI is NATIVE"
+        );
+    }
+
+    /// The Additional GUTI IE is decoded, because on the EPS→5GS path that -- not the
+    /// mobile identity -- is the UE's native 5G-GUTI (TS 24.501 §5.5.1.2.2).
+    #[test]
+    fn the_additional_guti_ie_is_decoded_not_just_counted() {
+        let (nas, _) = eps_mobility_registration_request(true);
+        let req = parse_registration_request_pdu(&nas).expect("parse");
+        let native = req
+            .additional_guti
+            .expect("additional GUTI must be decoded");
+        assert_eq!(
+            native.tmsi, 0xDEAD_BEEF,
+            "the Additional GUTI's own TMSI, distinct from the mapped identity's"
+        );
+        assert_ne!(
+            native.tmsi,
+            req.guti.as_ref().expect("guti").tmsi,
+            "the two identities must not be conflated"
+        );
+        assert!(
+            req.presencemask & reg_present::ADDITIONAL_GUTI != 0,
+            "and the §4.4.6 presence bit is still set"
+        );
     }
 
     #[test]

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -3042,6 +3042,12 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
                 p.get("mnc")?.as_str()?.to_string(),
             ))
         });
+    // #116: the AMF's per-session EPS-interworking indication (TS 29.502
+    // `SmContextCreateData.epsInterworkingInd`). Parsed here and passed to the UECM
+    // registration, which is the only thing that acts on it today: it decides whether a
+    // `pgwFqdn` is registered so an MME can resolve this PGW-C+SMF (the non-N26
+    // bootstrap). Previously the member was not read anywhere in smfd.
+    let eps_interworking = udm::EpsInterworkingInd::from_body(&req_body);
     udm::register_as_serving_smf(
         &supi,
         pdu_session_id,
@@ -3051,6 +3057,7 @@ async fn handle_sm_context_create(request: &SbiRequest) -> SbiResponse {
         serving_plmn
             .as_ref()
             .map(|(mcc, mnc)| (mcc.as_str(), mnc.as_str())),
+        eps_interworking,
     )
     .await;
     let subscribed = udm::fetch_sm_data(&supi, &dnn, sst, snssai_sd.as_deref()).await;

--- a/src/bins/nextgcore-smfd/src/udm.rs
+++ b/src/bins/nextgcore-smfd/src/udm.rs
@@ -276,6 +276,87 @@ pub async fn fetch_sm_data(
     Some(data)
 }
 
+/// `EpsInterworkingIndication` (TS 29.502 `SmContextCreateData.epsInterworkingInd`).
+///
+/// The AMF tells the SMF, per PDU session, whether it may need to move to EPS and by
+/// which mechanism. Before #116 the member was not parsed at all, so every session
+/// looked identical to a non-interworking one and the SMF had no basis for registering
+/// a `pgwFqdn`.
+///
+/// The enum is modelled as the OpenAPI defines it rather than as a bool, because the
+/// four values are not two: `WITHOUT_N26` and `WITH_N26` differ in *mechanism* and
+/// `IWK_NON_3GPP` is a different interface again. Collapsing them would discard the
+/// distinction the next issue (#62, the N26 leg) needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EpsInterworkingInd {
+    /// `NONE`, or the member absent — the default. Not the same as "unknown": TS 29.502
+    /// gives no default, and an absent indication means the AMF is not asking for
+    /// interworking, which is what `NONE` says.
+    #[default]
+    None,
+    /// `WITH_N26` — interworking using the N26 interface (single-registration mode).
+    WithN26,
+    /// `WITHOUT_N26` — interworking without N26 (the UE may use dual registration).
+    WithoutN26,
+    /// `IWK_NON_3GPP` — interworking with non-3GPP access.
+    IwkNon3gpp,
+}
+
+impl EpsInterworkingInd {
+    /// Parse the member from an `SmContextCreateData` body.
+    ///
+    /// An UNRECOGNISED string is `None` rather than an error: the OpenAPI defines the
+    /// type as `anyOf [enum, string]` explicitly "to provide forward-compatibility with
+    /// future extensions", so a future value must not fail the session — and treating
+    /// something unknown as interworking-capable would register a `pgwFqdn` on a guess.
+    pub fn from_body(body: &serde_json::Value) -> Self {
+        match body.get("epsInterworkingInd").and_then(|v| v.as_str()) {
+            Some("WITH_N26") => Self::WithN26,
+            Some("WITHOUT_N26") => Self::WithoutN26,
+            Some("IWK_NON_3GPP") => Self::IwkNon3gpp,
+            Some("NONE") | None => Self::None,
+            Some(other) => {
+                log::info!(
+                    "epsInterworkingInd={other:?} is not a value this build recognises; \
+                     treated as NONE (TS 29.502 defines the type as forward-compatible)"
+                );
+                Self::None
+            }
+        }
+    }
+
+    /// Does this indication mean the session may move to EPS?
+    ///
+    /// `IWK_NON_3GPP` is EXCLUDED: it is interworking with non-3GPP access, not with
+    /// the EPC, so it does not imply an MME will ever look for a PGW-C+SMF.
+    pub fn is_interworking(self) -> bool {
+        matches!(self, Self::WithN26 | Self::WithoutN26)
+    }
+
+    /// The wire spelling, for logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "NONE",
+            Self::WithN26 => "WITH_N26",
+            Self::WithoutN26 => "WITHOUT_N26",
+            Self::IwkNon3gpp => "IWK_NON_3GPP",
+        }
+    }
+}
+
+/// The PGW-C+SMF FQDN to register with the UDM, from `SMF_PGW_FQDN`.
+///
+/// An env var, like every other smfd switch: this daemon has no clap `Args` struct
+/// (see `eps_iwk`'s note on why the interworking leg is a runtime switch and not a
+/// cargo feature). Blank is treated as unset so an empty value in a compose file does
+/// not register an empty FQDN.
+fn configured_pgw_fqdn() -> Option<String> {
+    std::env::var("SMF_PGW_FQDN")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 /// `Nudm_UECM_Registration` — register as the serving SMF for this PDU session
 /// (TS 29.503 §5.3.2.2, `PUT .../registrations/smf-registrations/{pduSessionId}`).
 ///
@@ -296,6 +377,7 @@ pub async fn register_as_serving_smf(
     sst: u8,
     sd: Option<&str>,
     plmn: Option<(&str, &str)>,
+    eps_interworking: EpsInterworkingInd,
 ) -> bool {
     if !enabled() {
         return false;
@@ -327,6 +409,48 @@ pub async fn register_as_serving_smf(
     });
     if let Some(sd) = sd {
         body["singleNssai"]["sd"] = serde_json::json!(sd);
+    }
+
+    // `pgwFqdn` (TS 29.503 `SmfRegistration`, optional) — the non-N26 interworking
+    // bootstrap (#116). It is how an MME, resolving the subscriber through the
+    // HSS/UDM, finds THIS PGW-C+SMF for a session the UE established on 5GS. Without
+    // it the non-N26 path cannot start at all, whatever else is implemented.
+    //
+    // Sent only when BOTH hold:
+    //
+    // 1. the AMF said the session is EPS-interworking-capable (`epsInterworkingInd`
+    //    `WITH_N26` or `WITHOUT_N26`) -- honouring the indication rather than
+    //    registering a PGW FQDN for a session that will never move to EPS; and
+    // 2. an FQDN is configured (`SMF_PGW_FQDN`).
+    //
+    // No FQDN is DERIVED when the variable is unset, and that is deliberate.
+    // TS 23.003 §19.4.2.8 fixes the zone (`node.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org`)
+    // and explicitly places it "into the operator's control", so the leaf label is the
+    // operator's to choose -- a name synthesised here would be well-formed and still
+    // NXDOMAIN. An MME that resolves a fabricated FQDN and fails is worse off than an
+    // MME that finds no `pgwFqdn` and falls back to its own APN-based PGW selection,
+    // so the member is omitted and the reason logged.
+    if eps_interworking.is_interworking() {
+        match configured_pgw_fqdn() {
+            Some(fqdn) => {
+                body["pgwFqdn"] = serde_json::json!(fqdn);
+                log::info!(
+                    "[{supi}] PSI {pdu_session_id} is EPS-interworking-capable \
+                     (epsInterworkingInd={}): registering pgwFqdn={fqdn} so an MME can \
+                     resolve this PGW-C+SMF through the UDM/HSS (TS 29.503 SmfRegistration)",
+                    eps_interworking.as_str()
+                );
+            }
+            None => log::warn!(
+                "[{supi}] PSI {pdu_session_id} is EPS-interworking-capable \
+                 (epsInterworkingInd={}) but SMF_PGW_FQDN is not set, so no pgwFqdn is \
+                 registered: an MME cannot resolve this PGW-C+SMF through the UDM/HSS and \
+                 will fall back to its own PGW selection. Not synthesised -- TS 23.003 \
+                 §19.4.2.8 leaves the leaf label under operator control, so a made-up name \
+                 would resolve to nothing",
+                eps_interworking.as_str()
+            ),
+        }
     }
 
     let path = format!("/nudm-uecm/v1/{supi}/registrations/smf-registrations/{pdu_session_id}");
@@ -761,7 +885,16 @@ mod tests {
         set_for_test(false);
         assert!(fetch_sm_data("imsi-1", "internet", 1, None).await.is_none());
         assert!(
-            !register_as_serving_smf("imsi-1", 5, "internet", 1, None, Some(("001", "01"))).await
+            !register_as_serving_smf(
+                "imsi-1",
+                5,
+                "internet",
+                1,
+                None,
+                Some(("001", "01")),
+                EpsInterworkingInd::None
+            )
+            .await
         );
     }
     /// #79 criterion 1, on the wire: the SMF really performs
@@ -830,8 +963,16 @@ mod tests {
 
         let supi = "imsi-001010000000079";
         assert!(
-            register_as_serving_smf(supi, 5, "internet", 1, Some("010203"), Some(("001", "01")))
-                .await,
+            register_as_serving_smf(
+                supi,
+                5,
+                "internet",
+                1,
+                Some("010203"),
+                Some(("001", "01")),
+                EpsInterworkingInd::None
+            )
+            .await,
             "the UECM registration must succeed against a 201"
         );
         let data = fetch_sm_data(supi, "internet", 1, Some("010203"))
@@ -892,13 +1033,193 @@ mod tests {
         // A registration with no serving PLMN is NOT sent: plmnId is required, and
         // inventing one would record the session as served somewhere it is not.
         seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
-        assert!(!register_as_serving_smf(supi, 6, "internet", 1, None, None).await);
+        assert!(
+            !register_as_serving_smf(supi, 6, "internet", 1, None, None, EpsInterworkingInd::None)
+                .await
+        );
         let after = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
         assert!(
             !after
                 .iter()
                 .any(|(_, uri, _, _)| uri.contains("smf-registrations") && uri.contains(supi)),
             "no PLMN means no registration on the wire, got {after:?}"
+        );
+
+        set_for_test(false);
+        std::env::remove_var("UDM_SBI_ADDR");
+        std::env::remove_var("UDM_SBI_PORT");
+        udm.stop().await.expect("stop");
+    }
+    /// #116 criterion 3 (the parse half): `epsInterworkingInd` is read as the four
+    /// values TS 29.502 defines, and only the two that mean EPS count as interworking.
+    #[test]
+    fn eps_interworking_ind_is_parsed_as_ts29502_defines_it() {
+        let of = |v: serde_json::Value| EpsInterworkingInd::from_body(&v);
+        assert_eq!(
+            of(serde_json::json!({})),
+            EpsInterworkingInd::None,
+            "an absent member is NONE: TS 29.502 gives no default, and absent means the \
+             AMF is not asking for interworking"
+        );
+        assert_eq!(
+            of(serde_json::json!({"epsInterworkingInd": "NONE"})),
+            EpsInterworkingInd::None
+        );
+        assert_eq!(
+            of(serde_json::json!({"epsInterworkingInd": "WITH_N26"})),
+            EpsInterworkingInd::WithN26
+        );
+        assert_eq!(
+            of(serde_json::json!({"epsInterworkingInd": "WITHOUT_N26"})),
+            EpsInterworkingInd::WithoutN26
+        );
+        assert_eq!(
+            of(serde_json::json!({"epsInterworkingInd": "IWK_NON_3GPP"})),
+            EpsInterworkingInd::IwkNon3gpp
+        );
+        assert_eq!(
+            of(serde_json::json!({"epsInterworkingInd": "SOMETHING_REL20"})),
+            EpsInterworkingInd::None,
+            "an unrecognised value is NONE, not an error: the OpenAPI defines the type \
+             as anyOf[enum, string] expressly for forward compatibility, and treating \
+             something unknown as interworking would register a pgwFqdn on a guess"
+        );
+
+        assert!(EpsInterworkingInd::WithN26.is_interworking());
+        assert!(EpsInterworkingInd::WithoutN26.is_interworking());
+        assert!(
+            !EpsInterworkingInd::IwkNon3gpp.is_interworking(),
+            "IWK_NON_3GPP is interworking with NON-3GPP access, not with the EPC: no MME \
+             will ever look for a PGW-C+SMF because of it"
+        );
+        assert!(!EpsInterworkingInd::None.is_interworking());
+    }
+
+    /// #116 criterion 3 (the wire half): the UECM registration carries `pgwFqdn` for an
+    /// EPS-interworking session, and does NOT for a session the AMF did not mark.
+    ///
+    /// The recorded request body is the assertion, for the reason #79's test gives: a
+    /// return-value check would pass against a function that sent nothing.
+    #[tokio::test]
+    async fn the_uecm_registration_carries_pgw_fqdn_only_for_an_interworking_session() {
+        use nextgcore_sbi::message::{SbiRequest, SbiResponse};
+        use nextgcore_sbi::server::{SbiServer, SbiServerConfig};
+        use std::net::SocketAddr;
+
+        nextgcore_sbi::security::set_sbi_profile_override(nextgcore_sbi::security::SbiProfile::Dev);
+        // The switch, the UDM_SBI_* environment AND `SMF_PGW_FQDN` are all
+        // process-global; one lock covers all of them (#308 -- a second lock would be a
+        // second disjoint agreement about the same variables).
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
+        set_for_test(true);
+
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let (l, addr) = nextgcore_sbi::test_support::bound_listener().into_parts();
+        let port = addr.port();
+        let udm = SbiServer::on_listener(
+            SbiServerConfig::new(SocketAddr::from(([127, 0, 0, 1], port))),
+            l,
+        );
+        udm.start(move |req: SbiRequest| {
+            let sink = sink.clone();
+            async move {
+                if req.header.uri.contains("smf-registrations") {
+                    sink.lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push(req.http.content.clone().unwrap_or_default());
+                }
+                SbiResponse::with_status(201)
+            }
+        })
+        .await
+        .expect("udm start");
+        std::env::set_var("UDM_SBI_ADDR", "127.0.0.1");
+        std::env::set_var("UDM_SBI_PORT", port.to_string());
+        std::env::set_var(
+            "SMF_PGW_FQDN",
+            "topon.smf-pgw.node.epc.mnc01.mcc001.3gppnetwork.org",
+        );
+
+        let supi = "imsi-001010000000116";
+        // An EPS-interworking session: pgwFqdn present, so an MME resolving this
+        // subscriber through the HSS/UDM can find this PGW-C+SMF.
+        assert!(
+            register_as_serving_smf(
+                supi,
+                5,
+                "internet",
+                1,
+                None,
+                Some(("001", "01")),
+                EpsInterworkingInd::WithoutN26
+            )
+            .await
+        );
+        let bodies = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let body: serde_json::Value =
+            serde_json::from_str(bodies.last().expect("a registration was sent")).expect("json");
+        assert_eq!(
+            body["pgwFqdn"],
+            serde_json::json!("topon.smf-pgw.node.epc.mnc01.mcc001.3gppnetwork.org"),
+            "SmfRegistration.pgwFqdn must carry the configured FQDN verbatim (TS 29.503)"
+        );
+        // Still a conformant registration: the four `required` members survive.
+        for required in ["smfInstanceId", "pduSessionId", "singleNssai", "plmnId"] {
+            assert!(
+                body.get(required).is_some(),
+                "SmfRegistration.{required} is required, got {body}"
+            );
+        }
+
+        // A session the AMF did NOT mark for interworking: no pgwFqdn. Registering one
+        // would advertise an EPS path for a session that will never take it.
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        assert!(
+            register_as_serving_smf(
+                supi,
+                6,
+                "internet",
+                1,
+                None,
+                Some(("001", "01")),
+                EpsInterworkingInd::None
+            )
+            .await
+        );
+        let bodies = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let body: serde_json::Value =
+            serde_json::from_str(bodies.last().expect("a registration was sent")).expect("json");
+        assert!(
+            body.get("pgwFqdn").is_none(),
+            "epsInterworkingInd=NONE must not register a pgwFqdn, got {body}"
+        );
+
+        // Configured-but-not-interworking and interworking-but-not-configured are
+        // different: with no FQDN the member is OMITTED rather than synthesised, because
+        // TS 23.003 §19.4.2.8 leaves the leaf label under operator control and a made-up
+        // name would resolve to nothing.
+        std::env::remove_var("SMF_PGW_FQDN");
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        assert!(
+            register_as_serving_smf(
+                supi,
+                7,
+                "internet",
+                1,
+                None,
+                Some(("001", "01")),
+                EpsInterworkingInd::WithN26
+            )
+            .await
+        );
+        let bodies = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let body: serde_json::Value =
+            serde_json::from_str(bodies.last().expect("a registration was sent")).expect("json");
+        assert!(
+            body.get("pgwFqdn").is_none(),
+            "with SMF_PGW_FQDN unset no FQDN is invented, got {body}"
         );
 
         set_for_test(false);

--- a/src/libs/nextgcore-nas/src/fiveg/message.rs
+++ b/src/libs/nextgcore-nas/src/fiveg/message.rs
@@ -353,6 +353,12 @@ pub struct RegistrationAccept {
     pub allowed_nssai: Option<Nssai>,
     /// Rejected NSSAI
     pub rejected_nssai: Option<Vec<u8>>,
+    /// 5GS network feature support (TS 24.501 §9.11.3.5), carrying the `IWK N26`
+    /// bit a UE needs in order to know which 5GS↔EPS interworking mode is on
+    /// offer (§5.5.1.2.4). `None` omits the IE, which is what this core did
+    /// unconditionally before #116 — so an S1-mode-capable UE could not learn
+    /// that interworking existed at all.
+    pub network_feature_support: Option<crate::interworking::FiveGsNetworkFeatureSupport>,
     /// PDU session status
     pub pdu_session_status: Option<PduSessionStatus>,
     /// T3512 value
@@ -392,6 +398,12 @@ impl RegistrationAccept {
             buf.put_u8(0x11); // IEI
             buf.put_u8(rejected_nssai.len() as u8);
             buf.put_slice(rejected_nssai);
+        }
+        if let Some(nfs) = self.network_feature_support {
+            // 5GS network feature support (TS 24.501 §9.11.3.5): TLV, IEI 0x21.
+            // Placed here to keep the §8.2.7 table order — after Rejected NSSAI
+            // (0x11) / Configured NSSAI (0x31), before PDU session status (0x50).
+            buf.put_slice(&nfs.encode_tlv());
         }
         if let Some(ref pss) = self.pdu_session_status {
             buf.put_u8(0x50); // IEI
@@ -476,6 +488,31 @@ impl RegistrationAccept {
                         });
                     }
                     msg.rejected_nssai = Some(buf.copy_to_bytes(len).to_vec());
+                }
+                0x21 => {
+                    // 5GS network feature support (TLV, TS 24.501 §9.11.3.5). Only
+                    // octet 3 is modelled, but the whole contents field is consumed
+                    // so the IE walk stays aligned — a decoder that stopped after
+                    // the modelled octet would read the next octet as an IEI.
+                    buf.advance(1);
+                    if buf.remaining() < 1 {
+                        return Err(NasError::BufferTooShort {
+                            expected: 1,
+                            actual: buf.remaining(),
+                        });
+                    }
+                    let len = buf.get_u8() as usize;
+                    if buf.remaining() < len {
+                        return Err(NasError::BufferTooShort {
+                            expected: len,
+                            actual: buf.remaining(),
+                        });
+                    }
+                    let contents = buf.copy_to_bytes(len);
+                    msg.network_feature_support =
+                        crate::interworking::FiveGsNetworkFeatureSupport::decode_contents(
+                            &contents,
+                        );
                 }
                 0x50 => {
                     buf.advance(1);

--- a/src/libs/nextgcore-nas/src/interworking.rs
+++ b/src/libs/nextgcore-nas/src/interworking.rs
@@ -1,0 +1,408 @@
+//! 5GS↔EPS interworking: identity mapping and the capability the AMF signals.
+//!
+//! Two things live here, both from #116, because both are needed before any
+//! interworking procedure can be attempted and neither belongs to one NF:
+//!
+//! - **5G-GUTI ↔ EPS GUTI mapping** (TS 23.003 §2.10.2). A UE moving between the two
+//!   systems presents a temporary identity mapped from the other system's, and the
+//!   receiving core has to perform the reverse mapping to find its own context
+//!   (§2.10.2.1.3, §2.10.2.2.3).
+//! - **The 5GS network feature support IE** (TS 24.501 §9.11.3.5), whose IWK N26 bit
+//!   is how a UE learns which interworking mode is on offer.
+//!
+//! These were promoted to production code from nothing: before #116 the only
+//! GUTI-mapping arithmetic in the tree was in `libs/nextgcore-nas/tests` fixtures,
+//! so no NF could perform it.
+
+use crate::eps::types::EpsGuti;
+use crate::fiveg::types::FiveGGuti;
+
+// ============================================================================
+// 5G-GUTI <-> EPS GUTI (TS 23.003 Section 2.10.2)
+// ============================================================================
+
+/// Map a 5G-GUTI to an EPS GUTI (TS 23.003 §2.10.2.1.2).
+///
+/// The mapping is a **bijection**, which is why it round-trips exactly and why
+/// [`eps_guti_to_5g_guti`] is its exact inverse: the 5GS side spends
+/// 8 + 10 + 6 = 24 bits on `<AMF Region ID><AMF Set ID><AMF Pointer>` and the EPS
+/// side spends 16 + 8 = 24 on `<MME Group ID><MME Code>`, so nothing is lost or
+/// invented in either direction. That is worth stating because a "mapping" between
+/// identity spaces is usually lossy, and a lossy one could not satisfy §2.10.2.1.3
+/// (the old AMF must recover its *stored* 5G-GUTI from the GUTI an MME sends).
+///
+/// Per §2.10.2.1.2, bit by bit:
+///
+/// | 5GS | bits | EPS |
+/// |---|---|---|
+/// | `<MCC>`, `<MNC>` | — | `<MCC>`, `<MNC>` (pass through) |
+/// | `<AMF Region ID>` | 7..0 | `<MME Group ID>` 15..8 |
+/// | `<AMF Set ID>` | 9..2 | `<MME Group ID>` 7..0 |
+/// | `<AMF Set ID>` | 1..0 | `<MME Code>` 7..6 |
+/// | `<AMF Pointer>` | 5..0 | `<MME Code>` 5..0 |
+/// | `<5G-TMSI>` | — | `<M-TMSI>` |
+///
+/// The two-bit split of `<AMF Set ID>` across the Group-ID/Code boundary is the part
+/// that is easy to get wrong, and getting it wrong is invisible to a round-trip test
+/// written against this function alone — the same self-consistency trap that let a
+/// wrong payload-container type ship in #91. `eps_guti_mapping_matches_ts23003_2_10_2`
+/// therefore asserts the byte layout against hand-computed values from the clause,
+/// not just `f(g(x)) == x`.
+pub fn five_g_guti_to_eps_guti(guti: &FiveGGuti) -> EpsGuti {
+    let set_id = guti.amf_set_id & 0x03FF;
+    EpsGuti {
+        plmn_id: guti.plmn_id.clone(),
+        // Region ID -> MME GID 15..8; Set ID 9..2 -> MME GID 7..0.
+        mme_gid: ((guti.amf_region_id as u16) << 8) | ((set_id >> 2) & 0x00FF),
+        // Set ID 1..0 -> MME Code 7..6; Pointer 5..0 -> MME Code 5..0.
+        mme_code: (((set_id & 0x0003) as u8) << 6) | (guti.amf_pointer & 0x3F),
+        m_tmsi: guti.tmsi,
+    }
+}
+
+/// Map an EPS GUTI to a 5G-GUTI (TS 23.003 §2.10.2.2.2).
+///
+/// The exact inverse of [`five_g_guti_to_eps_guti`]; see there for the bit table and
+/// why the mapping loses nothing.
+pub fn eps_guti_to_5g_guti(guti: &EpsGuti) -> FiveGGuti {
+    FiveGGuti {
+        plmn_id: guti.plmn_id.clone(),
+        // MME GID 15..8 -> Region ID.
+        amf_region_id: (guti.mme_gid >> 8) as u8,
+        // MME GID 7..0 -> Set ID 9..2; MME Code 7..6 -> Set ID 1..0.
+        amf_set_id: ((guti.mme_gid & 0x00FF) << 2) | ((guti.mme_code >> 6) as u16 & 0x0003),
+        // MME Code 5..0 -> Pointer 5..0.
+        amf_pointer: guti.mme_code & 0x3F,
+        tmsi: guti.m_tmsi,
+    }
+}
+
+// ============================================================================
+// 5GS network feature support IE (TS 24.501 Section 9.11.3.5)
+// ============================================================================
+
+/// IEI of the 5GS network feature support IE in REGISTRATION ACCEPT.
+///
+/// TS 24.501 Table 8.2.7.1: `21`, optional, format TLV, length 3-6.
+pub const IEI_5GS_NETWORK_FEATURE_SUPPORT: u8 = 0x21;
+
+/// `IWK N26` — octet 3, bit 7 of the 5GS network feature support IE.
+///
+/// TS 24.501 Table 9.11.3.5.1 (spec text: `24501-j62.txt:75100`).
+pub const IWK_N26_BIT: u8 = 0x40;
+
+/// `IMS-VoPS-3GPP` — octet 3, bit 1. Kept as a named constant so the IE builder
+/// below is not writing bare hex for the one other bit it can be asked to set.
+pub const IMS_VOPS_3GPP_BIT: u8 = 0x01;
+
+/// What the AMF advertises in the `IWK N26` bit (TS 24.501 §9.11.3.5).
+///
+/// # The bit is inverted from the obvious reading, and that is the whole point
+///
+/// It is **not** "N26 is supported". Table 9.11.3.5.1 names it *"Interworking
+/// without N26 interface indicator"*, so:
+///
+/// - `0` = "interworking without N26 interface **not** supported" → the AMF **has**
+///   N26, and per §5.5.1.2.4 the UE must then operate in **single-registration** mode;
+/// - `1` = "interworking without N26 interface supported" → the AMF has **no** N26,
+///   and a UE that supports it **may** operate in dual-registration mode.
+///
+/// Setting the bit because "we support interworking" would therefore tell every UE
+/// the exact opposite of the truth, and it is the kind of error that round-trips
+/// clean through an encode/decode test. Hence an enum rather than a `bool`: at a call
+/// site `Iwk26::WithoutN26Supported` cannot be confused with "N26 supported", where
+/// `true` can.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Iwk26 {
+    /// The AMF has an N26 interface to an MME. Encodes IWK N26 = **0**.
+    N26Supported,
+    /// The AMF has no N26 interface; interworking is the non-N26 kind. Encodes
+    /// IWK N26 = **1**.
+    WithoutN26Supported,
+}
+
+impl Iwk26 {
+    /// The octet-3 bit value this posture encodes.
+    pub fn bit(self) -> u8 {
+        match self {
+            // Deliberately: N26 present => bit CLEAR. See the type's doc.
+            Self::N26Supported => 0,
+            Self::WithoutN26Supported => IWK_N26_BIT,
+        }
+    }
+}
+
+/// The 5GS network feature support IE, as much of it as this core has an answer for.
+///
+/// Only the two octet-3 bits the AMF can honestly speak to are modelled. The rest of
+/// octet 3 (`EMC`, `EMF`, `MPSI`, `IMS-VoPS-N3GPP`) and the optional octets 4-6 are
+/// **omitted rather than sent as zero-with-meaning**: a length of 1 makes the UE read
+/// octets 4-6 as all-zero anyway (§9.11.3.5), and zero is the correct "not supported"
+/// for every bit in them, so a 1-octet contents field is both the shortest legal
+/// encoding and the truthful one. Emitting three octets of zeroes would assert the
+/// same thing at greater length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FiveGsNetworkFeatureSupport {
+    /// Interworking-without-N26 posture (octet 3, bit 7).
+    pub iwk_n26: Iwk26,
+    /// IMS voice over PS over 3GPP access (octet 3, bit 1).
+    pub ims_vops_3gpp: bool,
+}
+
+impl FiveGsNetworkFeatureSupport {
+    /// Encode as a TLV: IEI, length, then the octet-3 contents.
+    ///
+    /// One content octet, so the length is 1 — the minimum §9.11.3.5 allows, and the
+    /// UE treats octets 4-6 as zero.
+    pub fn encode_tlv(&self) -> [u8; 3] {
+        let mut octet3 = self.iwk_n26.bit();
+        if self.ims_vops_3gpp {
+            octet3 |= IMS_VOPS_3GPP_BIT;
+        }
+        [IEI_5GS_NETWORK_FEATURE_SUPPORT, 1, octet3]
+    }
+
+    /// Decode from the IE's **contents** (i.e. after IEI and length).
+    ///
+    /// Returns `None` for an empty contents field, which §9.11.3.5 does not permit
+    /// (minimum length 3 octets total, so at least one content octet).
+    pub fn decode_contents(contents: &[u8]) -> Option<Self> {
+        let octet3 = *contents.first()?;
+        Some(Self {
+            iwk_n26: if octet3 & IWK_N26_BIT != 0 {
+                Iwk26::WithoutN26Supported
+            } else {
+                Iwk26::N26Supported
+            },
+            ims_vops_3gpp: octet3 & IMS_VOPS_3GPP_BIT != 0,
+        })
+    }
+}
+
+// ============================================================================
+// 5GMM capability (TS 24.501 Section 9.11.3.1) -- the S1-mode bit only
+// ============================================================================
+
+/// IEI of the 5GMM capability IE in REGISTRATION REQUEST.
+///
+/// TS 24.501 Table 8.2.6.1: `10`, optional, format TLV, length 3-15.
+pub const IEI_5GMM_CAPABILITY: u8 = 0x10;
+
+/// `S1 mode` ("EPC NAS supported") — octet 3, bit 1 of the 5GMM capability IE.
+///
+/// TS 24.501 Table 9.11.3.1.1. This is the bit that gates everything else:
+/// §5.5.1.2.4 makes the AMF signal `IWK N26` **only** to a UE that included an
+/// S1-mode indication, so without parsing it there is nothing to answer.
+pub const S1_MODE_BIT: u8 = 0x01;
+
+/// Does this 5GMM capability contents field claim S1 mode (EPC NAS) support?
+///
+/// Takes the IE **contents** (after IEI and length), which is what a byte-level IE
+/// walk has in hand — amfd's registration parser is hand-rolled and does not go
+/// through [`crate::fiveg::ie::FiveGmmCapability`]'s decoder.
+///
+/// # Why this delegates instead of masking the bit itself
+///
+/// [`crate::fiveg::ie::FiveGmmCapability`] ALREADY derives `s1_mode` from the same
+/// octet with the same mask. A second `& 0x01` here would be a second implementation
+/// of one wire fact, and the two would be free to drift — the shape that has bitten
+/// this tree repeatedly (three modules spelling `Pdr` for different types in #335,
+/// four hand-maintained wire tables wrong in #340). So this function synthesises the
+/// length octet the decoder expects and asks the existing type, making it a *reframing*
+/// of one implementation rather than a rival to it.
+///
+/// An empty or unparseable contents field reads as "not claimed", which is the
+/// fail-closed answer: advertising an interworking posture to a UE that never asked
+/// for one is the worse error.
+pub fn claims_s1_mode(contents: &[u8]) -> bool {
+    let Some(&octet3) = contents.first() else {
+        return false;
+    };
+    // `FiveGmmCapability::decode` expects `length` then the capability octets; the
+    // caller has only the contents, so the length is reconstructed from them.
+    let mut framed = bytes::Bytes::from(
+        std::iter::once(contents.len() as u8)
+            .chain(contents.iter().copied())
+            .collect::<Vec<u8>>(),
+    );
+    match crate::fiveg::ie::FiveGmmCapability::decode(&mut framed) {
+        Ok(cap) => cap.s1_mode,
+        // A malformed IE still has an octet 3, and the bit's position does not depend
+        // on the octets after it. Falling back to it keeps a UE that claimed S1 mode in
+        // a slightly-off IE from being silently treated as not having asked.
+        Err(_) => octet3 & S1_MODE_BIT != 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::types::PlmnId;
+
+    fn plmn() -> PlmnId {
+        PlmnId::new([0, 0, 1], [0, 1, 0], 2)
+    }
+
+    /// TS 23.003 §2.10.2 by hand, not by round-trip.
+    ///
+    /// A round-trip proves only that the two functions are inverses of each other —
+    /// it would pass with the `<AMF Set ID>` split placed at any bit boundary, as
+    /// long as both directions agreed. So the field values are computed here from
+    /// the clause and asserted literally, which is the only form that pins
+    /// conformance rather than self-consistency (#91).
+    #[test]
+    fn eps_guti_mapping_matches_ts23003_2_10_2() {
+        // Region 0xAB; Set ID 0b10_0110_1101 (0x26D); Pointer 0b10_1010 (0x2A).
+        let five_g = FiveGGuti {
+            plmn_id: plmn(),
+            amf_region_id: 0xAB,
+            amf_set_id: 0x026D,
+            amf_pointer: 0x2A,
+            tmsi: 0x1234_5678,
+        };
+        let eps = five_g_guti_to_eps_guti(&five_g);
+
+        // MME GID 15..8 = Region ID = 0xAB.
+        // MME GID  7..0 = Set ID bits 9..2 = 0x026D >> 2 = 0x9B.
+        assert_eq!(
+            eps.mme_gid, 0xAB9B,
+            "MME Group ID is <AMF Region ID> then <AMF Set ID> bits 9..2 \
+             (TS 23.003 2.10.2.1.2)"
+        );
+        // MME Code 7..6 = Set ID bits 1..0 = 0b01 -> 0b0100_0000.
+        // MME Code 5..0 = Pointer        = 0b10_1010.
+        assert_eq!(
+            eps.mme_code, 0b0110_1010,
+            "MME Code is <AMF Set ID> bits 1..0 then <AMF Pointer> bits 5..0 \
+             (TS 23.003 2.10.2.1.2)"
+        );
+        assert_eq!(eps.m_tmsi, 0x1234_5678, "<5G-TMSI> maps to <M-TMSI>");
+        assert_eq!(eps.plmn_id, plmn(), "MCC/MNC pass through unchanged");
+
+        // And the reverse direction, computed from 2.10.2.2.2 the same way.
+        let back = eps_guti_to_5g_guti(&eps);
+        assert_eq!(back.amf_region_id, 0xAB);
+        assert_eq!(back.amf_set_id, 0x026D);
+        assert_eq!(back.amf_pointer, 0x2A);
+        assert_eq!(back.tmsi, 0x1234_5678);
+    }
+
+    /// The mapping is a bijection (24 bits each side), so it must survive a
+    /// round trip for every corner of the field ranges -- including the all-ones
+    /// case, where a mask that is one bit too wide would bleed into a neighbour.
+    #[test]
+    fn eps_guti_mapping_round_trips_at_the_field_boundaries() {
+        for (region, set, pointer) in [
+            (0x00u8, 0x0000u16, 0x00u8),
+            (0xFF, 0x03FF, 0x3F), // every bit of every field set
+            (0x01, 0x0001, 0x01),
+            (0x80, 0x0200, 0x20),
+            (0xFF, 0x0000, 0x3F),
+            (0x00, 0x03FF, 0x00),
+        ] {
+            let g = FiveGGuti {
+                plmn_id: plmn(),
+                amf_region_id: region,
+                amf_set_id: set,
+                amf_pointer: pointer,
+                tmsi: 0xDEAD_BEEF,
+            };
+            let back = eps_guti_to_5g_guti(&five_g_guti_to_eps_guti(&g));
+            assert_eq!(back, g, "5G-GUTI -> GUTI -> 5G-GUTI must be lossless");
+        }
+    }
+
+    /// The inverted bit, pinned against the clause in both directions.
+    ///
+    /// This is the assertion that would have caught "set the bit because we support
+    /// interworking": with N26 present the bit is CLEAR.
+    #[test]
+    fn iwk_n26_bit_matches_ts24501_table_9_11_3_5_1() {
+        assert_eq!(
+            IWK_N26_BIT, 0x40,
+            "IWK N26 is octet 3 bit 7 (24501-j62.txt:75100)"
+        );
+        assert_eq!(
+            Iwk26::N26Supported.bit(),
+            0,
+            "an AMF that HAS N26 sets IWK N26 = 0, 'interworking without N26 \
+             interface not supported'"
+        );
+        assert_eq!(
+            Iwk26::WithoutN26Supported.bit(),
+            0x40,
+            "an AMF with NO N26 sets IWK N26 = 1, 'interworking without N26 \
+             interface supported'"
+        );
+
+        // TLV shape: IEI 0x21, length 1, contents.
+        let ie = FiveGsNetworkFeatureSupport {
+            iwk_n26: Iwk26::WithoutN26Supported,
+            ims_vops_3gpp: false,
+        };
+        assert_eq!(
+            ie.encode_tlv(),
+            [0x21, 0x01, 0x40],
+            "IEI 21, length 1, octet 3 with only IWK N26 set (TS 24.501 Table 8.2.7.1)"
+        );
+
+        // Decode is the inverse, and the OTHER posture must not decode as this one.
+        assert_eq!(
+            FiveGsNetworkFeatureSupport::decode_contents(&[0x40]),
+            Some(ie)
+        );
+        assert_eq!(
+            FiveGsNetworkFeatureSupport::decode_contents(&[0x00]),
+            Some(FiveGsNetworkFeatureSupport {
+                iwk_n26: Iwk26::N26Supported,
+                ims_vops_3gpp: false,
+            })
+        );
+        assert_eq!(
+            FiveGsNetworkFeatureSupport::decode_contents(&[0x41]),
+            Some(FiveGsNetworkFeatureSupport {
+                iwk_n26: Iwk26::WithoutN26Supported,
+                ims_vops_3gpp: true,
+            }),
+            "bit 1 is IMS-VoPS-3GPP and is independent of bit 7"
+        );
+        assert_eq!(
+            FiveGsNetworkFeatureSupport::decode_contents(&[]),
+            None,
+            "an empty contents field is not a legal IE"
+        );
+    }
+
+    #[test]
+    fn s1_mode_bit_matches_ts24501_table_9_11_3_1_1() {
+        assert_eq!(S1_MODE_BIT, 0x01, "S1 mode is octet 3 bit 1");
+        assert_eq!(IEI_5GMM_CAPABILITY, 0x10, "5GMM capability IEI is 10");
+        assert!(claims_s1_mode(&[0x01]), "bit 1 set = S1 mode supported");
+        assert!(
+            claims_s1_mode(&[0xFF]),
+            "S1 mode is bit 1 regardless of the other capability bits"
+        );
+        assert!(!claims_s1_mode(&[0x02]), "bit 2 is HO attach, not S1 mode");
+        assert!(!claims_s1_mode(&[0x00]));
+        assert!(
+            !claims_s1_mode(&[]),
+            "an unparseable capability is read as NOT claiming S1 mode: \
+             advertising an interworking posture to a UE that never asked is worse"
+        );
+
+        // The bit comes from ONE implementation, not two: `claims_s1_mode` must agree
+        // with `FiveGmmCapability`'s own decoder for every octet-3 value, because a
+        // second `& 0x01` here is exactly how two spellings of one wire fact drift.
+        for octet3 in 0u8..=255 {
+            let mut framed = bytes::Bytes::from(vec![1u8, octet3]);
+            let via_type = crate::fiveg::ie::FiveGmmCapability::decode(&mut framed)
+                .expect("a 1-octet capability decodes")
+                .s1_mode;
+            assert_eq!(
+                claims_s1_mode(&[octet3]),
+                via_type,
+                "octet3={octet3:#04x}: claims_s1_mode must agree with FiveGmmCapability"
+            );
+        }
+    }
+}

--- a/src/libs/nextgcore-nas/src/lib.rs
+++ b/src/libs/nextgcore-nas/src/lib.rs
@@ -40,6 +40,7 @@ pub mod common;
 pub mod eps;
 pub mod error;
 pub mod fiveg;
+pub mod interworking;
 
 #[cfg(test)]
 mod property_tests;

--- a/src/libs/nextgcore-nas/tests/message_roundtrip.rs
+++ b/src/libs/nextgcore-nas/tests/message_roundtrip.rs
@@ -368,10 +368,92 @@ fn gmm_registration_accept_full_ie_roundtrip() {
         tai_list: Some(test_tai_list()),
         allowed_nssai: Some(test_nssai()),
         rejected_nssai: Some(vec![0x01, 0x01, 0x7B]),
+        // #116: the 5GS network feature support IE (0x21), so the decode arm is
+        // exercised in the middle of a full IE walk rather than on its own. That is the
+        // property that matters here: an IE whose contents length is not consumed
+        // exactly leaves the walk misaligned, and the NEXT IE is then read from the
+        // wrong offset -- which shows up as a corrupted `pdu_session_status`, not as a
+        // complaint about 0x21.
+        network_feature_support: Some(nextgcore_nas::interworking::FiveGsNetworkFeatureSupport {
+            iwk_n26: nextgcore_nas::interworking::Iwk26::WithoutN26Supported,
+            ims_vops_3gpp: true,
+        }),
         pdu_session_status: Some(test_pdu_session_status()),
         t3512_value: Some(GprsTimer3::new(GprsTimer3::UNIT_1_HOUR, 1)),
         t3502_value: Some(GprsTimer2::new(12)),
     }));
+}
+
+/// #116: the 5GS network feature support IE survives a full encode/decode, and its
+/// bytes are the ones TS 24.501 Table 8.2.7.1 and Table 9.11.3.5.1 specify.
+///
+/// Byte-asserted as well as round-tripped, because a round trip proves only that the
+/// codec is its own inverse: the same wrong bit on both sides is invisible to it. That
+/// is exactly how a swapped payload-container type shipped in #91.
+#[test]
+fn gmm_registration_accept_network_feature_support_bytes() {
+    let accept = RegistrationAccept {
+        registration_result: RegistrationResult {
+            sms_allowed: true,
+            value: RegistrationResultValue::ThreeGppAccess,
+        },
+        network_feature_support: Some(nextgcore_nas::interworking::FiveGsNetworkFeatureSupport {
+            iwk_n26: nextgcore_nas::interworking::Iwk26::WithoutN26Supported,
+            ims_vops_3gpp: false,
+        }),
+        ..Default::default()
+    };
+    let mut buf = BytesMut::new();
+    accept.encode(&mut buf);
+    assert_eq!(
+        buf.to_vec(),
+        vec![
+            0x01, 0x09, // 5GS registration result (LV)
+            0x21, 0x01, 0x40, // IEI 0x21, len 1, octet 3: IWK N26 (bit 7) SET
+        ],
+        "IWK N26 SET means 'interworking WITHOUT N26 supported'. A 0x00 here would \
+         claim the opposite -- that an N26 interface exists"
+    );
+
+    // And the IE is positioned per the §8.2.7 table: after Rejected NSSAI (0x11),
+    // before PDU session status (0x50).
+    let ordered = RegistrationAccept {
+        registration_result: RegistrationResult {
+            sms_allowed: true,
+            value: RegistrationResultValue::ThreeGppAccess,
+        },
+        rejected_nssai: Some(vec![0x01]),
+        network_feature_support: Some(nextgcore_nas::interworking::FiveGsNetworkFeatureSupport {
+            iwk_n26: nextgcore_nas::interworking::Iwk26::N26Supported,
+            ims_vops_3gpp: true,
+        }),
+        pdu_session_status: Some(test_pdu_session_status()),
+        ..Default::default()
+    };
+    let mut buf = BytesMut::new();
+    ordered.encode(&mut buf);
+    let bytes = buf.to_vec();
+    let at_11 = bytes
+        .iter()
+        .position(|&b| b == 0x11)
+        .expect("rejected NSSAI");
+    let at_21 = bytes
+        .iter()
+        .position(|&b| b == 0x21)
+        .expect("feature support");
+    let at_50 = bytes
+        .iter()
+        .position(|&b| b == 0x50)
+        .expect("session status");
+    assert!(
+        at_11 < at_21 && at_21 < at_50,
+        "IEI order must be 0x11 < 0x21 < 0x50 (TS 24.501 Table 8.2.7.1), got {bytes:02X?}"
+    );
+    assert_eq!(
+        bytes[at_21 + 2] & 0x40,
+        0,
+        "N26Supported encodes IWK N26 CLEAR"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #116.

Spec: `specs/fix-5gs-eps-interworking-seam.md`

Criterion 6 is an explicit either/or — deliver **N26**, or complete the **non-N26** path "and document it as the supported mode". This takes the second branch, which is also the order #116's own suggested approach asks for. The N26 leg is #62.

## Three cited sites were stale, and two would have made this unreachable

Re-verified at `bf57ddd` before writing anything.

| #116 says | actually | consequence |
|---|---|---|
| criterion 2: populate `context.s1_mode` via the parser at `gmm_handler.rs:52-83` | **that parser is dead** — `gmm_handler::handle_registration_request` has three callers, all inside `mod tests` (`:776`). `ngap_path.rs:6508` already says "Mirrors the (dead-code) gmm_handler logic" | done in `parse_registration_request_pdu`, the parser the live path uses |
| criterion 7: `ngap_handler.rs:657-658` errors when `handover_type != 0` | **that reject no longer exists**; only the `HO_TARGET_NOT_ALLOWED` constant survives | its absence was *worse* — see below |
| `s1_mode` at `context.rs:1989` | `context.rs:2070`, on `GmmCapability` | line drift only |

Also already present, contrary to the gap description: `smfd/src/eps_iwk.rs` (EBI assignment over Namf_Communication, #117) and `gsm_build::encode_mapped_eps_bearer_context`.

### Criterion 7 was a silent mis-handling, not an over-strict reject

With the reject gone, `handle_handover_required` logged the type and passed `required.handover_type` **straight into the `HandoverRequest`**. A `fivegs-to-eps` preparation was resolved against connected gNBs and either failed with `unknown-target-id` (a cause that describes an MME as an unknown gNB, sending an operator after a RAN misconfiguration) or, if a gNB id happened to match, **was forwarded to a gNB** as a handover this AMF cannot perform.

Now declined with `ho-target-not-allowed` (CauseRadioNetwork 8) plus local cleanup. The UE keeps its registration and PDU sessions — the graceful degradation #116 asks for.

## The IWK N26 bit is inverted from the obvious reading

The most important finding here. `IWK N26` is **not** "N26 supported". TS 24.501 Table 9.11.3.5.1 (`24501-j62.txt:75100`) names it *"Interworking **without** N26 interface indicator"*:

| bit | means | UE behaviour (§5.5.1.2.4) |
|---|---|---|
| `0` | interworking without N26 **not** supported → the AMF **has** N26 | must use single-registration mode |
| `1` | interworking without N26 supported → the AMF has **no** N26 | may use dual-registration mode |

Setting the bit because "we support interworking" tells every UE the exact opposite of the truth, and a UE believing it would expect session continuity on a move this core cannot perform. It also round-trips clean through an encode/decode test — #91's symmetric-defect trap.

Two defences: an `enum Iwk26 { N26Supported, WithoutN26Supported }` rather than a `bool` (`WithoutN26Supported` can't be misread the way `true` can), and a literal assertion of both encodings against the clause. **Ships as `WithoutN26Supported` (bit SET)** — there is no N26 leg.

## Criteria 1–5, 8

- **C1**: `FiveGsNetworkFeatureSupport` (IEI `0x21`, TLV) in `nextgcore-nas`, on `RegistrationAccept`, encoded in §8.2.7 table order with a decode arm that consumes the whole contents field so the IE walk stays aligned. Emitted **only to a UE that claimed S1 mode** — exactly what §5.5.1.2.4 requires — so C1 depends on C2.
  **Stated deviation**: no config knob. `iwk_n26_posture()` is a constant; its only other setting would advertise an N26 interface that does not exist, and a knob whose non-default value is always a lie is worse than a constant. #62 changes that one function.
- **C2**: the 5GMM capability IE (`0x10`) was walked past by the default TLV arm, and `gmm_capability.s1_mode` had **no writer at all**. `claims_s1_mode` **delegates to `FiveGmmCapability`'s existing decoder** instead of masking the bit again — a second `& 0x01` is one wire fact with two spellings, free to drift (#335, #340) — with a test that the two agree for **all 256** octet-3 values.
- **C4**: there is no separate identity *type* for a mapped 5G-GUTI (§9.11.3.4 has one `5G-GUTI` value), which is why storing it as native was silent. The discriminator is the **EPS NAS message container** (§5.5.1.2.2; §5.5.1.3.4 c.2 reads the same way round), previously skipped. The mapped identity is now reverse-mapped per §2.10.2.1.3 into a new `AmfUe.mapped_eps_guti` rather than `old_guti`, and the **Additional GUTI IE is decoded** because per §5.5.1.2.2 that is the UE's native 5G-GUTI. The container's contents are deliberately **not** interpreted: decoding an EPS ATTACH/TAU *is* the N26 leg.
- **C5**: GUTI mapping promoted from test fixtures to production. A **bijection** (8+10+6 vs 16+8 bits) — it has to be lossless for §2.10.2.1.3 to work at all. Asserted against hand-computed clause values, not just a round trip, which would pass with the `<AMF Set ID>` split at *any* bit boundary as long as both directions agreed.
- **C3**: `epsInterworkingInd` parsed as the four values TS 29.502 defines (not a bool — `WITH_N26`/`WITHOUT_N26` differ in mechanism and `IWK_NON_3GPP` is another interface, a distinction #62 needs); unrecognised values are `NONE` per the OpenAPI's forward-compatibility clause. `pgwFqdn` (verified against `TS29503_Nudm_UECM.yaml`) is registered when the AMF marked the session **and** `SMF_PGW_FQDN` is set. `IWK_NON_3GPP` deliberately doesn't count.
  **No FQDN is derived when unset**: TS 23.003 §19.4.2.8 fixes the zone but places the leaf label "into the operator's control", so a synthesised name is well-formed and still NXDOMAIN — and an MME that resolves a fabricated FQDN is worse off than one that finds none and falls back to APN-based selection.
- **C8**: `features.html` already marked GTPv2-C (S5/S8/N26) **prototype**, "no wire listener" — so `index.html` contradicted the project's own matrix. Both sites now claim a full 4G/EPC **network-function set** (which does exist) with interworking named **partial**, saying which parts work and that there is no N26 and therefore no session continuity.

## Revert-verify

Five behavioural reverts (value/condition flips, never deletions — a revert that fails to *compile* proves nothing, per #48), each grep-confirmed applied and restored, each failing its own **named** assertion:

| revert | test that failed |
|---|---|
| `iwk_n26_posture()` → `N26Supported` | `registration_accept_carries_iwk_n26_only_for_an_s1_mode_ue` |
| `req.s1_mode = false && …` | `the_live_parser_captures_ue_s1_mode_capability` |
| `guti_is_mapped_from_eps` → `false && …` | `a_mapped_eps_guti_is_recognised_as_mapped_and_reverse_maps_to_the_4g_guti` |
| `Ht::FivegsToEps => return None` | `an_inter_system_handover_is_declined_with_ho_target_not_allowed` |
| drop the `body["pgwFqdn"]` assignment | `the_uecm_registration_carries_pgw_fqdn_only_for_an_interworking_session` |

C7 asserts the **decision**, not the transmission: driving `handle_handover_required` needs an SCTP-connected gNB the unit harness lacks (`context.rs` says so in as many words), so `inter_system_handover_refusal` is split out — the same split used for #70, #91, #48, #69. It also pins `HoTargetNotAllowed as i64 == 8` so renaming the enum can't silently change the wire value.

## Ceilings

- **No N26 leg**: no GTPv2-C toward an MME, no Forward Relocation, no inter-system session continuity. That is #62; every claim here is worded to stay true when it lands.
- **The EPS NAS message container is captured, not interpreted.**
- **`pgwFqdn` is registered and nothing here consumes it** — it is the bootstrap an MME/HSS uses, and this core has no MME-facing S5/S8 listener to be found *on*.
- **`mapped_eps_guti` has no reader yet.** Named explicitly because "production writer, no production reader" is the #325/#335/#341 shape — the difference is that the alternative was *losing* the identity, not storing it twice.
- **The EPS→5GS path still asks for a SUCI** and re-authenticates rather than retrieving context from the old MME. Honest degradation, not continuity.

## Verification

- Workspace **6550 tests, 0 failures** (6538 + 12). `cargo clippy --workspace` 0 errors, `cargo fmt --all -- --check` clean.
- Wire constants read out of the vendored specs, not memory: `24501-j62.txt`, `23003-k00.txt`, `TS29503_Nudm_UECM.yaml`, `TS29502_Nsmf_PDUSession.yaml`.