### PR TITLE
fix(smfd,s1ap,mmed): the mapped EPS QCI, and S1AP's two interworking handover types (#62)

### DIFF
--- a/specs/fix-eps-interworking-qci-and-s1ap-handover-type.md
+++ b/specs/fix-eps-interworking-qci-and-s1ap-handover-type.md
@@ -1,0 +1,168 @@
+# fix(smfd,s1ap,mmed): the mapped EPS QCI, and S1AP's two interworking handover types
+
+Closes #62. Splits its criteria 5 and 7 to **#347**.
+
+## The split is the author's own, not a convenience
+
+#62's suggested approach says: *"Consider splitting phases 2–3 (amfd+mmed N26 GTPv2-C + GUTI
+mapping) into a follow-on issue."* So this follows the refinement recorded for #108 — when an
+issue's own text scopes a part out, file it and close the parent on the rest, stating which
+criteria moved and where.
+
+**Split to #347: criteria 5 (N26 GTPv2-C Context Request/Response + Forward Relocation) and 7
+(idle-mode TAU-with-N26).** Criterion 9's feature gate goes with them: it gates "the new N26
+procedure", and nothing here adds one.
+
+## Five of nine criteria were already met, and one named the wrong members
+
+Re-verified at `54e5aa3`.
+
+| criterion | state |
+|---|---|
+| 1. mapped EBI + mapped EPS QoS per PDU session | **half met.** #117 stores the EBI, QFI, 5QI and ARP (`eps_iwk::record_mapped_eps_bearer`). The mapped **QCI** had a defect — below |
+| 2. `SmContextRetrieve` returns the EPS PDN connection | **met** — #78 added it, #117 made it name the EBI |
+| 3. `handle_pdu_session_create` not hardcoded | **met** — #79 replaced the `pduSessionRef "1"` / `REL_DUE_TO_HO` stub with a deliberate `501` |
+| 4. 5G-GUTI ↔ 4G-GUTI mapping | **met** — #116, `nextgcore_nas::interworking`, bijective and round-tripped |
+| 6. `ho_type_to_s1ap` no longer collapses to `IntraLte` | **gap** — fixed here |
+| 8. test | **met** via the `SmContextRetrieve` branch criterion 8 itself offers; extended here |
+
+**Criterion 2 named members that do not belong to the response.** It asks for
+`epsPdnCnxInfo`/`epsBearerInfo`. `TS29502_Nsmf_PDUSession.yaml` gives `SmContextRetrievedData`
+a **required** `ueEpsPdnConnection` (an `EpsPdnCnxContainer`), and `EpsPdnCnxInfo` /
+`EpsBearerInfo` are described as *"from H-SMF to V-SMF, or from SMF to I-SMF"* — a different
+interface. The tree already implements the correct member. Recorded because implementing the
+issue's spelling would have added two members no AMF reads while leaving the required one as
+it was — the same class as #93's divergent config key.
+
+## Criterion 1 — one wire fact with two spellings, and the untested one was wrong
+
+`gsm_build::qci_for_5qi` already existed. `build_ue_eps_pdn_connection` was its **second call
+site, and it did not call it**: it pushed `sess.session_qos.index` — the raw 5QI — under a
+comment asserting that value "is what maps onto the EPS QCI".
+
+For the standardised 5QIs 1..=9 that is true, which is exactly why it was invisible: every
+default session (5QI 9) produced a correct octet. For anything else the container handed to
+an AMF, and onward to an MME, **declared a QCI that TS 23.203 does not define**.
+
+The two descriptions of one bearer therefore disagreed:
+
+| audience | path | on a 5QI with no EPS equivalent |
+|---|---|---|
+| the **UE** | `gsm_build::encode_mapped_eps_bearer_context` → `qci_for_5qi` | omits the mapped-EPS-QoS parameter entirely |
+| the **MME** | `build_ue_eps_pdn_connection` → raw 5QI | claims a QCI equal to the 5QI |
+
+That is #335's and #340's shape — two copies of one fact, only the tested one right — and the
+untested copy was the one on the interworking path.
+
+**Spec basis.** TS 23.502 Annex C: *"For standardized 5QIs, the QCI is one to one mapped to the
+5QI. For non-standardized 5QIs, the SMF+PGW-C derives the QCI based on the 5QI and operator
+policy."* So the identity mapping is correct where it applies, and where it does not there is
+no value to invent.
+
+**A 5QI with no equivalent now encodes as QCI 0**, which TS 24.301 §9.9.4.3 reserves, with a
+warning naming the consequence. The octet cannot simply be omitted the way
+`encode_mapped_eps_bearer_context` omits its whole parameter, because #78's container layout
+is positional — and a reserved value an MME must reject is a better answer than a plausible
+wrong one that it would enforce.
+
+`qci_for_5qi`'s domain (1..=9) is **unchanged** and is a stated ceiling: Annex C permits a 1:1
+mapping for every standardised 5QI, and the standardised set (TS 23.501 Table 5.7.4-1) is
+`1-10, 65-67, 69-76, 79, 80, 82-90`. #117 chose the conservative subset that certainly has EPS
+equivalents. Widening it needs TS 23.203's QCI table to say which of those QCIs exist, and
+guessing would put back exactly the defect this fixes.
+
+## Criterion 6 — the two values were absent from the wire enum, not merely unmapped
+
+`nextgcore_s1ap::types::HandoverType` had five values and stopped at `gerantolte`. TS 36.413
+(`36413-j20.txt:30619`) says:
+
+```asn1
+HandoverType ::= ENUMERATED { intralte, ltetoutran, ltetogeran, utrantolte, gerantolte,
+                              ..., eps-to-5gs, fivegs-to-eps }
+```
+
+So `mmed`'s `ho_type_to_s1ap` had nothing to map its own `EpsTo5gs`/`FiveGsToEps` onto, and
+collapsed both onto `IntraLte` under the comment *"5GS interworking types never reach the S1AP
+handover path"*. That framing makes it look like a harmless placeholder. It is not: if one did
+reach it, the eNB was handed `intralte` for an inter-system move and would admit it as an
+ordinary LTE handover — a wrong value **acted on**, which is worse than an unused branch. The
+same collapse existed inbound (`ho_type_from_s1ap`), where it would have recorded the UE as
+doing an intra-LTE handover, so every later decision about it concerned the wrong procedure.
+
+**Being past the `...` marker is the interesting part.** These are extension additions, so
+X.691 §14.6 encodes them as the extension bit plus a normally-small index — `eps-to-5gs` is
+index **0** and `fivegs-to-eps` index **1**, not the constrained values 5 and 6. That works
+without touching the codec because `HANDOVER_TYPE_CONSTRAINT` is already
+`Constraint::extensible(0, 4)` and `encode_enumerated`/`decode_enumerated` already implement
+the extension path (encoding `value - max - 1`, decoding back onto `max + 1 + index`). The
+enum values 5 and 6 are internal; the wire form is the extension index.
+
+## Tests
+
+- `handover_type_interworking_values_round_trip_as_extension_additions` — asserts the raw
+  octet: extension bit **set**, index 0 then 1, and the round trip. Asserting the byte rather
+  than only the round trip is what makes it a conformance test; a round trip alone would pass
+  with the values encoded as root 5 and 6, which a peer would read as out of range.
+- `handover_type_root_values_are_unchanged` — the extension bit stays **clear** for all five
+  root values. The guard that matters for this change: adding values past the marker must not
+  shift anything already on the wire.
+- `the_retrieved_ue_eps_pdn_connection_carries_a_mapped_qci_not_the_raw_5qi` — drives the real
+  retrieve handler, decodes the container, and asserts 5QI 9 → QCI 9 and 5QI 82 → QCI 0. It
+  also asserts the two descriptions now agree (`qci_for_5qi(82) == None`), which is the
+  disagreement that made this a defect.
+- `interworking_handover_types_are_not_collapsed_onto_intra_lte` — both directions, plus all
+  five root mappings unchanged.
+
+## Revert-verify
+
+Three behavioural reverts, each grep-confirmed applied and restored, each failing its own
+named assertion:
+
+| revert | test that failed |
+|---|---|
+| `match Some(sess.session_qos.index)` instead of `qci_for_5qi(..)` | `..._carries_a_mapped_qci_not_the_raw_5qi` — "5QI 82 has no standardised EPS QCI, so the reserved QCI 0 goes on the wire" |
+| `EpsTo5gs => S1apHandoverType::IntraLte` | `interworking_handover_types_are_not_collapsed_onto_intra_lte` — "must go on the wire as eps-to-5gs, not as intralte" |
+| `Constraint::new(0, 6)` instead of `extensible(0, 4)` | `..._round_trip_as_extension_additions` — the extension-index assertion |
+
+The third is the valuable one: making the constraint non-extensible still **round-trips
+perfectly** through our own codec, and the test fails anyway — which is the proof that it pins
+the wire form rather than self-consistency.
+
+One test bug was found and fixed on the way, worth recording because it looked like a code
+defect: the first version extracted the extension index as `(octet >> 1) & 0x3F`, which
+reported 0 for both values. A normally-small non-negative is a single `0` bit followed by six
+value bits, so after the extension bit the octet is `[ext=1][small=0][v5..v0]` and the index is
+`octet & 0x3F`. The encoder was right; the assertion was reading the wrong bits — and it
+"passed" for `eps-to-5gs` by coincidence, since index 0 reads as 0 either way.
+
+## Ceilings, stated rather than implied
+
+- **No N26 interface** — #347. Nothing here adds an inter-CN procedure, which is why there is
+  no feature gate to add (criterion 9): the two changes are wire-correctness fixes to paths
+  that already existed.
+- **`qci_for_5qi` still maps only 1..=9**, as above.
+- **The QoS octet is the only QoS in the container.** ARP, GBR and MBR are not carried, though
+  Annex C says the EPS bearer's ARP/GBR/MBR come from the flow's ARP/GFBR/MFBR.
+  `record_mapped_eps_bearer` stores the ARP; #78's container layout has no field for it, and
+  widening a positional layout that a peer may already parse belongs with #347, which defines
+  the real PDN Connection IE.
+- **`ho_type_to_s1ap`'s two new values have no live producer**: nothing sets
+  `context::HandoverType::EpsTo5gs` on an S1AP path yet, because that is the TAU/handover
+  procedure in #347. The mapping is fixed now so that when a producer arrives it cannot emit
+  `intralte` by default — the collapse was the kind of defect that only surfaces once something
+  reaches it.
+
+## Verification
+
+- Workspace **6555 tests, 0 failures** (6550 + 5). `cargo clippy --workspace` 0 errors,
+  `cargo fmt --all -- --check` clean.
+- Wire values read out of the vendored specs: `36413-j20.txt:30619` (the ASN.1),
+  `23502-k20.txt` Annex C (the QCI rule), `23501-k20.txt` Table 5.7.4-1 (the standardised 5QI
+  set), `TS29502_Nsmf_PDUSession.yaml` (`ueEpsPdnConnection` vs `EpsPdnCnxInfo`).
+
+## Files
+
+- `src/bins/nextgcore-smfd/src/main.rs` — the container carries a mapped QCI; the test.
+- `src/libs/nextgcore-s1ap/src/types.rs` — `EpsTo5gs`, `FiveGsToEps` with the extension note.
+- `src/libs/nextgcore-s1ap/src/ie.rs` — decode arms; the two wire-form tests.
+- `src/bins/nextgcore-mmed/src/s1ap_handler.rs` — both mapping directions; the test.

--- a/src/bins/nextgcore-mmed/src/s1ap_handler.rs
+++ b/src/bins/nextgcore-mmed/src/s1ap_handler.rs
@@ -2072,16 +2072,33 @@ fn ho_type_from_s1ap(handover_type: S1apHandoverType) -> crate::context::Handove
         S1apHandoverType::LteToGeran => crate::context::HandoverType::LteToGeran,
         S1apHandoverType::UtranToLte => crate::context::HandoverType::UtranToLte,
         S1apHandoverType::GeranToLte => crate::context::HandoverType::GeranToLte,
+        // #62: the inbound direction too. An eNB that supports the extension can send
+        // either of these, and mapping them to `IntraLte` on the way in would record
+        // the UE as doing an intra-LTE handover — so every later decision about it
+        // (bearer handling, target selection) would be made about the wrong procedure.
+        S1apHandoverType::EpsTo5gs => crate::context::HandoverType::EpsTo5gs,
+        S1apHandoverType::FiveGsToEps => crate::context::HandoverType::FiveGsToEps,
     }
 }
 
 /// Map the context Handover Type onto the S1AP representation.
-/// 5GS interworking types never reach the S1AP handover path.
 fn ho_type_to_s1ap(handover_type: crate::context::HandoverType) -> S1apHandoverType {
     match handover_type {
-        crate::context::HandoverType::IntraLte
-        | crate::context::HandoverType::EpsTo5gs
-        | crate::context::HandoverType::FiveGsToEps => S1apHandoverType::IntraLte,
+        crate::context::HandoverType::IntraLte => S1apHandoverType::IntraLte,
+        // #62: these two used to collapse into `IntraLte` under the comment "5GS
+        // interworking types never reach the S1AP handover path". They are no longer
+        // unrepresentable: TS 36.413 defines `eps-to-5gs` and `fivegs-to-eps` as the
+        // two extension additions of `HandoverType` (`36413-j20.txt:30619`), and the
+        // wire enum now carries them.
+        //
+        // Collapsing was worse than the comment suggested. If one of them DID reach
+        // this path, the eNB was told "intra-LTE handover" about an inter-system move
+        // and would admit it as an ordinary LTE handover — the eNB acting on a wrong
+        // wire value, rather than an unused branch. Mapping them truthfully means an
+        // eNB that does not support the extension can reject a value it does not
+        // recognise, which is what the extension marker is for.
+        crate::context::HandoverType::EpsTo5gs => S1apHandoverType::EpsTo5gs,
+        crate::context::HandoverType::FiveGsToEps => S1apHandoverType::FiveGsToEps,
         crate::context::HandoverType::LteToUtran => S1apHandoverType::LteToUtran,
         crate::context::HandoverType::LteToGeran => S1apHandoverType::LteToGeran,
         crate::context::HandoverType::UtranToLte => S1apHandoverType::UtranToLte,
@@ -3691,6 +3708,53 @@ mod tests {
                 );
             }
             other => panic!("expected ErrorIndication, got {other:?}"),
+        }
+    }
+    /// #62 criterion 6: the 5GS interworking handover types are no longer collapsed
+    /// onto `IntraLte`, in either direction.
+    ///
+    /// The old mapping's comment said these "never reach the S1AP handover path", which
+    /// made it look like a harmless placeholder. It was not: if one DID reach it, the
+    /// eNB was handed `intralte` for an inter-system move and would admit it as an
+    /// ordinary LTE handover — a wrong value acted on, not an unused branch. Now they
+    /// map onto the two extension additions TS 36.413 defines
+    /// (`36413-j20.txt:30619`), so an eNB that does not implement the extension can
+    /// reject a value it does not recognise, which is what the `...` marker is for.
+    #[test]
+    fn interworking_handover_types_are_not_collapsed_onto_intra_lte() {
+        use crate::context::HandoverType as Ctx;
+
+        assert_eq!(
+            ho_type_to_s1ap(Ctx::EpsTo5gs),
+            S1apHandoverType::EpsTo5gs,
+            "EpsTo5gs must go on the wire as eps-to-5gs, not as intralte"
+        );
+        assert_eq!(
+            ho_type_to_s1ap(Ctx::FiveGsToEps),
+            S1apHandoverType::FiveGsToEps,
+            "FiveGsToEps must go on the wire as fivegs-to-eps, not as intralte"
+        );
+
+        // The inbound direction too: mapping these to IntraLte on the way IN would
+        // record the UE as doing an intra-LTE handover, so every later decision about
+        // it would be made about the wrong procedure.
+        assert_eq!(ho_type_from_s1ap(S1apHandoverType::EpsTo5gs), Ctx::EpsTo5gs);
+        assert_eq!(
+            ho_type_from_s1ap(S1apHandoverType::FiveGsToEps),
+            Ctx::FiveGsToEps
+        );
+
+        // Every OTHER mapping is unchanged -- the point of the guard is that adding the
+        // two extension values did not disturb the five root ones.
+        for (ctx, wire) in [
+            (Ctx::IntraLte, S1apHandoverType::IntraLte),
+            (Ctx::LteToUtran, S1apHandoverType::LteToUtran),
+            (Ctx::LteToGeran, S1apHandoverType::LteToGeran),
+            (Ctx::UtranToLte, S1apHandoverType::UtranToLte),
+            (Ctx::GeranToLte, S1apHandoverType::GeranToLte),
+        ] {
+            assert_eq!(ho_type_to_s1ap(ctx), wire, "{ctx:?} must be unchanged");
+            assert_eq!(ho_type_from_s1ap(wire), ctx, "{wire:?} must be unchanged");
         }
     }
 }

--- a/src/bins/nextgcore-smfd/src/main.rs
+++ b/src/bins/nextgcore-smfd/src/main.rs
@@ -5435,9 +5435,40 @@ fn build_ue_eps_pdn_connection(sess: &context::SmfSess, eps_bearer_id: Option<u8
         Some(addr) => buf.extend_from_slice(&addr.octets()),
         None => buf.extend_from_slice(&[0, 0, 0, 0]),
     }
-    // Default bearer QoS: the 5QI the session was authorised with, which is what
-    // maps onto the EPS QCI.
-    buf.push(sess.session_qos.index);
+    // Default bearer QoS as an EPS **QCI**, mapped per TS 23.502 Annex C.
+    //
+    // #62: this used to push `sess.session_qos.index` — the raw 5QI — with a comment
+    // asserting it "is what maps onto the EPS QCI". For the standardised 5QIs 1..=9
+    // that happens to be true, which is why it was invisible; for anything else the
+    // container handed to an AMF (and onward to an MME) declared a QCI value that
+    // TS 23.203 does not define, and an MME would either reject the PDN connection or
+    // enforce a QoS the session was never authorised with.
+    //
+    // The mapping already existed and this was its second, unmapped call site.
+    // `gsm_build::encode_mapped_eps_bearer_context` — the IE that tells the *UE* about
+    // the same bearer — goes through `qci_for_5qi`, so the two descriptions of one
+    // bearer disagreed: the UE was told "no mapped EPS QoS" while the MME was told a
+    // QCI equal to a 5QI with no EPS equivalent. One wire fact, two spellings, and only
+    // the tested one was right (#335, #340).
+    //
+    // A 5QI with no EPS equivalent encodes as **0**, which TS 24.301 §9.9.4.3 reserves.
+    // The layout here is positional (#78's), so the octet cannot be omitted the way
+    // `encode_mapped_eps_bearer_context` omits its whole parameter — and a reserved
+    // value an MME must reject is a better answer than a plausible wrong one.
+    match gsm_build::qci_for_5qi(sess.session_qos.index) {
+        Some(qci) => buf.push(qci),
+        None => {
+            log::warn!(
+                "[smContextRef={}] 5QI {} has no standardised EPS QCI (TS 23.502 Annex C maps only \
+                 standardised 5QIs one-to-one), so the ueEpsPdnConnection carries the \
+                 reserved QCI 0: this session's default bearer cannot be described to an \
+                 MME, and moving it to EPS will be refused rather than mis-enforced",
+                sess.sm_context_ref.as_deref().unwrap_or("unknown-ref"),
+                sess.session_qos.index
+            );
+            buf.push(0);
+        }
+    }
     // #117: the EPS bearer identity, when one was assigned. Appended rather than
     // inserted so the prefix stays identical to #78's output for a session without
     // one — a peer parsing the earlier form reads the same first bytes.
@@ -8967,6 +8998,76 @@ mod tests {
                 .map(|s| s.id),
             Some(second.id)
         );
+    }
+
+    /// #62 criterion 1: the `ueEpsPdnConnection` carries an EPS **QCI**, mapped per
+    /// TS 23.502 Annex C — not the raw 5QI.
+    ///
+    /// The defect was invisible for the default 5QI: Annex C maps standardised 5QIs
+    /// one-to-one, so for 5QI 9 the mapped and unmapped answers are the same octet.
+    /// It only shows on a 5QI with no EPS equivalent, which is why the test drives one.
+    ///
+    /// It also pins the DISAGREEMENT that made this a defect rather than a nit: the
+    /// same bearer is described to the UE by
+    /// `gsm_build::encode_mapped_eps_bearer_context`, which has always gone through
+    /// `qci_for_5qi`. So before this change the UE was told "no mapped EPS QoS" while
+    /// the MME was told a QCI equal to a 5QI that TS 23.203 does not define.
+    #[tokio::test]
+    async fn the_retrieved_ue_eps_pdn_connection_carries_a_mapped_qci_not_the_raw_5qi() {
+        let _state = crate::context::PROCESS_STATE_TEST_LOCK.lock().await;
+        use base64::Engine as _;
+
+        // Decode the QoS octet out of the container. Layout (#78, positional):
+        // [apn_len][apn ...][pdn_type][ipv4 x4][qci]  (+ [ebi] when assigned)
+        async fn qos_octet_for(sm_ref: &str) -> u8 {
+            let body: serde_json::Value = serde_json::from_str(
+                handle_sm_context_retrieve(sm_ref)
+                    .await
+                    .http
+                    .content
+                    .as_deref()
+                    .expect("body"),
+            )
+            .expect("json");
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(body["ueEpsPdnConnection"].as_str().expect("required"))
+                .expect("base64");
+            let apn_len = bytes[0] as usize;
+            // apn_len + 1 (len octet) + 1 (pdn type) + 4 (ipv4) = index of the QCI
+            bytes[apn_len + 6]
+        }
+
+        // A standardised 5QI: Annex C maps it 1:1, so the octet is the same number.
+        let standardised = seed_registered_session("imsi-001010000000620", 3, "internet");
+        assert_eq!(
+            qos_octet_for(&standardised).await,
+            9,
+            "5QI 9 is standardised, so the QCI is 9 (TS 23.502 Annex C, one-to-one)"
+        );
+
+        // A 5QI with NO EPS equivalent must not be emitted as if it were a QCI.
+        let unmappable = seed_registered_session("imsi-001010000000621", 4, "internet");
+        if let Ok(ctx) = smf_self().read() {
+            if let Some(mut sess) = ctx.sess_find_by_sm_context_ref(&unmappable) {
+                sess.session_qos.index = 82;
+                ctx.sess_update(&sess);
+            }
+        }
+        assert_eq!(
+            qos_octet_for(&unmappable).await,
+            0,
+            "5QI 82 has no standardised EPS QCI, so the reserved QCI 0 goes on the wire \
+             (TS 24.301 §9.9.4.3) -- an MME rejects that, where 82 would be enforced as \
+             a QCI the session was never authorised with"
+        );
+        // And the two descriptions of one bearer now agree: the UE-facing IE omits its
+        // QoS parameter for exactly the 5QIs the MME-facing container reports as 0.
+        assert_eq!(
+            gsm_build::qci_for_5qi(82),
+            None,
+            "the UE-facing mapped-EPS-bearer IE omits its QoS parameter for this 5QI"
+        );
+        assert_eq!(gsm_build::qci_for_5qi(9), Some(9));
     }
 
     /// #117 criterion 4: the retrieved `ueEpsPdnConnection` NAMES the assigned EBI

--- a/src/libs/nextgcore-s1ap/src/ie.rs
+++ b/src/libs/nextgcore-s1ap/src/ie.rs
@@ -2044,6 +2044,12 @@ pub fn decode_handover_type(field: &ProtocolIeField) -> S1apResult<HandoverType>
         2 => Ok(HandoverType::LteToGeran),
         3 => Ok(HandoverType::UtranToLte),
         4 => Ok(HandoverType::GeranToLte),
+        // The two extension additions after the `...` marker (#62). `decode_enumerated`
+        // returns them already re-based onto 5 and 6, so they read like root values
+        // here; the extension bit and the normally-small index are handled inside the
+        // decoder, which is why these arms are plain.
+        5 => Ok(HandoverType::EpsTo5gs),
+        6 => Ok(HandoverType::FiveGsToEps),
         _ => Err(S1apError::InvalidIeValue {
             ie_name: "HandoverType",
             reason: format!("unknown value {value}"),
@@ -3383,5 +3389,94 @@ pub fn decode_broadcast_cancelled_area_list(
             ie_name: "BroadcastCancelledAreaList",
             reason: format!("unsupported choice index {index}"),
         }),
+    }
+}
+
+#[cfg(test)]
+mod handover_type_tests {
+    use super::*;
+
+    /// #62: `eps-to-5gs` and `fivegs-to-eps` are the two EXTENSION ADDITIONS of
+    /// TS 36.413's `HandoverType`, and they round-trip.
+    ///
+    /// Both directions are asserted, and so is the fact that they are encoded as
+    /// extensions rather than as root values 5 and 6. That distinction is the whole
+    /// reason this was not a one-line enum edit: `HandoverType ::= ENUMERATED {
+    /// intralte, ltetoutran, ltetogeran, utrantolte, gerantolte, ..., eps-to-5gs,
+    /// fivegs-to-eps }` (`36413-j20.txt:30619`) puts them past the `...`, so X.691
+    /// §14.6 encodes them as the extension bit plus a normally-small index — 0 for
+    /// `eps-to-5gs`, 1 for `fivegs-to-eps` — not as the constrained numbers 5 and 6.
+    /// An implementation that emitted 5 in the root range would be read by a peer as a
+    /// root value out of range.
+    #[test]
+    fn handover_type_interworking_values_round_trip_as_extension_additions() {
+        for (ht, expected_index) in [
+            (HandoverType::EpsTo5gs, 0u64),
+            (HandoverType::FiveGsToEps, 1u64),
+        ] {
+            let mut container = ProtocolIeContainer::new();
+            encode_handover_type(&mut container, ht).expect("encode");
+            let field = container
+                .ies
+                .iter()
+                .find(|f| f.id == ProtocolIeId::HANDOVER_TYPE)
+                .expect("the IE must be present");
+
+            // The extension bit is the FIRST bit of the encoding, and the index
+            // follows it. Asserted on the raw octet so this pins the wire form, not
+            // just that our own decoder agrees with our own encoder (#91).
+            let first = field.value[0];
+            assert_eq!(
+                first & 0x80,
+                0x80,
+                "{ht:?}: bit 8 is the extension bit and must be SET for a value past \
+                 the `...` marker; clear would encode it as a root value"
+            );
+            // normally-small non-negative (X.691 §11.6): a single `0` bit, then 6 bits
+            // of value. So after the extension bit the octet is
+            // `[ext=1][small=0][v5..v0]` and the index is the low six bits.
+            let index = (first & 0x3F) as u64;
+            assert_eq!(
+                index, expected_index,
+                "{ht:?}: extension index is counted from the end of the root, so \
+                 eps-to-5gs is 0 and fivegs-to-eps is 1 -- NOT 5 and 6"
+            );
+
+            assert_eq!(
+                decode_handover_type(field).expect("decode"),
+                ht,
+                "{ht:?} must survive the round trip"
+            );
+        }
+    }
+
+    /// The five root values are untouched by the extension additions.
+    ///
+    /// The guard that matters for a change like this: adding values past the marker
+    /// must not shift the encoding of anything already on the wire, or every existing
+    /// LTE handover breaks.
+    #[test]
+    fn handover_type_root_values_are_unchanged() {
+        for ht in [
+            HandoverType::IntraLte,
+            HandoverType::LteToUtran,
+            HandoverType::LteToGeran,
+            HandoverType::UtranToLte,
+            HandoverType::GeranToLte,
+        ] {
+            let mut container = ProtocolIeContainer::new();
+            encode_handover_type(&mut container, ht).expect("encode");
+            let field = container
+                .ies
+                .iter()
+                .find(|f| f.id == ProtocolIeId::HANDOVER_TYPE)
+                .expect("the IE must be present");
+            assert_eq!(
+                field.value[0] & 0x80,
+                0,
+                "{ht:?} is a ROOT value: the extension bit must be CLEAR"
+            );
+            assert_eq!(decode_handover_type(field).expect("decode"), ht);
+        }
     }
 }

--- a/src/libs/nextgcore-s1ap/src/types.rs
+++ b/src/libs/nextgcore-s1ap/src/types.rs
@@ -423,6 +423,26 @@ pub enum HandoverType {
     LteToGeran = 2,
     UtranToLte = 3,
     GeranToLte = 4,
+    /// `eps-to-5gs`, the FIRST extension addition after the `...` marker (#62).
+    ///
+    /// TS 36.413 `HandoverType ::= ENUMERATED { intralte, ltetoutran, ltetogeran,
+    /// utrantolte, gerantolte, ..., eps-to-5gs, fivegs-to-eps }`
+    /// (`36413-j20.txt:30619`).
+    ///
+    /// The two interworking values were **absent from this enum entirely**, so
+    /// `mmed`'s `ho_type_to_s1ap` had nothing to map its own `EpsTo5gs` /
+    /// `FiveGsToEps` onto and collapsed both to `IntraLte` — putting
+    /// "intra-LTE handover" on the wire for an inter-system move. The eNB then
+    /// admits it as an ordinary LTE handover.
+    ///
+    /// Being past the extension marker matters for the encoding, not just the value:
+    /// `HANDOVER_TYPE_CONSTRAINT` is `Constraint::extensible(0, 4)`, so the APER
+    /// encoder writes the extension bit and then `value - 4 - 1` as a normally-small
+    /// non-negative number. `eps-to-5gs` is therefore extension index 0 and
+    /// `fivegs-to-eps` index 1 — NOT the plain constrained values 5 and 6.
+    EpsTo5gs = 5,
+    /// `fivegs-to-eps`, the second extension addition. See [`HandoverType::EpsTo5gs`].
+    FiveGsToEps = 6,
 }
 
 /// Handover Required - sent by source eNB to MME


### PR DESCRIPTION
Closes #62. Splits its criteria **5** and **7** to **#347**.

Spec: `specs/fix-eps-interworking-qci-and-s1ap-handover-type.md`

## The split is the author's own

#62's suggested approach says: *"Consider splitting phases 2–3 (amfd+mmed N26 GTPv2-C + GUTI mapping) into a follow-on issue."* So this follows the refinement recorded for #108 — when an issue's own text scopes a part out, file it and close the parent on the rest, naming which criteria moved and where.

**#347** carries criterion 5 (N26 GTPv2-C Context Request/Response + Forward Relocation) and criterion 7 (idle-mode TAU-with-N26). Criterion 9's feature gate goes with them — it gates "the new N26 procedure", and nothing here adds one.

## Five of nine criteria were already met, and one named the wrong members

Re-verified at `54e5aa3`:

| criterion | state |
|---|---|
| 1. mapped EBI + mapped EPS QoS | **half met** — #117 stores EBI/QFI/5QI/ARP; the mapped **QCI** had a defect (below) |
| 2. `SmContextRetrieve` returns the EPS PDN connection | **met** — #78, made to name the EBI by #117 |
| 3. `handle_pdu_session_create` not hardcoded | **met** — #79 replaced the `pduSessionRef "1"` / `REL_DUE_TO_HO` stub with a deliberate `501` |
| 4. 5G-GUTI ↔ 4G-GUTI mapping | **met** — #116, bijective and round-tripped |
| 6. `ho_type_to_s1ap` no longer collapses | **gap** — fixed here |
| 8. test | **met** via the `SmContextRetrieve` branch criterion 8 itself offers; extended here |

**Criterion 2 named members that do not belong to the response.** It asks for `epsPdnCnxInfo`/`epsBearerInfo`; `TS29502_Nsmf_PDUSession.yaml` gives `SmContextRetrievedData` a **required** `ueEpsPdnConnection`, and those two types are described as *"from H-SMF to V-SMF, or from SMF to I-SMF"* — a different interface. Implementing the issue's spelling would have added two members no AMF reads while leaving the required one alone (the #93 divergent-key shape).

## Criterion 1: one wire fact, two spellings, and the untested one was wrong

`gsm_build::qci_for_5qi` already existed. `build_ue_eps_pdn_connection` was its **second call site and did not call it** — it pushed the raw 5QI under a comment asserting that value "is what maps onto the EPS QCI".

True for standardised 5QIs 1..=9, which is exactly why it was invisible: every default session (5QI 9) produced a correct octet. For anything else, the container handed to an AMF and onward to an MME **declared a QCI TS 23.203 does not define**.

So the two descriptions of one bearer disagreed:

| audience | path | on a 5QI with no EPS equivalent |
|---|---|---|
| the **UE** | `encode_mapped_eps_bearer_context` → `qci_for_5qi` | omits the mapped-EPS-QoS parameter |
| the **MME** | `build_ue_eps_pdn_connection` → raw 5QI | claims a QCI equal to the 5QI |

#335's and #340's shape — two copies of one fact, only the tested one right, and the untested copy on the interworking path.

TS 23.502 Annex C: *"For standardized 5QIs, the QCI is one to one mapped to the 5QI. For non-standardized 5QIs, the SMF+PGW-C derives the QCI based on the 5QI and operator policy."* A 5QI with no equivalent now encodes as the **reserved QCI 0** (TS 24.301 §9.9.4.3) with a warning naming the consequence: #78's layout is positional so the octet cannot be omitted, and a value an MME must reject beats a plausible one it would enforce.

## Criterion 6: the values were absent from the wire enum, not merely unmapped

TS 36.413 (`36413-j20.txt:30619`):

```asn1
HandoverType ::= ENUMERATED { intralte, ltetoutran, ltetogeran, utrantolte, gerantolte,
                              ..., eps-to-5gs, fivegs-to-eps }
```

`nextgcore_s1ap`'s enum stopped at `gerantolte`, so `ho_type_to_s1ap` had nothing to map onto and collapsed both interworking types to `IntraLte` under *"5GS interworking types never reach the S1AP handover path"*. That reads as a harmless placeholder and isn't: an eNB handed `intralte` for an inter-system move admits it as an ordinary LTE handover — a wrong value **acted on**. The same collapse existed inbound, where it would record the UE as doing an intra-LTE handover, so every later decision concerned the wrong procedure. Both directions fixed.

**Being past the `...` marker is the substance.** X.691 §14.6 encodes extension additions as the extension bit plus a normally-small index — `eps-to-5gs` = **0**, `fivegs-to-eps` = **1** — not the constrained values 5 and 6. No codec change was needed: `HANDOVER_TYPE_CONSTRAINT` is already `Constraint::extensible(0, 4)` and the encoder/decoder already implement the extension path.

## Revert-verify

Three behavioural reverts, each grep-confirmed applied and restored, each failing its own named assertion:

| revert | test that failed |
|---|---|
| `match Some(sess.session_qos.index)` instead of `qci_for_5qi(..)` | `..._carries_a_mapped_qci_not_the_raw_5qi` |
| `EpsTo5gs => S1apHandoverType::IntraLte` | `interworking_handover_types_are_not_collapsed_onto_intra_lte` |
| `Constraint::new(0, 6)` instead of `extensible(0, 4)` | `..._round_trip_as_extension_additions` |

The third is the valuable one: with a non-extensible constraint the values still **round-trip perfectly** through our own codec, and the test fails anyway — proof that it pins the wire form and not self-consistency.

One **test** bug was found and fixed on the way, recorded because it looked like a code defect: the extension index is `octet & 0x3F`, not `(octet >> 1) & 0x3F`. The wrong version "passed" for `eps-to-5gs` by coincidence, since index 0 reads as 0 either way.

## Ceilings

- **No N26 interface** — #347. Hence no feature gate to add: both changes are wire-correctness fixes to paths that already existed.
- **`qci_for_5qi` still maps only 1..=9.** Annex C permits 1:1 for every standardised 5QI and the set is `1-10, 65-67, 69-76, 79, 80, 82-90`; widening needs TS 23.203's QCI table to say which of those QCIs exist, and guessing would reinstate the defect this fixes.
- **ARP/GBR/MBR are not carried** in the container, though Annex C derives them from the flow's ARP/GFBR/MFBR. `record_mapped_eps_bearer` stores the ARP; #78's positional layout has no field for it, and widening a layout a peer may already parse belongs with #347, which defines the real PDN Connection IE.
- **The two new handover values have no live producer yet** — that is the procedure in #347. The mapping is fixed now so that when one arrives it cannot emit `intralte` by default.

## Verification

- Workspace **6555 tests, 0 failures** (6550 + 5). `cargo clippy --workspace` 0 errors, `cargo fmt --all -- --check` clean.
- Wire values read from the vendored specs: `36413-j20.txt:30619`, `23502-k20.txt` Annex C, `23501-k20.txt` Table 5.7.4-1, `TS29502_Nsmf_PDUSession.yaml`.